### PR TITLE
Begin writing proto types.

### DIFF
--- a/gapic/generator/formatter.py
+++ b/gapic/generator/formatter.py
@@ -32,10 +32,10 @@ def fix_whitespace(code: str) -> str:
     code = re.sub(r'[ ]+\n', '\n', code)
 
     # Ensure at most two blank lines before top level definitions.
-    code = re.sub(r'\s+\n\s*\n\s*\n(class|def|@|#)', r'\n\n\n\1', code)
+    code = re.sub(r'\s+\n\s*\n\s*\n(class|def|@|#|_)', r'\n\n\n\1', code)
 
     # Ensure at most one line before nested definitions.
-    code = re.sub(r'\s+\n\s*\n(    )+(class|def|@|#)', r'\n\n\1\2', code)
+    code = re.sub(r'\s+\n\s*\n((    )+)(\w|_|@|#)', r'\n\n\1\3', code)
 
     # All files shall end in one and exactly one line break.
     return f'{code.rstrip()}\n'

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -22,7 +22,7 @@ import dataclasses
 import sys
 from typing import Callable, List, Mapping, Sequence, Tuple
 
-from google.longrunning import operations_pb2
+from google.api import annotations_pb2
 from google.protobuf import descriptor_pb2
 
 from gapic.schema import metadata
@@ -386,7 +386,7 @@ class _ProtoBuilder:
         # Iterate over the methods and collect them into a dictionary.
         answer = collections.OrderedDict()
         for meth_pb, i in zip(methods, range(0, sys.maxsize)):
-            types = meth_pb.options.Extensions[operations_pb2.operation_types]
+            lro = meth_pb.options.Extensions[annotations_pb2.operation]
 
             # If the output type is google.longrunning.Operation, we use
             # a specialized object in its place.
@@ -394,10 +394,10 @@ class _ProtoBuilder:
             if meth_pb.output_type.endswith('google.longrunning.Operation'):
                 output_type = self._get_operation_type(
                     response_type=self.all_messages[
-                        address.resolve(types.response)
+                        address.resolve(lro.response_type)
                     ],
                     metadata_type=self.all_messages.get(
-                        address.resolve(types.metadata),
+                        address.resolve(lro.metadata_type),
                     ),
                 )
 

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -81,15 +81,15 @@ class Proto:
         """
         return to_snake_case(self.name.split('/')[-1][:-len('.proto')])
 
-    @property
-    def python_modules(self) -> Sequence[Tuple[Sequence[str], str]]:
+    @cached_property
+    def python_modules(self) -> Tuple[Sequence[str], str]:
         """Return a sequence of Python modules, for import.
 
         The results of this method are in alphabetical order (by package,
         then module), and do not contain duplicates.
 
         Returns:
-            Sequence[str, str]: The package and module pair, intended
+            Tuple[Sequence[str], str]: The package and module pair, intended
             for use in a ``from package import module`` type
             of statement.
         """

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -106,7 +106,7 @@ class Proto:
 
         # We may have gotten an import for this proto.
         # Obviously no Python module may import itself; get rid of that.
-        answer.remove(self.meta.address.python_import)
+        answer = answer.difference({self.meta.address.python_import})
 
         # Done; return the sorted sequence.
         return tuple(sorted(list(answer)))

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -26,8 +26,8 @@ from google.api import annotations_pb2
 from google.protobuf import descriptor_pb2
 
 from gapic.schema import metadata
-from gapic.schema import naming
 from gapic.schema import wrappers
+from gapic.schema.naming import Naming
 from gapic.utils import cached_property
 from gapic.utils import to_snake_case
 
@@ -41,13 +41,17 @@ class Proto:
     messages: Mapping[str, wrappers.MessageType]
     enums: Mapping[str, wrappers.EnumType]
     file_to_generate: bool
+    meta: metadata.Metadata = dataclasses.field(
+        default_factory=metadata.Metadata,
+    )
 
     def __getattr__(self, name: str):
         return getattr(self.file_pb2, name)
 
     @classmethod
     def build(cls, file_descriptor: descriptor_pb2.FileDescriptorProto,
-            file_to_generate: bool, prior_protos: Mapping[str, 'Proto'] = None,
+            file_to_generate: bool, naming: Naming,
+            prior_protos: Mapping[str, 'Proto'] = None,
             ) -> 'Proto':
         """Build and return a Proto instance.
 
