### PR TITLE
Determine naming collisions up front. (Take 2.)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -5,4 +5,4 @@ ignore =
   E123, E124
   # Line over-indented for visual indent.
   # This works poorly with type annotations in method declarations.
-  E128, E131
+  E126, E128, E131

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -143,10 +143,14 @@ class Proto:
         return type(self)(
             file_pb2=self.file_pb2,
             services=self.services,
-            messages={k: v for k, v in self.messages.items()
-                      if not v.meta.address.parent},
-            enums={k: v for k, v in self.enums.items()
-                   if not v.meta.address.parent},
+            messages=collections.OrderedDict([
+                (k, v) for k, v in self.messages.items()
+                if not v.meta.address.parent
+            ]),
+            enums=collections.OrderedDict([
+                (k, v) for k, v in self.enums.items()
+                if not v.meta.address.parent
+            ]),
             file_to_generate=False,
             meta=self.meta,
         )

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -353,15 +353,18 @@ class _ProtoBuilder:
         # own output files.
         return dataclasses.replace(naive,
             enums=collections.OrderedDict([
-                (k, v.context(naive.names)) for k, v in naive.enums.items()
+                (k, v.with_context(collisions=naive.names))
+                for k, v in naive.enums.items()
             ]),
             messages=collections.OrderedDict([
-                (k, v.context(naive.names)) for k, v in naive.messages.items()
+                (k, v.with_context(collisions=naive.names))
+                for k, v in naive.messages.items()
             ]),
             services=collections.OrderedDict([
-                (k, v.context(v.names)) for k, v in naive.services.items()
+                (k, v.with_context(collisions=v.names))
+                for k, v in naive.services.items()
             ]),
-            meta=naive.meta.context(naive.names),
+            meta=naive.meta.with_context(collisions=naive.names),
         )
 
     @cached_property

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -153,15 +153,6 @@ class Address:
             parent=self.parent + (self.name,) if self.name else self.parent,
         )
 
-    def context(self, collisions: Set[str]) -> 'Address':
-        """Return a derivative of this address with the provided context.
-
-        This method is used to address naming collisions. The returned
-        ``Address`` object aliases module names to avoid naming collisions in
-        the file being written.
-        """
-        return dataclasses.replace(self, collisions=frozenset(collisions))
-
     def rel(self, address: 'Address') -> str:
         """Return an identifier for this type, relative to the given address.
 
@@ -233,6 +224,15 @@ class Address:
             return f'{".".join(self.package)}.{selector}'
         return selector
 
+    def with_context(self, *, collisions: Set[str]) -> 'Address':
+        """Return a derivative of this address with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``Address`` object aliases module names to avoid naming collisions in
+        the file being written.
+        """
+        return dataclasses.replace(self, collisions=frozenset(collisions))
+
 
 @dataclasses.dataclass(frozen=True)
 class Metadata:
@@ -259,7 +259,7 @@ class Metadata:
             return '\n\n'.join(self.documentation.leading_detached_comments)
         return ''
 
-    def context(self, collisions: Set[str]) -> 'Metadata':
+    def with_context(self, *, collisions: Set[str]) -> 'Metadata':
         """Return a derivative of this metadata with the provided context.
 
         This method is used to address naming collisions. The returned
@@ -267,7 +267,7 @@ class Metadata:
         the file being written.
         """
         return dataclasses.replace(self,
-            address=self.address.context(collisions),
+            address=self.address.with_context(collisions=collisions),
         )
 
 

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -153,14 +153,14 @@ class Address:
             parent=self.parent + (self.name,) if self.name else self.parent,
         )
 
-    def context(self, context) -> 'Address':
+    def context(self, collisions: Set[str]) -> 'Address':
         """Return a derivative of this address with the provided context.
 
         This method is used to address naming collisions. The returned
         ``Address`` object aliases module names to avoid naming collisions in
         the file being written.
         """
-        return dataclasses.replace(self, collisions=frozenset(context.names))
+        return dataclasses.replace(self, collisions=frozenset(collisions))
 
     def rel(self, address: 'Address') -> str:
         """Return an identifier for this type, relative to the given address.
@@ -259,6 +259,17 @@ class Metadata:
             return '\n\n'.join(self.documentation.leading_detached_comments)
         return ''
 
