### PR TITLE
Convert documentation to ReStructured Text (RST).

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install pandoc
+          command: |
+            apt-get update
+            apt-get install -y pandoc
+      - run:
           name: Install nox and codecov.
           command: |
             pip install --pre nox-automation
@@ -34,6 +39,11 @@ jobs:
       - image: 'python:3.7'
     steps:
       - checkout
+      - run:
+          name: Install pandoc
+          command: |
+            apt-get update
+            apt-get install -y pandoc
       - run:
           name: Install nox and codecov.
           command: |
@@ -55,10 +65,10 @@ jobs:
           name: Install nox.
           command: pip install --pre nox-automation
       - run:
-          name: Install unzip.
+          name: Install pandoc and unzip.
           command: |
             apt-get update
-            apt-get install unzip
+            apt-get install -y pandoc unzip
       - run:
           name: Install protoc 3.6.1.
           command: |

--- a/docs/templates.rst
+++ b/docs/templates.rst
@@ -71,6 +71,9 @@ writing properly formatted templates.
 
 These are:
 
+* ``rst`` (:meth:`~.utils.rst.rst`): Converts a string to ReStructured Text.
+  If the string appears not to be formatted (contains no obvious Markdown
+  syntax characters), then this method forwards to ``wrap``.
 * ``snake_case`` (:meth:`~.utils.case.to_snake_case`): Converts a string in
   any sane case system to snake case.
 * ``wrap`` (:meth:`~.utils.lines.wrap`): Wraps arbitrary text. Keyword

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -60,6 +60,7 @@ class Generator:
         )
 
         # Add filters which templates require.
+        self._env.filters['rst'] = utils.rst
         self._env.filters['snake_case'] = utils.to_snake_case
         self._env.filters['wrap'] = utils.wrap
 

--- a/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
@@ -18,8 +18,7 @@ from .transports import {{ service.name }}Transport
 
 
 class {{ service.name }}:
