### PR TITLE
[fix] Allow comments to end in close-quote.

### DIFF
--- a/gapic/utils/rst.py
+++ b/gapic/utils/rst.py
@@ -52,5 +52,11 @@ def rst(text, width=72, indent=0, source_format='commonmark'):
     if '\n' in answer:
         answer += '\n' + ' ' * indent
 
+    # If the text ends in a double-quote, append a period.
+    # This ensures that we do not get a parse error when this output is
+    # followed by triple-quotes.
+    if answer.endswith('"'):
+        answer += '.'
+
     # Done; return the answer.
     return answer

--- a/tests/unit/utils/test_rst.py
+++ b/tests/unit/utils/test_rst.py
@@ -39,3 +39,10 @@ def test_rst_add_newline():
         s = 'The hail in Wales\nfalls mainly on the snails.'
         assert utils.rst(s) == s + '\n'
         assert convert_text.call_count == 0
+
+
+def test_rst_pad_close_quote():
+    with mock.patch.object(pypandoc, 'convert_text') as convert_text:
+        s = 'A value, as in "foo"'
+        assert utils.rst(s) == s + '.'
+        assert convert_text.call_count == 0


### PR DESCRIPTION
This commit fixes an error where a short comment that ended with a `"` character would cause a parse error when placed inside a docstring.