### PR TITLE
[feat] Add mypy checks to the generated output.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,20 @@ workflows:
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
+      - showcase-mypy:
+          requires:
+            - unit-3.6
+            - unit-3.7
+          filters:
+            tags:
+              only: /^\d+\.\d+\.\d+$/
       - showcase:
           requires:
             - docs
             - mypy
             - showcase-unit-3.6
             - showcase-unit-3.7
+            - showcase-mypy
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/
@@ -208,6 +216,30 @@ jobs:
       - run:
           name: Run unit tests.
           command: nox -s showcase_unit-3.7
+  showcase-mypy:
+    docker:
+      - image: python:3.7-slim
+    steps:
+      - checkout
+      - run:
+          name: Install system dependencies.
+          command: |
+            apt-get update
+            apt-get install -y curl pandoc unzip
+      - run:
+          name: Install protoc 3.7.1.
+          command: |
+            mkdir -p /usr/src/protoc/
+            curl --location https://github.com/google/protobuf/releases/download/v3.7.1/protoc-3.7.1-linux-x86_64.zip --output /usr/src/protoc/protoc-3.7.1.zip
+            cd /usr/src/protoc/
+            unzip protoc-3.7.1.zip
+            ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
+      - run:
+          name: Install nox.
+          command: pip install nox
+      - run:
+          name: Typecheck the generated output.
+          command: nox -s showcase_mypy
   unit-3.6:
     docker:
       - image: python:3.6-slim

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,8 +28,7 @@ workflows:
               only: /^\d+\.\d+\.\d+$/
       - showcase-mypy:
           requires:
-            - unit-3.6
-            - unit-3.7
+            - mypy
           filters:
             tags:
               only: /^\d+\.\d+\.\d+$/

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -176,7 +176,8 @@ class Generator:
         )
 
         # Sanity check: Do not render empty files.
-        if utils.empty(cgr_file.content) and not fn.endswith('__init__.py'):
+        if (utils.empty(cgr_file.content) and
+                not fn.endswith(('py.typed', '__init__.py'))):
             return {}
 
         # Return the filename and content in a length-1 dictionary

--- a/gapic/schema/imp.py
+++ b/gapic/schema/imp.py
@@ -31,4 +31,6 @@ class Import:
             answer = f"from {'.'.join(self.package)} {answer}"
         if self.alias:
             answer += f' as {self.alias}'
+        if self.module.endswith('_pb2'):
+            answer += '  # type: ignore'
         return answer

