### PR TITLE
Remove sending len to Jinja.

### DIFF
--- a/api_factory/generator/generator.py
+++ b/api_factory/generator/generator.py
@@ -111,7 +111,6 @@ class Generator:
             answer.append(CodeGeneratorResponse.File(
                 content=self._env.get_template(template_name).render(
                     api=self._api,
-                    len=len,
                     **additional_context
                 ).strip() + '\n',
                 name=self._get_output_filename(

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -62,11 +62,6 @@ Additionally, these templates receive two variables: the ``api`` variable
 discussed above, as well as a variable spelled ``service``, which corresponds
 to the :class:`~.schema.wrappers.Service` currently being iterated over.
 
-.. note::
-
-    Templates technically receive one additional variable, ``len``; this is
-    the ``len`` function from the standard library.
-
 
 Filters
 ~~~~~~~


### PR DESCRIPTION
The `length` filter exists, and we are no longer using `len` anyway.