### PR TITLE
Refactor the wrap filter.

### DIFF
--- a/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
@@ -17,7 +17,7 @@ from .transports import {{ service.name }}Transport
 
 
 class {{ service.name }}:
-    """{{ service.meta.doc|wrap(width=72, offset=(7, 4)) }}
+    """{{ service.meta.doc|wrap(width=72, offset=7, indent=4) }}
     """
     def __init__(self, *,
             credentials: credentials.Credentials = None,
@@ -57,12 +57,12 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.python_ident }}:
-        """{{ method.meta.doc|wrap(width=72, offset=(11, 8)) }}
+        """{{ method.meta.doc|wrap(width=72, offset=11, indent=8) }}
 
         Args:
             request ({{ method.input.sphinx_ident }}):
-                The request object.{{ ' ' }}
-                {{- method.input.meta.doc|wrap(width=72, offset=(36, 16)) }}
+                The request object.{{ ' ' -}}
+                {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             retry (~.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -71,7 +71,7 @@ class {{ service.name }}:
 
         Returns:
             {{ method.output.sphinx_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
+                {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         # Coerce the request to the protocol buffer object.
         if not isinstance(request, {{ method.input.python_ident }}):
@@ -128,12 +128,12 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.python_ident }}:
-        """{{ method.meta.doc|wrap(width=72, offset=(11, 8)) }}
+        """{{ method.meta.doc|wrap(width=72, offset=11, indent=8) }}
 
         Args:
             {%- for field in signature.fields.values() %}
             {{ field.name }} ({{ field.sphinx_ident }}):
-                {{ field.meta.doc|wrap(width=72, offset=(16, 16)) }}
+                {{ field.meta.doc|wrap(width=72, indent=16) }}
             {%- endfor %}
             retry (~.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -143,7 +143,7 @@ class {{ service.name }}:
 
         Returns:
             {{ method.output.sphinx_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
+                {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         return self.{{ method.name|snake_case }}(
             {{ method.input.python_ident }}(

--- a/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
@@ -71,7 +71,7 @@ class {{ service.name }}:
 
         Returns:
             {{ method.output.sphinx_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
         """
         # Coerce the request to the protocol buffer object.
         if not isinstance(request, {{ method.input.python_ident }}):
@@ -128,12 +128,12 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.python_ident }}:
-        """{{ method.meta.doc|wrap(width=72, subsequent_indent=' ' * 8) }}
+        """{{ method.meta.doc|wrap(width=72, offset=(11, 8)) }}
 
         Args:
             {%- for field in signature.fields.values() %}
             {{ field.name }} ({{ field.sphinx_ident }}):
