### PR TITLE
Add simple whitespace post-processing.

### DIFF
--- a/api_factory/generator/formatter.py
+++ b/api_factory/generator/formatter.py
@@ -32,10 +32,10 @@ def fix_whitespace(code: str) -> str:
     code = re.sub(r'[ ]+\n', '\n', code)
 
     # Ensure at most two blank lines before top level definitions.
-    code = re.sub(r'\s*\n\n\n(class|def|@)', r'\n\n\n\1', code)
+    code = re.sub(r'\s+\n\n\n(class|def|@)', r'\n\n\n\1', code)
 
     # Ensure at most one line before nested definitions.
-    code = re.sub(r'\s*\n\n(    )+(class|def|@)', r'\n\n\1\2', code)
+    code = re.sub(r'\s+\n\n(    )+(class|def|@)', r'\n\n\1\2', code)
 
     # All files shall end in one and exactly one line break.
     return f'{code.rstrip()}\n'

--- a/api_factory/generator/formatter.py
+++ b/api_factory/generator/formatter.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+
+def fix_whitespace(code: str) -> str:
+    """Perform basic whitespace post-processing.
+
+    This corrects a couple of formatting issues that Jinja templates
+    may struggle with (particularly blank line count, which is tough to
+    get consistently right when ``if`` or ``for`` are involved).
+
+    Args:
+        code (str): A string of code to be formatted.
+
+    Returns
+        str: Formatted code.
+    """
+    # Remove trailing whitespace from any line.
+    code = re.sub(r'[ ]+\n', '\n', code)
+
+    # Ensure at most two blank lines before top level definitions.
+    code = re.sub(r'\s*\n\n\n(class|def|@)', r'\n\n\n\1', code)
+
+    # Ensure at most one line before nested definitions.
+    code = re.sub(r'\s*\n\n(    )+(class|def|@)', r'\n\n\1\2', code)
+
+    # All files shall end in one and exactly one line break.
+    return f'{code.rstrip()}\n'

--- a/api_factory/generator/generator.py
+++ b/api_factory/generator/generator.py
@@ -22,7 +22,8 @@ from google.protobuf.compiler.plugin_pb2 import CodeGeneratorRequest
 from google.protobuf.compiler.plugin_pb2 import CodeGeneratorResponse
 
 from api_factory import utils
-from api_factory.generator.loader import TemplateLoader
+from api_factory.generator import formatter
+from api_factory.generator import loader
 from api_factory.schema import api
 
 
@@ -45,7 +46,7 @@ class Generator:
 
         # Create the jinja environment with which to render templates.
         self._env = jinja2.Environment(
-            loader=TemplateLoader(
+            loader=loader.TemplateLoader(
                 searchpath=os.path.join(_dirname, '..', 'templates'),
             ),
             undefined=jinja2.StrictUndefined,
@@ -111,10 +112,12 @@ class Generator:
         for template_name in templates:
             # Generate the File object.
             answer.append(CodeGeneratorResponse.File(
-                content=self._env.get_template(template_name).render(
-                    api=self._api,
-                    **additional_context
-                ).strip() + '\n',
+                content=formatter.fix_whitespace(
+                    self._env.get_template(template_name).render(
+                        api=self._api,
+                        **additional_context
+                    ),
+                ),
                 name=self._get_output_filename(
                     template_name,
                     context=additional_context,

--- a/tests/unit/generator/test_formatter.py
+++ b/tests/unit/generator/test_formatter.py
@@ -1,0 +1,92 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import textwrap
+
+from api_factory.generator import formatter
+
+
+def test_fix_whitespace_top_level():
+    assert formatter.fix_whitespace(textwrap.dedent("""\
+    import something
+
+
+    class Correct:
+        pass
+
+
+
+    class TooFarDown:
+        pass
+
+    class TooClose:  # remains too close
+        pass
+    """)) == textwrap.dedent("""\
+    import something
+
+
+    class Correct:
+        pass
+
+
+    class TooFarDown:
+        pass
+
+    class TooClose:  # remains too close
+        pass
+    """)
+
+
+def test_fix_whitespace_nested():
+    assert formatter.fix_whitespace(textwrap.dedent("""\
+    class JustAClass:
+        def foo(self):
+            pass
+
+
+        def too_far_down(self):
+            pass
+    """)) == textwrap.dedent("""\
+    class JustAClass:
+        def foo(self):
+            pass
+
+        def too_far_down(self):
+            pass
+    """)
+
+
+def test_fix_whitespace_decorators():
+    assert formatter.fix_whitespace(textwrap.dedent("""\
+    class JustAClass:
+        def foo(self):
+            pass
+
+
+        @property
+        def too_far_down(self):
+            return 42
+    """)) == textwrap.dedent("""\
+    class JustAClass:
+        def foo(self):
+            pass
+
+        @property
+        def too_far_down(self):
+            return 42
+    """)
+
+
+def test_file_newline_ending():
+    assert formatter.fix_whitespace('') == '\n'


### PR DESCRIPTION
This commit adds very basic whitespace formatting to nullify certain whitespace issues that are sufficiently difficult to get right in Jinja (particularly when `if` and `for` are involved).

This is not meant as a replacement for `yapf`. It is completely reasonable to want to run the resulting code through `yapf`, but I do not want to force this on all template authors. This commit is more humble and just applies very specific fixes that are more or less universally adopted and sufficiently difficult to do correctly in templates in all situations.