### PR TITLE
[feat] Add a CLI option to set the Python module

### DIFF
--- a/gapic/cli/generate.py
+++ b/gapic/cli/generate.py
@@ -56,7 +56,7 @@ def generate(
     # Build the API model object.
     # This object is a frozen representation of the whole API, and is sent
     # to each template in the rendering step.
-    api_schema = api.API.build(req.proto_file, package=package)
+    api_schema = api.API.build(req.proto_file, opts=opts, package=package)
 
     # Translate into a protobuf CodeGeneratorResponse; this reads the
     # individual templates and renders them.

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -26,7 +26,9 @@ class Options:
     on unrecognized arguments (essentially, we throw them away, but we do
     warn if it looks like it was meant for us).
     """
-    templates: Tuple[str]
+    templates: Tuple[str] = dataclasses.field(default=('DEFAULT',))
+    namespace: Tuple[str] = dataclasses.field(default=())
+    name: str = ''
 
     @classmethod
     def build(cls, opt_string: str) -> 'Options':
@@ -70,6 +72,8 @@ class Options:
 
         # Build the options instance.
         answer = Options(
+            name=opts.pop('name', ['']).pop(),
+            namespace=tuple(opts.pop('namespace', [])),
             templates=tuple([os.path.expanduser(i) for i in templates]),
         )
 

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -59,12 +59,12 @@ class Options:
             # Set the option.
             # Just assume everything is a list at this point, and the
             # final instantiation step can de-list-ify where appropriate.
-            opts.setdefault(opt, [])
-            opts[opt].append(value)
+            opts.setdefault(opt[13:], [])
+            opts[opt[13:]].append(value)
 
         # If templates are specified, one of the specified directories
         # may be our default; perform that replacement.
-        templates = opts.pop('python-gapic-templates', ['DEFAULT'])
+        templates = opts.pop('templates', ['DEFAULT'])
         while 'DEFAULT' in templates:
             templates[templates.index('DEFAULT')] = os.path.realpath(
                 os.path.join(os.path.dirname(__file__), '..', 'templates'),

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -56,11 +56,13 @@ class Options:
             if not opt.startswith('python-gapic-'):
                 continue
 
-            # Set the option.
+            # Set the option, using a key with the "python-gapic-" prefix
+            # stripped.
+            #
             # Just assume everything is a list at this point, and the
             # final instantiation step can de-list-ify where appropriate.
-            opts.setdefault(opt[13:], [])
-            opts[opt[13:]].append(value)
+            opts.setdefault(opt[len('python-gapic-'):], [])
+            opts[opt[len('python-gapic-'):]].append(value)
 
         # If templates are specified, one of the specified directories
         # may be our default; perform that replacement.

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -80,7 +80,7 @@ class Options:
         # If there are any options remaining, then we failed to recognize
         # them -- complain.
         for key in opts.keys():
-            warnings.warn(f'Unrecognized option: `{key}`.')
+            warnings.warn(f'Unrecognized option: `python-gapic-{key}`.')
 
         # Done; return the built options.
         return answer

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -26,6 +26,7 @@ from typing import Callable, List, Mapping, Sequence, Set, Tuple
 from google.longrunning import operations_pb2
 from google.protobuf import descriptor_pb2
 
+from gapic.generator import options
 from gapic.schema import metadata
 from gapic.schema import wrappers
 from gapic.schema import naming as api_naming
@@ -179,7 +180,8 @@ class API:
     @classmethod
     def build(cls,
             file_descriptors: Sequence[descriptor_pb2.FileDescriptorProto],
-            package: str = '') -> 'API':
+            package: str = '',
+            opts: options.Options = options.Options()) -> 'API':
         """Build the internal API schema based on the request.
 
         Args:
@@ -190,12 +192,13 @@ class API:
                 code should be explicitly generated (including subpackages).
                 Protos with packages outside this list are considered imports
                 rather than explicit targets.
+            opts (~.options.Options): CLI options passed to the generator.
         """
         # Save information about the overall naming for this API.
         naming = api_naming.Naming.build(*filter(
             lambda fd: fd.package.startswith(package),
             file_descriptors,
-        ))
+        ), opts=opts)
 
         # Iterate over each FileDescriptorProto and fill out a Proto
         # object describing it, and save these to the instance.

--- a/tests/unit/schema/test_naming.py
+++ b/tests/unit/schema/test_naming.py
@@ -16,6 +16,7 @@ import pytest
 
 from google.protobuf import descriptor_pb2
 
+from gapic.generator import options
 from gapic.schema import naming
 
 
@@ -142,6 +143,72 @@ def test_subpackages():
     assert n.name == 'Ads'
     assert n.namespace == ('Google',)
     assert n.version == 'v0'
+
+
+def test_cli_override_name():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.cloud.videointelligence.v1')
+    n = naming.Naming.build(proto1,
+        opts=options.Options(name='Video Intelligence'),
+    )
+    assert n.namespace == ('Google', 'Cloud')
+    assert n.name == 'Video Intelligence'
+    assert n.version == 'v1'
+
+
+def test_cli_override_name_underscores():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.cloud.videointelligence.v1')
+    n = naming.Naming.build(proto1,
+        opts=options.Options(name='video_intelligence'),
+    )
+    assert n.namespace == ('Google', 'Cloud')
+    assert n.name == 'Video Intelligence'
+    assert n.version == 'v1'
+
+
+def test_cli_override_namespace():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.spanner.v1')
+    n = naming.Naming.build(proto1,
+        opts=options.Options(namespace=('google', 'cloud')),
+    )
+    assert n.namespace == ('Google', 'Cloud')
+    assert n.name == 'Spanner'
+    assert n.version == 'v1'
+
+
+def test_cli_override_namespace_dotted():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.spanner.v1')
+    n = naming.Naming.build(proto1,
+        opts=options.Options(namespace=('google.cloud',)),
+    )
+    assert n.namespace == ('Google', 'Cloud')
+    assert n.name == 'Spanner'
+    assert n.version == 'v1'
+
+
+def test_cli_override_name_and_namespace():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.translation.v2')
+    n = naming.Naming.build(proto1,
+        opts=options.Options(namespace=('google', 'cloud'), name='translate'),
+    )
+    assert n.namespace == ('Google', 'Cloud')
+    assert n.name == 'Translate'
+    assert n.version == 'v2'
+
+
+def test_cli_override_name_and_namespace_versionless():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.translation')
+    n = naming.Naming.build(proto1,
+        opts=options.Options(namespace=('google', 'cloud'), name='translate'),
+    )
+    assert n.namespace == ('Google', 'Cloud')
+    assert n.name == 'Translate'
+    assert not n.version
 
 
 def make_naming(**kwargs) -> naming.Naming:


### PR DESCRIPTION
This allows us to translate between the actual proto package and the desired Python module when automatic inference does the wrong thing (e.g. think `google.spanner.v1` -> `google.cloud.spanner_v1`).