### PR TITLE
Fix the package name when namespace is empty.

### DIFF
--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -96,7 +96,7 @@ class Naming:
         package_info = cls(
             name=match['name'].capitalize(),
             namespace=tuple([i.capitalize()
-                             for i in match['namespace'].split('.')]),
+                             for i in match['namespace'].split('.') if i]),
             product_name=match['name'].capitalize(),
             product_url='',
             version=match.get('version', ''),
@@ -187,4 +187,4 @@ class Naming:
         # Piece the name and namespace together to come up with the
         # proper package name.
         answer = list(self.namespace) + self.name.split(' ')
-        return '-'.join(answer).lower()
+        return '-'.join(answer).lstrip('-').lower()

--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -187,4 +187,4 @@ class Naming:
         # Piece the name and namespace together to come up with the
         # proper package name.
         answer = list(self.namespace) + self.name.split(' ')
-        return '-'.join(answer).lstrip('-').lower()
+        return '-'.join(answer).lower()

--- a/tests/unit/schema/test_naming.py
+++ b/tests/unit/schema/test_naming.py
@@ -126,6 +126,20 @@ def test_build_with_annotations():
     assert n.product_name == 'Spanner'
 
 
+def test_build_no_namespace():
+    protos = (
+        descriptor_pb2.FileDescriptorProto(
+            name='foo_service.proto',
+            package='foo',
+        ),
+    )
+    n = naming.Naming.build(*protos)
+    assert n.name == 'Foo'
+    assert n.namespace == ()
+    assert n.version == ''
+    assert n.product_name == 'Foo'
+
+
 def test_inconsistent_metadata_error():
     # Set up the first proto.
     proto1 = descriptor_pb2.FileDescriptorProto(


### PR DESCRIPTION
This fixes an issue where the package name started with a hyphen if there was no namespace. The root cause was that the namespace was propagated through as `('')` (a tuple with one element: empty string) rather than `()` (empty tuple).

Fixes #29.