### PR TITLE
change showcase image in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,7 +93,7 @@ jobs:
   showcase:
     docker:
       - image: python:3.7-slim
-      - image: gcr.io/gapic-showcase/gapic-showcase:0.0.12
+      - image: gcr.io/gapic-images/gapic-showcase:0.0.12
     steps:
       - checkout
       - run:


### PR DESCRIPTION
change gapic-showcase image URL to use new image registry `gcr.io/gapic-images`