### PR TITLE
Table-setting for generating protos.

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -69,13 +69,19 @@ class Proto:
         """Return the appropriate module name for this service.
 
         Returns:
-            str: The service name, in snake case.
+            str: The module name for this service (which is the service
+                name in snake case).
         """
         return to_snake_case(self.name.split('/')[-1][:-len('.proto')])
 
     @cached_property
     def top(self) -> 'Proto':
-        """Return a proto shim which is only aware of top-level objects."""
+        """Return a proto shim which is only aware of top-level objects.
+
+        This is useful in a situation where a template wishes to iterate
+        over only those messages and enums that are at the top level of the
+        file.
+        """
         return type(self)(
             file_pb2=self.file_pb2,
             services=self.services,
@@ -307,7 +313,8 @@ class _ProtoBuilder:
                 ``SourceCodeInfo.Location`` in ``descriptor.proto``.
 
         Return:
-            Mapping: A sequence of the objects that were loaded.
+            Mapping[str, Union[~.MessageType, ~.Service, ~.EnumType]]: A
+                sequence of the objects that were loaded.
         """
         # Iterate over the list of children provided and call the
         # applicable loader function on each.

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -29,6 +29,7 @@ from gapic.schema import metadata
 from gapic.schema import naming
 from gapic.schema import wrappers
 from gapic.utils import cached_property
+from gapic.utils import to_snake_case
 
 
 @dataclasses.dataclass(frozen=True)
@@ -62,6 +63,28 @@ class Proto:
             file_to_generate=file_to_generate,
             prior_protos=prior_protos or {},
         ).proto
+
+    @property
+    def module_name(self) -> str:
+        """Return the appropriate module name for this service.
+
+        Returns:
+            str: The service name, in snake case.
+        """
+        return to_snake_case(self.name.split('/')[-1][:-len('.proto')])
+
+    @cached_property
+    def top(self) -> 'Proto':
+        """Return a proto shim which is only aware of top-level objects."""
+        return type(self)(
+            file_pb2=self.file_pb2,
+            services=self.services,
+            messages={k: v for k, v in self.messages.items()
+                      if not v.meta.address.parent},
+            enums={k: v for k, v in self.enums.items()
+                   if not v.meta.address.parent},
+            file_to_generate=False,
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -179,7 +202,7 @@ class _ProtoBuilder:
         # for each item as it is loaded.
         address = metadata.Address(
             module=file_descriptor.name.split('/')[-1][:-len('.proto')],
-            package=file_descriptor.package.split('.'),
+            package=tuple(file_descriptor.package.split('.')),
         )
 
         # Now iterate over the FileDescriptorProto and pull out each of
@@ -265,7 +288,7 @@ class _ProtoBuilder:
         )
 
     def _load_children(self, children: Sequence, loader: Callable, *,
-                       address: metadata.Address, path: Tuple[int]) -> None:
+                       address: metadata.Address, path: Tuple[int]) -> Mapping:
         """Return wrapped versions of arbitrary children from a Descriptor.
 
         Args:
@@ -282,11 +305,17 @@ class _ProtoBuilder:
             path (Tuple[int]): The location path up to this point. This is
                 used to correspond to documentation in
                 ``SourceCodeInfo.Location`` in ``descriptor.proto``.
+
+        Return:
+            Mapping: A sequence of the objects that were loaded.
         """
         # Iterate over the list of children provided and call the
         # applicable loader function on each.
+        answer = {}
         for child, i in zip(children, range(0, sys.maxsize)):
-            loader(child, address=address, path=path + (i,))
+            wrapped = loader(child, address=address, path=path + (i,))
+            answer[wrapped.name] = wrapped
+        return answer
 
     def _get_fields(self, field_pbs: List[descriptor_pb2.FieldDescriptorProto],
                     address: metadata.Address, path: Tuple[int],
@@ -379,11 +408,13 @@ class _ProtoBuilder:
         # Done; return the answer.
         return answer
 
-    def _load_message(self, message_pb: descriptor_pb2.DescriptorProto,
-                      address: metadata.Address, path: Tuple[int]) -> None:
+    def _load_message(self,
+            message_pb: descriptor_pb2.DescriptorProto,
+            address: metadata.Address,
+            path: Tuple[int],
+            ) -> wrappers.MessageType:
         """Load message descriptions from DescriptorProtos."""
-        ident = f'{str(address)}.{message_pb.name}'
-        message_addr = address.child(message_pb.name)
+        address = address.child(message_pb.name)
 
         # Load all nested items.
         #
@@ -392,38 +423,54 @@ class _ProtoBuilder:
         # type of one of this message's fields, and they need to be in
         # the registry for the field's message or enum attributes to be
         # set correctly.
-        self._load_children(message_pb.enum_type, address=message_addr,
-                            loader=self._load_enum, path=path + (4,))
-        self._load_children(message_pb.nested_type, address=message_addr,
-                            loader=self._load_message, path=path + (3,))
+        nested_enums = self._load_children(
+            message_pb.enum_type,
+            address=address,
+            loader=self._load_enum,
+            path=path + (4,),
+        )
+        nested_messages = self._load_children(
+            message_pb.nested_type,
+            address=address,
+            loader=self._load_message,
+            path=path + (3,),
+        )
         # self._load_children(message.oneof_decl, loader=self._load_field,
         #                     address=nested_addr, info=info.get(8, {}))
 
         # Create a dictionary of all the fields for this message.
         fields = self._get_fields(
             message_pb.field,
-            address=message_addr,
+            address=address,
             path=path + (2,),
         )
         fields.update(self._get_fields(
             message_pb.extension,
-            address=message_addr,
+            address=address,
             path=path + (6,),
         ))
 
         # Create a message correspoding to this descriptor.
-        self.messages[ident] = wrappers.MessageType(
+        self.messages[address.proto] = wrappers.MessageType(
             fields=fields,
             message_pb=message_pb,
+            nested_enums=nested_enums,
+            nested_messages=nested_messages,
             meta=metadata.Metadata(
                 address=address,
                 documentation=self.docs.get(path, self.EMPTY),
             ),
         )
+        return self.messages[address.proto]
 
-    def _load_enum(self, enum: descriptor_pb2.EnumDescriptorProto,
-                   address: metadata.Address, path: Tuple[int]) -> None:
+    def _load_enum(self,
+            enum: descriptor_pb2.EnumDescriptorProto,
+            address: metadata.Address,
+            path: Tuple[int],
+            ) -> wrappers.EnumType:
         """Load enum descriptions from EnumDescriptorProtos."""
+        address = address.child(enum.name)
+
         # Put together wrapped objects for the enum values.
         values = []
         for enum_value, i in zip(enum.value, range(0, sys.maxsize)):
@@ -436,8 +483,7 @@ class _ProtoBuilder:
             ))
 
         # Load the enum itself.
-        ident = f'{str(address)}.{enum.name}'
-        self.enums[ident] = wrappers.EnumType(
+        self.enums[address.proto] = wrappers.EnumType(
             enum_pb=enum,
             meta=metadata.Metadata(
                 address=address,
@@ -445,21 +491,25 @@ class _ProtoBuilder:
             ),
             values=values,
         )
+        return self.enums[address.proto]
 
-    def _load_service(self, service: descriptor_pb2.ServiceDescriptorProto,
-                      address: metadata.Address, path: Tuple[int]) -> None:
+    def _load_service(self,
+            service: descriptor_pb2.ServiceDescriptorProto,
+            address: metadata.Address,
+            path: Tuple[int],
+            ) -> wrappers.Service:
         """Load comments for a service and its methods."""
-        service_addr = address.child(service.name)
+        address = address.child(service.name)
 
         # Put together a dictionary of the service's methods.
         methods = self._get_methods(
             service.method,
-            address=service_addr,
+            address=address,
             path=path + (2,),
         )
 
         # Load the comments for the service itself.
-        self.services[f'{str(address)}.{service.name}'] = wrappers.Service(
+        self.services[address.proto] = wrappers.Service(
             meta=metadata.Metadata(
                 address=address,
                 documentation=self.docs.get(path, self.EMPTY),
@@ -467,3 +517,4 @@ class _ProtoBuilder:
             methods=methods,
             service_pb=service,
         )
+        return self.services[address.proto]

--- a/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
@@ -52,15 +52,15 @@ class {{ service.name }}:
     @dispatch
     {% endif -%}
     def {{ method.name|snake_case }}(self,
-            request: {{ method.input.python_ident }}, *,
+            request: {{ method.input.ident }}, *,
             retry: retry.Retry = None,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.python_ident }}:
+            ) -> {{ method.output.ident }}:
         """{{ method.meta.doc|wrap(width=72, offset=11, indent=8) }}
 
         Args:
-            request ({{ method.input.sphinx_ident }}):
+            request ({{ method.input.ident.sphinx }}):
                 The request object.{{ ' ' -}}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             retry (~.retry.Retry): Designation of what errors, if any,
@@ -70,12 +70,12 @@ class {{ service.name }}:
                 sent along with the request as metadata.
 
         Returns:
-            {{ method.output.sphinx_ident }}:
+            {{ method.output.ident.sphinx }}:
                 {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         # Coerce the request to the protocol buffer object.
-        if not isinstance(request, {{ method.input.python_ident }}):
-            request = {{ method.input.python_ident }}(**request)
+        if not isinstance(request, {{ method.input.ident }}):
+            request = {{ method.input.ident }}(**request)
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
@@ -107,9 +107,9 @@ class {{ service.name }}:
         response = operation.from_gapic(
             response,
             self._transport.operations_client,
-            {{ method.output.lro_response.python_ident }},
+            {{ method.output.lro_response.ident }},
             {%- if method.output.lro_metadata %}
-            metadata_type={{ method.output.lro_metadata.python_ident }},
+            metadata_type={{ method.output.lro_metadata.ident }},
             {%- endif %}
         )
         {%- endif %}
@@ -121,18 +121,18 @@ class {{ service.name }}:
     @{{ method.name|snake_case }}.register
     def _{{ method.name|snake_case }}_with_{{ signature.dispatch_field.name|snake_case }}(self,
             {%- for field in signature.fields.values() %}
-            {{ field.name  }}: {{ field.python_ident }}{% if loop.index0 > 0 and not field.required %} = None{% endif %},
+            {{ field.name  }}: {{ field.ident }}{% if loop.index0 > 0 and not field.required %} = None{% endif %},
             {%- endfor %}
             *,
             retry: retry.Retry = None,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.python_ident }}:
+            ) -> {{ method.output.ident }}:
         """{{ method.meta.doc|wrap(width=72, offset=11, indent=8) }}
 
         Args:
             {%- for field in signature.fields.values() %}
-            {{ field.name }} ({{ field.sphinx_ident }}):
+            {{ field.name }} ({{ field.ident.sphinx }}):
                 {{ field.meta.doc|wrap(width=72, indent=16) }}
             {%- endfor %}
             retry (~.retry.Retry): Designation of what errors, if any,
@@ -142,11 +142,11 @@ class {{ service.name }}:
                 sent alont with the request as metadata.
 
         Returns:
-            {{ method.output.sphinx_ident }}:
+            {{ method.output.ident.sphinx }}:
                 {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         return self.{{ method.name|snake_case }}(
-            {{ method.input.python_ident }}(
+            {{ method.input.ident }}(
                 {%- for field in signature.fields.values() %}
                 {{ field.name }}={{ field.name }},
                 {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
@@ -57,8 +57,8 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def {{ method.name|snake_case }}(
             self,
-            request: {{ method.input.python_ident }},
-            ) -> {{ method.output.python_ident }}:
+            request: {{ method.input.ident }},
+            ) -> {{ method.output.ident }}:
         raise NotImplementedError
     {%- endfor %}
 {% endblock %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
@@ -82,8 +82,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
     @property
     def {{ method.name|snake_case }}(self) -> Callable[
-            [{{ method.input.python_ident }}],
-            {{ method.output.python_ident }}]:
+            [{{ method.input.ident }}],
+            {{ method.output.ident }}]:
         """Return a callable for the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=40, indent=8) }}
