### PR TITLE
[fix] Do not silently drop `--python-gapic-` options.

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -25,10 +25,10 @@ while [ -n "$1" ]; do
     * )
       # If this switch begins with "--python-gapic-" or "--gapic-", then it is
       # meant for us.
-      if [ "${1:0:15}" == "--python-gapic-" ]; then
+      if [[ $1 == --python-gapic-* ]]; then
         PLUGIN_OPTIONS="$PLUGIN_OPTIONS,$1=$2"
         shift 2
-      else if [ "${1:0:8}" == "--gapic-" ]; then
+      else if [[ $1 == --gapic-* ]]; then
         PLUGIN_OPTIONS="$PLUGIN_OPTIONS,$1=$2"
         shift 2
       else

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,17 +18,23 @@ PLUGIN_OPTIONS=""
 # Parse out options.
 while [ -n "$1" ]; do
   case "$1" in
-    --python-gapic-templates )
-      PLUGIN_OPTIONS="$PLUGIN_OPTIONS,python-gapic-templates=$2"
-      shift 2
-      ;;
     -- )
       shift
       break
       ;;
     * )
-      # Ignore anything we do not recognize.
-      shift
+      # If this switch begins with "--python-gapic-" or "--gapic-", then it is
+      # meant for us.
+      if [ "${1:0:15}" == "--python-gapic-" ]; then
+        PLUGIN_OPTIONS="$PLUGIN_OPTIONS,$1=$2"
+        shift 2
+      else if [ "${1:0:8}" == "--gapic-" ]; then
+        PLUGIN_OPTIONS="$PLUGIN_OPTIONS,$1=$2"
+        shift 2
+      else
+        # Ignore anything we do not recognize.
+        shift
+      fi
       ;;
   esac
 done


### PR DESCRIPTION
This is a follow-up to #126, where I added a CLI option, but neglected to update the Docker entrypoint script to actually pass it on to the generator, making the option useless when using Docker (the common case for now).

This updates the script to be more robust, and check the prefix rather than an index of every known option.