@@ -56,11 +60,14 @@ class Proto:
                 object describing the proto file.
             file_to_generate (bool): Whether this is a file which is
                 to be directly generated, or a dependency.
+            naming (~.Naming): The :class:`~.Naming` instance associated
+                with the API.
             prior_protos (~.Proto): Previous, already processed protos.
                 These are needed to look up messages in imported protos.
         """
         return _ProtoBuilder(file_descriptor,
             file_to_generate=file_to_generate,
+            naming=naming,
             prior_protos=prior_protos or {},
         ).proto
 
@@ -73,6 +80,36 @@ class Proto:
                 name in snake case).
         """
         return to_snake_case(self.name.split('/')[-1][:-len('.proto')])
+
+    @property
+    def python_modules(self) -> Sequence[Tuple[Sequence[str], str]]:
+        """Return a sequence of Python modules, for import.
+
+        The results of this method are in alphabetical order (by package,
+        then module), and do not contain duplicates.
+
+        Returns:
+            Sequence[str, str]: The package and module pair, intended
+            for use in a ``from package import module`` type
+            of statement.
+        """
+        answer = set()
+        for message in self.messages.values():
+            for field in message.fields.values():
+                # We only need to add imports for fields that
+                # are messages or enums.
+                if not field.message and not field.enum:
+                    continue
+
+                # Add the appropriate Python import for the field.
+                answer.add(field.type.ident.python_import)
+
+        # We may have gotten an import for this proto.
+        # Obviously no Python module may import itself; get rid of that.
+        answer.remove(self.meta.address.python_import)
+
+        # Done; return the sorted sequence.
+        return tuple(sorted(list(answer)))
 
     @cached_property
     def top(self) -> 'Proto':
@@ -90,6 +127,7 @@ class Proto:
             enums={k: v for k, v in self.enums.items()
                    if not v.meta.address.parent},
             file_to_generate=False,
+            meta=self.meta,
         )
 
 
@@ -105,7 +143,7 @@ class API:
     An instance of this object is made available to every template
     (as ``api``).
     """
-    naming: naming.Naming
+    naming: Naming
     protos: Mapping[str, Proto]
 
     @classmethod
@@ -124,7 +162,7 @@ class API:
                 rather than explicit targets.
         """
         # Save information about the overall naming for this API.
-        n = naming.Naming.build(*filter(
+        naming = Naming.build(*filter(
             lambda fd: fd.package.startswith(package),
             file_descriptors,
         ))
@@ -136,11 +174,12 @@ class API:
             protos[fd.name] = _ProtoBuilder(
                 file_descriptor=fd,
                 file_to_generate=fd.package.startswith(package),
+                naming=naming,
                 prior_protos=protos,
             ).proto
 
         # Done; return the API.
-        return cls(naming=n, protos=protos)
+        return cls(naming=naming, protos=protos)
 
     @cached_property
     def enums(self) -> Mapping[str, wrappers.EnumType]:
@@ -182,6 +221,7 @@ class _ProtoBuilder:
 
     def __init__(self, file_descriptor: descriptor_pb2.FileDescriptorProto,
                  file_to_generate: bool,
+                 naming: Naming,
                  prior_protos: Mapping[str, Proto] = None):
         self.messages = {}
         self.enums = {}
@@ -206,7 +246,8 @@ class _ProtoBuilder:
         # We put this together by a baton pass of sorts: everything in
         # this file *starts with* this address, which is appended to
         # for each item as it is loaded.
-        address = metadata.Address(
+        self.address = metadata.Address(
+            api_naming=naming,
             module=file_descriptor.name.split('/')[-1][:-len('.proto')],
             package=tuple(file_descriptor.package.split('.')),
         )
@@ -220,9 +261,9 @@ class _ProtoBuilder:
         # below is because `repeated DescriptorProto message_type = 4;` in
         # descriptor.proto itself).
         self._load_children(file_descriptor.enum_type, self._load_enum,
-                            address=address, path=(5,))
+                            address=self.address, path=(5,))
         self._load_children(file_descriptor.message_type, self._load_message,
-                            address=address, path=(4,))
+                            address=self.address, path=(4,))
 
         # Edge case: Protocol buffers is not particularly picky about
         # ordering, and it is possible that a message will have had a field
@@ -246,7 +287,7 @@ class _ProtoBuilder:
         # same files.
         if file_to_generate:
             self._load_children(file_descriptor.service, self._load_service,
-                                address=address, path=(6,))
+                                address=self.address, path=(6,))
         # TODO(lukesneeringer): oneofs are on path 7.
 
     @property
