### PR TITLE
Switch Jinja to strict undefined.

### DIFF
--- a/api_factory/generator/generator.py
+++ b/api_factory/generator/generator.py
@@ -44,9 +44,12 @@ class Generator:
         self._api = api_schema
 
         # Create the jinja environment with which to render templates.
-        self._env = jinja2.Environment(loader=TemplateLoader(
-            searchpath=os.path.join(_dirname, '..', 'templates'),
-        ))
+        self._env = jinja2.Environment(
+            loader=TemplateLoader(
+                searchpath=os.path.join(_dirname, '..', 'templates'),
+            ),
+            undefined=jinja2.StrictUndefined,
+        )
 
         # Add filters which templates require.
         self._env.filters['snake_case'] = utils.to_snake_case

--- a/api_factory/schema/wrappers.py
+++ b/api_factory/schema/wrappers.py
@@ -377,7 +377,7 @@ class Method:
         # Sanity check: If there are no signatures (which should be by far
         # the common case), just abort now.
         if len(sig_pb2.fields) == 0:
-            return ()
+            return MethodSignatures(all=())
 
         # Signatures are annotated with an `additional_signatures` key that
         # allows for specifying additional signatures. This is an uncommon

--- a/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
@@ -16,11 +16,6 @@ from .transports import get_transport_class
 from .transports import {{ service.name }}Transport
 
 
-# LIBRARY_VERSION: str = pkg_resources.get_distribution(
-#     '{{ api.warehouse_package_name }}',
-# ).version
-
-
 class {{ service.name }}:
     """{{ service.meta.doc|wrap(width=72, subsequent_indent='    ') }}
     """
@@ -107,7 +102,7 @@ class {{ service.name }}:
         # Send the request.
         response = rpc(request, retry=retry,
                        timeout=timeout, metadata=metadata)
-        {%- if method.output.lro_response %}
+        {%- if method.output.lro_response is defined %}
 
         # Wrap the response in an operation future
         response = operation.from_gapic(

--- a/api_factory/templates/$namespace/$name_$version/$service/transports/__init__.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/transports/__init__.py.j2
@@ -34,7 +34,7 @@ def get_transport_class(
             then the first transport in the registry is used.
 
     Returns:
-        Type[{{ service.label }}Transport]: The transport class to use.
+        Type[{{ service.name }}Transport]: The transport class to use.
     """
     # If a specific transport is requested, return that one.
     if label:

--- a/api_factory/templates/_base.py.j2
+++ b/api_factory/templates/_base.py.j2
@@ -1,9 +1,3 @@
 # -*- coding: utf-8 -*-
-{%- if api.copyright %}
-# Copyright {{ api.copyright.year }} {{ api.copyright.label }}
-{%- if api.copyright.license %}
-#
-# {{ api.copyright.license.boilerplate_notice|subsequent_indent('# ') }}
-{%- endif %}{% endif %}
 {% block content %}
 {% endblock %}


### PR DESCRIPTION
This means any use of an undefined variable will raise an exception immediately, rather than silently printing empty string.