### PR TITLE
Initial commit for samplegen and associated unit tests

### DIFF
--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -25,7 +25,6 @@ from gapic import utils
 from gapic.generator import formatter
 from gapic.generator import options
 from gapic.schema import api
-from gapic.samplegen import utils as sampleutils
 
 
 class Generator:
@@ -55,7 +54,6 @@ class Generator:
         self._env.filters['snake_case'] = utils.to_snake_case
         self._env.filters['sort_lines'] = utils.sort_lines
         self._env.filters['wrap'] = utils.wrap
-        self._env.filters["split_downcase"] = sampleutils.split_caps_and_downcase
 
     def get_response(self, api_schema: api.API) -> CodeGeneratorResponse:
         """Return a :class:`~.CodeGeneratorResponse` for this library.

--- a/gapic/samplegen/__init__.py
+++ b/gapic/samplegen/__init__.py
@@ -1,0 +1,21 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from gapic.samplegen import samplegen
+from gapic.samplegen import utils
+
+__all__ = (
+    'samplegen',
+    'utils',
+)

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -1,0 +1,288 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import keyword
+import re
+import gapic.samplegen.utils
+
+from collections import defaultdict
+
+# Outstanding issues:
+# * Neither license nor copyright are defined
+# * In real sample configs, many variables are
+#   defined with an _implicit_ $resp variable.
+
+MIN_SCHEMA_VERSION = (1, 2, 0)
+
+VALID_CONFIG_TYPE = 'com.google.api.codegen.SampleConfigProto'
+
+# There are a couple of other names that should be reserved
+# for sample variable assignments, e.g. 'client', but there are diminishing returns:
+# the sample config author isn't a pathological adversary, they're a normal person
+# who may make mistakes occasionally.
+RESERVED_WORDS = frozenset(itertools.chain(keyword.kwlist, dir(__builtins__)))
+
+TEMPLATE_NAME = 'samplegen_template.j2'
+
+
+class ReservedVariableName(Exception):
+    pass
+
+
+class SchemaVersion(Exception):
+    pass
+
+
+class RpcMethodNotFound(Exception):
+    pass
+
+
+class InvalidConfigType(Exception):
+    pass
+
+
+class InvalidStatement(Exception):
+    pass
+
+
+class BadLoop(Exception):
+    pass
+
+
+class MismatchedPrintStatement(Exception):
+    pass
+
+
+class UndefinedVariableReference(Exception):
+    pass
+
+
+class BadAssignment(Exception):
+    pass
+
+
+class InconsistentRequestName(Exception):
+    pass
+
+
+class InvalidRequestSetup(Exception):
+    pass
+
+
+class DuplicateInputParameter(Exception):
+    pass
+
+
+def validate_response(response):
+    coll_kword = "collection"
+    var_kword = "variable"
+    map_kword = "map"
+    key_kword = "key"
+    val_kword = "value"
+    body_kword = "body"
+    # Do NOT need checks for valid lexical scoping
+    # because of python variable definition rules.
+    # E.g. the following is valid python:
+    #
+    # for i in range(10):
+    #   squid = "Squid {}".format(i)
+    #
+    # print("Last squid is {}".format(squid))
+
+    def handle_define(body):
+        m = re.match(r"^([^=]+)=([^=]+)$", body)
+        if not m:
+            raise BadAssignment("Bad assignment statement: {}", body)
+
+        var, rval = m.groups()
+        if var in RESERVED_WORDS:
+            raise ReservedVariableName(
+                "Tried to define a variable with reserved name: {}".format(var))
+
+        rval_base = rval.split(".")[0]
+        if not rval_base in var_defs:
+            raise UndefinedVariableReference("Reference to undefined variable: {}"
+                                             .format(rval_base))
+        # TODO: Need to validate the attributes of the response
+        #       based on the method return type.
+        # TODO: Need to check the defined variables
+        #       if the rhs references a non-response variable.
+        #
+        # Note: really checking for safety would be equivalent to
+        #       re-implementing the python interpreter.
+        var_defs.add(var)
+
+    def handle_print(body):
+        fmtStr = body[0]
+        numPrints = fmtStr.count("%s")
+        if numPrints != len(body) - 1:
+            raise MismatchedPrintStatement(
+                "Expected {} expresssions in print statement but received {}"
+                .format(numPrints, len(body) - 1))
+
+        for expression in body[1:]:
+            var = expression.split(".")[0]
+            if var not in var_defs:
+                raise UndefinedVariableReference("Reference to undefined variable: {}"
+                                                 .format(var))
+
+    def handle_comment(body):
+        fmtStr = body[0]
+        numVars = fmtStr.count("%s")
+        if numVars != len(body) - 1:
+            raise MismatchedPrintStatement(
+                "Expected {} var names in comment but received {}"
+                .format(numVars, len(body) - 1))
+
+        for var_name in body[1:]:
+            var_base = var_name.split(".")[0]
+            if var_base not in var_defs:
+                raise UndefinedVariableReference("Reference to undefined variable: {}"
+                                                 .format(var_base))
+
+    def handle_loop(body):
+        segments = set(body.keys())
+        map_args = {map_kword, body_kword}
+        if {coll_kword, var_kword, body_kword} == segments:
+            collection_name = body[coll_kword].split(".")[0]
+            # TODO: resolve the implicit $resp dilemma
+            # if collection_name.startswith("."):
+            #     collection_name = "$resp" + collection_name
+            if collection_name not in var_defs:
+                raise UndefinedVariableReference("Reference to undefined variable: {}"
+                                                 .format(collection_name))
+
+            var = body[var_kword]
+            if var in RESERVED_WORDS:
+                raise ReservedVariableName(
+                    "Tried to define a variable with reserved name: {}".format(var))
+
+            var_defs.add(var)
+
+            inner_validate(body[body_kword])
+
+        elif map_args <= segments:
+            segments -= {map_kword, body_kword}
+            map_name_base = body[map_kword].split(".")[0]
+            if map_name_base not in var_defs:
+                raise UndefinedVariableReference("Reference to undefined variable: {}"
+                                                 .format(map_name_base))
+
+            key = body.get(key_kword)
+            if key:
+                if key in RESERVED_WORDS:
+                    raise ReservedVariableName(
+                        "Tried to define a variable with reserved name: {}".format(key))
+
+                var_defs.add(key)
+                segments.remove(key_kword)
+
+            val = body.get(val_kword)
+            if val:
+                if val in RESERVED_WORDS:
+                    raise ReservedVariableName(
+                        "Tried to define a variable with reserved name: {}".format(val))
+
+                var_defs.add(val)
+                segments.remove(val_kword)
+
+            if not (key or val):
+                raise BadLoop(
+                    "Need at least one of 'key' or 'value' in a map loop")
+
+            if segments:
+                raise BadLoop("Unexpected keywords in loop statement: {}"
+                              .format(segments))
+
+            inner_validate(body[body_kword])
+
+        else:
+            raise BadLoop("Unexpected loop form: {}".format(segments))
+
+    # The response variable is special and guaranteed to exist.
+    var_defs = {"$resp"}
+    statement_dispatcher = {
+        "define": handle_define,
+        "print": handle_print,
+        "loop": handle_loop,
+        "comment": handle_comment
+    }
+
+    def inner_validate(sample_segment):
+        for statement in sample_segment:
+            if len(statement) != 1:
+                raise InvalidStatement(
+                    "Invalid statement: {}".format(statement))
+
+            keyword, body = next(iter(statement.items()))
+            handler = statement_dispatcher.get(keyword)
+            if not handler:
+                raise InvalidStatement("Invalid statement keyword: {}"
+                                       .format(keyword))
+
+            handler(body)
+
+        return True
+
+    return inner_validate(response)
+
+
+# TODO: this will eventually need the method name and the proto file
+# so that it can do the correct value transformation for enums.
+def validate_and_transform_request(request):
+    base_param_to_attrs = defaultdict(list)
+    input_params = set()
+    # request looks like
+    # [{"field": base.attr, "value": value, "input_parameter": varname},
+    # {"field": base.attr, "value": value, "comment": helpful_comment},
+    # {"field": base.attr, "value": value, value_is_file: True }]
+    #
+    # The base does not need to be the same for all arguments;
+    # input_parameter, comment, and value_is_file are all optional.
+    for field_assignment in request:
+        field_assignment_copy = dict(field_assignment)
+        input_param = field_assignment_copy.get("input_parameter")
+        if input_param:
+            if input_param in input_params:
+                raise DuplicateInputParameter(
+                    "Already declared input parameter: {}", input_param)
+
+            if input_param in RESERVED_WORDS:
+                raise ReservedVariableName(
+                    "Invalid input_parameter name: {}", input_param)
+
+            input_params.add(input_param)
+
+        field = field_assignment_copy.get("field")
+        if not field:
+            raise InvalidRequestSetup(
+                "No field attribute found in request setup assignment: {}",
+                field_assignment_copy)
+
+        m = re.match("^([^.]+)\.([^.]+)$", field)
+        if not m:
+            raise InvalidRequestSetup(
+                "Malformed request attribute description: {}", field)
+
+        base, attr = m.groups()
+        if base in RESERVED_WORDS:
+            raise ReservedVariableName(
+                "Tried to define '{}', which is a reserved name".format(base))
+
+        field_assignment_copy["field"] = attr
+        base_param_to_attrs[base].append(field_assignment_copy)
+
+    return [{"base": base, "body": body}
+            for base, body in base_param_to_attrs.items()]

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -37,6 +37,8 @@ RESERVED_WORDS = frozenset(itertools.chain(keyword.kwlist, dir(__builtins__)))
 
 TEMPLATE_NAME = 'samplegen_template.j2'
 
+TransformedRequest = namedtuple("TransformedRequest", ["base", "body"])
+
 
 class SampleError(Exception):
     pass
@@ -66,11 +68,15 @@ class BadLoop(SampleError):
     pass
 
 
-class MismatchedPrintStatement(SampleError):
+class MismatchedFormatSpecifier(SampleError):
     pass
 
 
 class UndefinedVariableReference(SampleError):
+    pass
+
+
+class RedefinedVariable(SampleError):
     pass
 
 
@@ -86,11 +92,14 @@ class InvalidRequestSetup(SampleError):
     pass
 
 
-class DuplicateInputParameter(SampleError):
-    pass
+class Validator:
+    """
+    Class that validates samples.
 
+    Contains methods that validate different segments of a sample and maintains
+    state that's relevant to validation across different segments.
+    """
 
-class ResponseValidator:
     COLL_KWORD = "collection"
     VAR_KWORD = "variable"
     MAP_KWORD = "map"
@@ -98,36 +107,132 @@ class ResponseValidator:
     VAL_KWORD = "value"
     BODY_KWORD = "body"
 
-    def __init__(self, response):
-        """Validates a "response" block from a sample config.
-
-        A full description of the response block is outside the scope of this code
-        and is better handled by reading the samplegen documentation.
-
+    def __init__(self):
+        """
         Args:
            response: list[dict{str:?}]: The structured data representing
                                         the sample's response.
+        """
+
+        # The response ($resp) variable is special and guaranteed to exist.
+        self.var_defs_: Set[str] = {"$resp"}
+
+    # TODO: this will eventually need the method name and the proto file
+    # so that it can do the correct value transformation for enums.
+    def validate_and_transform_request(self,
+                                       request: List[Mapping[str, str]]) -> List[TransformedRequest]:
+        """Validates the "request" block from a sample config and returns a transformed
+           version that aggregates attribute bases for use in the sample templates.
+
+           In the initial request, each dict has a "field" key that maps to a dotted
+           variable name, e.g. clam.shell.
+           Multiple dicts may share a variable base name; these indicate that multiple
+           attributes of a request parameter are being configured.
+
+           The only required keys in each dict are "field" and value".
+           Optional keys are "input_parameter" and "value_is_file".
+           All values in the initial request are strings
+           except for the value for "value_is_file", which is a bool.
+
+           The topmost dict of the return value has two keys: "base" and "body",
+           where "base" maps to a variable name, and "body" maps to a list of variable
+           assignment definitions. The only difference in the bottommost dicts
+           are that "field" maps only to the second part of a dotted variable name.
+           Other key/value combinations in the dict are unmodified for the time being.
+
+           TODO: Conduct module lookup and expansion for protobuf enums.
+                 Requires proto/method/message descriptors.
+           TODO: Permit single level field/oneof requst parameters.
+                 Requires proto/method/message descriptors.
+           TODO: Add/transform to list repeated element fields.
+                 Requires proto/method/message descriptors.
+
+           E.g. [{"field": "clam.shell", "value": "10 kg", "input_parameter": "shell"},
+                 {"field": "clam.pearls", "value": "3"},
+                 {"field": "squid.mantle", "value": "100 kg"}]
+                  ->
+                [TransformedRequest("clam",
+                  [{"field": "shell", "value": "10 kg", "input_parameter": "shell"},
+                   {"field": "pearls", "value": "3"}]),
+                 TransformedRequest("squid", [{"field": "mantle", "value": "100 kg"}])]
+
+           The transformation makes it easier to set up request parameters in jinja
+           because it doesn't have to engage in prefix detection, validation,
+           or aggregation logic.
+
+
+        Args:
+            request (list[dict{str:str}]): The request body from the sample config
+
+        Returns:
+            list[dict{str:(str|list[dict{str:str}])}]: The transformed request block.
 
         Raises:
-            BadAssignment: If a "define" statement is badly formed.
-            ReservedVariablename: If an attempted lvalue is a reserved word.
-            UndefinedVariableReference: If an attempted rvalue base is a previously
-                                        undeclared variable.
-            MismatchedPrintStatement: If the number of format string segments ("%s") in
-                                      a "print" or "comment" block does not equal the
-                                      size number of strings in the block minus 1.
-            BadLoop: If a "loop" segments has unexpected keywords
-                     or keyword combinatations.
+            RedefinedVariable: If an "input_parameter" attempts to redefine a
+                               previously defined variable.
+            ReservedVariableName: If an "input_parameter" value or a "base" value
+                                  is a reserved word.
+            InvalidRequestSetup: If a dict in the request lacks a "field" key
+                                 or the corresponding value is malformed.
+        """
+        base_param_to_attrs: Mapping[str,
+                                     List[Mapping[str, str]]] = defaultdict(list)
+        for field_assignment in request:
+            field_assignment_copy = dict(field_assignment)
+            input_param = field_assignment_copy.get("input_parameter")
+            if input_param:
+                self._handle_lvalue(input_param)
+
+            field = field_assignment_copy.get("field")
+            if not field:
+                raise InvalidRequestSetup(
+                    "No field attribute found in request setup assignment: {}",
+                    field_assignment_copy)
+
+            # TODO: properly handle top level fields
+            # E.g.
+            #
+            #  -field: edition
+            #   comment: The edition of the series.
+            #   value: '123'
+            #   input_parameter: edition
+            m = re.match(r"^([^.]+)\.([^.]+)$", field)
+            if not m:
+                raise InvalidRequestSetup(
+                    "Malformed request attribute description: {}", field)
+
+            base, attr = m.groups()
+            if base in RESERVED_WORDS:
+                raise ReservedVariableName(
+                    "Tried to define '{}', which is a reserved name".format(base))
+
+            field_assignment_copy["field"] = attr
+            base_param_to_attrs[base].append(field_assignment_copy)
+
+        return [TransformedRequest(base, body)
+                for base, body in base_param_to_attrs.items()]
+
+    def validate_response(self, response):
+        """Validates a "response" block from a sample config.
+
+        A full description of the response block is outside the scope of this code;
+        refer to the samplegen documentation.
+
+
+        Dispatches statements to sub-validators.
+
+        Args:
+            response: list[dict{str:?}]: The structured data representing
+                                         the sample's response.
+
+        Returns:
+            bool: True if response is valid.
+
+        Raises:
             InvalidStatement: If an unexpected key is found in a statement dict
                               or a statement dict has more than or less than one key.
         """
 
