### PR TITLE
Remove subsequent_indent filter.

### DIFF
--- a/api_factory/generator/generator.py
+++ b/api_factory/generator/generator.py
@@ -53,7 +53,6 @@ class Generator:
 
         # Add filters which templates require.
         self._env.filters['snake_case'] = utils.to_snake_case
-        self._env.filters['subsequent_indent'] = utils.subsequent_indent
         self._env.filters['wrap'] = utils.wrap
 
     def get_response(self) -> CodeGeneratorResponse:

--- a/api_factory/utils/__init__.py
+++ b/api_factory/utils/__init__.py
@@ -16,7 +16,6 @@ from api_factory.utils.cache import cached_property
 from api_factory.utils.case import to_snake_case
 from api_factory.utils.filename import to_valid_filename
 from api_factory.utils.filename import to_valid_module_name
-from api_factory.utils.lines import subsequent_indent
 from api_factory.utils.lines import wrap
 from api_factory.utils.placeholder import Placeholder
 

--- a/api_factory/utils/lines.py
+++ b/api_factory/utils/lines.py
@@ -15,26 +15,6 @@
 import textwrap
 
 
-def subsequent_indent(text: str, prefix: str) -> str:
-    """Decorates the text string with the given prefix on hanging lines.
-
-    A "hanging" line is any line except for the first one. After prefixing,
-    if any lines end in whitespace, that whitespace is stripped.
-
-    This is provided to all templates as the ``subsequent_indent`` filter.
-
-    Args:
-        text (str): The text string.
-        prefix (str): The prefix to use.
-
-    Returns:
-        str: The string with all hanging lines prefixed.
-    """
-    lines = text.split('\n')
-    lines[1:] = [f'{prefix}{s}'.rstrip() for s in lines[1:]]
-    return '\n'.join(lines)
-
-
 def wrap(text: str, width: int, initial_width: int = None,
          subsequent_indent: str = '', antecedent_trailer: str = '') -> str:
     """Wrap the given string to the given width.

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -28,7 +28,7 @@ from api_factory.schema import naming
 from api_factory.schema import wrappers
 
 
-def test_proto_builder_constructor():
+def test_constructor():
     # Create a generator.
     g = generator.Generator(api_schema=make_api())
     assert isinstance(g._api, api.API)
@@ -38,7 +38,6 @@ def test_proto_builder_constructor():
     # to establish this and templates will depend on it.
     assert isinstance(g._env, jinja2.Environment)
     assert 'snake_case' in g._env.filters
-    assert 'subsequent_indent' in g._env.filters
     assert 'wrap' in g._env.filters
 
 

--- a/tests/unit/utils/test_lines.py
+++ b/tests/unit/utils/test_lines.py
@@ -15,13 +15,6 @@
 from api_factory.utils import lines
 
 
-def test_subsequent_indent():
-    assert lines.subsequent_indent(
-        text='# foo\nbar\nbaz',
-        prefix='# ',
-    ) == '# foo\n# bar\n# baz'
-
-
 def test_wrap_noop():
     assert lines.wrap('foo bar baz', width=80) == 'foo bar baz'
 


### PR DESCRIPTION
It was only used for the code to print the Apache license, which is gone now.
This does _not_ remove the `subsequent_indent` keyword argument to `wrap`, which is used all over the place.