### PR TITLE
Determine naming collisions up front.

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -42,6 +42,7 @@ class Proto:
     messages: Mapping[str, wrappers.MessageType]
     enums: Mapping[str, wrappers.EnumType]
     file_to_generate: bool
+    collisions: Set[str] = dataclasses.field(default_factory=frozenset)
     meta: metadata.Metadata = dataclasses.field(
         default_factory=metadata.Metadata,
     )
@@ -83,32 +84,6 @@ class Proto:
         return to_snake_case(self.name.split('/')[-1][:-len('.proto')])
 
     @cached_property
-    def names(self) -> Set[str]:
-        """Return a set of names used by this proto.
-
-        This is used for detecting naming collisions in the module names
-        used for imports.
-        """
-        # Add names of all enums, messages, and fields.
-        answer = {e.name for e in self.enums.values()}
-        for message in self.messages.values():
-            answer = answer.union({f.name for f in message.fields.values()})
-            answer.add(message.name)
-
-        # Identify any import module names where the same module name is used
-        # from distinct packages.
-        modules = {}
-        for t in chain(*[m.field_types for m in self.messages.values()]):
-            modules.setdefault(t.ident.module, set())
-            modules[t.ident.module].add(t.ident.package)
-        for module_name, packages in modules.items():
-            if len(packages) > 1:
-                answer.add(module_name)
-
-        # Return the set of collision names.
-        return frozenset(answer)
-
-    @cached_property
     def python_modules(self) -> Sequence[Tuple[str, str]]:
         """Return a sequence of Python modules, for import.
 
@@ -121,12 +96,12 @@ class Proto:
             of statement.
         """
         answer = set()
-        self_reference = self.meta.address.context(self).python_import
+        self_reference = self.meta.address.python_import
         for t in chain(*[m.field_types for m in self.messages.values()]):
             # Add the appropriate Python import for the field.
             # Sanity check: We do make sure that we are not trying to have
             # a module import itself.
-            imp = t.ident.context(self).python_import
+            imp = t.ident.python_import
             if imp != self_reference:
                 answer.add(imp)
 
