### PR TITLE
Add field headers

### DIFF
--- a/api_factory/generator/generator.py
+++ b/api_factory/generator/generator.py
@@ -14,7 +14,7 @@
 
 import io
 import os
-from typing import Any, Callable, Iterable, Mapping, Sequence
+from typing import Any, Iterable, Mapping, Sequence
 
 import jinja2
 

--- a/api_factory/generator/templates/$namespace/$name_$version/$service/client.py.j2
+++ b/api_factory/generator/templates/$namespace/$name_$version/$service/client.py.j2
@@ -4,6 +4,9 @@
 import functools
 import pkg_resources
 from typing import Mapping, Optional, Sequence, Tuple, Union
+{%- if service.has_field_headers %}
+from urllib import parse
+{%- endif %}
 
 from google.api_core import gapic_v1
 {%- if service.has_lro %}
@@ -54,8 +57,8 @@ class {{ service.name }}:
         else:
             Transport = get_transport_class(transport)
             self._transport = Transport(credentials=credentials)
+    {%- for method in service.methods.values() %}
 
-    {% for method in service.methods.values() -%}
     @functools.singledispatch
     def {{ method.name|snake_case }}(self,
             request: {{ method.input.pb2_module }}.{{ method.input.name }}, *,
@@ -97,6 +100,38 @@ class {{ service.name }}:
             default_timeout=None,  # FIXME
             client_info=self.client_info,
         )
+        {%- if method.field_headers %}
+
+        # Ensure metadata is a mutable sequence.
+        if metadata is None:
+            metadata = []
+        else:
+            metadata = list(metadata)
+
+        # Add request headers to metadata.
+        try:
+            request_headers = (
+                {%- for field_header in method.field_headers %}
+                ('{{ field_header.header }}', '{{ field_header.field }}', request.{{ field_header.field }}),
+                {%- endfor %}
+            )
+        except AttributeError:
+            # Suppress when attribute missing.
+            pass
+        else:
+            request_metadata = [
+                (
+                    header,
+                    '{}={}'.format(
+                        parse.quote_plus(key),
+                        parse.quote_plus(value),
+                    ),
+                )
+                for (header, key, value)
+                in request_headers
+            ]
+            metadata.extend(request_metadata)
+        {%- endif %}
 
         # Send the request.
         response = rpc(request, retry=retry, timeout=timeout, metadata=metadata)

--- a/api_factory/generator/templates/$namespace/$name_$version/$service/client.py.j2
+++ b/api_factory/generator/templates/$namespace/$name_$version/$service/client.py.j2
@@ -103,34 +103,25 @@ class {{ service.name }}:
         {%- if method.field_headers %}
 
         # Ensure metadata is a mutable sequence.
-        if metadata is None:
-            metadata = []
-        else:
-            metadata = list(metadata)
+        metadata = list(metadata)
 
         # Add request headers to metadata.
+        {%- for field_header in method.field_headers %}
+
         try:
-            request_headers = (
-                {%- for field_header in method.field_headers %}
-                ('{{ field_header.header }}', '{{ field_header.field }}', request.{{ field_header.field }}),
-                {%- endfor %}
-            )
+            header_value = request.{{ field_header.field }}
         except AttributeError:
             # Suppress when attribute missing.
             pass
         else:
-            request_metadata = [
-                (
-                    header,
-                    '{}={}'.format(
-                        parse.quote_plus(key),
-                        parse.quote_plus(value),
-                    ),
-                )
-                for (header, key, value)
-                in request_headers
-            ]
-            metadata.extend(request_metadata)
+            metadata.append((
+                '{{ field_header.header }}',
+                '{}={}'.format(
+                    parse.quote_plus('{{ field_header.field }}'),
+                    parse.quote_plus(header_value),
+                ),
+            ))
+        {%- endfor %}
         {%- endif %}
 
         # Send the request.

--- a/api_factory/generator/templates/$namespace/$name_$version/$service/transports/base.py.j2
+++ b/api_factory/generator/templates/$namespace/$name_$version/$service/transports/base.py.j2
@@ -52,13 +52,13 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
         """Return the client designed to process long-running operations."""
         raise NotImplementedError
     {%- endif %}