+    def context(self, collisions: Set[str]) -> 'Metadata':
+        """Return a derivative of this metadata with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``Address`` object aliases module names to avoid naming collisions in
+        the file being written.
+        """
+        return dataclasses.replace(self,
+            address=self.address.context(collisions),
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class FieldIdentifier:
@@ -275,7 +286,3 @@ class FieldIdentifier:
         if self.repeated:
             return f'Sequence[{self.ident.sphinx}]'
         return self.ident.sphinx
-
-    def context(self, arg) -> 'FieldIdentifier':
-        """Return self. Provided for compatibility with Address."""
-        return self

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -181,12 +181,17 @@ class MessageType:
         references.
         """
         return dataclasses.replace(self,
-            fields={k: v.context(collisions) for k, v in self.fields.items()}
-                if not skip_fields else self.fields,
-            nested_enums={k: v.context(collisions)
-                for k, v in self.nested_enums.items()},
-            nested_messages={k: v.context(collisions, skip_fields=skip_fields)
-                for k, v in self.nested_messages.items()},
+            fields=collections.OrderedDict([
+                (k, v.context(collisions)) for k, v in self.fields.items()
+            ]) if not skip_fields else self.fields,
+            nested_enums=collections.OrderedDict([
+                (k, v.context(collisions))
+                for k, v in self.nested_enums.items()
+            ]),
+            nested_messages=collections.OrderedDict([
+                (k, v.context(collisions, skip_fields=skip_fields))
+                for k, v in self.nested_messages.items()
+            ]),
             meta=self.meta.context(collisions),
         )
 
@@ -619,7 +624,8 @@ class Service:
         in the file being written.
         """
         return dataclasses.replace(self,
-            methods={k: v.context(collisions)
-                for k, v in self.methods.items()},
+            methods=collections.OrderedDict([
+                (k, v.context(collisions)) for k, v in self.methods.items()
+            ]),
             meta=self.meta.context(collisions),
         )

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -128,6 +128,20 @@ class Field:
         raise TypeError('Unrecognized protobuf type. This code should '
                         'not be reachable; please file a bug.')
 
+    def context(self, collisions: Set[str]) -> 'Field':
+        """Return a derivative of this field with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``Field`` object aliases module names to avoid naming collisions
+        in the file being written.
+        """
+        return dataclasses.replace(self,
+            message=self.message.context(collisions, skip_fields=True)
+                if self.message else None,
+            enum=self.enum.context(collisions) if self.enum else None,
+            meta=self.meta.context(collisions),
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class MessageType:
@@ -152,7 +166,32 @@ class MessageType:
                 answer.append(field.type)
         return tuple(answer)
 
-    def get_field(self, *field_path: Sequence[str]) -> Field:
+    def context(self,
+            collisions: Set[str], *,
+            skip_fields: bool = False,
+            ) -> 'MessageType':
+        """Return a derivative of this message with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``MessageType`` object aliases module names to avoid naming collisions
+        in the file being written.
+
+        The ``skip_fields`` argument will omit applying the context to the
+        underlying fields. This provides for an "exit" in the case of circular
+        references.
+        """
+        return dataclasses.replace(self,
+            fields={k: v.context(collisions) for k, v in self.fields.items()}
+                if not skip_fields else self.fields,
+            nested_enums={k: v.context(collisions)
+                for k, v in self.nested_enums.items()},
+            nested_messages={k: v.context(collisions, skip_fields=skip_fields)
+                for k, v in self.nested_messages.items()},
+            meta=self.meta.context(collisions),
+        )
+
+    def get_field(self, *field_path: Sequence[str],
+            collisions: Set[str] = frozenset()) -> Field:
         """Return a field arbitrarily deep in this message's structure.
 
         This method recursively traverses the message tree to return the
@@ -171,12 +210,21 @@ class MessageType:
             KeyError: If a repeated field is used in the non-terminal position
                 in the path.
         """
+        # If collisions are not explicitly specified, retrieve them
+        # from this message's address.
+        # This ensures that calls to `get_field` will return a field with
+        # the same context, regardless of the number of levels through the
+        # chain (in order to avoid infinite recursion on circular references,
+        # we only shallowly bind message references held by fields; this
+        # binds deeply in the one spot where that might be a problem).
+        collisions = collisions or self.meta.address.collisions
+
         # Get the first field in the path.
         cursor = self.fields[field_path[0]]
 
         # Base case: If this is the last field in the path, return it outright.
         if len(field_path) == 1:
-            return cursor
+            return cursor.context(collisions)
 
         # Sanity check: If cursor is a repeated field, then raise an exception.
         # Repeated fields are only permitted in the terminal position.
@@ -191,7 +239,7 @@ class MessageType:
 
         # Recursion case: Pass the remainder of the path to the sub-field's
         # message.
-        return cursor.message.get_field(*field_path[1:])
+        return cursor.message.get_field(*field_path[1:], collisions=collisions)
 
     @property
     def ident(self) -> metadata.Address:
@@ -227,6 +275,15 @@ class EnumType:
     def ident(self) -> metadata.Address:
         """Return the identifier data to be used in templates."""
         return self.meta.address
+
+    def context(self, collisions: Set[str]) -> 'EnumType':
+        """Return a derivative of this enum with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``EnumType`` object aliases module names to avoid naming collisions in
+        the file being written.
+        """
+        return dataclasses.replace(self, meta=self.meta.context(collisions))
 
 
 @dataclasses.dataclass(frozen=True)
@@ -275,6 +332,7 @@ class OperationType:
                 name='Operation',
                 module='operation',
                 package=('google', 'api_core'),
+                collisions=self.lro_response.meta.address.collisions,
             ),
             documentation=descriptor_pb2.SourceCodeInfo.Location(
                 leading_comments='An object representing a long-running '
@@ -297,6 +355,18 @@ class OperationType:
         # that this generator is not forced to take an entire dependency
         # on google.api_core just to get these strings.
         return 'Operation'
+
+    def context(self, collisions: Set[str]) -> 'OperationType':
+        """Return a derivative of this operation with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``OperationType`` object aliases module names to avoid naming
+        collisions in the file being written.
+        """
+        return dataclasses.replace(self,
+            lro_response=self.lro_response.context(collisions),
+            lro_metadata=self.lro_metadata.context(collisions),
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -380,6 +450,19 @@ class Method:
 
         # Done; return a tuple of signatures.
         return MethodSignatures(all=tuple(answer))
+
+    def context(self, collisions: Set[str]) -> 'Method':
+        """Return a derivative of this method with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``Method`` object aliases module names to avoid naming collisions
+        in the file being written.
+        """
+        return dataclasses.replace(self,
+            input=self.input.context(collisions),
+            output=self.output.context(collisions),
+            meta=self.meta.context(collisions),
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -519,7 +602,7 @@ class Service:
         answer = set()
         for method in self.methods.values():
             for t in method.ref_types:
-                answer.add(t.ident.context(self).python_import)
+                answer.add(t.ident.python_import)
         return tuple(sorted(list(answer)))
 
     @property
@@ -527,3 +610,16 @@ class Service:
         """Return whether the service has a long-running method."""
         return any([getattr(m.output, 'lro_response', None)
                     for m in self.methods.values()])
+
+    def context(self, collisions: Set[str]) -> 'Service':
+        """Return a derivative of this service with the provided context.
+
+        This method is used to address naming collisions. The returned
+        ``Service`` object aliases module names to avoid naming collisions
+        in the file being written.
+        """
+        return dataclasses.replace(self,
+            methods={k: v.context(collisions)
+                for k, v in self.methods.items()},
+            meta=self.meta.context(collisions),
+        )

--- a/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/client.py.j2
@@ -51,15 +51,15 @@ class {{ service.name }}:
     @dispatch
     {% endif -%}
     def {{ method.name|snake_case }}(self,
-            request: {{ method.input.ident.context(service) }}, *,
+            request: {{ method.input.ident }}, *,
             retry: retry.Retry = None,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.ident.context(service) }}:
+            ) -> {{ method.output.ident }}:
         """{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
-            request ({{ method.input.ident.context(service).sphinx }}):
+            request ({{ method.input.ident.sphinx }}):
                 The request object.{{ ' ' -}}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             retry (~.retry.Retry): Designation of what errors, if any,
@@ -69,12 +69,12 @@ class {{ service.name }}:
                 sent along with the request as metadata.
 
         Returns:
-            {{ method.output.ident.context(service).sphinx }}:
+            {{ method.output.ident.sphinx }}:
                 {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         # Coerce the request to the protocol buffer object.
-        if not isinstance(request, {{ method.input.ident.context(service) }}):
-            request = {{ method.input.ident.context(service) }}(**request)
+        if not isinstance(request, {{ method.input.ident }}):
+            request = {{ method.input.ident }}(**request)
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
@@ -106,9 +106,9 @@ class {{ service.name }}:
         response = operation.from_gapic(
             response,
             self._transport.operations_client,
-            {{ method.output.lro_response.ident.context(service) }},
+            {{ method.output.lro_response.ident }},
             {%- if method.output.lro_metadata %}
-            metadata_type={{ method.output.lro_metadata.ident.context(service) }},
+            metadata_type={{ method.output.lro_metadata.ident }},
             {%- endif %}
         )
         {%- endif %}
@@ -120,18 +120,18 @@ class {{ service.name }}:
     @{{ method.name|snake_case }}.register
     def _{{ method.name|snake_case }}_with_{{ signature.dispatch_field.name|snake_case }}(self,
             {%- for field in signature.fields.values() %}
-            {{ field.name  }}: {{ field.ident.context(service) }}{% if loop.index0 > 0 and not field.required %} = None{% endif %},
+            {{ field.name  }}: {{ field.ident }}{% if loop.index0 > 0 and not field.required %} = None{% endif %},
             {%- endfor %}
             *,
             retry: retry.Retry = None,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.ident.context(service) }}:
+            ) -> {{ method.output.ident }}:
         """{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
             {%- for field in signature.fields.values() %}
-            {{ field.name }} ({{ field.ident.context(service).sphinx }}):
+            {{ field.name }} ({{ field.ident.sphinx }}):
                 {{ field.meta.doc|wrap(width=72, indent=16) }}
             {%- endfor %}
             retry (~.retry.Retry): Designation of what errors, if any,
@@ -141,11 +141,11 @@ class {{ service.name }}:
                 sent alont with the request as metadata.
 
         Returns:
-            {{ method.output.ident.context(service).sphinx }}:
+            {{ method.output.ident.sphinx }}:
                 {{ method.output.meta.doc|wrap(width=72, indent=16) }}
         """
         return self.{{ method.name|snake_case }}(
-            {{ method.input.ident.context(service) }}(
+            {{ method.input.ident }}(
                 {%- for field in signature.fields.values() %}
                 {{ field.name }}={{ field.name }},
                 {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/base.py.j2
@@ -57,8 +57,8 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
     @abc.abstractmethod
     def {{ method.name|snake_case }}(
             self,
-            request: {{ method.input.ident.context(service) }},
-            ) -> {{ method.output.ident.context(service) }}:
+            request: {{ method.input.ident }},
+            ) -> {{ method.output.ident }}:
         raise NotImplementedError
     {%- endfor %}
 

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/grpc.py.j2
@@ -82,8 +82,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
     @property
     def {{ method.name|snake_case }}(self) -> Callable[
-            [{{ method.input.ident.context(service) }}],
-            {{ method.output.ident.context(service) }}]:
+            [{{ method.input.ident }}],
+            {{ method.output.ident }}]:
         """Return a callable for the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=40, indent=8) }}