@@ -258,6 +299,9 @@ class _ProtoBuilder:
             file_to_generate=self.file_to_generate,
             messages=self.messages,
             services=self.services,
+            meta=metadata.Metadata(
+                address=self.address,
+            ),
         )
 
     @cached_property
@@ -358,7 +402,7 @@ class _ProtoBuilder:
                 enum=self.all_enums.get(field_pb.type_name.lstrip('.')),
                 message=self.all_messages.get(field_pb.type_name.lstrip('.')),
                 meta=metadata.Metadata(
-                    address=address,
+                    address=address.child(field_pb.name, path + (i,)),
                     documentation=self.docs.get(path + (i,), self.EMPTY),
                 ),
             )
@@ -406,7 +450,7 @@ class _ProtoBuilder:
                 input=self.all_messages[meth_pb.input_type.lstrip('.')],
                 method_pb=meth_pb,
                 meta=metadata.Metadata(
-                    address=address,
+                    address=address.child(meth_pb.name, path + (i,)),
                     documentation=self.docs.get(path + (i,), self.EMPTY),
                 ),
                 output=output_type,
@@ -421,7 +465,7 @@ class _ProtoBuilder:
             path: Tuple[int],
             ) -> wrappers.MessageType:
         """Load message descriptions from DescriptorProtos."""
-        address = address.child(message_pb.name)
+        address = address.child(message_pb.name, path)
 
         # Load all nested items.
         #
@@ -476,7 +520,7 @@ class _ProtoBuilder:
             path: Tuple[int],
             ) -> wrappers.EnumType:
         """Load enum descriptions from EnumDescriptorProtos."""
-        address = address.child(enum.name)
+        address = address.child(enum.name, path)
 
         # Put together wrapped objects for the enum values.
         values = []
@@ -506,7 +550,7 @@ class _ProtoBuilder:
             path: Tuple[int],
             ) -> wrappers.Service:
         """Load comments for a service and its methods."""
