### PR TITLE
[fix] Fix LRO support, add Showcase test.

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -19,8 +19,8 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core >= 1.3.0, < 2.0.0dev',
-        'googleapis-common-protos >= 1.6.0b7',
+        'google-api-core >= 1.8.0, < 2.0.0dev',
+        'googleapis-common-protos >= 1.5.8',
         'grpcio >= 1.10.0',
         'proto-plus >= 0.3.0',
     ),

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     install_requires=(
         'click >= 6.7',
-        'googleapis-common-protos >= 1.6.0b7',
+        'googleapis-common-protos >= 1.6.0b8',
         'jinja2 >= 2.10',
         'protobuf >= 3.5.1',
         'pypandoc >= 1.4',

--- a/tests/system/test_grpc_lro.py
+++ b/tests/system/test_grpc_lro.py
@@ -1,0 +1,29 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from datetime import datetime, timedelta, timezone
+
+from google import showcase_v1alpha3
+
+
+def test_lro(echo):
+    wait_request = {
+        'end_time': datetime.now(tz=timezone.utc) + timedelta(seconds=1),
+        'success': {'content': 'The hail in Wales falls mainly '
+                               'on the snails...eventually.'},
+    }
+    future = echo.wait(wait_request)
+    response = future.result()
+    assert isinstance(response, showcase_v1alpha3.WaitResponse)
+    assert response.content.endswith('the snails...eventually.')


### PR DESCRIPTION
This commit fixes long-standing issues with LRO and adds a Showcase test for them.

The underlying changes are actually in api-core:

  * googleapis/google-cloud-python#7427
  * googleapis/google-cloud-python#7430

The tests will fail (thus preventing merge) until google-api-core 1.8.0 is released (see googleapis/google-cloud-python#7431).

Fixes #34.