### PR TITLE
[refactor] Remove the `proto.top` attribute.

### DIFF
--- a/gapic/templates/$namespace/$name/__init__.py.j2
+++ b/gapic/templates/$namespace/$name/__init__.py.j2
@@ -19,7 +19,7 @@ from ..{{ api.naming.versioned_module_name }}.services.{{ service.name|snake_cas
 -#}
 {% for proto in api.protos.values()|sort(attribute='module_name')
         if proto.meta.address.subpackage == api.subpackage_view -%}
-{% for message in proto.top.messages.values()|sort(attribute='name') -%}
+{% for message in proto.messages.values()|sort(attribute='name') -%}
 from ..{{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
 {% endfor %}{% endfor %}
 
@@ -37,7 +37,7 @@ __all__ = (
     {%- endfor %}
     {%- for proto in api.protos.values()|sort(attribute='module_name')
             if proto.meta.address.subpackage == api.subpackage_view %}
-    {%- for message in proto.top.messages.values()|sort(attribute='name') %}
+    {%- for message in proto.messages.values()|sort(attribute='name') %}
     '{{ message.name }}',
     {%- endfor %}{% endfor %}
 )

--- a/gapic/templates/$namespace/$name_$version/$sub/__init__.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/__init__.py.j2
@@ -19,7 +19,7 @@ from .services.{{ service.name|snake_case }} import {{ service.name }}
 -#}
 {% for proto in api.protos.values()|sort(attribute='module_name')
         if proto.meta.address.subpackage == api.subpackage_view -%}
-{% for message in proto.top.messages.values()|sort(attribute='name') -%}
+{% for message in proto.messages.values()|sort(attribute='name') -%}
 from .types.{{ proto.module_name }} import {{ message.name }}
 {% endfor %}{% endfor %}
 
@@ -37,7 +37,7 @@ __all__ = (
     {%- endfor %}
     {%- for proto in api.protos.values()|sort(attribute='module_name')
             if proto.meta.address.subpackage == api.subpackage_view %}
-    {%- for message in proto.top.messages.values()|sort(attribute='name') %}
+    {%- for message in proto.messages.values()|sort(attribute='name') %}
     '{{ message.name }}',
     {%- endfor %}{% endfor %}
 )

--- a/gapic/templates/$namespace/$name_$version/$sub/types/$proto.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/$proto.py.j2
@@ -20,21 +20,21 @@ __protobuf__ = {{ p }}.module(
     marshal='{{ api.naming.proto_package }}',
     {% endif -%}
     manifest={
-    {%- for enum in proto.top.enums.values() %}
+    {%- for enum in proto.enums.values() %}
         '{{ enum.name }}',
     {%- endfor %}
-    {%- for message in proto.top.messages.values() %}
+    {%- for message in proto.messages.values() %}
         '{{ message.name }}',
     {%- endfor %}
     },
 )
 
 
-{% for enum in proto.top.enums.values() -%}
+{% for enum in proto.enums.values() -%}
     {% include '$namespace/$name_$version/$sub/types/_enum.py.j2' with context %}
 {% endfor %}
 
-{% for message in proto.top.messages.values() -%}
+{% for message in proto.messages.values() -%}
     {% include "$namespace/$name_$version/$sub/types/_message.py.j2" with context %}
 {% endfor %}
 {% endwith %}

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -332,14 +332,14 @@ def test_messages_nested():
     bar = 'google.example.v3.Foo.Bar'
 
     # Get the message.
-    assert len(proto.messages) == 2
-    assert proto.messages[foo].name == 'Foo'
-    assert proto.messages[bar].name == 'Bar'
+    assert len(proto.all_messages) == 2
+    assert proto.all_messages[foo].name == 'Foo'
+    assert proto.all_messages[bar].name == 'Bar'
 
-    # Assert that the `top` shim only shows top-level messages.
-    assert len(proto.top.messages) == 1
-    assert proto.top.messages[foo] is proto.messages[foo]
-    assert bar not in proto.top.messages
+    # Assert that the `messages` property only shows top-level messages.
+    assert len(proto.messages) == 1
+    assert proto.messages[foo] is proto.messages[foo]
+    assert bar not in proto.messages
 
 
 def test_services():


### PR DESCRIPTION
There is essentially never a point in template writing where it is *not* desirable to use top, so just use it all the time.

Refactors the original `messages` and `enums` properties to `all_messages` and `all_enums`.

Fixes #84.