### PR TITLE
Pin Sphinx below 1.8.0

### DIFF
--- a/nox.py
+++ b/nox.py
@@ -85,7 +85,7 @@ def showcase(session):
 def docs(session):
     """Build the docs."""
 
-    session.install('sphinx', 'sphinx_rtd_theme')
+    session.install('sphinx < 1.8', 'sphinx_rtd_theme')
     session.install('.')
 
     # Build the docs!


### PR DESCRIPTION
Sphinx 1.8.0 introduces a bug in string-specified type annotations which I can not work around at the moment.