-                {{ field.meta.doc|wrap(width=72, offset=16) }}
+                {{ field.meta.doc|wrap(width=72, offset=(16, 16)) }}
             {%- endfor %}
             retry (~.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -143,7 +143,7 @@ class {{ service.name }}:
 
         Returns:
             {{ method.output.sphinx_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
         """
         return self.{{ method.name|snake_case }}(
             {{ method.input.python_ident }}(

--- a/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/client.py.j2
@@ -17,7 +17,7 @@ from .transports import {{ service.name }}Transport
 
 
 class {{ service.name }}:
-    """{{ service.meta.doc|wrap(width=72, subsequent_indent='    ') }}
+    """{{ service.meta.doc|wrap(width=72, offset=(7, 4)) }}
     """
     def __init__(self, *,
             credentials: credentials.Credentials = None,
@@ -57,12 +57,12 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.python_ident }}:
-        """{{ method.meta.doc|wrap(width=72, subsequent_indent=' ' * 8) }}
+        """{{ method.meta.doc|wrap(width=72, offset=(11, 8)) }}
 
         Args:
             request ({{ method.input.sphinx_ident }}):
-                The request object. {{ method.input.meta.doc|wrap(width=72,
-                initial_width=36, subsequent_indent=' ' * 16) }}
+                The request object.{{ ' ' }}
+                {{- method.input.meta.doc|wrap(width=72, offset=(36, 16)) }}
             retry (~.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
@@ -71,8 +71,7 @@ class {{ service.name }}:
 
         Returns:
             {{ method.output.sphinx_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, initial_width=56,
-                                               subsequent_indent=' ' * 16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
         """
         # Coerce the request to the protocol buffer object.
         if not isinstance(request, {{ method.input.python_ident }}):
@@ -134,8 +133,7 @@ class {{ service.name }}:
         Args:
             {%- for field in signature.fields.values() %}
             {{ field.name }} ({{ field.sphinx_ident }}):
-                {{ field.meta.doc|wrap(width=72, initial_width=56,
-                    subsequent_indent=' ' * 16) }}
+                {{ field.meta.doc|wrap(width=72, offset=16) }}
             {%- endfor %}
             retry (~.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -145,8 +143,7 @@ class {{ service.name }}:
 
         Returns:
             {{ method.output.sphinx_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, initial_width=56,
-                                               subsequent_indent=' ' * 16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
         """
         return self.{{ method.name|snake_case }}(
             {{ method.input.python_ident }}(

--- a/api_factory/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
@@ -20,7 +20,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
     """gRPC backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, offset=(4, 4)) }}
+    {{ service.meta.doc|wrap(width=72, indent=4) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -85,15 +85,16 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
             [{{ method.input.python_ident }}],
             {{ method.output.python_ident }}]:
         """Return a callable for the {{- ' ' -}}
-        {{ (method.name|snake_case).replace('_',' ')|wrap(width=70, offset=(40, 8)) }}
+        {{ (method.name|snake_case).replace('_',' ')|wrap(
+                width=70, offset=40, indent=8) }}
         {{- ' ' -}} method over gRPC.
 
-        {{ method.meta.doc|wrap(width=72, offset=(8, 8)) }}
+        {{ method.meta.doc|wrap(width=72, indent=8) }}
 
         Returns:
             Callable[[~.{{ method.input.name }}],
                     ~.{{ method.output.name }}]:
-                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
+                {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         # Generate a "stub function" on-the-fly which will actually make
         # the request.

--- a/api_factory/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
@@ -20,7 +20,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
     """gRPC backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, offset=4) }}
+    {{ service.meta.doc|wrap(width=72, offset=(4, 4)) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -88,12 +88,12 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         {{ (method.name|snake_case).replace('_',' ')|wrap(width=70, offset=(40, 8)) }}
         {{- ' ' -}} method over gRPC.
 
-        {{ method.meta.doc|wrap(width=72, offset=8) }}
+        {{ method.meta.doc|wrap(width=72, offset=(8, 8)) }}
 
         Returns:
             Callable[[~.{{ method.input.name }}],
                     ~.{{ method.output.name }}]:
-                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
         """
         # Generate a "stub function" on-the-fly which will actually make
         # the request.

--- a/api_factory/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/transports/grpc.py.j2
@@ -20,7 +20,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
     """gRPC backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, subsequent_indent='    ') }}
+    {{ service.meta.doc|wrap(width=72, offset=4) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -84,17 +84,16 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
     def {{ method.name|snake_case }}(self) -> Callable[
             [{{ method.input.python_ident }}],
             {{ method.output.python_ident }}]:
-        """Return a callable for the
-        {{- ' ' + (method.name|snake_case).replace('_',' ')|wrap(width=70,
-        initial_width=25, subsequent_indent="        ") }} method over gRPC.
+        """Return a callable for the {{- ' ' -}}
+        {{ (method.name|snake_case).replace('_',' ')|wrap(width=70, offset=(40, 8)) }}
+        {{- ' ' -}} method over gRPC.
 
-        {{ method.meta.doc|wrap(width=72, subsequent_indent=' ' * 8) }}
+        {{ method.meta.doc|wrap(width=72, offset=8) }}
 
         Returns:
             Callable[[~.{{ method.input.name }}],
                     ~.{{ method.output.name }}]:
-                {{ method.output.meta.doc|wrap(width=72, initial_width=56,
-                                               subsequent_indent=' ' * 16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
         """
         # Generate a "stub function" on-the-fly which will actually make
         # the request.

--- a/api_factory/templates/$namespace/$name_$version/$service/transports/http.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/transports/http.py.j2
@@ -17,7 +17,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}HttpTransport({{ service.name }}Transport):
     """HTTP backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, subsequent_indent='    ') }}
+    {{ service.meta.doc|wrap(width=72, offset=4) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -68,20 +68,20 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
             request: {{ method.input.python_module }}.{{ method.input.name }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.python_module }}.{{ method.output.name }}:
-        """Call the {{ (method.name|snake_case).replace('_',' ')|wrap(width=70,
-        initial_width=25, subsequent_indent="        ") }} method over HTTP.
+        """Call the {{- ' ' -}}
+        {{ (method.name|snake_case).replace('_',' ')|wrap(width=70, offset=(45, 8)) }}
+        {{- ' ' -}} method over HTTP.
 
         Args:
             request (~.{{ method.input.python_ident }}):
-                The request object. {{ method.input.meta.doc|wrap(width=72,
-                initial_width=36, subsequent_indent=' ' * 16) }}
+                The request object. {{- ' ' -}}
+                {{ method.input.meta.doc|wrap(width=72, offset=(36, 16)) }}
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent alont with the request as metadata.
 
         Returns:
             ~.{{ method.output.python_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, initial_width=56,
-                                               subsequent_indent=' ' * 16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
         """
         # Serialize the input.
         data = request.SerializeToString()

--- a/api_factory/templates/$namespace/$name_$version/$service/transports/http.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/transports/http.py.j2
@@ -17,7 +17,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}HttpTransport({{ service.name }}Transport):
     """HTTP backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, offset=4) }}
+    {{ service.meta.doc|wrap(width=72, offset=(4, 4)) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -81,7 +81,7 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
 
         Returns:
             ~.{{ method.output.python_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, offset=16) }}
+                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
         """
         # Serialize the input.
         data = request.SerializeToString()

--- a/api_factory/templates/$namespace/$name_$version/$service/transports/http.py.j2
+++ b/api_factory/templates/$namespace/$name_$version/$service/transports/http.py.j2
@@ -17,7 +17,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}HttpTransport({{ service.name }}Transport):
     """HTTP backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, offset=(4, 4)) }}
+    {{ service.meta.doc|wrap(width=72, indent=4) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -69,19 +69,20 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.python_module }}.{{ method.output.name }}:
         """Call the {{- ' ' -}}
-        {{ (method.name|snake_case).replace('_',' ')|wrap(width=70, offset=(45, 8)) }}
+        {{ (method.name|snake_case).replace('_',' ')|wrap(
+                width=70, offset=45, indent=8) }}
         {{- ' ' -}} method over HTTP.
 
         Args:
             request (~.{{ method.input.python_ident }}):
                 The request object. {{- ' ' -}}
-                {{ method.input.meta.doc|wrap(width=72, offset=(36, 16)) }}
+                {{ method.input.meta.doc|wrap(width=72, offset=36 indent=16) }}
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent alont with the request as metadata.
 
         Returns:
             ~.{{ method.output.python_ident }}:
-                {{ method.output.meta.doc|wrap(width=72, offset=(16, 16)) }}
+                {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         # Serialize the input.
         data = request.SerializeToString()

--- a/api_factory/utils/lines.py
+++ b/api_factory/utils/lines.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import textwrap
-from typing import Sequence
+from typing import Tuple
 
 
-def wrap(text: str, width: int, offset: Sequence[int, int] = (0, 0)) -> str:
+def wrap(text: str, width: int, offset: Tuple[int, int] = (0, 0)) -> str:
     """Wrap the given string to the given width.
 
     This uses :meth:`textwrap.fill` under the hood, but provides useful

--- a/api_factory/utils/lines.py
+++ b/api_factory/utils/lines.py
@@ -13,10 +13,10 @@
 # limitations under the License.
 
 import textwrap
-from typing import Tuple, Union
+from typing import Sequence
 
 
-def wrap(text: str, width: int, offset: Tuple[int, int] = (0, 0)) -> str:
+def wrap(text: str, width: int, offset: Sequence[int, int] = (0, 0)) -> str:
     """Wrap the given string to the given width.
 
     This uses :meth:`textwrap.fill` under the hood, but provides useful

--- a/api_factory/utils/lines.py
+++ b/api_factory/utils/lines.py
@@ -16,7 +16,7 @@ import textwrap
 from typing import Tuple, Union
 
 
-def wrap(text: str, width: int, offset: Union[int, Tuple[int,int]] = 0) -> str:
+def wrap(text: str, width: int, offset: Tuple[int, int] = (0, 0)) -> str:
     """Wrap the given string to the given width.
 
     This uses :meth:`textwrap.fill` under the hood, but provides useful
@@ -29,13 +29,16 @@ def wrap(text: str, width: int, offset: Union[int, Tuple[int,int]] = 0) -> str:
         width (int): The width at which to wrap the text. If offset is
             provided, these are automatically counted against this.
         offset (Union[int, Tuple[int, int]]): An offset for the text.
-            This can be specified as an int or a tuple or two ints (using an
-            int is identical to a tuple with that int specified twice);
-            the tuple form is ``(first_line, subsequent_lines)``.
+            This is specified as a tuple or two ints; the tuple form
+            is ``(first_line, subsequent_lines)``.
+
+            The intention here is to be an expression of intent
+            (the first line will end up offset by ``X``, all subsequent lines
+            by ``Y``), which means a divergence in implementation:
 
             The first line value applies to the first line; this value is
             subtracted from ``width`` for the first line only. No leading
-            whitespace is added (the template is assumed to have it).
+            whitespace is actually added (the template is assumed to have it).
 
             The subsequent lines value applies to all subsequent lines; each
             line will be indented by this many characters.
@@ -46,10 +49,6 @@ def wrap(text: str, width: int, offset: Union[int, Tuple[int,int]] = 0) -> str:
     # Sanity check: If there is empty text, abort.
     if not text:
         return ''
-
-    # Coerce the offset value into a tuple.
-    if isinstance(offset, int):
-        offset = (offset, offset)
 
     # Protocol buffers preserves single initial spaces after line breaks
     # when parsing comments (such as the space before the "w" in "when" here).

--- a/tests/unit/utils/test_lines.py
+++ b/tests/unit/utils/test_lines.py
@@ -38,21 +38,25 @@ def test_wrap_strips():
     assert lines.wrap('foo bar baz  ', width=80) == 'foo bar baz'
 
 
-def test_wrap_subsequent_indent():
-    assert lines.wrap(
-        '# foo bar baz',
-        width=5,
-        subsequent_indent='# ',
-    ) == '# foo\n# bar\n# baz'
-
-
-def test_wrap_initial_width():
+def test_wrap_offset():
     assert lines.wrap(
         'The hail in Wales falls mainly on the snails.',
-        width=20,
-        initial_width=8,
+        width=36, offset=8,
+    ) == 'The hail in Wales falls\n        mainly on the snails.'
+
+
+def test_wrap_subsequent_offset():
+    assert lines.wrap('foo bar baz',
+        width=5, offset=(0, 2)
+    ) == 'foo\n  bar\n  baz'
+
+
+def test_wrap_initial_offset():
+    assert lines.wrap(
+        'The hail in Wales falls mainly on the snails.',
+        width=20, offset=(12, 0),
     ) == 'The hail\nin Wales falls\nmainly on the\nsnails.'
 
 
-def test_wrap_initial_width_short():
-    assert lines.wrap('foo bar', width=30, initial_width=20) == 'foo bar'
+def test_wrap_offset_short():
+    assert lines.wrap('foo bar', width=30, offset=10) == 'foo bar'

--- a/tests/unit/utils/test_lines.py
+++ b/tests/unit/utils/test_lines.py
@@ -33,16 +33,16 @@ def test_wrap_strips():
 
 def test_wrap_subsequent_offset():
     assert lines.wrap('foo bar baz',
-        width=5, offset=(0, 2)
+        width=5, offset=0, indent=2,
     ) == 'foo\n  bar\n  baz'
 
 
 def test_wrap_initial_offset():
     assert lines.wrap(
         'The hail in Wales falls mainly on the snails.',
-        width=20, offset=(12, 0),
+        width=20, offset=12, indent=0,
     ) == 'The hail\nin Wales falls\nmainly on the\nsnails.'
 
 
-def test_wrap_offset_short():
-    assert lines.wrap('foo bar', width=30, offset=(10, 10)) == 'foo bar'
+def test_wrap_indent_short():
+    assert lines.wrap('foo bar', width=30, indent=10) == 'foo bar'

--- a/tests/unit/utils/test_lines.py
+++ b/tests/unit/utils/test_lines.py
@@ -31,13 +31,6 @@ def test_wrap_strips():
     assert lines.wrap('foo bar baz  ', width=80) == 'foo bar baz'
 
 
-def test_wrap_offset():
-    assert lines.wrap(
-        'The hail in Wales falls mainly on the snails.',
-        width=36, offset=8,
-    ) == 'The hail in Wales falls\n        mainly on the snails.'
-
-
 def test_wrap_subsequent_offset():
     assert lines.wrap('foo bar baz',
         width=5, offset=(0, 2)
@@ -52,4 +45,4 @@ def test_wrap_initial_offset():
 
 
 def test_wrap_offset_short():
-    assert lines.wrap('foo bar', width=30, offset=10) == 'foo bar'
+    assert lines.wrap('foo bar', width=30, offset=(10, 10)) == 'foo bar'


### PR DESCRIPTION
This replaces the `initial_width` and `subsequent_indent` keyword arguments with a single `offset` argument. The `offset` can be a int or a two-tuple of ints (first line and subsequent lines, respectively), and the behavior is the same.

This does remove the ability to have a `subsequent_indent` which is anything other than spaces, which did not end up being used in real life (at least not yet). If it is needed, the `subsequent_indent` stand-alone filter could be resurrected (see #14).

This change markedly improves readability of templates where `wrap` is being used. Similarly, the syntactic change from "initial width" to "initial offset" ends up being far more intuitive (I had used "initial width" incorrectly about half the time and had to debug it).