### PR TITLE
Bump proto-plus to 0.1.0a2 in generated code.

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -22,7 +22,7 @@ setuptools.setup(
         'google-api-core >= 1.3.0, < 2.0.0dev',
         'googleapis-common-protos >= 1.6.0b6',
         'grpcio >= 1.10.0',
-        'proto-plus >= 0.1.0a1',
+        'proto-plus >= 0.1.0a2',
     ),
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
The underlying change gets around the issue where creating descriptors in a file not ending in `_pb2.py` does not work if you are using the C++ protobuf implementation.