@@ -103,8 +103,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         if '{{ method.name|snake_case }}' not in self._stubs:
             self._stubs['{{ method.name|snake_case }}'] = self.grpc_channel.{{ method.grpc_stub_type }}(
                 '/{{ '.'.join(method.meta.address.package) }}.{{ service.name }}/{{ method.name }}',
-                request_serializer={{ method.input.ident.context(service) }}.serialize,
-                response_deserializer={{ method.output.ident.context(service) }}.deserialize,
+                request_serializer={{ method.input.ident }}.serialize,
+                response_deserializer={{ method.output.ident }}.deserialize,
             )
         return self._stubs['{{ method.name|snake_case }}']
     {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
+++ b/gapic/templates/$namespace/$name_$version/services/$service/transports/http.py.j2
@@ -65,23 +65,23 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
     {%- for method in service.methods.values() %}
 
     def {{ method.name|snake_case }}(self,
-            request: {{ method.input.ident.context(service) }}, *,
+            request: {{ method.input.ident }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> {{ method.output.ident.context(service) }}:
+            ) -> {{ method.output.ident }}:
         """Call the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=45, indent=8) }}
         {{- ' ' -}} method over HTTP.
 
         Args:
-            request (~.{{ method.input.ident.context(service) }}):
+            request (~.{{ method.input.ident }}):
                 The request object.
                 {{ method.input.meta.doc|rst(width=72, indent=16) }}
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent alont with the request as metadata.
 
         Returns:
-            ~.{{ method.output.ident.context(service) }}:
+            ~.{{ method.output.ident }}:
                 {{ method.output.meta.doc|rst(width=72, indent=16) }}
         """
         # Serialize the input.
@@ -102,7 +102,7 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
         )
 
         # Return the response.
-        return {{ method.output.ident.context(service) }}.FromString(
+        return {{ method.output.ident }}.FromString(
             response.content,
         )
     {%- endfor %}

--- a/gapic/templates/$namespace/$name_$version/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/_message.py.j2
@@ -16,7 +16,7 @@ class {{ message.name }}({{ p }}.Message):
     {%- for field in message.fields.values() %}
     {{ field.name }} = {{ p }}.{% if field.repeated %}Repeated{% endif %}Field({{ p }}.{{ field.proto_type }}, number={{ field.number }}
     {%- if field.enum or field.message %},
-        {{ field.proto_type.lower() }}={{ field.type.ident.context(proto).rel(message.ident) }},
+        {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
     {% endif %})
     """{{ field.meta.doc|rst(indent=4) }}"""
     {% endfor %}

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -25,12 +25,12 @@ def test_address_str():
     assert str(addr) == 'baz.Bacon'
 
 
-def test_address_str_context():
+def test_address_str_with_context():
     addr = metadata.Address(
         package=('foo', 'bar'),
         module='baz',
         name='Bacon',
-    ).context({'baz'})
+    ).with_context({'baz'})
     assert str(addr) == 'fb_baz.Bacon'
 
 

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -30,7 +30,7 @@ def test_address_str_with_context():
         package=('foo', 'bar'),
         module='baz',
         name='Bacon',
-    ).with_context({'baz'})
+    ).with_context(collisions={'baz'})
     assert str(addr) == 'fb_baz.Bacon'
 
 

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
 import typing
 
 from google.protobuf import descriptor_pb2

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -26,12 +26,11 @@ def test_address_str():
 
 
 def test_address_str_context():
