### PR TITLE
[fix] Nested messages in string form should always begin at root.

### DIFF
--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -176,14 +176,6 @@ class Address:
         """
         # Is this referencing a message in the same proto file?
         if self.package == address.package and self.module == address.module:
-            # It is possible that a field references a message that has
-            # not yet been declared. If so, send its name enclosed in quotes
-            # (a string) instead.
-            if (len(self.module_path) == len(address.module_path) and
-                    self.module_path > address.module_path or
-                    self == address):
-                return f"'{self.name}'"
-
             # Edge case: If two (or more) messages are nested under a common
             # parent message, and one references another, then return that
             # enclosed in quotes.
@@ -202,6 +194,12 @@ class Address:
             # namespace.
             if self.parent and self.parent[0] == address.name:
                 return '.'.join(self.parent[1:] + (self.name,))
+
+            # It is possible that a field references a message that has
+            # not yet been declared. If so, send its name enclosed in quotes
+            # (a string) instead.
+            if self.module_path > address.module_path or self == address:
+                return f"'{'.'.join(self.parent + (self.name,))}'"
 
             # This is a message in the same module, already declared.
             # Send its name.

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -104,6 +104,18 @@ def test_address_rel_nested_sibling():
     assert addr.rel(other) == "'Spam.Bacon'"
 
 
+def test_address_rel_nested_sibling_later():
+    addr = metadata.Address(
+        module='baz', name='Bacon', module_path=(4, 0, 3, 1),
+        package=('foo', 'bar'), parent=('Spam',)
+    )
+    other = metadata.Address(
+        module='baz', name='Ham', module_path=(4, 0, 3, 0),
+        package=('foo', 'bar'), parent=('Spam',)
+    )
+    assert addr.rel(other) == "'Spam.Bacon'"
+
+
 def test_address_rel_nested_parent():
     parent = metadata.Address(module='baz', name='Ham', package=('foo', 'bar'))
     child = metadata.Address(


### PR DESCRIPTION
This commit makes it so that when referring to nested messages as strings, the full qualified name is always used.

It fixes a bug where a partial name would be used if the referenced message was declared later.