### PR TITLE
Update the executable name.

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -59,7 +59,7 @@ for each plugin invoked; you just want these to match:
   # assume that api-common-protos is next to it.
   $ protoc google/cloud/vision/v1/*.proto \
       --proto_path=../api-common-protos/ --proto_path=. \
-      --python_out=/dest/ --pyclient_out=/dest/
+      --python_out=/dest/ --python_gapic_out=/dest/
 
 .. note::
 

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -52,7 +52,8 @@ API Generator for Python
 
 This package is provided as a standard Python library, and can be installed
 the usual ways. It fundamentally provides a CLI command,
-``protoc-gen-pyclient``, so you will want to install using a mechanism
+``protoc-gen-python_gapic``, (yes, the mismatch of ``kebob-case`` and
+``snake_case`` is weird, sorry), so you will want to install using a mechanism
 that is conducive to making CLI commands available.
 
 Additionally, this program currently only runs against Python 3.6 or
@@ -81,8 +82,8 @@ To ensure the tool is installed properly:
 
 .. code-block:: shell
 
-  $ which protoc-gen-pyclient
-  /path/to/protoc-gen-pyclient
+  $ which protoc-gen-python_gapic
+  /path/to/protoc-gen-python_gapic
 
 .. _pyenv: https://github.com/pyenv/pyenv
 .. _pipsi: https://github.com/mitsuhiko/pipsi

--- a/nox.py
+++ b/nox.py
@@ -71,7 +71,7 @@ def showcase(session):
         # Write out a client library for Showcase.
         session.run('protoc',
             f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
-            f'--pyclient_out={tmp_dir}',
+            f'--python_gapic_out={tmp_dir}',
             'google/showcase/v1alpha2/echo.proto',
         )
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     long_description=README,
     entry_points="""[console_scripts]
         protoc-gen-dump=gapic.cli.dump:dump
-        protoc-gen-pyclient=gapic.cli.generate:generate
+        protoc-gen-python_gapic=gapic.cli.generate:generate
     """,
     platforms='Posix; MacOS X',
     include_package_data=True,


### PR DESCRIPTION
This makes the executable name be `protoc-gen-python_gapic` (yes, the mixture of `kebob-case` and `snake_case` is a crime against all that is good, right, and salutary; all alternatives within the `protoc` constraints are worse) and the plugin switch therefore becomes `--python_gapic_out`.