### PR TITLE
[fix] Add MANIFEST.in to generated output.

### DIFF
--- a/gapic/templates/MANIFEST.in.j2
+++ b/gapic/templates/MANIFEST.in.j2
@@ -1,0 +1,2 @@
+recursive-include {{ '/'.join(api.naming.module_namespace + (api.naming.module_name,)) }} *.py
+recursive-include {{ '/'.join(api.naming.module_namespace + (api.naming.versioned_module_name,)) }} *.py


### PR DESCRIPTION
This ensures that when the library is installed, that all files are consistently copied, even when PEP 420 namespace packages are in use.