### PR TITLE
Remove package metadata

### DIFF
--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -17,7 +17,6 @@ import os
 import re
 from typing import Iterable, Sequence, Tuple
 
-from google.api import client_pb2
 from google.protobuf import descriptor_pb2
 
 from gapic import utils
@@ -116,37 +115,6 @@ class Naming:
             raise ValueError('All protos must have the same proto package '
                              'up to and including the version.')
 
-        # Iterate over the metadata annotations and collect the package
-        # information from there.
-        #
-        # This creates a naming class non-empty metadata annotation and
-        # uses Python's set logic to de-duplicate. There should only be one.
-        explicit_pkgs = set()
-        for fd in file_descriptors:
-            pkg = fd.options.Extensions[client_pb2.client_package]
-            naming = cls(
-                name=pkg.title or pkg.product_title,
-                namespace=tuple(pkg.namespace),
-                version=pkg.version,
-            )
-            if naming:
-                explicit_pkgs.add(naming)
-
-        # Sanity check: Ensure that any google.api.metadata provisions were
-        # consistent.
-        if len(explicit_pkgs) > 1:
-            raise ValueError(
-                'If the google.api.client_package annotation is provided in '
-                'more than one file, it must be consistent.',
-            )
-
-        # Merge the package naming information and the metadata naming
-        # information, with the latter being preferred.
-        # Return a Naming object which effectively merges them.
-        if len(explicit_pkgs):
-            return dataclasses.replace(package_info,
-                **dataclasses.asdict(explicit_pkgs.pop()),
-            )
         return package_info
 
     def __bool__(self):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     install_requires=(
         'click >= 6.7',
-        'googleapis-common-protos >= 1.5.10',
+        'googleapis-common-protos >= 1.6.0',
         'jinja2 >= 2.10',
         'protobuf >= 3.7.1',
         'pypandoc >= 1.4',

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     install_requires=(
         'click >= 6.7',
-        'googleapis-common-protos >= 1.6.0b8',
+        'googleapis-common-protos >= 1.5.10',
         'jinja2 >= 2.10',
         'protobuf >= 3.7.1',
         'pypandoc >= 1.4',

--- a/tests/unit/schema/test_naming.py
+++ b/tests/unit/schema/test_naming.py
@@ -14,7 +14,6 @@
 
 import pytest
 
-from google.api import client_pb2
 from google.protobuf import descriptor_pb2
 
 from gapic.schema import naming

--- a/tests/unit/schema/test_naming.py
+++ b/tests/unit/schema/test_naming.py
@@ -110,25 +110,6 @@ def test_build_no_annotations_no_version():
     assert n.version == ''
 
 
-def test_build_with_annotations():
-    proto = descriptor_pb2.FileDescriptorProto(
-        name='spanner.proto',
-        package='google.spanner.v1',
-    )
-    proto.options.Extensions[client_pb2.client_package].MergeFrom(
-        client_pb2.Package(
-            namespace=['Google', 'Cloud'],
-            title='Spanner',
-            version='v1',
-        ),
-    )
-    n = naming.Naming.build(proto)
-    assert n.name == 'Spanner'
-    assert n.namespace == ('Google', 'Cloud')
-    assert n.version == 'v1'
-    assert n.product_name == 'Spanner'
-
-
 def test_build_no_namespace():
     protos = (
         descriptor_pb2.FileDescriptorProto(
@@ -141,32 +122,6 @@ def test_build_no_namespace():
     assert n.namespace == ()
     assert n.version == ''
     assert n.product_name == 'Foo'
-
-
-def test_inconsistent_metadata_error():
-    # Set up the first proto.
-    proto1 = descriptor_pb2.FileDescriptorProto(
-        name='spanner.proto',
-        package='google.spanner.v1',
-    )
-    proto1.options.Extensions[client_pb2.client_package].MergeFrom(
-        client_pb2.Package(namespace=['Google', 'Cloud']),
-    )
-
-    # Set up the second proto.
-    # Note that
-    proto2 = descriptor_pb2.FileDescriptorProto(
-        name='spanner2.proto',
-        package='google.spanner.v1',
-    )
-    proto2.options.Extensions[client_pb2.client_package].MergeFrom(
-        client_pb2.Package(title='Spanner', namespace=['Google', 'Cloud']),
-    )
-
-    # This should error. Even though the data in the metadata is consistent,
-    # it is expected to exactly match, and it does not.
-    with pytest.raises(ValueError):
-        naming.Naming.build(proto1, proto2)
 
 
 def test_inconsistent_package_error():

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -16,6 +16,7 @@ import collections
 from typing import Sequence
 
 from google.api import annotations_pb2
+from google.api import client_pb2
 from google.api import http_pb2
 from google.protobuf import descriptor_pb2
 
@@ -200,6 +201,11 @@ def make_method(
     if http_rule:
         ext_key = annotations_pb2.http
         method_pb.options.Extensions[ext_key].MergeFrom(http_rule)
+
+    # If there are signatures, include them.
+    for sig in signatures:
+        ext_key = client_pb2.method_signature
+        method_pb.options.Extensions[ext_key].append(sig)
 
     # Instantiate the wrapper class.
     return wrappers.Method(

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -16,7 +16,6 @@ import collections
 from typing import Sequence
 
 from google.api import annotations_pb2
-from google.api import client_pb2
 from google.api import http_pb2
 from google.protobuf import descriptor_pb2
 
@@ -201,11 +200,6 @@ def make_method(
     if http_rule:
         ext_key = annotations_pb2.http
         method_pb.options.Extensions[ext_key].MergeFrom(http_rule)
-
-    # If there are signatures, include them.
-    for sig in signatures:
-        ext_key = client_pb2.method_signature
-        method_pb.options.Extensions[ext_key].append(sig)
 
     # Instantiate the wrapper class.
     return wrappers.Method(


### PR DESCRIPTION
This removes the `package` annotation that we never got in, and moves to a stable common protos package.