@@ -159,7 +134,7 @@ class Proto:
         returns the same string, but it returns a modified version if
         it will cause a naming collision with messages or fields in this proto.
         """
-        if string in self.names:
+        if string in self.collisions:
             return self.disambiguate(f'_{string}')
         return string
 
@@ -281,6 +256,7 @@ class _ProtoBuilder:
         # for each item as it is loaded.
         self.address = metadata.Address(
             api_naming=naming,
+            collisions=self._get_names(file_descriptor),
             module=file_descriptor.name.split('/')[-1][:-len('.proto')],
             package=tuple(file_descriptor.package.split('.')),
         )
@@ -348,6 +324,60 @@ class _ProtoBuilder:
         return collections.ChainMap({}, self.messages,
             *[p.messages for p in self.prior_protos.values()],
         )
+
+    def _flatten_message_pbs(self,
+            message_pbs: Sequence[descriptor_pb2.DescriptorProto]
+            ) -> Sequence[descriptor_pb2.DescriptorProto]:
+        """Return a list of protobuf messages, including nested ones."""
+        answer = []
+        for message_pb in message_pbs:
+            answer.append(message_pb)
+            answer += self._flatten_message_pbs(message_pb.nested_type)
+        return answer
+
+    def _get_names(self, fd: descriptor_pb2.FileDescriptorProto) -> Set[str]:
+        """Return a set of names used by this proto.
+
+        This is used for detecting naming collisions in the module names
+        used for imports.
+
+        We determine the names from the FileDescriptorSet directly so that
+        we already know the full list as we create the pieces of the structure.
+        """
+        field_types = set()
+
+        # Piece together a list of enum, message, and field names.
+        # The case scheme in protocol buffers matches the case scheme in
+        # Python for all of these, so no case-conversion is required.
+        answer = {e.name for e in fd.enum_type}
+        for message_pb in self._flatten_message_pbs(fd.message_type):
+            answer = answer.union({message_pb.name}).union(
+                {f.name for f in message_pb.field},
+            ).union(
+                {e.name for e in message_pb.enum_type},
+            )
+
+            # Also track the field types we encounter.
+            field_types = field_types.union(
+                {f.type_name.lstrip('.') for f in message_pb.field
+                if isinstance(f.type_name, str)},
+            )
+
+        # Identify any import module names where the same module name is used
+        # from distinct packages.
+        modules = {}
+        all_types = collections.ChainMap({}, self.all_messages, self.all_enums)
+        for field_type in field_types:
+            t = all_types.get(field_type, None)
+            if t:
+                modules.setdefault(t.ident.module, set())
+                modules[t.ident.module].add(t.ident.package)
+        for module_name, packages in modules.items():
+            if len(packages) > 1:
+                answer.add(module_name)
+
+        # Return the set of collision names.
+        return frozenset(answer)
 
     def _get_operation_type(self,
             response_type: wrappers.Method,
@@ -578,16 +608,35 @@ class _ProtoBuilder:
         return self.enums[address.proto]
 
     def _load_service(self,
-            service: descriptor_pb2.ServiceDescriptorProto,
+            svc_pb: descriptor_pb2.ServiceDescriptorProto,
             address: metadata.Address,
             path: Tuple[int],
             ) -> wrappers.Service:
         """Load comments for a service and its methods."""
-        address = address.child(service.name, path)
+        address = address.child(svc_pb.name, path)
+
+        # Determine the names used by this service.
+        # Method names are `snake_case` in Python, so we case-convert those.
+        collisions = {svc_pb.name}.union(
+            {to_snake_case(i.name) for i in svc_pb.method},
+        )
+
+        # Identify any import module names where the same module name is used
+        # from distinct packages.
+        modules = {}
+        for t in chain(*[m.ref_types for m in self._get_methods(
+                svc_pb.method, address=address, path=path + (2,)).values()]):
+            modules.setdefault(t.ident.module, set())
+            modules[t.ident.module].add(t.ident.package)
+        for module_name, packages in modules.items():
+            if len(packages) > 1:
+                collisions.add(module_name)
+
+        # Augment the address with the collision information.
+        address = address.context(collisions)
 
         # Put together a dictionary of the service's methods.
-        methods = self._get_methods(
-            service.method,
+        methods = self._get_methods(svc_pb.method,
             address=address,
             path=path + (2,),
         )
@@ -599,6 +648,6 @@ class _ProtoBuilder:
                 documentation=self.docs.get(path, self.EMPTY),
             ),
             methods=methods,
-            service_pb=service,
+            service_pb=svc_pb,
         )
         return self.services[address.proto]

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -153,7 +153,7 @@ class Address:
             parent=self.parent + (self.name,) if self.name else self.parent,
         )
 
-    def context(self, collisions: Set[str]) -> 'Address':
+    def bind(self, collisions: Set[str]) -> 'Address':
         """Return a derivative of this address with the provided context.
 
         This method is used to address naming collisions. The returned
@@ -259,6 +259,16 @@ class Metadata:
             return '\n\n'.join(self.documentation.leading_detached_comments)
         return ''
 
+    def bind(self, collisions: Set[str]) -> 'Metadata':
+        """Return a derivative of this metadata with the provided context.
+
+        This method is used to address naming collisions, and is a pass-through
+        to :meth:`~.Address.context`.
+        """
+        return dataclasses.replace(self,
+            address=self.address.bind(collisions),
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class FieldIdentifier:
@@ -276,6 +286,6 @@ class FieldIdentifier:
             return f'Sequence[{self.ident.sphinx}]'
         return self.ident.sphinx
 
-    def context(self, arg) -> 'FieldIdentifier':
+    def bind(self, arg) -> 'FieldIdentifier':
         """Return self. Provided for compatibility with Address."""
         return self

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -153,14 +153,14 @@ class Address:
             parent=self.parent + (self.name,) if self.name else self.parent,
         )
 
-    def context(self, context) -> 'Address':
+    def context(self, collisions: Set[str]) -> 'Address':
         """Return a derivative of this address with the provided context.
 
         This method is used to address naming collisions. The returned
         ``Address`` object aliases module names to avoid naming collisions in
         the file being written.
         """
