### PR TITLE
[refactor] Explicitly declare the marshal using the package name.

### DIFF
--- a/gapic/templates/$namespace/$name_$version/types/$sub/$proto.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/$sub/$proto.py.j2
@@ -14,15 +14,6 @@ import proto{% if p != 'proto' %} as {{ p }}{% endif -%}
 {{ import_ }}
 {% endfor %}
 
-
-{% for enum in proto.top.enums.values() -%}
-    {% include '$namespace/$name_$version/types/$sub/_enum.py.j2' with context %}
-{% endfor %}
-
-{% for message in proto.top.messages.values() -%}
-    {% include "$namespace/$name_$version/types/$sub/_message.py.j2" with context %}
-{% endfor %}
-
 __all__ = (
     {%- for enum in proto.top.enums.values() %}
     '{{ enum.name }}',
@@ -31,4 +22,12 @@ __all__ = (
     '{{ message.name }}',
     {%- endfor %}
 )
+
+{% for enum in proto.top.enums.values() -%}
+    {% include '$namespace/$name_$version/types/$sub/_enum.py.j2' with context %}
+{% endfor %}
+
+{% for message in proto.top.messages.values() -%}
+    {% include "$namespace/$name_$version/types/$sub/_message.py.j2" with context %}
+{% endfor %}
 {% endwith %}{% endblock %}

--- a/gapic/templates/$namespace/$name_$version/types/$sub/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/types/$sub/_message.py.j2
@@ -23,4 +23,5 @@ class {{ message.name }}({{ p }}.Message):
 
     class Meta:
         package = '{{ message.ident.proto_package }}'
+        marshal = '{{ api.naming.warehouse_package_name }}'
 {{ '\n\n' }}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -22,7 +22,7 @@ setuptools.setup(
         'google-api-core >= 1.3.0, < 2.0.0dev',
         'googleapis-common-protos >= 1.6.0b6',
         'grpcio >= 1.10.0',
-        'proto-plus >= 0.1.0',
+        'proto-plus >= 0.2.1',
     ),
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
This makes it so that each installed package uses a distinct [proto-plus][1] marshal (allowing the ability for advanced customization without stomping on one another).

[1]: https://github.com/googleapis/proto-plus-python