-        address = address.child(service.name)
+        address = address.child(service.name, path)
 
         # Put together a dictionary of the service's methods.
         methods = self._get_methods(

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -27,7 +27,7 @@ from google.protobuf import descriptor_pb2
 
 from gapic.schema import metadata
 from gapic.schema import wrappers
-from gapic.schema.naming import Naming
+from gapic.schema import naming as api_naming
 from gapic.utils import cached_property
 from gapic.utils import to_snake_case
 
@@ -50,7 +50,7 @@ class Proto:
 
     @classmethod
     def build(cls, file_descriptor: descriptor_pb2.FileDescriptorProto,
-            file_to_generate: bool, naming: Naming,
+            file_to_generate: bool, naming: api_naming.Naming,
             prior_protos: Mapping[str, 'Proto'] = None,
             ) -> 'Proto':
         """Build and return a Proto instance.
@@ -143,7 +143,7 @@ class API:
     An instance of this object is made available to every template
     (as ``api``).
     """
-    naming: Naming
+    naming: api_naming.Naming
     protos: Mapping[str, Proto]
 
     @classmethod
@@ -162,7 +162,7 @@ class API:
                 rather than explicit targets.
         """
         # Save information about the overall naming for this API.
-        naming = Naming.build(*filter(
+        naming = api_naming.Naming.build(*filter(
             lambda fd: fd.package.startswith(package),
             file_descriptors,
         ))
@@ -221,7 +221,7 @@ class _ProtoBuilder:
 
     def __init__(self, file_descriptor: descriptor_pb2.FileDescriptorProto,
                  file_to_generate: bool,
-                 naming: Naming,
+                 naming: api_naming.Naming,
                  prior_protos: Mapping[str, Proto] = None):
         self.messages = {}
         self.enums = {}

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -82,14 +82,14 @@ class Proto:
         return to_snake_case(self.name.split('/')[-1][:-len('.proto')])
 
     @cached_property
-    def python_modules(self) -> Tuple[Sequence[str], str]:
+    def python_modules(self) -> Sequence[Tuple[str, str]]:
         """Return a sequence of Python modules, for import.
 
         The results of this method are in alphabetical order (by package,
         then module), and do not contain duplicates.
 
         Returns:
-            Tuple[Sequence[str], str]: The package and module pair, intended
+            Sequence[Tuple[str, str]]: The package and module pair, intended
             for use in a ``from package import module`` type
             of statement.
         """

--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -120,7 +120,7 @@ class Naming:
                 name=meta.package_name or meta.product_name,
                 namespace=tuple(meta.package_namespace),
                 product_name=meta.product_name,
-                product_url=meta.product_url,
+                product_url=meta.product_uri,
                 version='',
             )
             if naming:

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -452,21 +452,8 @@ class Service:
         for method in self.methods.values():
             # Add the module containing both the request and response
             # messages. (These are usually the same, but not necessarily.)
-            answer.add((
-                '.'.join(method.input.ident.package),
-                method.input.ident.module + '_pb2',
-            ))
-            answer.add((
-                '.'.join(method.output.ident.package),
-                # TODO(#34): This is obviously unacceptable and gross and
-                #            generally vomit-inducing.
-                #
-                #            I am not fixing this right now because *_pb2
-                #            is about to go away.
-                method.output.ident.module + '_pb2'
-                if not getattr(method.output, 'lro_response', None)
-                else method.output.ident.module,
-            ))
+            answer.add(method.input.ident.python_import)
+            answer.add(method.output.ident.python_import)
 
             # If this method has flattening that is honored, add its
             # modules.
@@ -476,23 +463,14 @@ class Service:
             for sig in method.signatures.single_dispatch:
                 for field in sig.fields.values():
                     if not isinstance(field.type, PythonType):
-                        answer.add((
-                            '.'.join(field.type.ident.package),
-                            field.type.ident.module + '_pb2',
-                        ))
+                        answer.add(field.type.ident.python_import)
 
             # If this method has LRO, it is possible (albeit unlikely) that
             # the LRO messages reside in a different module.
             if getattr(method.output, 'lro_response', None):
-                answer.add((
-                    '.'.join(method.output.lro_response.ident.package),
-                    method.output.lro_response.ident.module + '_pb2',
-                ))
+                answer.add(method.output.lro_response.ident.python_import)
             if getattr(method.output, 'lro_metadata', None):
-                answer.add((
-                    '.'.join(method.output.lro_metadata.ident.package),
-                    method.output.lro_metadata.ident.module + '_pb2',
-                ))
+                answer.add(method.output.lro_metadata.ident.python_import)
         return tuple(sorted(answer))
 
     @property

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -444,7 +444,7 @@ class Service:
         then module), and do not contain duplicates.
 
         Returns:
-            Sequence[str, str]: The package and module pair, intended
+            Sequence[Tuple[str, str]]: The package and module pair, intended
             for use in a ``from package import module`` type
             of statement.
         """

--- a/gapic/templates/$namespace/$name/__init__.py.j2
+++ b/gapic/templates/$namespace/$name/__init__.py.j2
@@ -3,13 +3,14 @@
 {% block content %}
 # Import each service from {{ api.naming.version }} into the unversioned namespace.
 {% for service in api.services.values() -%}
+from ..{{ api.naming.versioned_module_name }} import types
 from ..{{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }} import {{ service.name }}
 {% endfor %}
 
 __all__ = (
-    '{{ api.naming.version }}',
     {%- for service in api.services.values() %}
     '{{ service.name }}',
     {%- endfor %}
+    'types',
 )
 {% endblock %}

--- a/gapic/templates/$namespace/$name/__init__.py.j2
+++ b/gapic/templates/$namespace/$name/__init__.py.j2
@@ -1,9 +1,8 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-# Import each service from {{ api.naming.version }} into the unversioned namespace.
-{% for service in api.services.values() -%}
 from ..{{ api.naming.versioned_module_name }} import types
+{% for service in api.services.values() -%}
 from ..{{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }} import {{ service.name }}
 {% endfor %}
 

--- a/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
@@ -10,6 +10,7 @@ from google.auth import credentials
 
 {% for package, python_module in service.python_modules -%}
 from {{ package }} import {{ python_module }}
+{%- if python_module.endswith('_pb2') %} as {{ python_module[:-4] }}{% endif %}
 {% endfor %}
 from ...utils import dispatch
 from .transports import get_transport_class
@@ -167,4 +168,9 @@ class {{ service.name }}:
                 client library.
         """
         return gapic_v1.client_info.ClientInfo()
+
+
+__all__ = (
+    '{{ service.name }}',
+)
 {% endblock %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
@@ -12,6 +12,7 @@ from google.auth import credentials
 
 {% for package, python_module in service.python_modules -%}
 from {{ package }} import {{ python_module }}
+{%- if python_module.endswith('_pb2') %} as {{ python_module[:-4] }}{% endif %}
 {% endfor %}
 
 class {{ service.name }}Transport(metaclass=abc.ABCMeta):
@@ -61,4 +62,9 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
             ) -> {{ method.output.ident }}:
         raise NotImplementedError
     {%- endfor %}
+
+
+__all__ = (
+    '{{ service.name }}Transport',
+)
 {% endblock %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
@@ -13,6 +13,7 @@ import grpc
 
 {% for package, python_module in service.python_modules -%}
 from {{ package }} import {{ python_module }}
+{%- if python_module.endswith('_pb2') %} as {{ python_module[:-4] }}{% endif %}
 {% endfor %}
 from .base import {{ service.name }}Transport
 
@@ -103,9 +104,14 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         if '{{ method.name|snake_case }}' not in self._stubs:
             self._stubs['{{ method.name|snake_case }}'] = self.grpc_channel.{{ method.grpc_stub_type }}(
                 '/{{ '.'.join(method.meta.address.package) }}.{{ service.name }}/{{ method.name }}',
-                request_serializer={{ method.input.ident }}.SerializeToString,
-                response_deserializer={{ method.output.ident }}.FromString,
+                request_serializer={{ method.input.ident }}.serialize,
+                response_deserializer={{ method.output.ident }}.deserialize,
             )
         return self._stubs['{{ method.name|snake_case }}']
     {%- endfor %}
+
+
+__all__ = (
+    '{{ service.name }}GrpcTransport',
+)
 {%- endblock -%}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
@@ -10,6 +10,7 @@ from google.auth.transport.requests import AuthorizedSession
 
 {% for package, python_module in service.python_modules -%}
 from {{ package }} import {{ python_module }}
+{%- if python_module.endswith('_pb2') %} as {{ python_module[:-4] }}{% endif %}
 {% endfor %}
 from .base import {{ service.name }}Transport
 
@@ -106,4 +107,9 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
             response.content,
         )
     {%- endfor %}
+
+
+__all__ = (
+    '{{ service.name }}HttpTransport',
+)
 {% endblock %}

--- a/gapic/templates/$namespace/$name_$version/types/$proto.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/$proto.py.j2
@@ -1,0 +1,33 @@
+{% extends "_base.py.j2" %}
+
+{% block content %}
+class _:
+    # Note: This strange "import within the `_` class" is to avoid potential
+    # naming collisions; since we can not control the names chosen for
+    # fields, we do this instead.
+    import enum
+    import proto
+
+    {% for package, python_module in proto.python_modules -%}
+    from {{ package }} import {{ python_module }}
+    {%- if python_module.endswith('_pb2') %} as {{ python_module[:-4] }}{% endif %}
+    {% endfor %}
+
+
+{% for enum in proto.top.enums.values() -%}
+    {% include '$namespace/$name_$version/types/_enum.py.j2' %}
+{% endfor %}
+
+{% for message in proto.top.messages.values() -%}
+    {% include "$namespace/$name_$version/types/_message.py.j2" %}
+{% endfor %}
+
+__all__ = (
+    {%- for enum in proto.top.enums.values() %}
+    '{{ enum.name }}',
+    {%- endfor -%}
+    {%- for message in proto.top.messages.values() %}
+    '{{ message.name }}',
+    {%- endfor %}
+)
+{% endblock %}

--- a/gapic/templates/$namespace/$name_$version/types/_enum.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/_enum.py.j2
@@ -1,0 +1,7 @@
+class {{ enum.name }}(_.enum.IntEnum):
+    """{{ enum.meta.doc|wrap(width=72, indent=4) }}
+    """
+    {% for enum_value in enum.values -%}
+    {{ enum_value.name }} = {{ enum_value.number }}
+    {% endfor -%}
+{{ '\n\n' }}

--- a/gapic/templates/$namespace/$name_$version/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/_message.py.j2
@@ -1,0 +1,27 @@
+class {{ message.name }}(_.proto.Message):
+    """{{ message.meta.doc|wrap(width=72, indent=4) }}
+    """
+    {# Iterate over nested enums. -#}
+    {% for enum in message.nested_enums.values() %}{% filter indent -%}
+        {% include '$namespace/$name_$version/types/_enum.py.j2' %}
+    {% endfilter %}{% endfor -%}
+
+    {#- Iterate over nested messages. -#}
+    {% for submessage in message.nested_messages.values() -%}
+        {% with message = submessage %}{% filter indent %}
+            {%- include '$namespace/$name_$version/types/_message.py.j2' %}
+        {% endfilter %}{% endwith %}
+    {% endfor -%}
+
+    {# Iterate over fields. -#}
+    {%- for field in message.fields.values() %}
+    {{ field.name }} = _.proto.{% if field.repeated %}Repeated{% endif %}Field(_.proto.{{ field.proto_type }}, number={{ field.number }}
+    {%- if field.enum or field.message %},
+        {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
+    {% endif %})
+    """{{ field.meta.doc|wrap(width=72, offset=4, indent=4) }}"""
+    {% endfor %}
+
+    class Meta:
+        package = '{{ message.ident.proto_package }}'
+{{ '\n\n' }}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -20,14 +20,14 @@ setuptools.setup(
     include_package_data=True,
     install_requires=(
         'google-api-core >= 1.3.0, < 2.0.0dev',
-        'googleapis-common-protos >= 1.6.0b4',
+        'googleapis-common-protos >= 1.6.0b6',
         'grpcio >= 1.10.0',
+        'proto-plus >= 0.1.0a1',
     ),
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',

--- a/nox.py
+++ b/nox.py
@@ -71,7 +71,7 @@ def showcase(session):
         # Write out a client library for Showcase.
         session.run('protoc',
             f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
-            f'--python_out={tmp_dir}', f'--pyclient_out={tmp_dir}',
+            f'--pyclient_out={tmp_dir}',
             'google/showcase/v1alpha1/showcase.proto',
         )
 

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     install_requires=(
         'click >= 6.7',
-        'googleapis-common-protos >= 1.6.0b4',
+        'googleapis-common-protos >= 1.6.0b6',
         'grpcio >= 1.9.1',
         'jinja2 >= 2.10',
         'protobuf >= 3.5.1',

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -259,6 +259,7 @@ def make_proto(file_pb: descriptor_pb2.FileDescriptorProto,
     prior_protos = prior_protos or {}
     return api._ProtoBuilder(file_pb,
         file_to_generate=file_to_generate,
+        naming=make_naming(),
         prior_protos=prior_protos,
     ).proto
 

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -15,7 +15,8 @@
 from typing import Sequence
 from unittest import mock
 
-from google.longrunning import operations_pb2
+from google.api import annotations_pb2
+from google.api import longrunning_pb2
 from google.protobuf import descriptor_pb2
 
 from gapic.schema import api
@@ -361,10 +362,10 @@ def test_lro():
         input_type='google.example.v3.AsyncDoThingRequest',
         output_type='google.longrunning.Operation',
     )
-    method_pb2.options.Extensions[operations_pb2.operation_types].MergeFrom(
-        operations_pb2.OperationTypes(
-            response='google.example.v3.AsyncDoThingResponse',
-            metadata='google.example.v3.AsyncDoThingMetadata',
+    method_pb2.options.Extensions[annotations_pb2.operation].MergeFrom(
+        longrunning_pb2.OperationData(
+            response_type='google.example.v3.AsyncDoThingResponse',
+            metadata_type='google.example.v3.AsyncDoThingMetadata',
         ),
     )
 

--- a/tests/unit/schema/wrappers/test_enums.py
+++ b/tests/unit/schema/wrappers/test_enums.py
@@ -36,8 +36,8 @@ def test_enum_value_properties():
 
 def test_enum_ident():
     message = make_enum('Baz', package='foo.v1', module='bar')
-    assert str(message.ident) == 'bar_pb2.Baz'
-    assert message.ident.sphinx == '~.bar_pb2.Baz'
+    assert str(message.ident) == 'bar.Baz'
+    assert message.ident.sphinx == '~.bar.Baz'
 
 
 def make_enum(name: str, package: str = 'foo.bar.v1', module: str = 'baz',

--- a/tests/unit/schema/wrappers/test_message.py
+++ b/tests/unit/schema/wrappers/test_message.py
@@ -41,8 +41,8 @@ def test_message_docstring():
 
 def test_message_ident():
     message = make_message('Baz', package='foo.v1', module='bar')
-    assert str(message.ident) == 'bar_pb2.Baz'
-    assert message.ident.sphinx == '~.bar_pb2.Baz'
+    assert str(message.ident) == 'bar.Baz'
+    assert message.ident.sphinx == '~.bar.Baz'
 
 
 def test_get_field():

--- a/tests/unit/schema/wrappers/test_operation.py
+++ b/tests/unit/schema/wrappers/test_operation.py
@@ -44,4 +44,4 @@ def test_operation_meta():
     )
     operation = wrappers.OperationType(lro_response=lro_response)
     assert 'representing a long-running operation' in operation.meta.doc
-    assert ':class:`~.foo_pb2.LroResponse`' in operation.meta.doc
+    assert ':class:`~.foo.LroResponse`' in operation.meta.doc

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -57,20 +57,20 @@ def test_service_python_modules():
         get_method('Yawn', 'a.b.v1.c.YawnRequest', 'x.y.v1.z.YawnResponse'),
     ))
     assert service.python_modules == (
-        ('a.b.v1', 'c_pb2'),
-        ('foo', 'bacon_pb2'),
-        ('foo', 'bar_pb2'),
-        ('foo', 'baz_pb2'),
-        ('x.y.v1', 'z_pb2'),
+        ('a.b.v1', 'c'),
+        ('foo', 'bacon'),
+        ('foo', 'bar'),
+        ('foo', 'baz'),
+        ('x.y.v1', 'z'),
     )
 
 
 def test_service_python_modules_lro():
     service = make_service_with_method_options()
     assert service.python_modules == (
-        ('foo', 'bar_pb2'),
-        ('foo', 'baz_pb2'),
-        ('foo', 'qux_pb2'),
+        ('foo', 'bar'),
+        ('foo', 'baz'),
+        ('foo', 'qux'),
         ('google.api_core', 'operation'),
     )
 
@@ -89,10 +89,10 @@ def test_service_python_modules_signature():
     )
     # type=5 is int, so nothing is added.
     assert service.python_modules == (
-        ('a.b.c', 'v2_pb2'),
-        ('foo', 'bar_pb2'),
-        ('foo', 'baz_pb2'),
-        ('foo', 'qux_pb2'),
+        ('a.b.c', 'v2'),
+        ('foo', 'bar'),
+        ('foo', 'baz'),
+        ('foo', 'qux'),
         ('google.api_core', 'operation'),
     )
 


### PR DESCRIPTION
This PR adds writing of protos.

Each proto which is supposed to be generated has a corresponding entry in the `types/` directory, which renders the enums and messages. The messages use the (not yet public) proto runtime to use idiomatic Python types.

Side-effect: Fixes #28.

## Known Issues

  * ~Showcase does not pass yet because the runtime is not public. (This obviously blocks the merge; the rest should not.)~
  * No Markdown to RST conversion yet.
  * We blindly assume which any proto we are not rendering ourselves uses the original, pb2 style protos. This is certain to be false in some cases (e.g. Spanner's sub-APIs).
  * There is a potential for naming conflicts if the same proto imports from a proto with the same name from two different pacakges.