-        return dataclasses.replace(self, collisions=frozenset(context.names))
+        return dataclasses.replace(self, collisions=frozenset(collisions))
 
     def rel(self, address: 'Address') -> str:
         """Return an identifier for this type, relative to the given address.

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -519,7 +519,7 @@ class Service:
         answer = set()
         for method in self.methods.values():
             for t in method.ref_types:
-                answer.add(t.ident.context(self).python_import)
+                answer.add(t.ident.python_import)
         return tuple(sorted(list(answer)))
 
     @property

--- a/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
@@ -51,15 +51,15 @@ class {{ service.name }}:
     @dispatch
     {% endif -%}
     def {{ method.name|snake_case }}(self,
-            request: {{ method.input.ident.context(service) }}, *,
+            request: {{ method.input.ident }}, *,
             retry: retry.Retry = None,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.ident.context(service) }}:
+            ) -> {{ method.output.ident }}:
         """{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
-            request ({{ method.input.ident.context(service).sphinx }}):
+            request ({{ method.input.ident.sphinx }}):
                 The request object.{{ ' ' -}}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             retry (~.retry.Retry): Designation of what errors, if any,
@@ -69,12 +69,12 @@ class {{ service.name }}:
                 sent along with the request as metadata.
 
         Returns:
-            {{ method.output.ident.context(service).sphinx }}:
+            {{ method.output.ident.sphinx }}:
                 {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         # Coerce the request to the protocol buffer object.
-        if not isinstance(request, {{ method.input.ident.context(service) }}):
-            request = {{ method.input.ident.context(service) }}(**request)
+        if not isinstance(request, {{ method.input.ident }}):
+            request = {{ method.input.ident }}(**request)
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
@@ -106,9 +106,9 @@ class {{ service.name }}:
         response = operation.from_gapic(
             response,
             self._transport.operations_client,
-            {{ method.output.lro_response.ident.context(service) }},
+            {{ method.output.lro_response.ident }},
             {%- if method.output.lro_metadata %}
-            metadata_type={{ method.output.lro_metadata.ident.context(service) }},
+            metadata_type={{ method.output.lro_metadata.ident }},
             {%- endif %}
         )
         {%- endif %}
@@ -120,18 +120,18 @@ class {{ service.name }}:
     @{{ method.name|snake_case }}.register
     def _{{ method.name|snake_case }}_with_{{ signature.dispatch_field.name|snake_case }}(self,
             {%- for field in signature.fields.values() %}
-            {{ field.name  }}: {{ field.ident.context(service) }}{% if loop.index0 > 0 and not field.required %} = None{% endif %},
+            {{ field.name  }}: {{ field.ident }}{% if loop.index0 > 0 and not field.required %} = None{% endif %},
             {%- endfor %}
             *,
             retry: retry.Retry = None,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.ident.context(service) }}:
+            ) -> {{ method.output.ident }}:
         """{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
             {%- for field in signature.fields.values() %}
-            {{ field.name }} ({{ field.ident.context(service).sphinx }}):
+            {{ field.name }} ({{ field.ident.sphinx }}):
                 {{ field.meta.doc|wrap(width=72, indent=16) }}
             {%- endfor %}
             retry (~.retry.Retry): Designation of what errors, if any,
@@ -141,11 +141,11 @@ class {{ service.name }}:
                 sent alont with the request as metadata.
 
         Returns:
-            {{ method.output.ident.context(service).sphinx }}:
+            {{ method.output.ident.sphinx }}:
                 {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         return self.{{ method.name|snake_case }}(
-            {{ method.input.ident.context(service) }}(
+            {{ method.input.ident }}(
                 {%- for field in signature.fields.values() %}
                 {{ field.name }}={{ field.name }},
                 {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
@@ -57,8 +57,8 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def {{ method.name|snake_case }}(
             self,
-            request: {{ method.input.ident.context(service) }},
-            ) -> {{ method.output.ident.context(service) }}:
+            request: {{ method.input.ident }},
+            ) -> {{ method.output.ident }}:
         raise NotImplementedError
     {%- endfor %}
 

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
@@ -82,8 +82,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
     @property
     def {{ method.name|snake_case }}(self) -> Callable[
-            [{{ method.input.ident.context(service) }}],
-            {{ method.output.ident.context(service) }}]:
+            [{{ method.input.ident }}],
+            {{ method.output.ident }}]:
         """Return a callable for the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=40, indent=8) }}