-    Names = collections.namedtuple('Names', ['names'])
     addr = metadata.Address(
         package=('foo', 'bar'),
         module='baz',
         name='Bacon',
-    ).context(Names(names={'baz'}))
+    ).context({'baz'})
     assert str(addr) == 'fb_baz.Bacon'
 
 
@@ -139,11 +138,6 @@ def test_doc_trailing_trumps_detached():
 def test_doc_detached_joined():
     meta = make_doc_meta(detached=['foo', 'bar'])
     assert meta.doc == 'foo\n\nbar'
-
-
-def test_field_identifier_context():
-    fi = metadata.FieldIdentifier(ident=metadata.Address(), repeated=False)
-    assert fi.context(None) is fi
 
 
 def make_doc_meta(

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -119,6 +119,13 @@ def test_address_resolve():
     assert addr.resolve('google.example.Bacon') == 'google.example.Bacon'
 
 
+def test_metadata_with_context():
+    meta = metadata.Metadata()
+    assert meta.with_context(
+        collisions={'foo', 'bar'},
+    ).address.collisions == {'foo', 'bar'}
+
+
 def test_doc_nothing():
     meta = metadata.Metadata()
     assert meta.doc == ''

--- a/tests/unit/schema/wrappers/test_message.py
+++ b/tests/unit/schema/wrappers/test_message.py
@@ -45,6 +45,14 @@ def test_message_ident():
     assert message.ident.sphinx == '~.bar.Baz'
 
 
+def test_message_ident_collisions():
+    message = make_message('Baz', package='foo.v1', module='bar').with_context(
+        collisions={'bar'},
+    )
+    assert str(message.ident) == 'fv_bar.Baz'
+    assert message.ident.sphinx == '~.fv_bar.Baz'
+
+
 def test_get_field():
     fields = (make_field('field_one'), make_field('field_two'))
     message = make_message('Message', fields=fields)


### PR DESCRIPTION
This is an attempt to determine and resolve naming collisions logically prior to templates (in other words, so templates do not have to worry about it and they just get the "right thing").

Closes #57.