### PR TITLE
Add MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include README.rst LICENSE
+recursive-include gapic *.json *.proto
+recursive-include gapic/templates *.j2
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__


### PR DESCRIPTION
This is needed for templates to persist through a standard `pip install`.