+    {%- for method in service.methods.values() %}
 
-    {% for method in service.methods.values() -%}
     @abc.abstractmethod
     def {{ method.name|snake_case }}(
             self,
             request: {{ method.input.pb2_module }}.{{ method.input.name }},
             ) -> {{ method.output.pb2_module }}.{{ method.output.name }}:
         raise NotImplementedError
-    {% endfor -%}
+    {%- endfor %}
 {% endblock %}

--- a/api_factory/generator/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
+++ b/api_factory/generator/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
@@ -78,8 +78,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         # Return the client from cache.
         return self.__dict__['operations_client']
     {%- endif %}
+    {%- for method in service.methods.values() %}
 
-    {% for method in service.methods.values() -%}
     def {{ method.name|snake_case }}(self,
             request: {{ method.input.pb2_module }}.{{ method.input.name }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
@@ -115,6 +115,5 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
         # Return the response.
         return stub(request, metadata=metadata)
-
-    {% endfor -%}
+    {%- endfor %}
 {%- endblock -%}

--- a/api_factory/generator/templates/$namespace/$name_$version/$service/transports/http.py.j2
+++ b/api_factory/generator/templates/$namespace/$name_$version/$service/transports/http.py.j2
@@ -62,8 +62,8 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
         # Return the client from cache.
         return self.__dict__['operations_client']
     {%- endif %}
+    {%- for method in service.methods.values() %}
 
-    {% for method in service.methods.values() -%}
     def {{ method.name|snake_case }}(self,
             request: {{ method.input.pb2_module }}.{{ method.input.name }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
@@ -99,5 +99,5 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
         return {{ method.output.pb2_module }}.{{ method.output.name }}.FromString(
             response.content,
         )
-    {% endfor %}
+    {%- endfor %}
 {% endblock %}

--- a/api_factory/schema/pb/headers_pb2.py
+++ b/api_factory/schema/pb/headers_pb2.py
@@ -20,23 +20,70 @@ DESCRIPTOR = _descriptor.FileDescriptor(
   name='google/api/experimental/headers.proto',
   package='google.api.experimental',
   syntax='proto3',
-  serialized_pb=_b('\n%google/api/experimental/headers.proto\x12\x17google.api.experimental\x1a google/protobuf/descriptor.proto:5\n\x0cheader_param\x12\x1d.google.protobuf.FieldOptions\x18\xf0\x8c\x03 \x01(\tb\x06proto3')
+  serialized_pb=_b('\n%google/api/experimental/headers.proto\x12\x17google.api.experimental\x1a google/protobuf/descriptor.proto\",\n\x0b\x46ieldHeader\x12\r\n\x05\x66ield\x18\x01 \x01(\t\x12\x0e\n\x06header\x18\x02 \x01(\t:]\n\rfield_headers\x12\x1e.google.protobuf.MethodOptions\x18\xf0\x8c\x03 \x03(\x0b\x32$.google.api.experimental.FieldHeaderb\x06proto3')
   ,
   dependencies=[google_dot_protobuf_dot_descriptor__pb2.DESCRIPTOR,])
 
 
-HEADER_PARAM_FIELD_NUMBER = 50800
-header_param = _descriptor.FieldDescriptor(
-  name='header_param', full_name='google.api.experimental.header_param', index=0,
-  number=50800, type=9, cpp_type=9, label=1,
-  has_default_value=False, default_value=_b("").decode('utf-8'),
+FIELD_HEADERS_FIELD_NUMBER = 50800
+field_headers = _descriptor.FieldDescriptor(
+  name='field_headers', full_name='google.api.experimental.field_headers', index=0,
+  number=50800, type=11, cpp_type=10, label=3,
+  has_default_value=False, default_value=[],
   message_type=None, enum_type=None, containing_type=None,
   is_extension=True, extension_scope=None,
   options=None, file=DESCRIPTOR)
 
-DESCRIPTOR.extensions_by_name['header_param'] = header_param
+
+_FIELDHEADER = _descriptor.Descriptor(
+  name='FieldHeader',
+  full_name='google.api.experimental.FieldHeader',
+  filename=None,
+  file=DESCRIPTOR,
+  containing_type=None,
+  fields=[
+    _descriptor.FieldDescriptor(
+      name='field', full_name='google.api.experimental.FieldHeader.field', index=0,
+      number=1, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+    _descriptor.FieldDescriptor(
+      name='header', full_name='google.api.experimental.FieldHeader.header', index=1,
+      number=2, type=9, cpp_type=9, label=1,
+      has_default_value=False, default_value=_b("").decode('utf-8'),
+      message_type=None, enum_type=None, containing_type=None,
+      is_extension=False, extension_scope=None,
+      options=None, file=DESCRIPTOR),
+  ],
+  extensions=[
+  ],
+  nested_types=[],
+  enum_types=[
+  ],
+  options=None,
+  is_extendable=False,
+  syntax='proto3',
+  extension_ranges=[],
+  oneofs=[
+  ],
+  serialized_start=100,
+  serialized_end=144,
+)
+
+DESCRIPTOR.message_types_by_name['FieldHeader'] = _FIELDHEADER
+DESCRIPTOR.extensions_by_name['field_headers'] = field_headers
 _sym_db.RegisterFileDescriptor(DESCRIPTOR)
 
-google_dot_protobuf_dot_descriptor__pb2.FieldOptions.RegisterExtension(header_param)
+FieldHeader = _reflection.GeneratedProtocolMessageType('FieldHeader', (_message.Message,), dict(
+  DESCRIPTOR = _FIELDHEADER,
+  __module__ = 'google.api.experimental.headers_pb2'
+  # @@protoc_insertion_point(class_scope:google.api.experimental.FieldHeader)
+  ))
+_sym_db.RegisterMessage(FieldHeader)
+
+field_headers.message_type = _FIELDHEADER
+google_dot_protobuf_dot_descriptor__pb2.MethodOptions.RegisterExtension(field_headers)
 
 # @@protoc_insertion_point(module_scope)

--- a/api_factory/schema/wrappers.py
+++ b/api_factory/schema/wrappers.py
@@ -28,7 +28,7 @@ Documentation is consistently at ``{thing}.meta.doc``.
 """
 
 import dataclasses
-from typing import List, Mapping, Sequence, Tuple
+from typing import Callable, List, Mapping, Sequence, Tuple
 
 from google.protobuf import descriptor_pb2
 
@@ -193,22 +193,22 @@ class Service:
     @property
     def has_lro(self) -> bool:
         """Return whether the service has a long-running method."""
-        return self._any_method('lro_payload')
+        return self._any_method(lambda m: getattr(m, 'lro_payload'))
 
     @property
     def has_field_headers(self) -> bool:
         """Return whether the service has a method containing field headers."""
-        return self._any_method('field_headers')
+        return self._any_method(lambda m: getattr(m, 'field_headers'))
 
-    def _any_method(self, attr: str) -> bool:
-        """Return whether the service has a method containing ``attr``.
+    def _any_method(self, predicate: Callable) -> bool:
+        """Return whether the service has a method that fulfills ``predicate``.
 
         Args:
-            attr (str): The attribute to check for presence in the service
-                methods.
+            predicate (Callable[Method]): Function specifying the criteria
+                testing the methods in the service.
 
         Returns:
             bool: True if any method of the service contains the specified
                 attribute.
         """
-        return any(getattr(method, attr) for method in self.methods.values())
+        return any(predicate(method) for method in self.methods.values())

--- a/api_factory/schema/wrappers.py
+++ b/api_factory/schema/wrappers.py
@@ -35,6 +35,7 @@ from google.protobuf import descriptor_pb2
 from api_factory import utils
 from api_factory.schema.metadata import Metadata
 from api_factory.schema.pb import client_pb2
+from api_factory.schema.pb import headers_pb2
 from api_factory.schema.pb import overload_pb2
 
 
@@ -107,6 +108,11 @@ class Method:
     def overloads(self):
         """Return the overloads defined for this method."""
         return self.method_pb.options.Extensions[overload_pb2.overloads]
+
+    @property
+    def field_headers(self):
+        """Return the field headers defined for this method."""
+        return self.method_pb.options.Extensions[headers_pb2.field_headers]
 
 
 @dataclasses.dataclass(frozen=True)
@@ -187,4 +193,22 @@ class Service:
     @property
     def has_lro(self) -> bool:
         """Return whether the service has a long-running method."""
-        return any(method.lro_payload for method in self.methods.values())
+        return self._any_method('lro_payload')
+
+    @property
+    def has_field_headers(self) -> bool:
+        """Return whether the service has a method containing field headers."""
+        return self._any_method('field_headers')
+
+    def _any_method(self, attr: str) -> bool:
+        """Return whether the service has a method containing ``attr``.
+
+        Args:
+            attr (str): The attribute to check for presence in the service
+                methods.
+
+        Returns:
+            bool: True if any method of the service contains the specified
+                attribute.
+        """
+        return any(getattr(method, attr) for method in self.methods.values())

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -16,6 +16,7 @@ from google.protobuf import descriptor_pb2
 
 from api_factory.schema import metadata
 from api_factory.schema import wrappers
+from api_factory.schema.pb import headers_pb2
 from api_factory.schema.pb import overload_pb2
 
 
@@ -35,6 +36,10 @@ def get_method() -> wrappers.Method:
     # Set an overload in the method descriptor.
     ext_key = overload_pb2.overloads
     method_pb.options.Extensions[ext_key].extend([overload_pb2.Overload()])
+
+    # Set a field header in the method descriptor.
+    ext_key = headers_pb2.field_headers
+    method_pb.options.Extensions[ext_key].extend([headers_pb2.FieldHeader()])
 
     # Instantiate the wrapper class.
     return wrappers.Method(
@@ -70,3 +75,9 @@ def test_method_overloads():
     method = get_method()
     for overload in method.overloads:
         assert isinstance(overload, overload_pb2.Overload)
+
+
+def test_method_field_headers():
+    method = get_method()
+    for field_header in method.field_headers:
+        assert isinstance(field_header, headers_pb2.FieldHeader)


### PR DESCRIPTION
Related googleapis/googleapis#505

Looks like
```diff
@functools.singledispatch
def create_device_registry(self,
        request: device_manager_pb2.CreateDeviceRegistryRequest, *,
        retry: retry.Retry = None,
        timeout: float = None,
        metadata: Sequence[Tuple[str, str]] = (),
        ) -> resources_pb2.DeviceRegistry:
    """Creates a device registry that contains devices.

    Args:
        request (~.device_manager_pb2.CreateDeviceRegistryRequest):
            The request object. Request for `CreateDeviceRegistry`.
        retry (~.retry.Retry): Designation of what errors, if any,
            should be retried.
        timeout (float): The timeout for this request.
        metadata (Sequence[Tuple[str, str]]): Strings which should be
            sent alont with the request as metadata.

    Returns:
        ~.resources_pb2.DeviceRegistry:
           A container for a group of devices.
    """
    # Wrap the RPC method; this adds retry and timeout information,
    # and friendly error handling.
    rpc = gapic_v1.method.wrap_method(
        self._transport.create_device_registry,
        default_retry=None,  # FIXME
        default_timeout=None,  # FIXME
        client_info=self.client_info,
    )

+  # Ensure metadata is a mutable sequence.
+  metadata = list(metadata)

+  # Add request headers to metadata.

+  try:
+      header_value = request.parent
+  except AttributeError:
+      # Suppress when attribute missing.
+      pass
+  else:
+      metadata.append((
+          'x-goog-request-params',
+          '{}={}'.format(
+              parse.quote_plus('parent'),
+              parse.quote_plus(header_value),
+          ),
+      ))

+  try:
+      header_value = request.device_registry.name
+  except AttributeError:
+      # Suppress when attribute missing.
+      pass
+  else:
+      metadata.append((
+          'x-goog-request-params',
+          '{}={}'.format(
+              parse.quote_plus('device_registry.name'),
+              parse.quote_plus(header_value),
+          ),
+      ))

    # Send the request.
    response = rpc(request, retry=retry, timeout=timeout, metadata=metadata)

    # Done; return the response.
    return response
```