### PR TITLE
[fix] Docstrings with generated content should be raw.

### DIFF
--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -59,7 +59,7 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.ident }}:
-        """{{ method.meta.doc|rst(width=72, indent=8) }}
+        r"""{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
             request (:class:`{{ method.input.ident.sphinx }}`):
@@ -126,7 +126,7 @@ class {{ service.name }}:
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.ident }}:
-        """{{ method.meta.doc|rst(width=72, indent=8) }}
+        r"""{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
             {%- for field in signature.fields.values() %}

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/grpc.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/grpc.py.j2
@@ -102,7 +102,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
     def {{ method.name|snake_case }}(self) -> Callable[
             [{{ method.input.ident }}],
             {{ method.output.ident }}]:
-        """Return a callable for the {{- ' ' -}}
+        r"""Return a callable for the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=40, indent=8) }}
         {{- ' ' -}} method over gRPC.

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/http.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/http.py.j2
@@ -71,7 +71,7 @@ class {{ service.name }}HttpTransport({{ service.name }}Transport):
             request: {{ method.input.ident }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.ident }}:
-        """Call the {{- ' ' -}}
+        r"""Call the {{- ' ' -}}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=45, indent=8) }}
         {{- ' ' -}} method over HTTP.

--- a/gapic/templates/$namespace/$name_$version/$sub/types/_enum.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/_enum.py.j2
@@ -1,5 +1,5 @@
 class {{ enum.name }}({{ e }}.IntEnum):
-    """{{ enum.meta.doc|rst(indent=4) }}"""
+    r"""{{ enum.meta.doc|rst(indent=4) }}"""
     {% for enum_value in enum.values -%}
     {{ enum_value.name }} = {{ enum_value.number }}
     {% endfor -%}

--- a/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
@@ -1,5 +1,5 @@
 class {{ message.name }}({{ p }}.Message):
-    """{{ message.meta.doc|rst(indent=4) }}{% if message.fields|length %}
+    r"""{{ message.meta.doc|rst(indent=4) }}{% if message.fields|length %}
 
     Attributes:
     {%- for field in message.fields.values() %}


### PR DESCRIPTION
This fixes an issue where comments with backslashes can cause a syntax error.