@@ -103,8 +103,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         if '{{ method.name|snake_case }}' not in self._stubs:
             self._stubs['{{ method.name|snake_case }}'] = self.grpc_channel.{{ method.grpc_stub_type }}(
                 '/{{ '.'.join(method.meta.address.package) }}.{{ service.name }}/{{ method.name }}',
-                request_serializer={{ method.input.python_module }}.{{ method.input.name }}.SerializeToString,
-                response_deserializer={{ method.output.python_module }}.{{ method.output.name }}.FromString,
+                request_serializer={{ method.input.ident }}.SerializeToString,
+                response_deserializer={{ method.output.ident }}.FromString,
             )
         return self._stubs['{{ method.name|snake_case }}']
     {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
@@ -65,23 +65,23 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
     {%- for method in service.methods.values() %}
 
     def {{ method.name|snake_case }}(self,
-            request: {{ method.input.python_module }}.{{ method.input.name }}, *,
+            request: {{ method.input.ident }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.python_module }}.{{ method.output.name }}:
+            ) -> {{ method.output.ident }}:
         """Call the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=45, indent=8) }}
         {{- ' ' -}} method over HTTP.
 
         Args:
-            request (~.{{ method.input.python_ident }}):
+            request (~.{{ method.input.ident }}):
                 The request object. {{- ' ' -}}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent alont with the request as metadata.
 
         Returns:
-            ~.{{ method.output.python_ident }}:
+            ~.{{ method.output.ident }}:
                 {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         # Serialize the input.
@@ -102,7 +102,7 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
         )
 
         # Return the response.
-        return {{ method.output.python_ident }}.FromString(
+        return {{ method.output.ident }}.FromString(
             response.content,
         )
     {%- endfor %}

--- a/gapic/utils/lines.py
+++ b/gapic/utils/lines.py
@@ -51,8 +51,7 @@ def wrap(text: str, width: int, *, offset: int = None, indent: int = 0) -> str:
     # Re-wrapping causes these to be two spaces; correct for this.
     text = text.replace('\n ', '\n')
 
-    # If the initial width is different (in other words, the initial offset
-    # is non-zero), break off the beginning of the string.
+    # Break off the first line of the string to address non-zero offsets.
     first = ''
     if offset > 0:
         initial = textwrap.wrap(text,

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -20,28 +20,52 @@ from gapic.schema import metadata
 
 
 def test_address_str_no_parent():
-    addr = metadata.Address(package=('foo', 'bar'), module='baz')
-    assert str(addr) == 'foo.bar'
+    addr = metadata.Address(package=('foo', 'bar'), module='baz', name='Bacon')
+    assert str(addr) == 'baz_pb2.Bacon'
 
 
 def test_address_str_parent():
-    addr = metadata.Address(package=('foo', 'bar'), module='baz',
+    addr = metadata.Address(package=('foo', 'bar'), module='baz', name='Bacon',
                             parent=('spam', 'eggs'))
-    assert str(addr) == 'foo.bar.spam.eggs'
+    assert str(addr) == 'baz_pb2.Bacon'
 
 
-def test_address_child():
+def test_address_proto():
+    addr = metadata.Address(package=('foo', 'bar'), module='baz', name='Bacon')
+    assert addr.proto == 'foo.bar.Bacon'
+    assert addr.proto_package == 'foo.bar'
+
+
+def test_address_child_no_parent():
     addr = metadata.Address(package=('foo', 'bar'), module='baz')
-    child = addr.child('bacon')
-    assert child.parent == ('bacon',)
-    assert str(child) == 'foo.bar.bacon'
-    grandchild = child.child('ham')
-    assert grandchild.parent == ('bacon', 'ham')
-    assert str(grandchild) == 'foo.bar.bacon.ham'
+    child = addr.child('Bacon')
+    assert child.name == 'Bacon'
+    assert child.parent == ()
+
+
+def test_address_child_with_parent():
+    addr = metadata.Address(package=('foo', 'bar'), module='baz')
+    child = addr.child('Bacon')
+    grandchild = child.child('Ham')
+    assert grandchild.parent == ('Bacon',)
+    assert grandchild.name == 'Ham'
+
+
+def test_address_rel():
+    addr = metadata.Address(package=('foo', 'bar'), module='baz', name='Bacon')
+    assert addr.rel(
+        metadata.Address(package=('foo', 'bar'), module='baz'),
+    ) == 'Bacon'
+    assert addr.rel(
+        metadata.Address(package=('foo', 'not_bar'), module='baz'),
+    ) == 'baz_pb2.Bacon'
+    assert addr.rel(
+        metadata.Address(package=('foo', 'bar'), module='not_baz'),
+    ) == 'baz_pb2.Bacon'
 
 
 def test_address_resolve():
-    addr = metadata.Address(package=('foo', 'bar'), module='baz')
+    addr = metadata.Address(package=('foo', 'bar'), module='baz', name='Qux')
     assert addr.resolve('Bacon') == 'foo.bar.Bacon'
     assert addr.resolve('foo.bar.Bacon') == 'foo.bar.Bacon'
     assert addr.resolve('google.example.Bacon') == 'google.example.Bacon'

--- a/tests/unit/schema/wrappers/test_enums.py
+++ b/tests/unit/schema/wrappers/test_enums.py
@@ -34,14 +34,10 @@ def test_enum_value_properties():
         assert ev.name == expected
 
 
-def test_enum_python_ident():
+def test_enum_ident():
     message = make_enum('Baz', package='foo.v1', module='bar')
-    assert message.python_ident == 'bar_pb2.Baz'
-
-
-def test_enum_sphinx_ident():
-    message = make_enum('Baz', package='foo.v1', module='bar')
-    assert message.sphinx_ident == '~.bar_pb2.Baz'
+    assert str(message.ident) == 'bar_pb2.Baz'
+    assert message.ident.sphinx == '~.bar_pb2.Baz'
 
 
 def make_enum(name: str, package: str = 'foo.bar.v1', module: str = 'baz',
@@ -60,6 +56,7 @@ def make_enum(name: str, package: str = 'foo.bar.v1', module: str = 'baz',
         values=[wrappers.EnumValueType(enum_value_pb=evpb)
                 for evpb in enum_value_pbs],
         meta=meta or metadata.Metadata(address=metadata.Address(
+            name=name,
             package=tuple(package.split('.')),
             module=module,
         )),

--- a/tests/unit/schema/wrappers/test_field.py
+++ b/tests/unit/schema/wrappers/test_field.py
@@ -18,7 +18,6 @@ from google.api import annotations_pb2
 from google.protobuf import descriptor_pb2
 
 from gapic.schema import wrappers
-from gapic.schema.metadata import Address, Metadata
 
 
 def test_field_properties():
@@ -35,10 +34,18 @@ def test_field_is_primitive():
     assert primitive_field.is_primitive
 
 
+def test_field_proto_type():
+    Type = descriptor_pb2.FieldDescriptorProto.Type
+    primitive_field = make_field(type=Type.Value('TYPE_INT32'))
+    assert primitive_field.proto_type == 'INT32'
+
+
 def test_field_not_primitive():
     Type = descriptor_pb2.FieldDescriptorProto.Type
     message = wrappers.MessageType(
         fields={},
+        nested_messages={},
+        nested_enums={},
         message_pb=descriptor_pb2.DescriptorProto(),
     )
     non_primitive_field = make_field(
@@ -49,17 +56,17 @@ def test_field_not_primitive():
     assert not non_primitive_field.is_primitive
 
 
-def test_python_ident():
+def test_ident():
     Type = descriptor_pb2.FieldDescriptorProto.Type
     field = make_field(type=Type.Value('TYPE_BOOL'))
-    assert field.python_ident == 'bool'
+    assert str(field.ident) == 'bool'
 
 
-def test_python_ident_repeated():
+def test_ident_repeated():
     Type = descriptor_pb2.FieldDescriptorProto.Type
     REP = descriptor_pb2.FieldDescriptorProto.Label.Value('LABEL_REPEATED')
     field = make_field(type=Type.Value('TYPE_BOOL'), label=REP)
-    assert field.python_ident == 'Sequence[bool]'
+    assert str(field.ident) == 'Sequence[bool]'
 
 
 def test_repeated():
@@ -85,17 +92,17 @@ def test_not_required():
     assert not field.required
 
 
-def test_sphinx_ident():
+def test_ident_sphinx():
     Type = descriptor_pb2.FieldDescriptorProto.Type
     field = make_field(type=Type.Value('TYPE_BOOL'))
-    assert field.sphinx_ident == 'bool'
+    assert field.ident.sphinx == 'bool'
 
 
-def test_sphinx_ident_repeated():
+def test_ident_sphinx_repeated():
     Type = descriptor_pb2.FieldDescriptorProto.Type
     REP = descriptor_pb2.FieldDescriptorProto.Label.Value('LABEL_REPEATED')
     field = make_field(type=Type.Value('TYPE_BOOL'), label=REP)
-    assert field.sphinx_ident == 'Sequence[bool]'
+    assert field.ident.sphinx == 'Sequence[bool]'
 
 
 def test_type_primitives():
@@ -111,6 +118,8 @@ def test_type_message():
     T = descriptor_pb2.FieldDescriptorProto.Type
     message = wrappers.MessageType(
         fields={},
+        nested_messages={},
+        nested_enums={},
         message_pb=descriptor_pb2.DescriptorProto(),
     )
     field = make_field(

--- a/tests/unit/schema/wrappers/test_message.py
+++ b/tests/unit/schema/wrappers/test_message.py
@@ -39,19 +39,10 @@ def test_message_docstring():
     assert message.meta.doc == 'Lorem ipsum'
 
 
-def test_message_python_package():
-    message = make_message('Spam', module='eggs')
-    assert message.python_module == 'eggs_pb2'
-
-
-def test_message_python_ident():
+def test_message_ident():
     message = make_message('Baz', package='foo.v1', module='bar')
-    assert message.python_ident == 'bar_pb2.Baz'
-
-
-def test_message_sphinx_ident():
-    message = make_message('Baz', package='foo.v1', module='bar')
-    assert message.sphinx_ident == '~.bar_pb2.Baz'
+    assert str(message.ident) == 'bar_pb2.Baz'
+    assert message.ident.sphinx == '~.bar_pb2.Baz'
 
 
 def test_get_field():
@@ -102,7 +93,10 @@ def make_message(name: str, package: str = 'foo.bar.v1', module: str = 'baz',
     return wrappers.MessageType(
         message_pb=message_pb,
         fields=collections.OrderedDict((i.name, i) for i in fields),
+        nested_messages={},
+        nested_enums={},
         meta=meta or metadata.Metadata(address=metadata.Address(
+            name=name,
             package=tuple(package.split('.')),
             module=module,
         )),

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -30,9 +30,7 @@ def test_method_types():
                          package='foo.bar', module='bacon')
     assert method.name == 'DoSomething'
     assert method.input.name == 'Input'
-    assert method.input.python_module == 'baz_pb2'
     assert method.output.name == 'Output'
-    assert method.output.python_module == 'baz_pb2'
 
 
 def test_method_signature():
@@ -110,6 +108,7 @@ def make_method(
         input=input_message,
         output=output_message,
         meta=metadata.Metadata(address=metadata.Address(
+            name=name,
             package=package,
             module=module,
         )),
@@ -125,8 +124,11 @@ def make_message(name: str, package: str = 'foo.bar.v1', module: str = 'baz',
     )
     return wrappers.MessageType(
         message_pb=message_pb,
+        nested_messages={},
+        nested_enums={},
         fields=collections.OrderedDict((i.name, i) for i in fields),
         meta=metadata.Metadata(address=metadata.Address(
+            name=name,
             package=tuple(package.split('.')),
             module=module,
         )),

--- a/tests/unit/schema/wrappers/test_operation.py
+++ b/tests/unit/schema/wrappers/test_operation.py
@@ -21,19 +21,26 @@ from gapic.schema import wrappers
 def test_operation():
     lro_response = wrappers.MessageType(
         fields={},
+        nested_messages={},
+        nested_enums={},
         message_pb=descriptor_pb2.DescriptorProto(name='LroResponse'),
     )
     operation = wrappers.OperationType(lro_response=lro_response)
     assert operation.name == 'Operation'
-    assert operation.python_ident == 'operation.Operation'
-    assert operation.sphinx_ident == '~.operation.Operation'
+    assert str(operation.ident) == 'operation.Operation'
+    assert operation.ident.sphinx == '~.operation.Operation'
 
 
 def test_operation_meta():
     lro_response = wrappers.MessageType(
         fields={},
+        nested_messages={},
+        nested_enums={},
         message_pb=descriptor_pb2.DescriptorProto(name='LroResponse'),
-        meta=metadata.Metadata(address=metadata.Address(module='foo')),
+        meta=metadata.Metadata(address=metadata.Address(
+            name='LroResponse',
+            module='foo',
+        )),
     )
     operation = wrappers.OperationType(lro_response=lro_response)
     assert 'representing a long-running operation' in operation.meta.doc

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -185,8 +185,8 @@ def get_method(name: str,
     # Define a method descriptor. Set the field headers if appropriate.
     method_pb = descriptor_pb2.MethodDescriptorProto(
         name=name,
-        input_type=input_.proto_path,
-        output_type=output.proto_path,
+        input_type=input_.ident.proto,
+        output_type=output.ident.proto,
     )
     if lro_response_type:
         output = wrappers.OperationType(
@@ -227,9 +227,12 @@ def get_message(dot_path: str, *,
             field_pb=i,
             message=get_message(i.type_name) if i.type_name else None,
         ) for i in fields},
+        nested_messages={},
+        nested_enums={},
         message_pb=descriptor_pb2.DescriptorProto(name=name, field=fields),
         meta=metadata.Metadata(address=metadata.Address(
-            package=pkg,
+            name=name,
+            package=tuple(pkg),
             module=module,
         )),
     )

--- a/tests/unit/schema/wrappers/test_signature.py
+++ b/tests/unit/schema/wrappers/test_signature.py
@@ -53,6 +53,8 @@ def test_signatures_single_dispatch():
             message=wrappers.MessageType(
                 fields={},
                 message_pb=descriptor_pb2.DescriptorProto(name='Bacon'),
+                nested_enums={},
+                nested_messages={},
             ),
             name='bar',
             type=T.Value('TYPE_MESSAGE'),


### PR DESCRIPTION
This commit makes several schema edits and additions in order to facilitate generating pb2 replacements directly.

In particular, it:

  * Adds support for a `$proto` rewrite for filenames (such files receive a `proto` variable), and adds loader support for such.
  * Refactors `Address` to include the `name` of the object it is attached to, enabling it to be used as the `ident` object.
  * Refactors the various `*_ident` properties into the address, and re-orders template use (e.g. `sphinx_ident` is now `ident.sphinx`).
      * Additionally, `python_ident` is now just `ident` in templates.
  * Adds a `rel` method for getting identifiers relative to the file being generated. This deals with a problem that will surface in replacing pb2s where a file would attempt to import or reference itself.

LROs are slightly broken in a slightly different way than before (note that they were broken in the status quo ante due to a bug in `OperationType`), and `OperationType` turned out to be a mistake. Filed #34 to track this, and it will be fixed after pb2 replacements are introduced (since they will significantly alter what the fix is).