### PR TITLE
add generic options flag to gapic script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN pip install /usr/src/gapic-generator-python
 # Define the generator as an entry point.
 ENTRYPOINT protoc --proto_path=/protos/ --proto_path=/in/ \
                   --python_gapic_out=/out/ \
+                  --python_gapic_opt=$PLUGIN_OPTIONS \
                   `find /in/ -name *.proto`

--- a/gapic.sh
+++ b/gapic.sh
@@ -20,11 +20,12 @@ CMD="$0"
 IMAGE=
 IN=
 OUT=
+PLUGIN_OPTIONS=
 PROTO_PATH=`pwd`
 
 # Print help and exit.
 function show_help {
-  echo "Usage: $CMD --image IMAGE --in IN_DIR --out OUT_DIR [--path PATH_DIR]"
+  echo "Usage: $CMD --image IMAGE --in IN_DIR --out OUT_DIR [--options PLUGIN_OPTIONS --path PATH_DIR]"
   echo ""
   echo "Required arguments:"
   echo "      --image  The Docker image to use. The script will attempt to pull"
@@ -34,9 +35,10 @@ function show_help {
   echo "  -o, --out    Destination directory for the completed client library."
   echo ""
   echo "Optional arguments:"
-  echo "  -p, --path   The base import path for the protos. Assumed to be the"
-  echo "               current working directory if unspecified."
-  echo "  -h, --help   This help information."
+  echo "      --options   Options to be passed to the generator plugin"
+  echo "  -p, --path      The base import path for the protos. Assumed to be the"
+  echo "                  current working directory if unspecified."
+  echo "  -h, --help      This help information."
   exit 0
 }
 
@@ -47,6 +49,7 @@ while true; do
     --image ) IMAGE="$2"; shift 2 ;;
     -i | --in ) IN="$2"; shift 2 ;;
     -o | --out ) OUT="$2"; shift 2 ;;
+    --options ) PLUGIN_OPTIONS="$2"; shift 2 ;;
     -p | --path ) PROTO_PATH=$2; shift 2 ;;
     -- ) shift; break; ;;
     * ) break ;;
@@ -97,5 +100,6 @@ docker run \
   --mount type=bind,source=$OUT,destination=/out \
   --rm \
   --user $UID \
+  --env "PLUGIN_OPTIONS=$PLUGIN_OPTIONS" \
   $IMAGE
 exit $?


### PR DESCRIPTION
* add `--options` to `gapic.sh`
* add `--python_gapic_opt=$PLUGIN_OPTIONS` to Docker wrapper's protoc invocation

Note: ^ this requires an image build to take effect

Note: cross tested the script using an updated gapic-generator-go image, which worked