### PR TITLE
Using HTTPS for git clone

### DIFF
--- a/docs/api-configuration.rst
+++ b/docs/api-configuration.rst
@@ -47,7 +47,7 @@ Your best bet is to likely clone this repository:
 
 .. code-block:: shell
 
-  $ git clone git@github.com:googleapis/api-common-protos.git
+  $ git clone https://github.com/googleapis/api-common-protos.git
   $ cd api-common-protos
   $ git checkout --track -b input-contract origin/input-contract
 

--- a/docs/getting-started/_example.rst
+++ b/docs/getting-started/_example.rst
@@ -7,7 +7,7 @@ a special branch:
 
 .. code-block:: shell
 
-  $ git clone git@github.com:googleapis/googleapis.git
+  $ git clone https://github.com/googleapis/googleapis.git
   $ cd googleapis
   $ git checkout --track -b input-contract origin/input-contract
   $ cd ..

--- a/docs/getting-started/local.rst
+++ b/docs/getting-started/local.rst
@@ -88,7 +88,7 @@ As for this library itself, the recommended installation approach is
     # Due to its experimental state, this tool is not published to a
     # package manager; you should clone it.
     # (You can pip install it from GitHub, not not if you want to tinker.)
-    git clone git@github.com:googleapis/gapic-generator-python.git
+    git clone https://github.com/googleapis/gapic-generator-python.git
     cd gapic-generator-python/
 
     # Install the tool. This will handle the virtualenv for you, and
@@ -123,7 +123,7 @@ which define certain client-specific annotations. These are in the
 
 .. code-block:: shell
 
-  $ git clone git@github.com:googleapis/api-common-protos.git
+  $ git clone https://github.com/googleapis/api-common-protos.git
   $ cd api-common-protos
   $ git checkout --track -b input-contract origin/input-contract
   $ cd ..


### PR DESCRIPTION
Fixes #111 
Using HTTPS instead of SSH can avoid the cases of Permission Denied (publicKey).