@@ -103,8 +103,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         if '{{ method.name|snake_case }}' not in self._stubs:
             self._stubs['{{ method.name|snake_case }}'] = self.grpc_channel.{{ method.grpc_stub_type }}(
                 '/{{ '.'.join(method.meta.address.package) }}.{{ service.name }}/{{ method.name }}',
-                request_serializer={{ method.input.ident.context(service) }}.serialize,
-                response_deserializer={{ method.output.ident.context(service) }}.deserialize,
+                request_serializer={{ method.input.ident }}.serialize,
+                response_deserializer={{ method.output.ident }}.deserialize,
             )
         return self._stubs['{{ method.name|snake_case }}']
     {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
@@ -65,23 +65,23 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
     {%- for method in service.methods.values() %}
 
     def {{ method.name|snake_case }}(self,
-            request: {{ method.input.ident.context(service) }}, *,
+            request: {{ method.input.ident }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.ident.context(service) }}:
+            ) -> {{ method.output.ident }}:
         """Call the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=45, indent=8) }}
         {{- ' ' -}} method over HTTP.
 
         Args:
-            request (~.{{ method.input.ident.context(service) }}):
+            request (~.{{ method.input.ident }}):
                 The request object.
                 {{ method.input.meta.doc|rst(width=72, indent=16) }}
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent alont with the request as metadata.
 
         Returns:
-            ~.{{ method.output.ident.context(service) }}:
+            ~.{{ method.output.ident }}:
                 {{ method.output.meta.doc|rst(width=72, indent=16) }}
         """
         # Serialize the input.
@@ -102,7 +102,7 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
         )
 
         # Return the response.
-        return {{ method.output.ident.context(service) }}.FromString(
+        return {{ method.output.ident }}.FromString(
             response.content,
         )
     {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/_message.py.j2
@@ -16,7 +16,7 @@ class {{ message.name }}({{ p }}.Message):
     {%- for field in message.fields.values() %}
     {{ field.name }} = {{ p }}.{% if field.repeated %}Repeated{% endif %}Field({{ p }}.{{ field.proto_type }}, number={{ field.number }}
     {%- if field.enum or field.message %},
-        {{ field.proto_type.lower() }}={{ field.type.ident.context(proto).rel(message.ident) }},
+        {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
     {% endif %})
     """{{ field.meta.doc|rst(indent=4) }}"""
     {% endfor %}

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -167,7 +167,7 @@ def test_render_templates_duplicate():
     assert files['foo'].content == 'Hello, I am the second.\n'
 
 
-def test_render_templates_additional_context():
+def test_render_templates_additional_bind():
     g = generator.Generator(api_schema=make_api())
 
     # Determine the templates to be rendered.

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -25,13 +25,13 @@ def test_address_str():
     assert str(addr) == 'baz.Bacon'
 
 
-def test_address_str_context():
+def test_address_str_bind():
     Names = collections.namedtuple('Names', ['names'])
     addr = metadata.Address(
         package=('foo', 'bar'),
         module='baz',
         name='Bacon',
-    ).context(Names(names={'baz'}))
+    ).bind(Names(names={'baz'}))
     assert str(addr) == 'fb_baz.Bacon'
 
 
@@ -141,9 +141,9 @@ def test_doc_detached_joined():
     assert meta.doc == 'foo\n\nbar'
 
 
-def test_field_identifier_context():
+def test_field_identifier_bind():
     fi = metadata.FieldIdentifier(ident=metadata.Address(), repeated=False)
-    assert fi.context(None) is fi
+    assert fi.bind(None) is fi
 
 
 def make_doc_meta(


### PR DESCRIPTION
This is an attempt to determine and resolve naming collisions logically prior to templates (in other words, so templates do not have to worry about it and they just get the "right thing").

This is the promised follow-up to #51. To be honest, I am a little conflicted about it. The removal of the constant `.context(...)` calls in templates are an obvious improvement, but this feels more brittle.

Tests are not migrated yet; I would like feedback on the approach before updating them.