-    """{{ service.meta.doc|wrap(width=72, offset=7, indent=4) }}
-    """
+    """{{ service.meta.doc|rst(width=72, indent=4) }}"""
     def __init__(self, *,
             credentials: credentials.Credentials = None,
             transport: Union[str, {{ service.name }}Transport] = None,
@@ -58,7 +57,7 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.ident }}:
-        """{{ method.meta.doc|wrap(width=72, offset=11, indent=8) }}
+        """{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
             request ({{ method.input.ident.sphinx }}):
@@ -129,7 +128,7 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.ident }}:
-        """{{ method.meta.doc|wrap(width=72, offset=11, indent=8) }}
+        """{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
             {%- for field in signature.fields.values() %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
@@ -21,7 +21,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
     """gRPC backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, indent=4) }}
+    {{ service.meta.doc|rst(width=72, indent=4) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -90,12 +90,12 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 width=70, offset=40, indent=8) }}
         {{- ' ' -}} method over gRPC.
 
-        {{ method.meta.doc|wrap(width=72, indent=8) }}
+        {{ method.meta.doc|rst(width=72, indent=8) }}
 
         Returns:
             Callable[[~.{{ method.input.name }}],
                     ~.{{ method.output.name }}]:
-                {{ method.output.meta.doc|wrap(width=72, indent=16) }}
+                {{ method.output.meta.doc|rst(width=72, indent=16) }}
         """
         # Generate a "stub function" on-the-fly which will actually make
         # the request.

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
@@ -18,7 +18,7 @@ from .base import {{ service.name }}Transport
 class {{ service.name }}HttpTransport({{ service.name }}Transport):
     """HTTP backend transport for {{ service.name }}.
 
-    {{ service.meta.doc|wrap(width=72, indent=4) }}
+    {{ service.meta.doc|rst(width=72, indent=4) }}
 
     This class defines the same methods as the primary client, so the
     primary client can load the underlying transport implementation
@@ -76,14 +76,14 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
 
         Args:
             request (~.{{ method.input.ident }}):
-                The request object. {{- ' ' -}}
-                {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
+                The request object.
+                {{ method.input.meta.doc|rst(width=72, indent=16) }}
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent alont with the request as metadata.
 
         Returns:
             ~.{{ method.output.ident }}:
-                {{ method.output.meta.doc|wrap(width=72, indent=16) }}
+                {{ method.output.meta.doc|rst(width=72, indent=16) }}
         """
         # Serialize the input.
         data = request.SerializeToString()

--- a/gapic/templates/$namespace/$name_$version/types/_enum.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/_enum.py.j2
@@ -1,6 +1,5 @@
 class {{ enum.name }}(_.enum.IntEnum):
-    """{{ enum.meta.doc|wrap(width=72, indent=4) }}
-    """
+    """{{ enum.meta.doc|rst(width=72, indent=4) }}"""
     {% for enum_value in enum.values -%}
     {{ enum_value.name }} = {{ enum_value.number }}
     {% endfor -%}

--- a/gapic/templates/$namespace/$name_$version/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/_message.py.j2
@@ -1,6 +1,5 @@
 class {{ message.name }}(_.proto.Message):
-    """{{ message.meta.doc|wrap(width=72, indent=4) }}
-    """
+    """{{ message.meta.doc|rst(indent=4) }}"""
     {# Iterate over nested enums. -#}
     {% for enum in message.nested_enums.values() %}{% filter indent -%}
         {% include '$namespace/$name_$version/types/_enum.py.j2' %}
@@ -19,7 +18,7 @@ class {{ message.name }}(_.proto.Message):
     {%- if field.enum or field.message %},
         {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
     {% endif %})
-    """{{ field.meta.doc|wrap(width=72, offset=4, indent=4) }}"""
+    """{{ field.meta.doc|rst(indent=4) }}"""
     {% endfor %}
 
     class Meta:

--- a/gapic/utils/__init__.py
+++ b/gapic/utils/__init__.py
@@ -18,11 +18,13 @@ from gapic.utils.filename import to_valid_filename
 from gapic.utils.filename import to_valid_module_name
 from gapic.utils.lines import wrap
 from gapic.utils.placeholder import Placeholder
+from gapic.utils.rst import rst
 
 
 __all__ = (
     'cached_property',
     'Placeholder',
+    'rst',
     'to_snake_case',
     'to_valid_filename',
     'to_valid_module_name',

--- a/gapic/utils/lines.py
+++ b/gapic/utils/lines.py
@@ -44,7 +44,7 @@ def wrap(text: str, width: int, *, offset: int = None, indent: int = 0) -> str:
 
     # If the offset is None, default it to the indent value.
     if offset is None:
-        offset = indent + 3
+        offset = indent
 
     # Protocol buffers preserves single initial spaces after line breaks
     # when parsing comments (such as the space before the "w" in "when" here).

--- a/gapic/utils/lines.py
+++ b/gapic/utils/lines.py
@@ -44,7 +44,7 @@ def wrap(text: str, width: int, *, offset: int = None, indent: int = 0) -> str:
 
     # If the offset is None, default it to the indent value.
     if offset is None:
-        offset = indent
+        offset = indent + 3
 
     # Protocol buffers preserves single initial spaces after line breaks
     # when parsing comments (such as the space before the "w" in "when" here).
@@ -52,23 +52,42 @@ def wrap(text: str, width: int, *, offset: int = None, indent: int = 0) -> str:
     text = text.replace('\n ', '\n')
 
     # Break off the first line of the string to address non-zero offsets.
-    first = ''
-    if offset > 0:
-        initial = textwrap.wrap(text,
+    first = text.split('\n')[0] + '\n'
+    if len(first) > width - offset:
+        initial = textwrap.wrap(first,
             break_long_words=False,
             width=width - offset,
         )
+        # Strip the first \n from the text so it is not misidentified as an
+        # intentionally short line below.
+        text = text.replace('\n', ' ', 1)
+
+        # Save the new `first` line.
         first = f'{initial[0]}\n'
-        text = ' '.join(initial[1:])
+    text = text[len(first):].strip()
+    if not text:
+        return first.strip()
+
+    # Tokenize the rest of the text to try to preserve line breaks
+    # that semantically matter.
+    tokens = []
+    token = ''
+    for line in text.split('\n'):
+        token += line + '\n'
+        if len(line) < width * 0.75:
+            tokens.append(token)
+            token = ''
+    if token:
+        tokens.append(token)
 
     # Wrap the remainder of the string at the desired width.
     return '{first}{text}'.format(
         first=first,
-        text=textwrap.fill(
+        text='\n'.join([textwrap.fill(
             break_long_words=False,
-            initial_indent=' ' * indent if first else '',
+            initial_indent=' ' * indent,
             subsequent_indent=' ' * indent,
-            text=text,
+            text=token,
             width=width,
-        ),
+        ) for token in tokens]),
     ).rstrip('\n')

--- a/gapic/utils/rst.py
+++ b/gapic/utils/rst.py
@@ -1,0 +1,56 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+import pypandoc
+
+from gapic.utils.lines import wrap
+
+
+def rst(text, width=72, indent=0, source_format='commonmark'):
+    """Convert the given text to ReStructured Text.
+
+    Args:
+        text (str): The text to convert.
+        width (int): The number of columns.
+        source_format (str): The source format. This is ``commonmark`` by
+            default, which is what is used by convention in protocol buffers.
+
+    Returns:
+        str: The same text, in RST format.
+    """
+    # Sanity check: If the text block does not appear to have any formatting,
+    # do not convert it.
+    # (This makes code generation significantly faster; calling out to pandoc
+    # is by far the most expensive thing we do.)
+    if not re.search(r'[|*`_[\]]', text):
+        answer = wrap(text, width=width, indent=indent, offset=indent + 3)
+    else:
+        # Convert from CommonMark to ReStructured Text.
+        answer = pypandoc.convert_text(text, 'rst',
+            format=source_format,
+            extra_args=['--columns=%d' % width],
+        ).strip().replace('\n', f"\n{' ' * indent}")
+
+    # Add a newline to the end of the document if any line breaks are
+    # already present.
+    #
+    # This causes the closing """ to be on the subsequent line only when
+    # appropriate.
+    if '\n' in answer:
+        answer += '\n' + ' ' * indent
+
+    # Done; return the answer.
+    return answer

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,10 @@ setup(
     install_requires=(
         'click >= 6.7',
         'googleapis-common-protos >= 1.6.0b6',
-        'grpcio >= 1.9.1',
+        'grpcio >= 1.10.0',
         'jinja2 >= 2.10',
         'protobuf >= 3.5.1',
+        'pypandoc >= 1.4',
     ),
     extras_require={
         ':python_version<"3.7"': ('dataclasses >= 0.4',),

--- a/tests/unit/utils/test_lines.py
+++ b/tests/unit/utils/test_lines.py
@@ -46,3 +46,7 @@ def test_wrap_initial_offset():
 
 def test_wrap_indent_short():
     assert lines.wrap('foo bar', width=30, indent=10) == 'foo bar'
+
+
+def test_wrap_short_line_preserved():
+    assert lines.wrap('foo\nbar\nbaz', width=80) == 'foo\nbar\nbaz'

--- a/tests/unit/utils/test_rst.py
+++ b/tests/unit/utils/test_rst.py
@@ -1,0 +1,41 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pypandoc
+
+from gapic import utils
+
+
+def test_rst_unformatted():
+    with mock.patch.object(pypandoc, 'convert_text') as convert_text:
+        assert utils.rst('The hail in Wales') == 'The hail in Wales'
+        assert convert_text.call_count == 0
+
+
+def test_rst_formatted():
+    with mock.patch.object(pypandoc, 'convert_text') as convert_text:
+        convert_text.side_effect = lambda *a, **kw: a[0].replace('`', '``')
+        assert utils.rst('The hail in `Wales`') == 'The hail in ``Wales``'
+        assert convert_text.call_count == 1
+        assert convert_text.mock_calls[0][1][1] == 'rst'
+        assert convert_text.mock_calls[0][2]['format'] == 'commonmark'
+
+
+def test_rst_add_newline():
+    with mock.patch.object(pypandoc, 'convert_text') as convert_text:
+        s = 'The hail in Wales\nfalls mainly on the snails.'
+        assert utils.rst(s) == s + '\n'
+        assert convert_text.call_count == 0


### PR DESCRIPTION
This commit adds `pypandoc` and converts docstrings to RST from Markdown.