--- a/gapic/templates/$namespace/$name/__init__.py.j2
+++ b/gapic/templates/$namespace/$name/__init__.py.j2
@@ -3,13 +3,15 @@
 {% block content %}
 {#  Import subpackages. -#}
 {% for subpackage in api.subpackages.keys() -%}
-from ..{{ api.naming.versioned_module_name }} import {{ subpackage }}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
+    {{ api.naming.versioned_module_name }} import {{ subpackage }}
 {% endfor -%}
 
 {#  Import services for this package. -#}
 {% for service in api.services.values()|sort(attribute='name')
         if service.meta.address.subpackage == api.subpackage_view -%}
-from ..{{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }} import {{ service.name }}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
+    {{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.name }}
 {% endfor -%}
 
 {#  Import messages from each proto.
@@ -20,7 +22,8 @@ from ..{{ api.naming.versioned_module_name }}.services.{{ service.name|snake_cas
 {% for proto in api.protos.values()|sort(attribute='module_name')
         if proto.meta.address.subpackage == api.subpackage_view -%}
 {% for message in proto.messages.values()|sort(attribute='name') -%}
-from ..{{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
+    {{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
 {% endfor %}{% endfor %}
 
 {#  Define __all__.

--- a/gapic/templates/$namespace/$name/py.typed.j2
+++ b/gapic/templates/$namespace/$name/py.typed.j2
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# The {{ api.naming.warehouse_package_name }} package uses inline types.

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -1,13 +1,14 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+from collections import OrderedDict
+from typing import Dict, Mapping, Optional, Sequence, Tuple, Type, Union
 import pkg_resources
-from typing import Mapping, Optional, Sequence, Tuple, Type, Union
 
-from google.api_core import exceptions
-from google.api_core import gapic_v1
-from google.api_core import retry as retries
-from google.auth import credentials
+from google.api_core import exceptions        # type: ignore
+from google.api_core import gapic_v1          # type: ignore
+from google.api_core import retry as retries  # type: ignore
+from google.auth import credentials           # type: ignore
 
 {% filter sort_lines -%}
 {% for method in service.methods.values() -%}
@@ -16,11 +17,42 @@ from google.auth import credentials
 {% endfor -%}
 {% endfor -%}
 {% endfilter %}
-from .transports import _transport_registry
-from .transports import {{ service.name }}Transport
+from .transports.base import {{ service.name }}Transport
+from .transports.grpc import {{ service.name }}GrpcTransport
 
 
-class {{ service.name }}:
+class {{ service.name }}Meta(type):
+    """Metaclass for the {{ service.name }} client.
+
+    This provides class-level methods for building and retrieving
+    support objects (e.g. transport) without polluting the client instance
+    objects.
+    """
+    _transport_registry = OrderedDict()  # type: Dict[str, Type[{{ service.name }}Transport]]
+    _transport_registry['grpc'] = {{ service.name }}GrpcTransport
+
+    def get_transport_class(cls,
+            label: str = None,
+            ) -> Type[{{ service.name }}Transport]:
+        """Return an appropriate transport class.
+
+        Args:
+            label: The name of the desired transport. If none is
+                provided, then the first transport in the registry is used.
+
+        Returns:
+            The transport class to use.
+        """
+        # If a specific transport is requested, return that one.
+        if label:
+            return cls._transport_registry[label]
+
+        # No transport is requested; return the default (that is, the first one
+        # in the dictionary).
+        return next(iter(cls._transport_registry.values()))
+
+
+class {{ service.name }}(metaclass={{ service.name }}Meta):
     """{{ service.meta.doc|rst(width=72, indent=4) }}"""
     def __init__(self, *,
             host: str{% if service.host %} = '{{ service.host }}'{% endif %},
@@ -50,7 +82,7 @@ class {{ service.name }}:
                                  'provide its credentials directly.')
             self._transport = transport
         else:
-            Transport = self.get_transport_class(transport)
+            Transport = type(self).get_transport_class(transport)
             self._transport = Transport(credentials=credentials, host=host)
 
     {% for method in service.methods.values() -%}
@@ -168,28 +200,7 @@ class {{ service.name }}:
         return response
         {%- endif %}
         {{ '\n' }}
-    {% endfor -%}
-
-    @classmethod
-    def get_transport_class(cls,
-            label: str = None,
-            ) -> Type[{{ service.name }}Transport]:
-        """Return an appropriate transport class.
-
-        Args:
-            label: The name of the desired transport. If none is
-                provided, then the first transport in the registry is used.
-
-        Returns:
-            The transport class to use.
-        """
-        # If a specific transport is requested, return that one.
-        if label:
-            return _transport_registry[label]
-
-        # No transport is requested; return the default (that is, the first one
-        # in the dictionary).
-        return next(iter(_transport_registry.values()))
+    {% endfor %}
 
 
 try:

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/__init__.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/__init__.py.j2
@@ -1,14 +1,15 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-import collections
+from collections import OrderedDict
+from typing import Dict, Type
 
 from .base import {{ service.name }}Transport
 from .grpc import {{ service.name }}GrpcTransport
 
 
 # Compile a registry of transports.
-_transport_registry = collections.OrderedDict()
+_transport_registry = OrderedDict()  # type: Dict[str, Type[{{ service.name }}Transport]]
 _transport_registry['grpc'] = {{ service.name }}GrpcTransport
 
 

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/base.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/base.py.j2
@@ -6,9 +6,9 @@ import typing
 
 from google import auth
 {%- if service.has_lro %}
-from google.api_core import operations_v1
+from google.api_core import operations_v1  # type: ignore
 {%- endif %}
-from google.auth import credentials
+from google.auth import credentials  # type: ignore
 
 {% filter sort_lines -%}
 {% for method in service.methods.values() -%}
@@ -20,7 +20,7 @@ from google.auth import credentials
 class {{ service.name }}Transport(metaclass=abc.ABCMeta):
     """Abstract transport class for {{ service.name }}."""
 
-    AUTH_SCOPES: typing.Tuple[str] = (
+    AUTH_SCOPES = (
         {%- for scope in service.oauth_scopes %}
         '{{ scope }}',
         {%- endfor %}
@@ -63,10 +63,10 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
     {%- endif %}
     {%- for method in service.methods.values() %}
 
-    def {{ method.name|snake_case }}(
-            self,
-            request: {{ method.input.ident }},
-            ) -> {{ method.output.ident }}:
+    @property
+    def {{ method.name|snake_case }}(self) -> typing.Callable[
+            [{{ method.input.ident }}],
+            {{ method.output.ident }}]:
         raise NotImplementedError
     {%- endfor %}
 

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/grpc.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/transports/grpc.py.j2
@@ -1,15 +1,15 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-from typing import Callable, Sequence, Tuple
+from typing import Callable, Dict, Sequence, Tuple
 
-from google.api_core import grpc_helpers
+from google.api_core import grpc_helpers   # type: ignore
 {%- if service.has_lro %}
-from google.api_core import operations_v1
+from google.api_core import operations_v1  # type: ignore
 {%- endif %}
-from google.auth import credentials
+from google.auth import credentials        # type: ignore
 
-import grpc
+import grpc  # type: ignore
 
 {% filter sort_lines -%}
 {% for method in service.methods.values() -%}
@@ -57,7 +57,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
         # Run the base constructor.
         super().__init__(host=host, credentials=credentials)
-        self._stubs = {}
+        self._stubs = {}  # type: Dict[str, Callable]
 
         # If a channel was explicitly provided, set it.
         if channel:

--- a/gapic/templates/$namespace/$name_$version/$sub/services/__init__.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/__init__.py.j2
@@ -1,0 +1,1 @@
+{% extends '_base.py.j2' %}

--- a/gapic/templates/$namespace/$name_$version/$sub/types/$proto.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/$proto.py.j2
@@ -3,7 +3,7 @@
 {% block content -%}
 {% with p = proto.disambiguate('proto') %}
 {% if proto.messages|length or proto.all_enums|length -%}
-import proto{% if p != 'proto' %} as {{ p }}{% endif -%}
+import proto{% if p != 'proto' %} as {{ p }}{% endif %}  # type: ignore
 {% endif %}
 
 {% for import_ in proto.python_modules -%}

--- a/gapic/templates/$namespace/$name_$version/py.typed.j2
+++ b/gapic/templates/$namespace/$name_$version/py.typed.j2
@@ -1,0 +1,2 @@
+# Marker file for PEP 561.
+# The {{ api.naming.warehouse_package_name }} package uses inline types.

--- a/gapic/templates/mypy.ini.j2
+++ b/gapic/templates/mypy.ini.j2
@@ -1,0 +1,3 @@
+[mypy]
+python_version = 3.5
+namespace_packages = True

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -3,7 +3,7 @@
 {% block content %}
 import os
 
-import nox
+import nox  # type: ignore
 
 
 @nox.session(python=['3.6', '3.7'])
@@ -21,5 +21,20 @@ def unit(session):
         '--cov-report=term',
         '--cov-report=html',
         os.path.join('tests', 'unit', '{{ api.naming.versioned_module_name }}'),
+    )
+
+
+@nox.session(python=['3.6', '3.7'])
+def mypy(session):
+    """Run the type checker."""
+    session.install('mypy')
+    session.install('.')
+    session.run(
+        'mypy',
+        {%- if api.naming.module_namespace %}
+        '{{ api.naming.module_namespace[0] }}',
+        {%- else %}
+        '{{ api.naming.versioned_module_name }}',
+        {%- endif %}
     )
 {% endblock %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -1,10 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-import io
-import os
-
-import setuptools
+import setuptools  # type: ignore
 
 
 setuptools.setup(

--- a/tests/unit/schema/test_imp.py
+++ b/tests/unit/schema/test_imp.py
@@ -30,6 +30,11 @@ def test_str_alias():
     assert str(i) == 'from foo.bar import baz as bacon'
 
 
+def test_str_untyped_pb2():
+    i = imp.Import(package=('foo', 'bar'), module='baz_pb2', alias='bacon')
+    assert str(i) == 'from foo.bar import baz_pb2 as bacon  # type: ignore'
+
+
 def test_str_eq():
     i1 = imp.Import(package=('foo', 'bar'), module='baz')
     i2 = imp.Import(package=('foo', 'bar'), module='baz')


### PR DESCRIPTION
Many things can not be typechecked yet due to Python 2 compatibility. We will come back to those as we move everything to Python 3.5+.

We also do not yet have exported type-checking in proto-plus; I will make a subsequent PR to remove the `#type: ignore` from that import once proto-plus type checking is fully in place and exported.