-        # The response ($resp) variable is special and guaranteed to exist.
-        self.var_defs_ = {"$resp"}
-
-        self.inner_validate_(response)
-
-    def inner_validate_(self, response):
         for statement in response:
             if len(statement) != 1:
                 raise InvalidStatement(
@@ -141,25 +246,45 @@ class ResponseValidator:
 
             validater(self, body)
 
-    def validate_comment_(self, body: List[str]):
-        fmt_str = body[0]
-        num_vars = fmt_str.count("%s")
-        if num_vars != len(body) - 1:
-            raise MismatchedPrintStatement(
-                "Expected {} var names in comment but received {}"
-                .format(num_vars, len(body) - 1))
+        return True
 
-        for var_name in body[1:]:
-            var_base = var_name.split(".")[0]
-            if var_base not in self.var_defs_:
-                raise UndefinedVariableReference("Reference to undefined variable: {}"
-                                                 .format(var_base))
+    def _handle_lvalue(self, lval):
+        """Internal helper method that does safety checks on an lvalue
+           and adds it to lexical scope.
 
-    def validate_print_(self, body: List[str]):
+        Raises:
+            ReservedVariableName: If an attempted lvalue is a reserved keyword.
+        """
+        if lval in RESERVED_WORDS:
+            raise ReservedVariableName(
+                "Tried to define a variable with reserved name: {}".format(lval))
+
+        # Even though it's valid python to reassign variables to any rvalue,
+        # the samplegen spec prohibits this.
+        if lval in self.var_defs_:
+            raise RedefinedVariable(
+                "Tried to redefine variable: {}".format(lval))
+
+        self.var_defs_.add(lval)
+
+    def _validate_format(self, body: List[str]):
+        """Validates a format string and corresponding arguments.
+
+         The number of format tokens in the string must equal the
+         number of arguments, and each argument must be a defined variable.
+
+         TODO: the attributes of the variable must correspond to attributes
+               of the variable's type.        
+
+         Raises:
+             MismatchedFormatSpecifier: If the number of format string segments ("%s") in
+                                        a "print" or "comment" block does not equal the
+                                        size number of strings in the block minus 1.
+        """
         fmt_str = body[0]
         num_prints = fmt_str.count("%s")
         if num_prints != len(body) - 1:
-            raise MismatchedPrintStatement(
+            raise MismatchedFormatSpecifier(
                 "Expected {} expresssions in print statement but received {}"
                 .format(num_prints, len(body) - 1))
 
@@ -169,20 +294,14 @@ class ResponseValidator:
                 raise UndefinedVariableReference("Reference to undefined variable: {}"
                                                  .format(var))
 
-    def validate_define_(self, body: str):
-        m = re.match(r"^([^=]+)=([^=]+)$", body)
-        if not m:
-            raise BadAssignment("Bad assignment statement: {}", body)
+    def _validate_define(self, body: str):
+        """"Validates 'define' statements.
 
-        var, rval = m.groups()
-        if var in RESERVED_WORDS:
-            raise ReservedVariableName(
-                "Tried to define a variable with reserved name: {}".format(var))
-
-        rval_base = rval.split(".")[0]
-        if not rval_base in self.var_defs_:
-            raise UndefinedVariableReference("Reference to undefined variable: {}"
-                                             .format(rval_base))
+         Raises:
+             BadAssignment: If a "define" statement is badly formed lexically.
+             UndefinedVariableReference: If an attempted rvalue base is a previously
+                                         undeclared variable.
+        """
         # TODO: Need to validate the attributes of the response
         #       based on the method return type.
         # TODO: Need to check the defined variables
@@ -190,9 +309,36 @@ class ResponseValidator:
         #
         # Note: really checking for safety would be equivalent to
         #       re-implementing the python interpreter.
-        self.var_defs_.add(var)
+        m = re.match(r"^([^=]+)=([^=]+)$", body)
+        if not m:
+            raise BadAssignment("Bad assignment statement: {}", body)
 
-    def validate_loop_(self, body):
+        lval, rval = m.groups()
+        self._handle_lvalue(lval)
+
+        rval_base = rval.split(".")[0]
+        if not rval_base in self.var_defs_:
+            raise UndefinedVariableReference("Reference to undefined variable: {}"
+                                             .format(rval_base))
+
+    def _validate_loop(self, body):
+        """Validates loop headers and statement bodies.
+
+        Checks for correctly defined loop constructs,
+        either 'collection' loops with a collection and iteration variable,
+        or 'map' loops with a map and at least one of 'key' or 'value'.
+        Loops also have a 'body', which contains statments that may
+        use the variables from the header.
+
+        The body statements are validated recursively.
+
+        Raises:
+            UndefinedVariableReference: If an attempted rvalue base is a previously
+                                        undeclared variable.
+            BadLoop: If a "loop" segments has unexpected keywords
+                     or keyword combinatations.
+
+        """
         segments = set(body.keys())
         map_args = {self.MAP_KWORD, self.BODY_KWORD}
 
@@ -204,12 +350,14 @@ class ResponseValidator:
         #     handle(m)
         #   print("Last mollusc: {}".format(m))
         #
-        # is valid python, the samplegen spec requires that errors are raised
+        # is allowed, the samplegen spec requires that errors are raised
         # if strict lexical scoping is violated.
         previous_defs = set(self.var_defs_)
 
         if {self.COLL_KWORD, self.VAR_KWORD, self.BODY_KWORD} == segments:
             collection_name = body[self.COLL_KWORD].split(".")[0]
+            # TODO: Once proto info is being passed in, validate the
+            #       [1:] in the collection name.
             # TODO: resolve the implicit $resp dilemma
             # if collection_name.startswith("."):
             #     collection_name = "$resp" + collection_name
@@ -218,16 +366,15 @@ class ResponseValidator:
                                                  .format(collection_name))
 
             var = body[self.VAR_KWORD]
-            if var in RESERVED_WORDS:
-                raise ReservedVariableName(
-                    "Tried to define a variable with reserved name: {}".format(var))
-
-            self.var_defs_.add(var)
-
-            self.inner_validate_(body[self.BODY_KWORD])
+            self._handle_lvalue(var)
 
         elif map_args <= segments:
-            segments -= {self.MAP_KWORD, self.BODY_KWORD}
+            segments -= map_args
+            segments -= {self.KEY_KWORD, self.VAL_KWORD}
+            if segments:
+                raise BadLoop("Unexpected keywords in loop statement: {}"
+                              .format(segments))
+
             map_name_base = body[self.MAP_KWORD].split(".")[0]
             if map_name_base not in self.var_defs_:
                 raise UndefinedVariableReference("Reference to undefined variable: {}"
@@ -235,142 +382,30 @@ class ResponseValidator:
 
             key = body.get(self.KEY_KWORD)
             if key:
-                if key in RESERVED_WORDS:
-                    raise ReservedVariableName(
-                        "Tried to define a variable with reserved name: {}".format(key))
-
-                self.var_defs_.add(key)
-                segments.remove(self.KEY_KWORD)
+                self._handle_lvalue(key)
 
             val = body.get(self.VAL_KWORD)
             if val:
-                if val in RESERVED_WORDS:
-                    raise ReservedVariableName(
-                        "Tried to define a variable with reserved name: {}".format(val))
-
-                self.var_defs_.add(val)
-                segments.remove(self.VAL_KWORD)
+                self._handle_lvalue(val)
 
             if not (key or val):
                 raise BadLoop(
                     "Need at least one of 'key' or 'value' in a map loop")
 
-            if segments:
-                raise BadLoop("Unexpected keywords in loop statement: {}"
-                              .format(segments))
-
-            self.inner_validate_(body[self.BODY_KWORD])
-
         else:
             raise BadLoop("Unexpected loop form: {}".format(segments))
 
+        self.validate_response(body[self.BODY_KWORD])
         # Restore the previous lexical scope.
         # This is stricter than python scope rules
         # because the samplegen spec mandates it.
         self.var_defs_ = previous_defs
 
-    # Add new statement keywords to this table
+    # Add new statement keywords to this table.
+    # TODO: add write_file validator and entry (and tests).
     STATEMENT_DISPATCH_TABLE = {
-        "define": validate_define_,
-        "print": validate_print_,
-        "loop": validate_loop_,
-        "comment": validate_comment_
+        "define": _validate_define,
+        "print": _validate_format,
+        "comment": _validate_format,
+        "loop": _validate_loop,
     }
-
-
-TransformedRequest = namedtuple("TransformedRequest", ["base", "body"])
-
-
-# TODO: this will eventually need the method name and the proto file
-# so that it can do the correct value transformation for enums.
-def validate_and_transform_request(request: List[Mapping[str, str]]) -> List[TransformedRequest]:
-    """Checks the "request" block from a sample config and returns a transformed version.
-
-       In the initial request, each dict has a "field" key that maps to a dotted
-       variable name, e.g. clam.shell.
-       Multiple dicts may share a variable base name; these indicate that multiple
-       attributes of a request parameter are being configured.
-
-       The only required keys in each dict are "field" and value".
-       Optional keys are "input_parameter" and "value_is_file".
-       All values in the initial request are strings
-       except for the value for "value_is_file", which is a bool.
-
-       The topmost dict of the return value has two keys: "base" and "body",
-       where "base" maps to a variable name, and "body" maps to a list of variable
-       assignment definitions. The only difference in the bottommost dicts
-       are that "field" maps only to the second part of a dotted variable name.
-       Other key/value combinations in the dict are unmodified for the time being.
-
-       E.g. [{"field": "clam.shell", "value": "10 kg", "input_parameter": "shell"},
-             {"field": "clam.pearls", "value": "3"},
-             {"field": "squid.mantle", "value": "100 kg"}]
-              ->
-            [TransformedRequest("clam",
-              [{"field": "shell", "value": "10 kg", "input_parameter": "shell"},
-               {"field": "pearls", "value": "3"}]),
-             TransformedRequest("squid", [{"field": "mantle", "value": "100 kg"}])]
-
-       The transformation makes it easier to set up request parameters in jinja
-       because it doesn't have to engage in prefix detection, validation,
-       or aggregation logic.
-
-
-    Args:
-        request (list[dict{str:str}]): The request body from the sample config
-
-    Returns:
-        list[dict{str:(str|list[dict{str:str}])}]: The transformed request block.
-
-    Raises:
-        DuplicateInputParameter: If an "input_parameter" value is repeated.
-        ReservedVariableName: If an "input_parameter" value or a "base" value
-                              is a reserved word.
-        InvalidRequestSetup: If a dict in the request lacks a "field" key
-                             or the corresponding value is malformed.
-    """
-    base_param_to_attrs: Mapping[str,
-                                 List[Mapping[str, str]]] = defaultdict(list)
-    input_params: Set[str] = set()
-    for field_assignment in request:
-        field_assignment_copy = dict(field_assignment)
-        input_param = field_assignment_copy.get("input_parameter")
-        if input_param:
-            if input_param in input_params:
-                raise DuplicateInputParameter(
-                    "Already declared input parameter: {}", input_param)
-
-            if input_param in RESERVED_WORDS:
-                raise ReservedVariableName(
-                    "Invalid input_parameter name: {}", input_param)
-
-            input_params.add(input_param)
-
-        field = field_assignment_copy.get("field")
-        if not field:
-            raise InvalidRequestSetup(
-                "No field attribute found in request setup assignment: {}",
-                field_assignment_copy)
-
-        # TODO: properly handle top level fields
-        # E.g.
-        #
-        #  -field: edition
-        #   comment: The edition of the series.
-        #   value: '123'
-        #   input_parameter: edition
-        m = re.match(r"^([^.]+)\.([^.]+)$", field)
-        if not m:
-            raise InvalidRequestSetup(
-                "Malformed request attribute description: {}", field)
-
-        base, attr = m.groups()
-        if base in RESERVED_WORDS:
-            raise ReservedVariableName(
-                "Tried to define '{}', which is a reserved name".format(base))
-
-        field_assignment_copy["field"] = attr
-        base_param_to_attrs[base].append(field_assignment_copy)
-
-    return [TransformedRequest(base, body)
-            for base, body in base_param_to_attrs.items()]

--- a/gapic/samplegen/utils.py
+++ b/gapic/samplegen/utils.py
@@ -41,18 +41,3 @@ class CallingForm(Enum):
             return cls.RequestStreamingServer
 
         return cls.Request
-
-
-def split_caps_and_downcase(s):
-    # API method names are pased in CamelCase
-    # but python samples want snake case.
-    # Don't do the join here for the sake of modularity.
-    toks = []
-    base_idx = 0
-    for idx, char in enumerate(s):
-        if base_idx != idx and char.isupper():
-            toks.append(s[base_idx:idx].lower())
-            base_idx = idx
-
-    toks.append(s[base_idx:].lower())
-    return toks

--- a/gapic/samplegen/utils.py
+++ b/gapic/samplegen/utils.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing miscellaneous utilities
+that will eventually move somewhere else (probably)."""
+
+from enum import Enum, auto
+
+
+class CallingForm(Enum):
+    Request = auto()
+    RequestPaged = auto()
+    LongRunningRequestAsync = auto()
+    RequestStreamingClient = auto()
+    RequestStreamingServer = auto()
+    RequestStreamingBidi = auto()
+    RequestPagedAll = auto()
+    LongRunningPromise = auto()
+
+    @classmethod
+    def method_default(cls, m):
+        if m.lro:
+            return cls.LongRunningRequestAsync
+        if m.paged_result_field:
+            return cls.RequestPagedAll
+        if m.client_streaming:
+            return (cls.RequestStreamingBidi if m.server_streaming else
+                    cls.RequestStreamingClient)
+        if m.server_streaming:
+            return cls.RequestStreamingServer
+
+        return cls.Request
+
+
+def split_caps_and_downcase(s):
+    # API method names are pased in CamelCase
+    # but python samples want snake case.
+    # Don't do the join here for the sake of modularity.
+    toks = []
+    base_idx = 0
+    for idx, char in enumerate(s):
+        if base_idx != idx and char.isupper():
+            toks.append(s[base_idx:idx].lower())
+            base_idx = idx
+
+    toks.append(s[base_idx:].lower())
+    return toks

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -18,7 +18,7 @@
 A careful reader may comment that there is duplication of effort
 between the python verification step and the dispatch/rendering here.
 There is a little, but not enough for it to be important because
-1) Other python artefacts (client libraries, unit tests, and so forth)
+1) Other python artifacts (client libraries, unit tests, and so forth)
    are generated using templates, so doing the same for generated samples is consistent.
 2) Using jinja for anything requiring real logic or data structures is a bad idea.
 #}
@@ -52,7 +52,7 @@ print({{ ([fmtStr] + elts[1:])|join(', ') }})
 
 {% macro renderCollectionLoop(statement) %}
 for {{ statement.variable }} in {{ statement.collection }}:
-  {{ dispatchStatement(statement.body) -}}
+    {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
 {% macro renderMapLoop(statement) %}
@@ -64,7 +64,7 @@ for {{ statement.key }} in {{ statement.map }}.keys():
 {% else %}
 for {{statement.key }}, {{ statement.value }} in {{ statement.map }}.items():
 {% endif %}
-  {{ dispatchStatement(statement.body) -}}
+    {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
 {% macro dispatchStatement(statement) %}
@@ -93,7 +93,7 @@ for {{statement.key }}, {{ statement.value }} in {{ statement.map }}.items():
 # {{ attr.input_parameter }} = "{{ attr.value }}"
     {% if "value_is_file" in attr and attr.value_is_file %}
 with open({{ attr.input_parameter }}, "rb") as f:
-  {{ baseName }}["{{ attr.field }}"] = f.read()
+    {{ baseName }}["{{ attr.field }}"] = f.read()
     {% else %}
 {{ baseName }}["{{ attr.field }}"] = {{ attr.input_parameter }}
     {% endif %}
@@ -113,22 +113,22 @@ with open({{ attr.input_parameter }}, "rb") as f:
 
 {% macro renderMainBlock(methodName, requestBlock) %}
 def main():
-  import argparse
+    import argparse
 
-  parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser()
 {% with arg_list = [] %}
 {% for attr in requestBlock if "input_parameter" in attr %}
-  parser.add_argument("--{{ attr.input_parameter }}",
-                      type=str,
-                      default="{{ attr.value }}")
+    parser.add_argument("--{{ attr.input_parameter }}",
+                        type=str,
+                        default="{{ attr.value }}")
 {% do arg_list.append("args." + attr.input_parameter) -%}
 {% endfor %}
-  args = parser.parse_args()
+    args = parser.parse_args()
 
-  sample_{{ methodName|split_downcase|join("_") }}({{ arg_list|join(", ") }})
+    sample_{{ methodName|snake_case }}({{ arg_list|join(", ") }})
 
 
 if __name__ == "__main__":
-  main()
+    main()
 {% endwith %}
 {% endmacro %}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -1,0 +1,127 @@
+{#
+ # Copyright (C) 2019  Google LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+ #}
+
+{#
+A careful reader may comment that there is duplication of effort
+between the python verification step and the dispatch/rendering here.
+There is a little, but not enough for it to be important because
+1) Other python artefacts (client libraries, unit tests, and so forth)
+   are generated using templates, so doing the same for generated samples is consistent.
+2) Using jinja for anything requiring real logic or data structures is a bad idea.
+#}
+
+{# response handling macros #}
+
+{% macro handlePrint(elts) %}
+  {# First elment is a format string, remaining elements are the format string parameters #}
+  {# Validating that the number of format params equals #}
+  {# the number of remaining params is handled by real python code #}
+  {% with fmtStr = ('\"' + elts[0] + '\"') |replace("%s", "{}") %}
+print({{ ([fmtStr] + elts[1:])|join(', ') }})
+  {% endwith -%}
+{% endmacro %}
+
+{% macro handleComment(elts) %}
+  {# First elment is a format string, remaining elements are the format string parameters #}
+  {# Validating that the number of format params equals #}
+  {# the number of remaining params is handled by real python code #}
+  {% with fmtStr = elts[0] %}
+# {{ fmtStr|format(*elts[1:]) }}
+  {% endwith %}
+{% endmacro %}
+
+{% macro handleDefine(statement) %}
+{# Python code already verified the form, no need to check #}
+{% set args = statement.split("=") %}
+{% set lvalue, rvalue = args %}
+{{ lvalue }} = {{ rvalue }}
+{% endmacro %}
+
+{% macro handleCollectionLoop(statement) %}
+for {{ statement.variable }} in {{ statement.collection }}:
+  {{ dispatchStatement(statement.body) -}}
+{% endmacro %}
+
+{% macro handleMapLoop(statement) %}
+  {# At least one of key and value exist; validated in python #}
+for {{ statement.key if "key" in statement else "_"}}, {{ statement.value if "value" in statement else "_" }} in {{ statement.map }}.items():
+  {{ dispatchStatement(statement.body) -}}
+{% endmacro %}
+
+{% macro dispatchStatement(statement) %}
+{# Each statement is a dict with a single key/value pair #}
+{% if "print" in statement %}
+{{ handlePrint(statement["print"]) -}}
+{% elif "comment" in statement %}
+{{ handleComment(statement["comment"]) -}}
+{% elif "loop" in statement %}
+  {% with loop = statement["loop"] %}
+    {% if "collection" in loop %}
+{{ handleCollectionLoop(loop) -}}
+    {% else %}
+{{ handleMapLoop(loop) -}}
+    {% endif %}
+  {% endwith %}
+{% endif %}
+{% endmacro %}
+
+{% macro handleRequestAttr(baseName, attr) %}
+{# Note: python code will have manipulated the value #}
+{# to be the correct enum from the right module, if necessary. #}
+{# Python is also responsible for verifying that each input parameter is unique,#}
+{# no parameter is a reserved keyword #}
+  {% if "input_parameter" in attr %}
+# {{ attr.input_parameter }} = "{{ attr.value }}"
+    {% if "value_is_file" in attr and attr.value_is_file %}
+with open({{ attr.input_parameter }}, "rb") as f:
+  {{ baseName }}["{{ attr.field }}"] = f.read()
+    {% else %}
+{{ baseName }}["{{ attr.field }}"] = {{ attr.input_parameter }}
+    {% endif %}
+  {% else %}
+{{ baseName }}["{{ attr.field }}"] = {{ attr.value }}
+  {% endif %}
+{% endmacro %}
+
+{% macro handleRequest(request) %}
+  {% for parameterBlock in request %}
+{{ parameterBlock.base }} = {}
+    {% for attr in parameterBlock.body %}
+{{ handleRequestAttr(parameterBlock.base, attr) }}
+    {% endfor %}
+  {% endfor %}
+{% endmacro %}
+
+{% macro handleMainBlock(methodName, requestBlock) %}
+def main():
+  import argparse
+
+  parser = argparse.ArgumentParser()
+{% set arg_list = [] %}
+{% for attr in requestBlock if "input_parameter" in attr %}
+  parser.add_argument("--{{ attr.input_parameter }}",
+                      type=str,
+                      default="{{ attr.value }}")
+{% do arg_list.append("args." + attr.input_parameter) -%}
+{% endfor %}
+  args = parser.parse_args()
+
+  sample_{{ methodName|split_downcase|join("_") }}({{ arg_list|join(", ") }})
+
+
+if __name__ == "__main__":
+  main()
+{% endmacro %}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -25,7 +25,7 @@ There is a little, but not enough for it to be important because
 
 {# response handling macros #}
 
-{% macro handlePrint(elts) %}
+{% macro renderPrint(elts) %}
   {# First elment is a format string, remaining elements are the format string parameters #}
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
@@ -34,7 +34,7 @@ print({{ ([fmtStr] + elts[1:])|join(', ') }})
   {% endwith -%}
 {% endmacro %}
 
-{% macro handleComment(elts) %}
+{% macro renderComment(elts) %}
   {# First elment is a format string, remaining elements are the format string parameters #}
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
@@ -43,42 +43,48 @@ print({{ ([fmtStr] + elts[1:])|join(', ') }})
   {% endwith %}
 {% endmacro %}
 
-{% macro handleDefine(statement) %}
+{% macro renderDefine(statement) %}
 {# Python code already verified the form, no need to check #}
-{% set args = statement.split("=") %}
-{% set lvalue, rvalue = args %}
+{% with lvalue, rvalue = statement.split("=") %}
 {{ lvalue }} = {{ rvalue }}
+{% endwith %}
 {% endmacro %}
 
-{% macro handleCollectionLoop(statement) %}
+{% macro renderCollectionLoop(statement) %}
 for {{ statement.variable }} in {{ statement.collection }}:
   {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
-{% macro handleMapLoop(statement) %}
-  {# At least one of key and value exist; validated in python #}
-for {{ statement.key if "key" in statement else "_"}}, {{ statement.value if "value" in statement else "_" }} in {{ statement.map }}.items():
+{% macro renderMapLoop(statement) %}
+ {# At least one of key and value exist; validated in python #}
+{% if "key" not in statement %}
+for {{ statement.value }} in {{ statement.map }}.values():
+{% elif "value" not in statement %}
+for {{ statement.key }} in {{ statement.map }}.keys():
+{% else %}
+for {{statement.key }}, {{ statement.value }} in {{ statement.map }}.items():
+{% endif %}
   {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
 {% macro dispatchStatement(statement) %}
 {# Each statement is a dict with a single key/value pair #}
 {% if "print" in statement %}
-{{ handlePrint(statement["print"]) -}}
+{{ renderPrint(statement["print"]) -}}
 {% elif "comment" in statement %}
-{{ handleComment(statement["comment"]) -}}
+{{ renderComment(statement["comment"]) -}}
 {% elif "loop" in statement %}
   {% with loop = statement["loop"] %}
     {% if "collection" in loop %}
-{{ handleCollectionLoop(loop) -}}
+{{ renderCollectionLoop(loop) -}}
     {% else %}
-{{ handleMapLoop(loop) -}}
+{{ renderMapLoop(loop) -}}
     {% endif %}
   {% endwith %}
 {% endif %}
 {% endmacro %}
 
-{% macro handleRequestAttr(baseName, attr) %}
+{% macro renderRequestAttr(baseName, attr) %}
 {# Note: python code will have manipulated the value #}
 {# to be the correct enum from the right module, if necessary. #}
 {# Python is also responsible for verifying that each input parameter is unique,#}
@@ -96,21 +102,21 @@ with open({{ attr.input_parameter }}, "rb") as f:
   {% endif %}
 {% endmacro %}
 
-{% macro handleRequest(request) %}
+{% macro renderRequest(request) %}
   {% for parameterBlock in request %}
 {{ parameterBlock.base }} = {}
     {% for attr in parameterBlock.body %}
-{{ handleRequestAttr(parameterBlock.base, attr) }}
+{{ renderRequestAttr(parameterBlock.base, attr) }}
     {% endfor %}
   {% endfor %}
 {% endmacro %}
 
-{% macro handleMainBlock(methodName, requestBlock) %}
+{% macro renderMainBlock(methodName, requestBlock) %}
 def main():
   import argparse
 
   parser = argparse.ArgumentParser()
-{% set arg_list = [] %}
+{% with arg_list = [] %}
 {% for attr in requestBlock if "input_parameter" in attr %}
   parser.add_argument("--{{ attr.input_parameter }}",
                       type=str,
@@ -124,4 +130,5 @@ def main():
 
 if __name__ == "__main__":
   main()
+{% endwith %}
 {% endmacro %}

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -83,7 +83,9 @@ def test_get_response_fails_invalid_file_paths():
         lt.return_value = ['foo/bar/$service/$proto/baz.py.j2']
         with pytest.raises(ValueError) as ex:
             g.get_response(api_schema=make_api())
-        assert '$proto' in str(ex) and '$service' in str(ex)
+
+        ex_str = str(ex.value)
+        assert '$proto' in ex_str and '$service' in ex_str
 
 
 def test_get_response_enumerates_services():
@@ -163,24 +165,25 @@ def test_get_filename():
     g = make_generator()
     template_name = '$namespace/$name_$version/foo.py.j2'
     assert g._get_filename(template_name,
-        api_schema=make_api(
-            naming=make_naming(namespace=(), name='Spam', version='v2'),
-        )
-    ) == 'spam_v2/foo.py'
+                           api_schema=make_api(
+                               naming=make_naming(
+                                   namespace=(), name='Spam', version='v2'),
+                           )
+                           ) == 'spam_v2/foo.py'
 
 
 def test_get_filename_with_namespace():
     g = make_generator()
     template_name = '$namespace/$name_$version/foo.py.j2'
     assert g._get_filename(template_name,
-        api_schema=make_api(
-            naming=make_naming(
-                name='Spam',
-                namespace=('Ham', 'Bacon'),
-                version='v2',
-            ),
-        ),
-    ) == 'ham/bacon/spam_v2/foo.py'
+                           api_schema=make_api(
+                               naming=make_naming(
+                                   name='Spam',
+                                   namespace=('Ham', 'Bacon'),
+                                   version='v2',
+                               ),
+                           ),
+                           ) == 'ham/bacon/spam_v2/foo.py'
 
 
 def test_get_filename_with_service():
@@ -248,15 +251,15 @@ def make_generator(opts_str: str = '') -> generator.Generator:
 
 
 def make_proto(file_pb: descriptor_pb2.FileDescriptorProto,
-        file_to_generate: bool = True, prior_protos: Mapping = None,
-        naming: naming.Naming = None,
-        ) -> api.Proto:
+               file_to_generate: bool = True, prior_protos: Mapping = None,
+               naming: naming.Naming = None,
+               ) -> api.Proto:
     prior_protos = prior_protos or {}
     return api._ProtoBuilder(file_pb,
-        file_to_generate=file_to_generate,
-        naming=naming or make_naming(),
-        prior_protos=prior_protos,
-    ).proto
+                             file_to_generate=file_to_generate,
+                             naming=naming or make_naming(),
+                             prior_protos=prior_protos,
+                             ).proto
 
 
 def make_api(*protos, naming: naming.Naming = None, **kwargs) -> api.API:

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -12,341 +12,363 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from collections import namedtuple
 
-import unittest
 import gapic.samplegen.samplegen as samplegen
 import gapic.samplegen.utils as utils
 
 
-class TestValidateResponse(unittest.TestCase):
-    def test_define(self):
-        define = {"define": "squid=$resp"}
-        self.assertTrue(samplegen.validate_response([define]))
-
-    def test_define_undefined_var(self):
-        define = {"define": "squid=humboldt"}
-        self.assertRaises(samplegen.UndefinedVariableReference,
-                          samplegen.validate_response, [define])
-
-    def test_define_reserved_varname(self):
-        define = {"define": "class=$resp"}
-        self.assertRaises(samplegen.ReservedVariableName,
-                          samplegen.validate_response, [define])
-
-    def test_define_add_var(self):
-        self.assertTrue(samplegen.validate_response([{"define": "squid=$resp"},
-                                                     {"define": "name=squid.name"}]))
-
-    def test_define_bad_form(self):
-        define = {"define": "mollusc=$resp.squid=$resp.clam"}
-        self.assertRaises(samplegen.BadAssignment,
-                          samplegen.validate_response, [define])
-
-    def test_print_basic(self):
-        print_statement = {"print": ["This is a squid"]}
-        self.assertTrue(samplegen.validate_response([print_statement]))
-
-    def test_print_fmt_str(self):
-        print_statement = {"print": ["This is a squid named %s", "$resp.name"]}
-        self.assertTrue(samplegen.validate_response([print_statement]))
-
-    def test_print_fmt_mismatch(self):
-        print_statement = {"print": ["This is a squid named %s"]}
-        self.assertRaises(samplegen.MismatchedPrintStatement,
-                          samplegen.validate_response, [print_statement])
-
-    def test_print_fmt_mismatch2(self):
-        print_statement = {"print": ["This is a squid", "$resp.name"]}
-        self.assertRaises(samplegen.MismatchedPrintStatement,
-                          samplegen.validate_response, [print_statement])
-
-    def test_print_undefined_var(self):
-        print_statement = {"print": ["This mollusc is a %s", "mollusc.type"]}
-        self.assertRaises(samplegen.UndefinedVariableReference,
-                          samplegen.validate_response, [print_statement])
-
-    def test_comment(self):
-        comment = {"comment": ["This is a mollusc"]}
-        self.assertTrue(samplegen.validate_response([comment]))
-
-    def test_comment_fmt_str(self):
-        comment = {"comment": ["This is a mollusc of class %s", "$resp.class"]}
-        self.assertTrue(samplegen.validate_response([comment]))
-
-    def test_comment_fmt_undefined_var(self):
-        comment = {"comment": ["This is a mollusc of class %s", "cephalopod"]}
-        self.assertRaises(samplegen.UndefinedVariableReference,
-                          samplegen.validate_response, [comment])
-
-    def test_comment_fmt_mismatch(self):
-        comment = {"comment": ["This is a mollusc of class %s"]}
-        self.assertRaises(samplegen.MismatchedPrintStatement,
-                          samplegen.validate_response, [comment])
-
-    def test_comment_fmt_mismatch2(self):
-        comment = {"comment": ["This is a mollusc of class ", "$resp.class"]}
-        self.assertRaises(samplegen.MismatchedPrintStatement,
-                          samplegen.validate_response, [comment])
-
-    def test_loop_collection(self):
-        loop = {"loop": {"collection": "$resp.molluscs",
-                         "variable": "m",
-                         "body": [{"print":
-                                   ["Mollusc of class: %s", "m.class"]}]}}
-        self.assertTrue(samplegen.validate_response([loop]))
-
-    def test_loop_undefined_collection(self):
-        loop = {"loop": {"collection": "squid",
-                         "variable": "s",
-                         "body": [{"print":
-                                   ["Squid: %s", "s"]}]}}
-        self.assertRaises(samplegen.UndefinedVariableReference,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_collection_extra_kword(self):
-        loop = {"loop": {"collection": "$resp.molluscs",
-                         "squid": "$resp.squids",
-                         "variable": "m",
-                         "body": [{"print":
-                                   ["Mollusc of class: %s", "m.class"]}]}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_collection_missing_kword(self):
-        loop = {"loop": {"collection": "$resp.molluscs",
-                         "body": [{"print":
-                                   ["Mollusc of class: %s", "m.class"]}]}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_collection_missing_kword2(self):
-        loop = {"loop": {"collection": "$resp.molluscs",
-                         "body": [{"print":
-                                   ["Mollusc: %s", "m.class"]}]}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_collection_missing_kword3(self):
-        loop = {"loop": {"collection": "$resp.molluscs",
-                         "variable": "r"}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_collection_reserved_loop_var(self):
-        loop = {"loop": {"collection": "$resp.molluscs",
-                         "variable": "class",
-                         "body": [{"print":
-                                   ["Mollusc: %s", "class.name"]}]}}
-        self.assertRaises(samplegen.ReservedVariableName,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_map(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "key": "cls",
-                         "value": "mollusc",
-                         "body": [{"print": ["A %s is a %s", "mollusc", "cls"]}]}}
-        self.assertTrue(samplegen.validate_response([loop]))
-
-    def test_loop_map_reserved_key(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "key": "class",
-                         "value": "mollusc",
-                         "body": [{"print": ["A %s is a %s", "mollusc", "class"]}]}}
-        self.assertRaises(samplegen.ReservedVariableName,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_map_reserved_val(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "key": "m",
-                         "value": "class",
-                         "body": [{"print": ["A %s is a %s", "m", "class"]}]}}
-        self.assertRaises(samplegen.ReservedVariableName,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_map_undefined(self):
-        loop = {"loop": {"map": "molluscs",
-                         "key": "name",
-                         "value": "mollusc",
-                         "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
-        self.assertRaises(samplegen.UndefinedVariableReference,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_map_no_key(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "value": "mollusc",
-                         "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
-        self.assertTrue(samplegen.validate_response([loop]))
-
-    def test_loop_map_no_value(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "key": "mollusc",
-                         "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
-        self.assertTrue(samplegen.validate_response([loop]))
-
-    def test_loop_map_no_key_or_value(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "body": [{"print": ["Dead loop"]}]}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_map_no_map(self):
-        loop = {"loop": {"key": "name",
-                         "value": "mollusc",
-                         "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_map_no_body(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "key": "name",
-                         "value": "mollusc"}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_loop_map_extra_kword(self):
-        loop = {"loop": {"map": "$resp.molluscs",
-                         "key": "name",
-                         "value": "mollusc",
-                         "phylum": "$resp.phylum",
-                         "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
-        self.assertRaises(samplegen.BadLoop,
-                          samplegen.validate_response, [loop])
-
-    def test_invalid_statement(self):
-        statement = {"print": ["Name"], "comment": ["Value"]}
-        self.assertRaises(samplegen.InvalidStatement,
-                          samplegen.validate_response, [statement])
-
-    def test_invalid_statement2(self):
-        statement = {"squidify": ["Statement body"]}
-        self.assertRaises(samplegen.InvalidStatement,
-                          samplegen.validate_response, [statement])
+def test_define():
+    define = {"define": "squid=$resp"}
+    assert samplegen.validate_response([define])
 
 
-class TestValidateRequest(unittest.TestCase):
-    def test_basic(self):
-        self.assertEqual(samplegen.validate_and_transform_request(
-            [{"field": "squid.mantle_length", "value": "100 cm"},
-             {"field": "squid.mantle_mass", "value": "10 kg"}]),
-
-            [{"base": "squid", "body": [{"field": "mantle_length",
-                                         "value": "100 cm"},
-                                        {"field": "mantle_mass",
-                                         "value": "10 kg"}]}]
-        )
-
-    def test_no_field_parameter(self):
-        self.assertRaises(samplegen.InvalidRequestSetup,
-                          samplegen.validate_and_transform_request,
-                          [{"squid": "humboldt"}])
-
-    def test_malformed_field_attr(self):
-        self.assertRaises(samplegen.InvalidRequestSetup,
-                          samplegen.validate_and_transform_request,
-                          [{"field": "squid"}])
-
-    def test_multiple_arguments(self):
-        self.assertEqual(samplegen.validate_and_transform_request(
-            [{"field": "squid.mantle_length",
-              "value": "100 cm",
-              "value_is_file": True},
-             {"field": "clam.shell_mass",
-              "value": "100 kg",
-              "comment": "Clams can be large"}]),
-
-            [{"base": "squid", "body": [{"field": "mantle_length",
-                                         "value": "100 cm",
-                                         "value_is_file": True}]},
-             {"base": "clam",  "body": [{"field": "shell_mass",
-                                         "value": "100 kg",
-                                         "comment": "Clams can be large"}]}]
-        )
-
-    def test_reserved_request_name(self):
-        self.assertRaises(samplegen.ReservedVariableName,
-                          samplegen.validate_and_transform_request,
-                          [{"field": "class.order", "value": "coleoidea"}])
-
-    def test_duplicate_input_param(self):
-        self.assertRaises(samplegen.DuplicateInputParameter,
-                          samplegen.validate_and_transform_request,
-                          [{"field": "squid.mantle_mass",
-                            "value": "10 kg",
-                            "input_parameter": "mantle_mass"},
-                           {"field": "clam.mantle_mass",
-                            "value": "1 kg",
-                            "input_parameter": "mantle_mass"}])
-
-    def test_reserved_input_param(self):
-        self.assertRaises(samplegen.ReservedVariableName,
-                          samplegen.validate_and_transform_request,
-                          [{"field": "mollusc.class",
-                            "value": "cephalopoda",
-                            "input_parameter": "class"}])
+def test_define_undefined_var():
+    define = {"define": "squid=humboldt"}
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        samplegen.validate_response([define])
 
 
-class Snakify(unittest.TestCase):
-    """split_caps_and_downcase is a small utility function
-    that is the first part of turning CamelCase into snake_case"""
-
-    def test_basic(self):
-        self.assertEqual(utils.split_caps_and_downcase("SquidClamWhelk"),
-                         ["squid", "clam", "whelk"])
-
-    def test_basic2(self):
-        self.assertEqual(utils.split_caps_and_downcase("squidClamWhelk"),
-                         ["squid", "clam", "whelk"])
-
-    def test_basic3(self):
-        self.assertEqual(utils.split_caps_and_downcase("SquidClamWhelK"),
-                         ["squid", "clam", "whel", "k"])
-
-    def test_basic4(self):
-        self.assertEqual(utils.split_caps_and_downcase("Squid"),
-                         ["squid"])
-
-    def test_basic5(self):
-        self.assertEqual(utils.split_caps_and_downcase("squid"),
-                         ["squid"])
-
-    def test_basic6(self):
-        self.assertEqual(utils.split_caps_and_downcase("SQUID"),
-                         ["s", "q", "u", "i", "d"])
+def test_define_reserved_varname():
+    define = {"define": "class=$resp"}
+    with pytest.raises(samplegen.ReservedVariableName):
+        samplegen.validate_response([define])
 
 
-class TestCallingForm(unittest.TestCase):
-    def test_calling_form(self):
-        DummyMethod = namedtuple("DummyMethod",
-                                 ["lro",
-                                  "paged_result_field",
-                                  "client_streaming",
-                                  "server_streaming"])
-
-        self.assertEqual(utils.CallingForm.method_default(
-            DummyMethod(True, False, False, False)),
-            utils.CallingForm.LongRunningRequestAsync)
-
-        self.assertEqual(utils.CallingForm.method_default(
-            DummyMethod(False, True, False, False)),
-            utils.CallingForm.RequestPagedAll)
-
-        self.assertEqual(utils.CallingForm.method_default(
-            DummyMethod(False, False, True, False)),
-            utils.CallingForm.RequestStreamingClient)
-
-        self.assertEqual(utils.CallingForm.method_default(
-            DummyMethod(False, False, False, True)),
-            utils.CallingForm.RequestStreamingServer)
-
-        self.assertEqual(utils.CallingForm.method_default(
-            DummyMethod(False, False, False, False)),
-            utils.CallingForm.Request)
-
-        self.assertEqual(utils.CallingForm.method_default(
-            DummyMethod(False, False, True, True)),
-            utils.CallingForm.RequestStreamingBidi)
+def test_define_add_var():
+    assert samplegen.validate_response([{"define": "squid=$resp"},
+                                        {"define": "name=squid.name"}])
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_define_bad_form():
+    define = {"define": "mollusc=$resp.squid=$resp.clam"}
+    with pytest.raises(samplegen.BadAssignment):
+        samplegen.validate_response([define])
+
+
+def test_print_basic():
+    print_statement = {"print": ["This is a squid"]}
+    assert samplegen.validate_response([print_statement])
+
+
+def test_print_fmt_str():
+    print_statement = {"print": ["This is a squid named %s", "$resp.name"]}
+    assert samplegen.validate_response([print_statement])
+
+
+def test_print_fmt_mismatch():
+    print_statement = {"print": ["This is a squid named %s"]}
+    with pytest.raises(samplegen.MismatchedPrintStatement):
+        samplegen.validate_response([print_statement])
+
+
+def test_print_fmt_mismatch2():
+    print_statement = {"print": ["This is a squid", "$resp.name"]}
+    with pytest.raises(samplegen.MismatchedPrintStatement):
+        samplegen.validate_response([print_statement])
+
+
+def test_print_undefined_var():
+    print_statement = {"print": ["This mollusc is a %s", "mollusc.type"]}
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        samplegen.validate_response([print_statement])
+
+
+def test_comment():
+    comment = {"comment": ["This is a mollusc"]}
+    assert samplegen.validate_response([comment])
+
+
+def test_comment_fmt_str():
+    comment = {"comment": ["This is a mollusc of class %s", "$resp.class"]}
+    assert samplegen.validate_response([comment])
+
+
+def test_comment_fmt_undefined_var():
+    comment = {"comment": ["This is a mollusc of class %s", "cephalopod"]}
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        samplegen.validate_response([comment])
+
+
+def test_comment_fmt_mismatch():
+    comment = {"comment": ["This is a mollusc of class %s"]}
+    with pytest.raises(samplegen.MismatchedPrintStatement):
+        samplegen.validate_response([comment])
+
+
+def test_comment_fmt_mismatch2():
+    comment = {"comment": ["This is a mollusc of class ", "$resp.class"]}
+    with pytest.raises(samplegen.MismatchedPrintStatement):
+        samplegen.validate_response([comment])
+
+
+def test_loop_collection():
+    loop = {"loop": {"collection": "$resp.molluscs",
+                     "variable": "m",
+                     "body": [{"print":
+                               ["Mollusc of class: %s", "m.class"]}]}}
+    assert samplegen.validate_response([loop])
+
+
+def test_loop_undefined_collection():
+    loop = {"loop": {"collection": "squid",
+                     "variable": "s",
+                     "body": [{"print":
+                               ["Squid: %s", "s"]}]}}
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        samplegen.validate_response([loop])
+
+
+def test_loop_collection_extra_kword():
+    loop = {"loop": {"collection": "$resp.molluscs",
+                     "squid": "$resp.squids",
+                     "variable": "m",
+                     "body": [{"print":
+                               ["Mollusc of class: %s", "m.class"]}]}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_loop_collection_missing_kword():
+    loop = {"loop": {"collection": "$resp.molluscs",
+                     "body": [{"print":
+                               ["Mollusc of class: %s", "m.class"]}]}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_loop_collection_missing_kword2():
+    loop = {"loop": {"collection": "$resp.molluscs",
+                     "body": [{"print":
+                               ["Mollusc: %s", "m.class"]}]}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_loop_collection_missing_kword3():
+    loop = {"loop": {"collection": "$resp.molluscs",
+                     "variable": "r"}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_loop_collection_reserved_loop_var():
+    loop = {"loop": {"collection": "$resp.molluscs",
+                     "variable": "class",
+                     "body": [{"print":
+                               ["Mollusc: %s", "class.name"]}]}}
+    with pytest.raises(samplegen.ReservedVariableName):
+        samplegen.validate_response([loop])
+
+
+def test_loop_map():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "key": "cls",
+                     "value": "mollusc",
+                     "body": [{"print": ["A %s is a %s", "mollusc", "cls"]}]}}
+    assert samplegen.validate_response([loop])
+
+
+def test_loop_map_reserved_key():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "key": "class",
+                     "value": "mollusc",
+                     "body": [{"print": ["A %s is a %s", "mollusc", "class"]}]}}
+    with pytest.raises(samplegen.ReservedVariableName):
+        samplegen.validate_response([loop])
+
+
+def test_loop_map_reserved_val():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "key": "m",
+                     "value": "class",
+                     "body": [{"print": ["A %s is a %s", "m", "class"]}]}}
+    with pytest.raises(samplegen.ReservedVariableName):
+        samplegen.validate_response([loop])
+
+
+def test_loop_map_undefined():
+    loop = {"loop": {"map": "molluscs",
+                     "key": "name",
+                     "value": "mollusc",
+                     "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        samplegen.validate_response([loop])
+
+
+def test_loop_map_no_key():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "value": "mollusc",
+                     "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
+    assert samplegen.validate_response([loop])
+
+
+def test_loop_map_no_value():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "key": "mollusc",
+                     "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
+    assert samplegen.validate_response([loop])
+
+
+def test_loop_map_no_key_or_value():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "body": [{"print": ["Dead loop"]}]}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_loop_map_no_map():
+    loop = {"loop": {"key": "name",
+                     "value": "mollusc",
+                     "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_loop_map_no_body():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "key": "name",
+                     "value": "mollusc"}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_loop_map_extra_kword():
+    loop = {"loop": {"map": "$resp.molluscs",
+                     "key": "name",
+                     "value": "mollusc",
+                     "phylum": "$resp.phylum",
+                     "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+    with pytest.raises(samplegen.BadLoop):
+        samplegen.validate_response([loop])
+
+
+def test_invalid_statement():
+    statement = {"print": ["Name"], "comment": ["Value"]}
+    with pytest.raises(samplegen.InvalidStatement):
+        samplegen.validate_response([statement])
+
+
+def test_invalid_statement2():
+    statement = {"squidify": ["Statement body"]}
+    with pytest.raises(samplegen.InvalidStatement):
+        samplegen.validate_response([statement])
+
+
+def test_basic():
+    assert samplegen.validate_and_transform_request(
+        [{"field": "squid.mantle_length",
+          "value": "100 cm"},
+         {"field": "squid.mantle_mass",
+          "value": "10 kg"}]) == [{"base": "squid",
+                                   "body": [{"field": "mantle_length",
+                                             "value": "100 cm"},
+                                            {"field": "mantle_mass",
+                                             "value": "10 kg"}]}]
+
+
+def test_no_field_parameter():
+    with pytest.raises(samplegen.InvalidRequestSetup):
+        samplegen.validate_and_transform_request([{"squid": "humboldt"}])
+
+
+def test_malformed_field_attr():
+    with pytest.raises(samplegen.InvalidRequestSetup):
+        samplegen.validate_and_transform_request([{"field": "squid"}])
+
+
+def test_multiple_arguments():
+    assert samplegen.validate_and_transform_request(
+        [{"field": "squid.mantle_length",
+          "value": "100 cm",
+          "value_is_file": True},
+         {"field": "clam.shell_mass",
+          "value": "100 kg",
+          "comment": "Clams can be large"}]) == [{"base": "squid",
+                                                  "body": [{"field": "mantle_length",
+                                                            "value": "100 cm",
+                                                            "value_is_file": True}]},
+                                                 {"base": "clam",
+                                                  "body": [{"field": "shell_mass",
+                                                            "value": "100 kg",
+                                                            "comment": "Clams can be large"}]}]
+
+
+def test_reserved_request_name():
+    with pytest.raises(samplegen.ReservedVariableName):
+        samplegen.validate_and_transform_request(
+            [{"field": "class.order", "value": "coleoidea"}])
+
+
+def test_duplicate_input_param():
+    with pytest.raises(samplegen.DuplicateInputParameter):
+        samplegen.validate_and_transform_request([{"field": "squid.mantle_mass",
+                                                   "value": "10 kg",
+                                                   "input_parameter": "mantle_mass"},
+                                                  {"field": "clam.mantle_mass",
+                                                   "value": "1 kg",
+                                                   "input_parameter": "mantle_mass"}])
+
+
+def test_reserved_input_param():
+    with pytest.raises(samplegen.ReservedVariableName):
+        samplegen.validate_and_transform_request([{"field": "mollusc.class",
+                                                   "value": "cephalopoda",
+                                                   "input_parameter": "class"}])
+
+
+# split_caps_and_downcase is a small utility function
+# that is the first part of turning CamelCase into snake_case
+
+def test_split_caps_and_downcase():
+    assert utils.split_caps_and_downcase("SquidClamWhelk") == [
+        "squid", "clam", "whelk"]
+
+
+def test_split_caps_and_downcase2():
+    assert utils.split_caps_and_downcase("squidClamWhelk") == [
+        "squid", "clam", "whelk"]
+
+
+def test_split_caps_and_downcase3():
+    assert utils.split_caps_and_downcase("SquidClamWhelK") == [
+        "squid", "clam", "whel", "k"]
+
+
+def test_split_caps_and_downcase4():
+    assert utils.split_caps_and_downcase("Squid") == ["squid"]
+
+
+def test_split_caps_and_downcase5():
+    assert utils.split_caps_and_downcase("squid") == ["squid"]
+
+
+def test_split_caps_and_downcase6():
+    assert utils.split_caps_and_downcase("SQUID") == ["s", "q", "u", "i", "d"]
+
+
+def test_calling_form():
+    DummyMethod = namedtuple("DummyMethod",
+                             ["lro",
+                              "paged_result_field",
+                              "client_streaming",
+                              "server_streaming"])
+
+    assert utils.CallingForm.method_default(DummyMethod(
+        True, False, False, False)) == utils.CallingForm.LongRunningRequestAsync
+
+    assert utils.CallingForm.method_default(DummyMethod(
+        False, True, False, False)) == utils.CallingForm.RequestPagedAll
+
+    assert utils.CallingForm.method_default(DummyMethod(
+        False, False, True, False)) == utils.CallingForm.RequestStreamingClient
+
+    assert utils.CallingForm.method_default(DummyMethod(
+        False, False, False, True)) == utils.CallingForm.RequestStreamingServer
+
+    assert utils.CallingForm.method_default(DummyMethod(
+        False, False, False, False)) == utils.CallingForm.Request
+
+    assert utils.CallingForm.method_default(DummyMethod(
+        False, False, True, True)) == utils.CallingForm.RequestStreamingBidi

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -1,0 +1,352 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import namedtuple
+
+import unittest
+import gapic.samplegen.samplegen as samplegen
+import gapic.samplegen.utils as utils
+
+
+class TestValidateResponse(unittest.TestCase):
+    def test_define(self):
+        define = {"define": "squid=$resp"}
+        self.assertTrue(samplegen.validate_response([define]))
+
+    def test_define_undefined_var(self):
+        define = {"define": "squid=humboldt"}
+        self.assertRaises(samplegen.UndefinedVariableReference,
+                          samplegen.validate_response, [define])
+
+    def test_define_reserved_varname(self):
+        define = {"define": "class=$resp"}
+        self.assertRaises(samplegen.ReservedVariableName,
+                          samplegen.validate_response, [define])
+
+    def test_define_add_var(self):
+        self.assertTrue(samplegen.validate_response([{"define": "squid=$resp"},
+                                                     {"define": "name=squid.name"}]))
+
+    def test_define_bad_form(self):
+        define = {"define": "mollusc=$resp.squid=$resp.clam"}
+        self.assertRaises(samplegen.BadAssignment,
+                          samplegen.validate_response, [define])
+
+    def test_print_basic(self):
+        print_statement = {"print": ["This is a squid"]}
+        self.assertTrue(samplegen.validate_response([print_statement]))
+
+    def test_print_fmt_str(self):
+        print_statement = {"print": ["This is a squid named %s", "$resp.name"]}
+        self.assertTrue(samplegen.validate_response([print_statement]))
+
+    def test_print_fmt_mismatch(self):
+        print_statement = {"print": ["This is a squid named %s"]}
+        self.assertRaises(samplegen.MismatchedPrintStatement,
+                          samplegen.validate_response, [print_statement])
+
+    def test_print_fmt_mismatch2(self):
+        print_statement = {"print": ["This is a squid", "$resp.name"]}
+        self.assertRaises(samplegen.MismatchedPrintStatement,
+                          samplegen.validate_response, [print_statement])
+
+    def test_print_undefined_var(self):
+        print_statement = {"print": ["This mollusc is a %s", "mollusc.type"]}
+        self.assertRaises(samplegen.UndefinedVariableReference,
+                          samplegen.validate_response, [print_statement])
+
+    def test_comment(self):
+        comment = {"comment": ["This is a mollusc"]}
+        self.assertTrue(samplegen.validate_response([comment]))
+
+    def test_comment_fmt_str(self):
+        comment = {"comment": ["This is a mollusc of class %s", "$resp.class"]}
+        self.assertTrue(samplegen.validate_response([comment]))
+
+    def test_comment_fmt_undefined_var(self):
+        comment = {"comment": ["This is a mollusc of class %s", "cephalopod"]}
+        self.assertRaises(samplegen.UndefinedVariableReference,
+                          samplegen.validate_response, [comment])
+
+    def test_comment_fmt_mismatch(self):
+        comment = {"comment": ["This is a mollusc of class %s"]}
+        self.assertRaises(samplegen.MismatchedPrintStatement,
+                          samplegen.validate_response, [comment])
+
+    def test_comment_fmt_mismatch2(self):
+        comment = {"comment": ["This is a mollusc of class ", "$resp.class"]}
+        self.assertRaises(samplegen.MismatchedPrintStatement,
+                          samplegen.validate_response, [comment])
+
+    def test_loop_collection(self):
+        loop = {"loop": {"collection": "$resp.molluscs",
+                         "variable": "m",
+                         "body": [{"print":
+                                   ["Mollusc of class: %s", "m.class"]}]}}
+        self.assertTrue(samplegen.validate_response([loop]))
+
+    def test_loop_undefined_collection(self):
+        loop = {"loop": {"collection": "squid",
+                         "variable": "s",
+                         "body": [{"print":
+                                   ["Squid: %s", "s"]}]}}
+        self.assertRaises(samplegen.UndefinedVariableReference,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_collection_extra_kword(self):
+        loop = {"loop": {"collection": "$resp.molluscs",
+                         "squid": "$resp.squids",
+                         "variable": "m",
+                         "body": [{"print":
+                                   ["Mollusc of class: %s", "m.class"]}]}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_collection_missing_kword(self):
+        loop = {"loop": {"collection": "$resp.molluscs",
+                         "body": [{"print":
+                                   ["Mollusc of class: %s", "m.class"]}]}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_collection_missing_kword2(self):
+        loop = {"loop": {"collection": "$resp.molluscs",
+                         "body": [{"print":
+                                   ["Mollusc: %s", "m.class"]}]}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_collection_missing_kword3(self):
+        loop = {"loop": {"collection": "$resp.molluscs",
+                         "variable": "r"}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_collection_reserved_loop_var(self):
+        loop = {"loop": {"collection": "$resp.molluscs",
+                         "variable": "class",
+                         "body": [{"print":
+                                   ["Mollusc: %s", "class.name"]}]}}
+        self.assertRaises(samplegen.ReservedVariableName,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_map(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "key": "cls",
+                         "value": "mollusc",
+                         "body": [{"print": ["A %s is a %s", "mollusc", "cls"]}]}}
+        self.assertTrue(samplegen.validate_response([loop]))
+
+    def test_loop_map_reserved_key(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "key": "class",
+                         "value": "mollusc",
+                         "body": [{"print": ["A %s is a %s", "mollusc", "class"]}]}}
+        self.assertRaises(samplegen.ReservedVariableName,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_map_reserved_val(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "key": "m",
+                         "value": "class",
+                         "body": [{"print": ["A %s is a %s", "m", "class"]}]}}
+        self.assertRaises(samplegen.ReservedVariableName,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_map_undefined(self):
+        loop = {"loop": {"map": "molluscs",
+                         "key": "name",
+                         "value": "mollusc",
+                         "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+        self.assertRaises(samplegen.UndefinedVariableReference,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_map_no_key(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "value": "mollusc",
+                         "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
+        self.assertTrue(samplegen.validate_response([loop]))
+
+    def test_loop_map_no_value(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "key": "mollusc",
+                         "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
+        self.assertTrue(samplegen.validate_response([loop]))
+
+    def test_loop_map_no_key_or_value(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "body": [{"print": ["Dead loop"]}]}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_map_no_map(self):
+        loop = {"loop": {"key": "name",
+                         "value": "mollusc",
+                         "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_map_no_body(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "key": "name",
+                         "value": "mollusc"}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_loop_map_extra_kword(self):
+        loop = {"loop": {"map": "$resp.molluscs",
+                         "key": "name",
+                         "value": "mollusc",
+                         "phylum": "$resp.phylum",
+                         "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+        self.assertRaises(samplegen.BadLoop,
+                          samplegen.validate_response, [loop])
+
+    def test_invalid_statement(self):
+        statement = {"print": ["Name"], "comment": ["Value"]}
+        self.assertRaises(samplegen.InvalidStatement,
+                          samplegen.validate_response, [statement])
+
+    def test_invalid_statement2(self):
+        statement = {"squidify": ["Statement body"]}
+        self.assertRaises(samplegen.InvalidStatement,
+                          samplegen.validate_response, [statement])
+
+
+class TestValidateRequest(unittest.TestCase):
+    def test_basic(self):
+        self.assertEqual(samplegen.validate_and_transform_request(
+            [{"field": "squid.mantle_length", "value": "100 cm"},
+             {"field": "squid.mantle_mass", "value": "10 kg"}]),
+
+            [{"base": "squid", "body": [{"field": "mantle_length",
+                                         "value": "100 cm"},
+                                        {"field": "mantle_mass",
+                                         "value": "10 kg"}]}]
+        )
+
+    def test_no_field_parameter(self):
+        self.assertRaises(samplegen.InvalidRequestSetup,
+                          samplegen.validate_and_transform_request,
+                          [{"squid": "humboldt"}])
+
+    def test_malformed_field_attr(self):
+        self.assertRaises(samplegen.InvalidRequestSetup,
+                          samplegen.validate_and_transform_request,
+                          [{"field": "squid"}])
+
+    def test_multiple_arguments(self):
+        self.assertEqual(samplegen.validate_and_transform_request(
+            [{"field": "squid.mantle_length",
+              "value": "100 cm",
+              "value_is_file": True},
+             {"field": "clam.shell_mass",
+              "value": "100 kg",
+              "comment": "Clams can be large"}]),
+
+            [{"base": "squid", "body": [{"field": "mantle_length",
+                                         "value": "100 cm",
+                                         "value_is_file": True}]},
+             {"base": "clam",  "body": [{"field": "shell_mass",
+                                         "value": "100 kg",
+                                         "comment": "Clams can be large"}]}]
+        )
+
+    def test_reserved_request_name(self):
+        self.assertRaises(samplegen.ReservedVariableName,
+                          samplegen.validate_and_transform_request,
+                          [{"field": "class.order", "value": "coleoidea"}])
+
+    def test_duplicate_input_param(self):
+        self.assertRaises(samplegen.DuplicateInputParameter,
+                          samplegen.validate_and_transform_request,
+                          [{"field": "squid.mantle_mass",
+                            "value": "10 kg",
+                            "input_parameter": "mantle_mass"},
+                           {"field": "clam.mantle_mass",
+                            "value": "1 kg",
+                            "input_parameter": "mantle_mass"}])
+
+    def test_reserved_input_param(self):
+        self.assertRaises(samplegen.ReservedVariableName,
+                          samplegen.validate_and_transform_request,
+                          [{"field": "mollusc.class",
+                            "value": "cephalopoda",
+                            "input_parameter": "class"}])
+
+
+class Snakify(unittest.TestCase):
+    """split_caps_and_downcase is a small utility function
+    that is the first part of turning CamelCase into snake_case"""
+
+    def test_basic(self):
+        self.assertEqual(utils.split_caps_and_downcase("SquidClamWhelk"),
+                         ["squid", "clam", "whelk"])
+
+    def test_basic2(self):
+        self.assertEqual(utils.split_caps_and_downcase("squidClamWhelk"),
+                         ["squid", "clam", "whelk"])
+
+    def test_basic3(self):
+        self.assertEqual(utils.split_caps_and_downcase("SquidClamWhelK"),
+                         ["squid", "clam", "whel", "k"])
+
+    def test_basic4(self):
+        self.assertEqual(utils.split_caps_and_downcase("Squid"),
+                         ["squid"])
+
+    def test_basic5(self):
+        self.assertEqual(utils.split_caps_and_downcase("squid"),
+                         ["squid"])
+
+    def test_basic6(self):
+        self.assertEqual(utils.split_caps_and_downcase("SQUID"),
+                         ["s", "q", "u", "i", "d"])
+
+
+class TestCallingForm(unittest.TestCase):
+    def test_calling_form(self):
+        DummyMethod = namedtuple("DummyMethod",
+                                 ["lro",
+                                  "paged_result_field",
+                                  "client_streaming",
+                                  "server_streaming"])
+
+        self.assertEqual(utils.CallingForm.method_default(
+            DummyMethod(True, False, False, False)),
+            utils.CallingForm.LongRunningRequestAsync)
+
+        self.assertEqual(utils.CallingForm.method_default(
+            DummyMethod(False, True, False, False)),
+            utils.CallingForm.RequestPagedAll)
+
+        self.assertEqual(utils.CallingForm.method_default(
+            DummyMethod(False, False, True, False)),
+            utils.CallingForm.RequestStreamingClient)
+
+        self.assertEqual(utils.CallingForm.method_default(
+            DummyMethod(False, False, False, True)),
+            utils.CallingForm.RequestStreamingServer)
+
+        self.assertEqual(utils.CallingForm.method_default(
+            DummyMethod(False, False, False, False)),
+            utils.CallingForm.Request)
+
+        self.assertEqual(utils.CallingForm.method_default(
+            DummyMethod(False, False, True, True)),
+            utils.CallingForm.RequestStreamingBidi)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -18,10 +18,12 @@ from collections import namedtuple
 import gapic.samplegen.samplegen as samplegen
 import gapic.samplegen.utils as utils
 
+# validate_response tests
+
 
 def test_define():
     define = {"define": "squid=$resp"}
-    assert samplegen.Validator().validate_response([define])
+    samplegen.Validator().validate_response([define])
 
 
 def test_define_undefined_var():
@@ -37,8 +39,8 @@ def test_define_reserved_varname():
 
 
 def test_define_add_var():
-    assert samplegen.Validator().validate_response([{"define": "squid=$resp"},
-                                                    {"define": "name=squid.name"}])
+    samplegen.Validator().validate_response([{"define": "squid=$resp"},
+                                             {"define": "name=squid.name"}])
 
 
 def test_define_bad_form():
@@ -74,12 +76,12 @@ def test_define_input_param_redefinition():
 
 def test_print_basic():
     print_statement = {"print": ["This is a squid"]}
-    assert samplegen.Validator().validate_response([print_statement])
+    samplegen.Validator().validate_response([print_statement])
 
 
 def test_print_fmt_str():
     print_statement = {"print": ["This is a squid named %s", "$resp.name"]}
-    assert samplegen.Validator().validate_response([print_statement])
+    samplegen.Validator().validate_response([print_statement])
 
 
 def test_print_fmt_mismatch():
@@ -102,12 +104,12 @@ def test_print_undefined_var():
 
 def test_comment():
     comment = {"comment": ["This is a mollusc"]}
-    assert samplegen.Validator().validate_response([comment])
+    samplegen.Validator().validate_response([comment])
 
 
 def test_comment_fmt_str():
     comment = {"comment": ["This is a mollusc of class %s", "$resp.class"]}
-    assert samplegen.Validator().validate_response([comment])
+    samplegen.Validator().validate_response([comment])
 
 
 def test_comment_fmt_undefined_var():
@@ -133,7 +135,7 @@ def test_loop_collection():
                      "variable": "m",
                      "body": [{"print":
                                ["Mollusc of class: %s", "m.class"]}]}}
-    assert samplegen.Validator().validate_response([loop])
+    samplegen.Validator().validate_response([loop])
 
 
 def test_loop_collection_redefinition():
@@ -202,7 +204,7 @@ def test_loop_map():
                      "key": "cls",
                      "value": "mollusc",
                      "body": [{"print": ["A %s is a %s", "mollusc", "cls"]}]}}
-    assert samplegen.Validator().validate_response([loop])
+    samplegen.Validator().validate_response([loop])
 
 
 def test_collection_loop_lexical_scope_variable():
@@ -284,14 +286,14 @@ def test_loop_map_no_key():
     loop = {"loop": {"map": "$resp.molluscs",
                      "value": "mollusc",
                      "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
-    assert samplegen.Validator().validate_response([loop])
+    samplegen.Validator().validate_response([loop])
 
 
 def test_loop_map_no_value():
     loop = {"loop": {"map": "$resp.molluscs",
                      "key": "mollusc",
                      "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
-    assert samplegen.Validator().validate_response([loop])
+    samplegen.Validator().validate_response([loop])
 
 
 def test_loop_map_no_key_or_value():
@@ -357,7 +359,8 @@ def test_invalid_statement2():
         samplegen.Validator().validate_response([statement])
 
 
-def test_basic():
+# validate_and_transform_request tests
+def test_validate_request_basic():
     assert samplegen.Validator().validate_and_transform_request(
         [{"field": "squid.mantle_length",
           "value": "100 cm"},
@@ -370,19 +373,19 @@ def test_basic():
                                              "value": "10 kg"}])]
 
 
-def test_no_field_parameter():
+def test_validate_request_no_field_parameter():
     with pytest.raises(samplegen.InvalidRequestSetup):
         samplegen.Validator().validate_and_transform_request(
             [{"squid": "humboldt"}])
 
 
-def test_malformed_field_attr():
+def test_validate_request_malformed_field_attr():
     with pytest.raises(samplegen.InvalidRequestSetup):
         samplegen.Validator().validate_and_transform_request(
             [{"field": "squid"}])
 
 
-def test_multiple_arguments():
+def test_validate_request_multiple_arguments():
     assert samplegen.Validator().validate_and_transform_request(
         [{"field": "squid.mantle_length",
           "value": "100 cm",
@@ -400,13 +403,13 @@ def test_multiple_arguments():
                                        "comment": "Clams can be large"}])]
 
 
-def test_reserved_request_name():
+def test_validate_request_reserved_request_name():
     with pytest.raises(samplegen.ReservedVariableName):
         samplegen.Validator().validate_and_transform_request(
             [{"field": "class.order", "value": "coleoidea"}])
 
 
-def test_duplicate_input_param():
+def test_validate_request_duplicate_input_param():
     with pytest.raises(samplegen.RedefinedVariable):
         samplegen.Validator().validate_and_transform_request(
             [{"field": "squid.mantle_mass",
@@ -417,7 +420,7 @@ def test_duplicate_input_param():
               "input_parameter": "mantle_mass"}])
 
 
-def test_reserved_input_param():
+def test_validate_request_reserved_input_param():
     with pytest.raises(samplegen.ReservedVariableName):
         samplegen.Validator().validate_and_transform_request(
             [{"field": "mollusc.class",
@@ -425,7 +428,7 @@ def test_reserved_input_param():
               "input_parameter": "class"}])
 
 
-def test_calling_form():
+def test_validate_request_calling_form():
     DummyMethod = namedtuple("DummyMethod",
                              ["lro",
                               "paged_result_field",

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -1,0 +1,318 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import jinja2
+import os.path as path
+import unittest
+import gapic.samplegen.samplegen as samplegen
+import gapic.samplegen.utils as utils
+
+
+class TestTemplating(unittest.TestCase):
+
+    def check_template(self, template_fragment, expected_output):
+        # Making a new environment for every unit test seems wasteful,
+        # but the obvious alternative (make env an instance attribute
+        # and passing a FunctionLoader whose load function returns
+        # a constantly reassigned string attribute) isn't any faster
+        # and is less clear.
+        env = jinja2.Environment(
+            loader=jinja2.ChoiceLoader(
+                [jinja2.FileSystemLoader(
+                    searchpath=path.realpath(path.join(path.dirname(__file__),
+                                                       "..", "..", "..",
+                                                       "gapic", "templates", "examples"))),
+                 jinja2.DictLoader({"template_fragment": template_fragment}),
+                 ]),
+
+            undefined=jinja2.StrictUndefined,
+            extensions=["jinja2.ext.do"],
+            trim_blocks=True, lstrip_blocks=True
+        )
+
+        env.filters["split_downcase"] = utils.split_caps_and_downcase
+
+        template = env.get_template("template_fragment")
+        text = template.render()
+        self.assertEqual(text, expected_output)
+
+    def test_handle_attr_value(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handleRequestAttr("mollusc", {"field": "order",
+                                       "value": "Molluscs.Cephalopoda.Coleoidea"}) }}
+''',
+            'mollusc["order"] = Molluscs.Cephalopoda.Coleoidea\n'
+        )
+
+    def test_handle_attr_input_parameter(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handleRequestAttr("squid", {"field": "species",
+                                     "value": "Humboldt",
+                                     "input_parameter": "species"}) }}
+''',
+            '# species = "Humboldt"\nsquid["species"] = species\n')
+
+    def test_handle_attr_file(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handleRequestAttr("classify_mollusc_request",
+                           {"field": "mollusc_video",
+                            "value": "path/to/mollusc/video.mkv",
+                            "input_parameter" : "mollusc_video_path",
+                            "value_is_file": True})
+}}
+''',
+            '''# mollusc_video_path = "path/to/mollusc/video.mkv"
+with open(mollusc_video_path, "rb") as f:
+  classify_mollusc_request["mollusc_video"] = f.read()
+'''
+        )
+
+    def test_handle_request_basic(self):
+        self.maxDiff = None
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+
+{{ frags.handleRequest([{"base": "cephalopod",
+                         "body": [{"field": "mantle_mass",
+                                   "value": "10 kg",
+                                   "input_parameter": "cephalopod_mass"},
+                                  {"field": "photo",
+                                   "value": "path/to/cephalopod/photo.jpg",
+                                   "input_parameter": "photo_path",
+                                   "value_is_file": True},
+                                  {"field": "order",
+                                   "value": "Molluscs.Cephalopoda.Coleoidea"}, ]},
+                        {"base": "gastropod",
+                         "body": [{"field": "mantle_mass",
+                                   "value": "1 kg",
+                                   "input_parameter": "gastropod_mass"},
+                                  {"field": "order",
+                                   "value": "Molluscs.Gastropoda.Pulmonata"},
+                                  {"field": "movie",
+                                   "value": "path/to/gastropod/movie.mkv",
+                                   "input_parameter": "movie_path",
+                                   "value_is_file": True}]}, ]) }}
+''',
+            '''
+cephalopod = {}
+# cephalopod_mass = "10 kg"
+cephalopod["mantle_mass"] = cephalopod_mass
+
+# photo_path = "path/to/cephalopod/photo.jpg"
+with open(photo_path, "rb") as f:
+  cephalopod["photo"] = f.read()
+
+cephalopod["order"] = Molluscs.Cephalopoda.Coleoidea
+
+gastropod = {}
+# gastropod_mass = "1 kg"
+gastropod["mantle_mass"] = gastropod_mass
+
+gastropod["order"] = Molluscs.Gastropoda.Pulmonata
+
+# movie_path = "path/to/gastropod/movie.mkv"
+with open(movie_path, "rb") as f:
+  gastropod["movie"] = f.read()
+
+'''
+        )
+
+    def test_handle_print(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handlePrint(["Mollusc"]) }}
+''',
+            '''print("Mollusc")
+'''
+        )
+
+    def test_handle_print_args(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handlePrint(["Molluscs: %s, %s, %s", "squid", "clam", "whelk"]) }}
+''',
+            '''print("Molluscs: {}, {}, {}", squid, clam, whelk)
+'''
+        )
+
+    def test_handle_comment(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handleComment(["Mollusc"]) }}
+''',
+            '''# Mollusc
+'''
+        )
+
+    def test_handle_comment_args(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handleComment(["Molluscs: %s, %s, %s", "squid", "clam", "whelk"]) }}
+''',
+            '''# Molluscs: squid, clam, whelk
+'''
+        )
+
+    def test_define(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handleDefine("squid=humboldt") }}
+''',
+            '''squid = humboldt
+'''
+        )
+
+    def test_dispatch_print(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.dispatchStatement({"print" : ["Squid"] }) }}
+''',
+            '''print("Squid")
+'''
+        )
+
+    def test_dispatch_comment(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.dispatchStatement({"comment" : ["Squid"] }) }}
+''',
+            '''# Squid
+'''
+        )
+
+    def test_collection_loop(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+
+{{ frags.handleCollectionLoop({"collection": "molluscs",
+                               "variable": "m",
+                               "body": {"print": ["Mollusc: %s", "m"]}}) }}''',
+            '''
+for m in molluscs:
+  print("Mollusc: {}", m)
+'''
+        )
+
+    def test_dispatch_collection_loop(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+
+{{ frags.dispatchStatement({"loop": {"collection": "molluscs",
+                               "variable": "m",
+                               "body": {"print": ["Mollusc: %s", "m"]}}}) }}''',
+            '''
+for m in molluscs:
+  print("Mollusc: {}", m)
+'''
+        )
+
+    def test_map_loop(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+
+{{ frags.handleMapLoop({"map": "molluscs",
+                        "key":"cls",
+                        "value":"example",
+                        "body": {"print": ["A %s is a %s", "example", "cls"] }})
+}}''',
+            '''
+for cls, example in molluscs.items():
+  print("A {} is a {}", example, cls)
+'''
+        )
+
+    def test_map_loop_no_key(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+
+{{ frags.handleMapLoop({"map": "molluscs",
+                        "value":"example",
+                        "body": {"print": ["A %s is a mollusc", "example"] }})
+}}''',
+            '''
+for _, example in molluscs.items():
+  print("A {} is a mollusc", example)
+'''
+        )
+
+    def test_map_loop_no_value(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+
+{{ frags.handleMapLoop({"map": "molluscs",
+                        "key":"cls",
+                        "body": {"print": ["A %s is a mollusc", "cls"] }})
+}}''',
+            '''
+for cls, _ in molluscs.items():
+  print("A {} is a mollusc", cls)
+'''
+        )
+
+    def test_dispatch_map_loop(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+
+{{ frags.dispatchStatement({"loop":{"map": "molluscs",
+                                    "key":"cls",
+                                    "value":"example",
+                                    "body": {
+                                      "print": ["A %s is a %s", "example", "cls"] }}})
+}}
+''',
+            '''
+for cls, example in molluscs.items():
+  print("A {} is a {}", example, cls)
+'''
+        )
+
+    def test_main_block(self):
+        self.check_template(
+            '''{% import "feature_fragments.j2" as frags %}
+{{ frags.handleMainBlock("ListMolluscs", [{"field": "list_molluscs.order",
+                                           "value": "coleoidea",
+                                           "input_parameter": "order"},
+                                          {"field ": "list_molluscs.mass",
+                                           "value": "60kg",
+                                           "input_parameter": "mass"},
+                                          {"field": "list_molluscs.zone",
+                                           "value": "MESOPELAGIC"},]) }}
+''',
+            '''def main():
+  import argparse
+
+  parser = argparse.ArgumentParser()
+  parser.add_argument("--order",
+                      type=str,
+                      default="coleoidea")
+  parser.add_argument("--mass",
+                      type=str,
+                      default="60kg")
+  args = parser.parse_args()
+
+  sample_list_molluscs(args.order, args.mass)
+
+
+if __name__ == "__main__":
+  main()
+'''
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -15,304 +15,323 @@
 
 import jinja2
 import os.path as path
-import unittest
+# import textwrap
 import gapic.samplegen.samplegen as samplegen
 import gapic.samplegen.utils as utils
 
+from textwrap import dedent
 
-class TestTemplating(unittest.TestCase):
 
-    def check_template(self, template_fragment, expected_output):
-        # Making a new environment for every unit test seems wasteful,
-        # but the obvious alternative (make env an instance attribute
-        # and passing a FunctionLoader whose load function returns
-        # a constantly reassigned string attribute) isn't any faster
-        # and is less clear.
-        env = jinja2.Environment(
-            loader=jinja2.ChoiceLoader(
-                [jinja2.FileSystemLoader(
-                    searchpath=path.realpath(path.join(path.dirname(__file__),
-                                                       "..", "..", "..",
-                                                       "gapic", "templates", "examples"))),
-                 jinja2.DictLoader({"template_fragment": template_fragment}),
-                 ]),
+def check_template(template_fragment, expected_output):
+    # Making a new environment for every unit test seems wasteful,
+    # but the obvious alternative (make env an instance attribute
+    # and passing a FunctionLoader whose load function returns
+    # a constantly reassigned string attribute) isn't any faster
+    # and is less clear.
+    env = jinja2.Environment(
+        loader=jinja2.ChoiceLoader(
+            [jinja2.FileSystemLoader(
+                searchpath=path.realpath(path.join(path.dirname(__file__),
+                                                   "..", "..", "..",
+                                                   "gapic", "templates", "examples"))),
+             jinja2.DictLoader(
+                 {"template_fragment": dedent(template_fragment)}),
+             ]),
 
-            undefined=jinja2.StrictUndefined,
-            extensions=["jinja2.ext.do"],
-            trim_blocks=True, lstrip_blocks=True
-        )
+        undefined=jinja2.StrictUndefined,
+        extensions=["jinja2.ext.do"],
+        trim_blocks=True, lstrip_blocks=True
+    )
 
-        env.filters["split_downcase"] = utils.split_caps_and_downcase
+    env.filters["split_downcase"] = utils.split_caps_and_downcase
 
-        template = env.get_template("template_fragment")
-        text = template.render()
-        self.assertEqual(text, expected_output)
+    template = env.get_template("template_fragment")
+    text = template.render()
+    assert text == dedent(expected_output)
 
-    def test_handle_attr_value(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handleRequestAttr("mollusc", {"field": "order",
-                                       "value": "Molluscs.Cephalopoda.Coleoidea"}) }}
-''',
-            'mollusc["order"] = Molluscs.Cephalopoda.Coleoidea\n'
-        )
 
-    def test_handle_attr_input_parameter(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handleRequestAttr("squid", {"field": "species",
-                                     "value": "Humboldt",
-                                     "input_parameter": "species"}) }}
-''',
-            '# species = "Humboldt"\nsquid["species"] = species\n')
+def test_render_attr_value():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderRequestAttr("mollusc",
+                                   {"field": "order",
+                                    "value": "Molluscs.Cephalopoda.Coleoidea"}) }}
+        ''',
+        '\nmollusc["order"] = Molluscs.Cephalopoda.Coleoidea\n'
+    )
 
-    def test_handle_attr_file(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handleRequestAttr("classify_mollusc_request",
-                           {"field": "mollusc_video",
-                            "value": "path/to/mollusc/video.mkv",
-                            "input_parameter" : "mollusc_video_path",
-                            "value_is_file": True})
-}}
-''',
-            '''# mollusc_video_path = "path/to/mollusc/video.mkv"
-with open(mollusc_video_path, "rb") as f:
-  classify_mollusc_request["mollusc_video"] = f.read()
-'''
-        )
 
-    def test_handle_request_basic(self):
-        self.maxDiff = None
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
+def test_render_attr_input_parameter():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderRequestAttr("squid", {"field": "species",
+                                             "value": "Humboldt",
+                                             "input_parameter": "species"}) }}
+        ''',
+        '\n# species = "Humboldt"\nsquid["species"] = species\n')
 
-{{ frags.handleRequest([{"base": "cephalopod",
-                         "body": [{"field": "mantle_mass",
-                                   "value": "10 kg",
-                                   "input_parameter": "cephalopod_mass"},
-                                  {"field": "photo",
-                                   "value": "path/to/cephalopod/photo.jpg",
-                                   "input_parameter": "photo_path",
-                                   "value_is_file": True},
-                                  {"field": "order",
-                                   "value": "Molluscs.Cephalopoda.Coleoidea"}, ]},
-                        {"base": "gastropod",
-                         "body": [{"field": "mantle_mass",
-                                   "value": "1 kg",
-                                   "input_parameter": "gastropod_mass"},
-                                  {"field": "order",
-                                   "value": "Molluscs.Gastropoda.Pulmonata"},
-                                  {"field": "movie",
-                                   "value": "path/to/gastropod/movie.mkv",
-                                   "input_parameter": "movie_path",
-                                   "value_is_file": True}]}, ]) }}
-''',
+
+def test_render_attr_file():
+    check_template(
+        '''
+            {% import "feature_fragments.j2" as frags %}
+            {{ frags.renderRequestAttr("classify_mollusc_request",
+                                       {"field": "mollusc_video",
+                                        "value": "path/to/mollusc/video.mkv",
+                                        "input_parameter" : "mollusc_video_path",
+                                        "value_is_file": True}) }}
+        ''',
+        '''
+            # mollusc_video_path = "path/to/mollusc/video.mkv"
+            with open(mollusc_video_path, "rb") as f:
+              classify_mollusc_request["mollusc_video"] = f.read()
+        ''')
+
+
+def test_render_request_basic():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderRequest([{"base": "cephalopod",
+                                 "body": [{"field": "mantle_mass",
+                                           "value": "10 kg",
+                                           "input_parameter": "cephalopod_mass"},
+                                          {"field": "photo",
+                                           "value": "path/to/cephalopod/photo.jpg",
+                                           "input_parameter": "photo_path",
+                                           "value_is_file": True},
+                                          {"field": "order",
+                                           "value": "Molluscs.Cephalopoda.Coleoidea"}, ]},
+                                {"base": "gastropod",
+                                 "body": [{"field": "mantle_mass",
+                                           "value": "1 kg",
+                                           "input_parameter": "gastropod_mass"},
+                                          {"field": "order",
+                                           "value": "Molluscs.Gastropoda.Pulmonata"},
+                                          {"field": "movie",
+                                           "value": "path/to/gastropod/movie.mkv",
+                                           "input_parameter": "movie_path",
+                                           "value_is_file": True}]}, ]) }}
+        ''',
+        '''
+            cephalopod = {}
+            # cephalopod_mass = "10 kg"
+            cephalopod["mantle_mass"] = cephalopod_mass
+            
+            # photo_path = "path/to/cephalopod/photo.jpg"
+            with open(photo_path, "rb") as f:
+              cephalopod["photo"] = f.read()
+            
+            cephalopod["order"] = Molluscs.Cephalopoda.Coleoidea
+            
+            gastropod = {}
+            # gastropod_mass = "1 kg"
+            gastropod["mantle_mass"] = gastropod_mass
+            
+            gastropod["order"] = Molluscs.Gastropoda.Pulmonata
+            
+            # movie_path = "path/to/gastropod/movie.mkv"
+            with open(movie_path, "rb") as f:
+              gastropod["movie"] = f.read()
+            
             '''
-cephalopod = {}
-# cephalopod_mass = "10 kg"
-cephalopod["mantle_mass"] = cephalopod_mass
+    )
 
-# photo_path = "path/to/cephalopod/photo.jpg"
-with open(photo_path, "rb") as f:
-  cephalopod["photo"] = f.read()
 
-cephalopod["order"] = Molluscs.Cephalopoda.Coleoidea
+def test_render_print():
+    check_template(
+        '''
+            {% import "feature_fragments.j2" as frags %}
+            {{ frags.renderPrint(["Mollusc"]) }}
+        ''',
+        '\nprint("Mollusc")\n'
+    )
 
-gastropod = {}
-# gastropod_mass = "1 kg"
-gastropod["mantle_mass"] = gastropod_mass
 
-gastropod["order"] = Molluscs.Gastropoda.Pulmonata
+def test_render_print_args():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderPrint(["Molluscs: %s, %s, %s", "squid", "clam", "whelk"]) }}
+        ''',
+        '\nprint("Molluscs: {}, {}, {}", squid, clam, whelk)\n'
+    )
 
-# movie_path = "path/to/gastropod/movie.mkv"
-with open(movie_path, "rb") as f:
-  gastropod["movie"] = f.read()
 
-'''
-        )
+def test_render_comment():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderComment(["Mollusc"]) }}
+        ''',
+        '\n# Mollusc\n'
+    )
 
-    def test_handle_print(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handlePrint(["Mollusc"]) }}
+
+def test_render_comment_args():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderComment(["Molluscs: %s, %s, %s", "squid", "clam", "whelk"]) }}
+        ''',
+        '\n# Molluscs: squid, clam, whelk\n'
+    )
+
+
+def test_define():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderDefine("squid=humboldt") }}
+        ''',
+        '\nsquid = humboldt\n'
+    )
+
+
+def test_dispatch_print():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.dispatchStatement({"print" : ["Squid"] }) }}
 ''',
-            '''print("Mollusc")
-'''
-        )
-
-    def test_handle_print_args(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handlePrint(["Molluscs: %s, %s, %s", "squid", "clam", "whelk"]) }}
-''',
-            '''print("Molluscs: {}, {}, {}", squid, clam, whelk)
-'''
-        )
-
-    def test_handle_comment(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handleComment(["Mollusc"]) }}
-''',
-            '''# Mollusc
-'''
-        )
-
-    def test_handle_comment_args(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handleComment(["Molluscs: %s, %s, %s", "squid", "clam", "whelk"]) }}
-''',
-            '''# Molluscs: squid, clam, whelk
-'''
-        )
-
-    def test_define(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handleDefine("squid=humboldt") }}
-''',
-            '''squid = humboldt
-'''
-        )
-
-    def test_dispatch_print(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.dispatchStatement({"print" : ["Squid"] }) }}
-''',
-            '''print("Squid")
-'''
-        )
-
-    def test_dispatch_comment(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.dispatchStatement({"comment" : ["Squid"] }) }}
-''',
-            '''# Squid
-'''
-        )
-
-    def test_collection_loop(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-
-{{ frags.handleCollectionLoop({"collection": "molluscs",
-                               "variable": "m",
-                               "body": {"print": ["Mollusc: %s", "m"]}}) }}''',
-            '''
-for m in molluscs:
-  print("Mollusc: {}", m)
-'''
-        )
-
-    def test_dispatch_collection_loop(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-
-{{ frags.dispatchStatement({"loop": {"collection": "molluscs",
-                               "variable": "m",
-                               "body": {"print": ["Mollusc: %s", "m"]}}}) }}''',
-            '''
-for m in molluscs:
-  print("Mollusc: {}", m)
-'''
-        )
-
-    def test_map_loop(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-
-{{ frags.handleMapLoop({"map": "molluscs",
-                        "key":"cls",
-                        "value":"example",
-                        "body": {"print": ["A %s is a %s", "example", "cls"] }})
-}}''',
-            '''
-for cls, example in molluscs.items():
-  print("A {} is a {}", example, cls)
-'''
-        )
-
-    def test_map_loop_no_key(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-
-{{ frags.handleMapLoop({"map": "molluscs",
-                        "value":"example",
-                        "body": {"print": ["A %s is a mollusc", "example"] }})
-}}''',
-            '''
-for _, example in molluscs.items():
-  print("A {} is a mollusc", example)
-'''
-        )
-
-    def test_map_loop_no_value(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-
-{{ frags.handleMapLoop({"map": "molluscs",
-                        "key":"cls",
-                        "body": {"print": ["A %s is a mollusc", "cls"] }})
-}}''',
-            '''
-for cls, _ in molluscs.items():
-  print("A {} is a mollusc", cls)
-'''
-        )
-
-    def test_dispatch_map_loop(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-
-{{ frags.dispatchStatement({"loop":{"map": "molluscs",
-                                    "key":"cls",
-                                    "value":"example",
-                                    "body": {
-                                      "print": ["A %s is a %s", "example", "cls"] }}})
-}}
-''',
-            '''
-for cls, example in molluscs.items():
-  print("A {} is a {}", example, cls)
-'''
-        )
-
-    def test_main_block(self):
-        self.check_template(
-            '''{% import "feature_fragments.j2" as frags %}
-{{ frags.handleMainBlock("ListMolluscs", [{"field": "list_molluscs.order",
-                                           "value": "coleoidea",
-                                           "input_parameter": "order"},
-                                          {"field ": "list_molluscs.mass",
-                                           "value": "60kg",
-                                           "input_parameter": "mass"},
-                                          {"field": "list_molluscs.zone",
-                                           "value": "MESOPELAGIC"},]) }}
-''',
-            '''def main():
-  import argparse
-
-  parser = argparse.ArgumentParser()
-  parser.add_argument("--order",
-                      type=str,
-                      default="coleoidea")
-  parser.add_argument("--mass",
-                      type=str,
-                      default="60kg")
-  args = parser.parse_args()
-
-  sample_list_molluscs(args.order, args.mass)
+        '\nprint("Squid")\n'
+    )
 
 
-if __name__ == "__main__":
-  main()
-'''
-        )
+def test_dispatch_comment():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.dispatchStatement({"comment" : ["Squid"] }) }}
+        ''',
+        '\n# Squid\n'
+    )
 
 
-if __name__ == "__main__":
-    unittest.main()
+def test_collection_loop():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderCollectionLoop({"collection": "molluscs",
+                                        "variable": "m",
+                                        "body": {"print": ["Mollusc: %s", "m"]}}) }}''',
+        '''
+        for m in molluscs:
+          print("Mollusc: {}", m)
+        '''
+    )
+
+
+def test_dispatch_collection_loop():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.dispatchStatement({"loop": {"collection": "molluscs",
+                                    "variable": "m",
+                                    "body": {"print": ["Mollusc: %s", "m"]}}}) }}''',
+        '''
+        for m in molluscs:
+          print("Mollusc: {}", m)
+        '''
+    )
+
+
+def test_map_loop():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderMapLoop({"map": "molluscs",
+                                "key":"cls",
+                                "value":"example",
+                                "body": {"print": ["A %s is a %s", "example", "cls"] }})
+        }}''',
+        '''
+        for cls, example in molluscs.items():
+          print("A {} is a {}", example, cls)
+        '''
+    )
+
+
+def test_map_loop_no_key():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderMapLoop({"map": "molluscs",
+                                "value":"example",
+                                "body": {"print": ["A %s is a mollusc", "example"] }})
+        }}''',
+        '''
+        for example in molluscs.values():
+          print("A {} is a mollusc", example)
+        '''
+    )
+
+
+def test_map_loop_no_value():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderMapLoop({"map": "molluscs",
+                                "key":"cls",
+                                "body": {"print": ["A %s is a mollusc", "cls"] }})
+        }}''',
+        '''
+        for cls in molluscs.keys():
+          print("A {} is a mollusc", cls)
+        '''
+    )
+
+
+def test_dispatch_map_loop():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.dispatchStatement({"loop":{"map": "molluscs",
+                                            "key":"cls",
+                                            "value":"example",
+                                            "body": {
+                                              "print": ["A %s is a %s", "example", "cls"] }}})
+        }}
+        ''',
+        '''
+        for cls, example in molluscs.items():
+          print("A {} is a {}", example, cls)
+        '''
+    )
+
+
+def test_main_block():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderMainBlock("ListMolluscs", [{"field": "list_molluscs.order",
+                                                   "value": "coleoidea",
+                                                   "input_parameter": "order"},
+                                                  {"field ": "list_molluscs.mass",
+                                                   "value": "60kg",
+                                                   "input_parameter": "mass"},
+                                                  {"field": "list_molluscs.zone",
+                                                   "value": "MESOPELAGIC"},]) }}
+        ''',
+        '''
+        def main():
+          import argparse
+        
+          parser = argparse.ArgumentParser()
+          parser.add_argument("--order",
+                              type=str,
+                              default="coleoidea")
+          parser.add_argument("--mass",
+                              type=str,
+                              default="60kg")
+          args = parser.parse_args()
+        
+          sample_list_molluscs(args.order, args.mass)
+        
+        
+        if __name__ == "__main__":
+          main()
+        '''
+    )

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -15,9 +15,8 @@
 
 import jinja2
 import os.path as path
-# import textwrap
 import gapic.samplegen.samplegen as samplegen
-import gapic.samplegen.utils as utils
+import gapic.utils as utils
 
 from textwrap import dedent
 
@@ -43,7 +42,7 @@ def check_template(template_fragment, expected_output):
         trim_blocks=True, lstrip_blocks=True
     )
 
-    env.filters["split_downcase"] = utils.split_caps_and_downcase
+    env.filters['snake_case'] = utils.to_snake_case
 
     template = env.get_template("template_fragment")
     text = template.render()
@@ -86,7 +85,7 @@ def test_render_attr_file():
         '''
             # mollusc_video_path = "path/to/mollusc/video.mkv"
             with open(mollusc_video_path, "rb") as f:
-              classify_mollusc_request["mollusc_video"] = f.read()
+                classify_mollusc_request["mollusc_video"] = f.read()
         ''')
 
 
@@ -116,26 +115,26 @@ def test_render_request_basic():
                                            "value_is_file": True}]}, ]) }}
         ''',
         '''
-            cephalopod = {}
-            # cephalopod_mass = "10 kg"
-            cephalopod["mantle_mass"] = cephalopod_mass
-            
-            # photo_path = "path/to/cephalopod/photo.jpg"
-            with open(photo_path, "rb") as f:
-              cephalopod["photo"] = f.read()
-            
-            cephalopod["order"] = Molluscs.Cephalopoda.Coleoidea
-            
-            gastropod = {}
-            # gastropod_mass = "1 kg"
-            gastropod["mantle_mass"] = gastropod_mass
-            
-            gastropod["order"] = Molluscs.Gastropoda.Pulmonata
-            
-            # movie_path = "path/to/gastropod/movie.mkv"
-            with open(movie_path, "rb") as f:
-              gastropod["movie"] = f.read()
-            
+        cephalopod = {}
+        # cephalopod_mass = "10 kg"
+        cephalopod["mantle_mass"] = cephalopod_mass
+        
+        # photo_path = "path/to/cephalopod/photo.jpg"
+        with open(photo_path, "rb") as f:
+            cephalopod["photo"] = f.read()
+        
+        cephalopod["order"] = Molluscs.Cephalopoda.Coleoidea
+        
+        gastropod = {}
+        # gastropod_mass = "1 kg"
+        gastropod["mantle_mass"] = gastropod_mass
+        
+        gastropod["order"] = Molluscs.Gastropoda.Pulmonata
+        
+        # movie_path = "path/to/gastropod/movie.mkv"
+        with open(movie_path, "rb") as f:
+            gastropod["movie"] = f.read()
+    
             '''
     )
 
@@ -143,8 +142,8 @@ def test_render_request_basic():
 def test_render_print():
     check_template(
         '''
-            {% import "feature_fragments.j2" as frags %}
-            {{ frags.renderPrint(["Mollusc"]) }}
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.renderPrint(["Mollusc"]) }}
         ''',
         '\nprint("Mollusc")\n'
     )
@@ -219,7 +218,7 @@ def test_collection_loop():
                                         "body": {"print": ["Mollusc: %s", "m"]}}) }}''',
         '''
         for m in molluscs:
-          print("Mollusc: {}", m)
+            print("Mollusc: {}", m)
         '''
     )
 
@@ -233,7 +232,7 @@ def test_dispatch_collection_loop():
                                     "body": {"print": ["Mollusc: %s", "m"]}}}) }}''',
         '''
         for m in molluscs:
-          print("Mollusc: {}", m)
+            print("Mollusc: {}", m)
         '''
     )
 
@@ -249,7 +248,7 @@ def test_map_loop():
         }}''',
         '''
         for cls, example in molluscs.items():
-          print("A {} is a {}", example, cls)
+            print("A {} is a {}", example, cls)
         '''
     )
 
@@ -264,7 +263,7 @@ def test_map_loop_no_key():
         }}''',
         '''
         for example in molluscs.values():
-          print("A {} is a mollusc", example)
+            print("A {} is a mollusc", example)
         '''
     )
 
@@ -279,7 +278,7 @@ def test_map_loop_no_value():
         }}''',
         '''
         for cls in molluscs.keys():
-          print("A {} is a mollusc", cls)
+            print("A {} is a mollusc", cls)
         '''
     )
 
@@ -297,7 +296,7 @@ def test_dispatch_map_loop():
         ''',
         '''
         for cls, example in molluscs.items():
-          print("A {} is a {}", example, cls)
+            print("A {} is a {}", example, cls)
         '''
     )
 
@@ -317,21 +316,21 @@ def test_main_block():
         ''',
         '''
         def main():
-          import argparse
-        
-          parser = argparse.ArgumentParser()
-          parser.add_argument("--order",
-                              type=str,
-                              default="coleoidea")
-          parser.add_argument("--mass",
-                              type=str,
-                              default="60kg")
-          args = parser.parse_args()
-        
-          sample_list_molluscs(args.order, args.mass)
-        
-        
+            import argparse
+
+            parser = argparse.ArgumentParser()
+            parser.add_argument("--order",
+                                type=str,
+                                default="coleoidea")
+            parser.add_argument("--mass",
+                                type=str,
+                                default="60kg")
+            args = parser.parse_args()
+
+            sample_list_molluscs(args.order, args.mass)
+
+
         if __name__ == "__main__":
-          main()
+            main()
         '''
     )


### PR DESCRIPTION
Add initial code (and unit tests) for validating and mutating parsed
sampleconfig.

Validates 'request' segments; transforms mutates 'request' to ease generation
of client method parameters.

Validates 'response' segments.

Validation includes checking for improper use of reserved words as
variable names, missing or unexpected keywords in blocks, and general
malformation of the sampleconfig.

Add initial jinja2 template macros and associated unit tests for
sample generation.

Generates 'request' setup block using values, input parameters, and
file content.

Generates 'response' handling blocks, using comment blocks, print
statements, assignment statements, collection loops, and mapped loops.
Loops are potentially recursive.

Generates 'main' block and invocation.