### PR TITLE
[chore] Silence W504 on flake8.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -6,3 +6,7 @@ ignore =
   # Line over-indented for visual indent.
   # This works poorly with type annotations in method declarations.
   E126, E128, E131
+  # Line break after binary operator.
+  # This catches line breaks after "and" / "or" as a means of breaking up
+  # long if statements, which PEP 8 explicitly encourages.
+  W504


### PR DESCRIPTION
PEP 8 explicitly encourages line breaks after binary operators
as a means of breaking up long if statements.