### PR TITLE
Improve docstrings on proto messages.

### DIFF
--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -2,7 +2,7 @@
 
 {% block content %}
 import pkg_resources
-from typing import Mapping, Optional, Sequence, Tuple, Union
+from typing import Mapping, Optional, Sequence, Tuple, Type, Union
 
 from google.api_core import gapic_v1
 from google.api_core import retry
@@ -62,7 +62,7 @@ class {{ service.name }}:
         """{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
-            request ({{ method.input.ident.sphinx }}):
+            request (:class:`{{ method.input.ident.sphinx }}`):
                 The request object.{{ ' ' -}}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             retry (~.retry.Retry): Designation of what errors, if any,
@@ -158,15 +158,15 @@ class {{ service.name }}:
 
     @classmethod
     def get_transport_class(cls,
-            label: str = None) -> {{ service.name }}Transport:
+            label: str = None) -> Type[{{ service.name }}Transport]:
         """Return an appropriate transport class.
 
         Args:
-            label (str): The name of the desired transport. If none is
+            label: The name of the desired transport. If none is
                 provided, then the first transport in the registry is used.
 
         Returns:
-            Type[{{ service.name }}Transport]: The transport class to use.
+            The transport class to use.
         """
         # If a specific transport is requested, return that one.
         if label:

--- a/gapic/templates/$namespace/$name_$version/$sub/types/_enum.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/_enum.py.j2
@@ -1,5 +1,5 @@
 class {{ enum.name }}({{ e }}.IntEnum):
-    """{{ enum.meta.doc|rst(width=72, indent=4) }}"""
+    """{{ enum.meta.doc|rst(indent=4) }}"""
     {% for enum_value in enum.values -%}
     {{ enum_value.name }} = {{ enum_value.number }}
     {% endfor -%}

--- a/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
@@ -1,11 +1,21 @@
 class {{ message.name }}({{ p }}.Message):
-    """{{ message.meta.doc|rst(indent=4) }}"""
-    {# Iterate over nested enums. -#}
-    {% for enum in message.nested_enums.values() %}{% filter indent -%}
-        {% include '$namespace/$name_$version/$sub/types/_enum.py.j2' %}
-    {% endfilter %}{% endfor -%}
+    """{{ message.meta.doc|rst(indent=4) }}{% if message.fields|length %}
 
-    {#- Iterate over nested messages. -#}
+    Attributes:
+    {%- for field in message.fields.values() %}
+        {{ field.name }} ({{ field.ident.sphinx }}):
+            {{ field.meta.doc|rst(indent=12, nl=False) }}
+    {%- endfor %}
+    {% endif -%}
+    """
+    {# Iterate over nested enums. -#}
+    {% for enum in message.nested_enums.values() -%}
+        {% filter indent %}
+            {%- include '$namespace/$name_$version/$sub/types/_enum.py.j2' %}
+        {% endfilter %}
+    {% endfor -%}
+
+    {# Iterate over nested messages. -#}
     {% for submessage in message.nested_messages.values() -%}
         {% with message = submessage %}{% filter indent %}
             {%- include '$namespace/$name_$version/$sub/types/_message.py.j2' %}
@@ -13,11 +23,10 @@ class {{ message.name }}({{ p }}.Message):
     {% endfor -%}
 
     {# Iterate over fields. -#}
-    {%- for field in message.fields.values() %}
+    {% for field in message.fields.values() -%}
     {{ field.name }} = {{ p }}.{% if field.repeated %}Repeated{% endif %}Field({{ p }}.{{ field.proto_type }}, number={{ field.number }}
     {%- if field.enum or field.message %},
         {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
     {% endif %})
-    """{{ field.meta.doc|rst(indent=4) }}"""
-    {% endfor %}
+    {% endfor -%}
 {{ '\n\n' }}

--- a/tests/unit/utils/test_rst.py
+++ b/tests/unit/utils/test_rst.py
@@ -41,6 +41,20 @@ def test_rst_add_newline():
         assert convert_text.call_count == 0
 
 
+def test_rst_force_add_newline():
+    with mock.patch.object(pypandoc, 'convert_text') as convert_text:
+        s = 'The hail in Wales'
+        assert utils.rst(s, nl=True) == s + '\n'
+        assert convert_text.call_count == 0
+
+
+def test_rst_disable_add_newline():
+    with mock.patch.object(pypandoc, 'convert_text') as convert_text:
+        s = 'The hail in Wales\nfalls mainly on the snails.'
+        assert utils.rst(s, nl=False) == s
+        assert convert_text.call_count == 0
+
+
 def test_rst_pad_close_quote():
     with mock.patch.object(pypandoc, 'convert_text') as convert_text:
         s = 'A value, as in "foo"'


### PR DESCRIPTION
Change the output of proto messages to include the attribute descriptions in the overall class.

This is a bit clearer and also improves the output in Sphinx.