### PR TITLE
[fix] Fix import error if a proto has only nested enums.

### DIFF
--- a/gapic/templates/$namespace/$name_$version/$sub/types/$proto.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/$proto.py.j2
@@ -2,7 +2,7 @@
 
 {% block content -%}
 {% with e = proto.disambiguate('enum'), p = proto.disambiguate('proto') %}
-{% if proto.enums|length -%}
+{% if proto.all_enums|length -%}
 import enum{% if e != 'enum' %} as {{ e }}{% endif %}
 
 {% endif -%}


### PR DESCRIPTION
No good way to add a test for that, but this is the kind of thing that generated unit tests _will_ catch.