### PR TITLE
Initial commit for generating an integrated sample

### DIFF
--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -72,13 +72,13 @@ class Generator:
         output_files: Dict[str, CodeGeneratorResponse.File] = OrderedDict()
 
         # TODO: handle sample_templates specially, generate samples.
-        sample_templates, other_templates = utils.partition(
+        sample_templates, client_templates = utils.partition(
             self._env.loader.list_templates(),
             lambda fname: os.path.basename(fname) == samplegen.TEMPLATE_NAME)
 
         # Iterate over each template and add the appropriate output files
         # based on that template.
-        for template_name in other_templates:
+        for template_name in client_templates:
             # Sanity check: Skip "private" templates.
             filename = template_name.split('/')[-1]
             if filename.startswith('_') and filename != '__init__.py.j2':

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -55,7 +55,7 @@ class Generator:
         self._env.filters['snake_case'] = utils.to_snake_case
         self._env.filters['sort_lines'] = utils.sort_lines
         self._env.filters['wrap'] = utils.wrap
-        self._env.filters['coerce_variable_name'] = samplegen.coerce_variable_name
+        self._env.filters['coerce_response_name'] = samplegen.coerce_response_name
 
     def get_response(self, api_schema: api.API) -> CodeGeneratorResponse:
         """Return a :class:`~.CodeGeneratorResponse` for this library.

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -55,7 +55,7 @@ class Generator:
         self._env.filters['snake_case'] = utils.to_snake_case
         self._env.filters['sort_lines'] = utils.sort_lines
         self._env.filters['wrap'] = utils.wrap
-        self._env.filters['resp_to_response'] = samplegen.resp_to_response
+        self._env.filters['coerce_variable_name'] = samplegen.coerce_variable_name
 
     def get_response(self, api_schema: api.API) -> CodeGeneratorResponse:
         """Return a :class:`~.CodeGeneratorResponse` for this library.
@@ -74,8 +74,8 @@ class Generator:
 
         # TODO: handle sample_templates specially, generate samples.
         sample_templates, client_templates = utils.partition(
-            self._env.loader.list_templates(),
-            lambda fname: os.path.basename(fname) == samplegen.TEMPLATE_NAME)
+            lambda fname: os.path.basename(fname) == samplegen.TEMPLATE_NAME,
+            self._env.loader.list_templates())
 
         # Iterate over each template and add the appropriate output files
         # based on that template.

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -70,9 +70,14 @@ class Generator:
         """
         output_files: Dict[str, CodeGeneratorResponse.File] = OrderedDict()
 
+        # TODO: handle sample_templates specially, generate samples.
+        sample_templates, other_templates = utils.partition(
+            self._env.loader.list_templates(),
+            lambda fname: os.path.basename(fname) == "sample.py.j2")
+
         # Iterate over each template and add the appropriate output files
         # based on that template.
-        for template_name in self._env.loader.list_templates():
+        for template_name in other_templates:
             # Sanity check: Skip "private" templates.
             filename = template_name.split('/')[-1]
             if filename.startswith('_') and filename != '__init__.py.j2':

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -55,6 +55,7 @@ class Generator:
         self._env.filters['snake_case'] = utils.to_snake_case
         self._env.filters['sort_lines'] = utils.sort_lines
         self._env.filters['wrap'] = utils.wrap
+        self._env.filters['resp_to_response'] = samplegen.resp_to_response
 
     def get_response(self, api_schema: api.API) -> CodeGeneratorResponse:
         """Return a :class:`~.CodeGeneratorResponse` for this library.

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -24,6 +24,7 @@ from google.protobuf.compiler.plugin_pb2 import CodeGeneratorResponse
 from gapic import utils
 from gapic.generator import formatter
 from gapic.generator import options
+from gapic.samplegen import samplegen
 from gapic.schema import api
 
 
@@ -73,7 +74,7 @@ class Generator:
         # TODO: handle sample_templates specially, generate samples.
         sample_templates, other_templates = utils.partition(
             self._env.loader.list_templates(),
-            lambda fname: os.path.basename(fname) == "sample.py.j2")
+            lambda fname: os.path.basename(fname) == samplegen.TEMPLATE_NAME)
 
         # Iterate over each template and add the appropriate output files
         # based on that template.

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -251,9 +251,6 @@ class Validator:
             response: list[dict{str:?}]: The structured data representing
                                          the sample's response.
 
-        Returns:
-            bool: True if response is valid.
-
         Raises:
             InvalidStatement: If an unexpected key is found in a statement dict
                               or a statement dict has more than or less than one key.

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -20,6 +20,7 @@ import re
 from gapic.samplegen import utils
 
 from collections import (defaultdict, namedtuple)
+from textwrap import dedent
 from typing import (List, Mapping, Set, Tuple)
 
 # Outstanding issues:
@@ -30,19 +31,22 @@ MIN_SCHEMA_VERSION = (1, 2, 0)
 
 VALID_CONFIG_TYPE = 'com.google.api.codegen.SampleConfigProto'
 
-FILE_HEADER = {"copyrightLines": ["Copyright (C) 2019  Google LLC"],
-               "licenseLines": ["Licensed under the Apache License, Version 2.0 (the \"License\");",
-                                "you may not use this file except in compliance with the License.",
-                                "You may obtain a copy of the License at",
-                                "",
-                                "     http://www.apache.org/licenses/LICENSE-2.0",
-                                "",
-                                "Unless required by applicable law or agreed to in writing, software",
-                                "distributed under the License is distributed on an \"AS IS\" BASIS,",
-                                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
-                                "See the License for the specific language governing permissions and",
-                                "limitations under the License."
-                                ]}
+FILE_HEADER = {"copyrightLines": "Copyright (C) 2019  Google LLC",
+               "licenseLines": dedent(
+                   """
+                   Licensed under the Apache License, Version 2.0 (the "License");
+                   you may not use this file except in compliance with the License.
+                   You may obtain a copy of the License at
+                      
+                        http://www.apache.org/licenses/LICENSE-2.0
+                      
+                   Unless required by applicable law or agreed to in writing, software
+                   distributed under the License is distributed on an "AS IS" BASIS,
+                   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+                   See the License for the specific language governing permissions and
+                   limitations under the License.
+                   """).strip()
+               }
 
 RESERVED_WORDS = frozenset(
     itertools.chain(keyword.kwlist,
@@ -232,8 +236,8 @@ class Validator:
         if (calling_form in {utils.CallingForm.RequestStreamingClient,
                              utils.CallingForm.RequestStreamingBidi} and
                 len(base_param_to_attrs) > 1):
-            raise InvalidRequestSetup("""There can be at most 1 base request in a
-            sample for a method with client side streaming""")
+            raise InvalidRequestSetup(("There can be at most 1 base request in a sample"
+                                       " for a method with client side streaming"))
 
         return [TransformedRequest(base, body)
                 for base, body in base_param_to_attrs.items()]

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -13,15 +13,16 @@
 # limitations under the License.
 
 import itertools
+import jinja2
 import keyword
 import re
-import gapic.samplegen.utils
+
+from gapic.samplegen import utils
 
 from collections import (defaultdict, namedtuple)
-from typing import (List, Mapping, Set)
+from typing import (List, Mapping, Set, Tuple)
 
 # Outstanding issues:
-# * Neither license nor copyright are defined
 # * In real sample configs, many variables are
 #   defined with an _implicit_ $resp variable.
 
@@ -29,13 +30,33 @@ MIN_SCHEMA_VERSION = (1, 2, 0)
 
 VALID_CONFIG_TYPE = 'com.google.api.codegen.SampleConfigProto'
 
-# There are a couple of other names that should be reserved
-# for sample variable assignments, e.g. 'client', but there are diminishing returns:
-# the sample config author isn't a pathological adversary, they're a normal person
-# who may make mistakes occasionally.
-RESERVED_WORDS = frozenset(itertools.chain(keyword.kwlist, dir(__builtins__)))
+FILE_HEADER = {"copyrightLines": ["Copyright (C) 2019  Google LLC"],
+               "licenseLines": ["Licensed under the Apache License, Version 2.0 (the \"License\");",
+                                "you may not use this file except in compliance with the License.",
+                                "You may obtain a copy of the License at",
+                                "",
+                                "     http://www.apache.org/licenses/LICENSE-2.0",
+                                "",
+                                "Unless required by applicable law or agreed to in writing, software",
+                                "distributed under the License is distributed on an \"AS IS\" BASIS,",
+                                "WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.",
+                                "See the License for the specific language governing permissions and",
+                                "limitations under the License."
+                                ]}
 
-TEMPLATE_NAME = 'samplegen_template.j2'
+RESERVED_WORDS = frozenset(
+    itertools.chain(keyword.kwlist,
+                    dir(__builtins__),
+                    {"client",
+                     "f",            # parameter used in file I/O statements
+                     "operation",    # temporary used in LROs
+                     "page",         # used in paginated responses
+                     "page_result",  # used in paginated responses
+                     "response",     # basic 'response'
+                     "stream",       # used in server and bidi streaming
+                     }))
+
+TEMPLATE_NAME = "sample.py.j2"
 
 TransformedRequest = namedtuple("TransformedRequest", ["base", "body"])
 
@@ -48,15 +69,15 @@ class ReservedVariableName(SampleError):
     pass
 
 
-class SchemaVersion(SampleError):
-    pass
-
-
 class RpcMethodNotFound(SampleError):
     pass
 
 
-class InvalidConfigType(SampleError):
+class UnknownService(SampleError):
+    pass
+
+
+class InvalidConfig(SampleError):
     pass
 
 
@@ -113,6 +134,7 @@ class Validator:
     # TODO: this will eventually need the method name and the proto file
     # so that it can do the correct value transformation for enums.
     def validate_and_transform_request(self,
+                                       calling_form: utils.CallingForm,
                                        request: List[Mapping[str, str]]) -> List[TransformedRequest]:
         """Validates and transforms the "request" block from a sample config.
 
@@ -174,6 +196,7 @@ class Validator:
         """
         base_param_to_attrs: Mapping[str,
                                      List[Mapping[str, str]]] = defaultdict(list)
+
         for field_assignment in request:
             field_assignment_copy = dict(field_assignment)
             input_param = field_assignment_copy.get("input_parameter")
@@ -205,6 +228,12 @@ class Validator:
 
             field_assignment_copy["field"] = attr
             base_param_to_attrs[base].append(field_assignment_copy)
+
+        if (calling_form in {utils.CallingForm.RequestStreamingClient,
+                             utils.CallingForm.RequestStreamingBidi} and
+                len(base_param_to_attrs) > 1):
+            raise InvalidRequestSetup("""There can be at most 1 base request in a
+            sample for a method with client side streaming""")
 
         return [TransformedRequest(base, body)
                 for base, body in base_param_to_attrs.items()]
@@ -268,7 +297,7 @@ class Validator:
          number of arguments, and each argument must be a defined variable.
 
          TODO: the attributes of the variable must correspond to attributes
-               of the variable's type.        
+               of the variable's type.
 
          Raises:
              MismatchedFormatSpecifier: If the number of format string segments ("%s") in
@@ -410,3 +439,36 @@ class Validator:
         "comment": _validate_format,
         "loop": _validate_loop,
     }
+
+
+def generate_sample(sample,
+                    env: jinja2.environment.Environment,
+                    api_schema) -> Tuple[str, jinja2.environment.TemplateStream]:
+    sample_template = env.get_template(TEMPLATE_NAME)
+
+    service_name = sample["service"]
+    service = api_schema.services.get(service_name)
+    if not service:
+        raise UnknownService("Unknown service: {}", service_name)
+
+    rpc_name = sample["rpc"]
+    rpc = service.methods.get(rpc_name)
+    if not rpc:
+        raise RpcMethodNotFound(
+            "Could not find rpc in service {}: {}".format(service_name, rpc_name))
+
+    calling_form = utils.CallingForm.method_default(rpc)
+
+    v = Validator()
+    sample["request"] = v.validate_and_transform_request(calling_form,
+                                                         sample["request"])
+    v.validate_response(sample["response"])
+
+    region_tag = sample["region_tag"]
+    sample_fpath = region_tag + str(calling_form) + ".py"
+
+    return sample_fpath, sample_template.stream(fileHeader=FILE_HEADER,
+                                                sample=sample,
+                                                imports=[],
+                                                callingForm=calling_form,
+                                                callingFormEnum=utils.CallingForm)

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -117,6 +117,20 @@ class InvalidRequestSetup(SampleError):
     pass
 
 
+def resp_to_response(s):
+    # In the sample config, the "$resp" keyword is used to refer to the
+    # item of interest as received by the corresponding calling form.
+    # For a 'regular', i.e. unary, synchronous, non-long-running method,
+    # it's the return value; for a server-streaming method, it's the iteration
+    # variable in the for loop that iterates over the return value, and for
+    # a long running promise, the user calls result on the method return value to
+    # resolve the future.
+    #
+    # The sample schema uses '$resp' as the special variable,
+    # but in the samples the 'response' variable is used instead.
+    return s.replace("$resp", "response")
+
+
 class Validator:
     """Class that validates samples.
 
@@ -465,8 +479,8 @@ def generate_sample(sample,
                                                          sample["request"])
     v.validate_response(sample["response"])
 
-    region_tag = sample["region_tag"]
-    sample_fpath = region_tag + str(calling_form) + ".py"
+    sample_id = sample["id"]
+    sample_fpath = sample_id + str(calling_form) + ".py"
 
     return sample_fpath, sample_template.stream(fileHeader=FILE_HEADER,
                                                 sample=sample,

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -21,7 +21,7 @@ from gapic.samplegen import utils
 
 from collections import (defaultdict, namedtuple)
 from textwrap import dedent
-from typing import (List, Mapping, Set, Tuple)
+from typing import (Dict, List, Mapping, Set, Tuple)
 
 # Outstanding issues:
 # * In real sample configs, many variables are
@@ -32,7 +32,7 @@ MIN_SCHEMA_VERSION = (1, 2, 0)
 VALID_CONFIG_TYPE = 'com.google.api.codegen.SampleConfigProto'
 
 # TODO: read in copyright and license from files.
-FILE_HEADER = {}
+FILE_HEADER: Dict[str, str] = {}
 
 RESERVED_WORDS = frozenset(
     itertools.chain(keyword.kwlist,

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -31,22 +31,8 @@ MIN_SCHEMA_VERSION = (1, 2, 0)
 
 VALID_CONFIG_TYPE = 'com.google.api.codegen.SampleConfigProto'
 
-FILE_HEADER = {"copyrightLines": "Copyright (C) 2019  Google LLC",
-               "licenseLines": dedent(
-                   """
-                   Licensed under the Apache License, Version 2.0 (the "License");
-                   you may not use this file except in compliance with the License.
-                   You may obtain a copy of the License at
-                      
-                        http://www.apache.org/licenses/LICENSE-2.0
-                      
-                   Unless required by applicable law or agreed to in writing, software
-                   distributed under the License is distributed on an "AS IS" BASIS,
-                   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-                   See the License for the specific language governing permissions and
-                   limitations under the License.
-                   """).strip()
-               }
+# TODO: read in copyright and license from files.
+FILE_HEADER = {}
 
 RESERVED_WORDS = frozenset(
     itertools.chain(keyword.kwlist,
@@ -117,7 +103,7 @@ class InvalidRequestSetup(SampleError):
     pass
 
 
-def resp_to_response(s):
+def coerce_variable_name(s):
     # In the sample config, the "$resp" keyword is used to refer to the
     # item of interest as received by the corresponding calling form.
     # For a 'regular', i.e. unary, synchronous, non-long-running method,
@@ -481,6 +467,8 @@ def generate_sample(sample,
 
     sample_id = sample["id"]
     sample_fpath = sample_id + str(calling_form) + ".py"
+
+    sample["package_name"] = api_schema.naming.warehouse_package_name
 
     return sample_fpath, sample_template.stream(fileHeader=FILE_HEADER,
                                                 sample=sample,

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -379,6 +379,7 @@ class Validator:
             raise InvalidStatement(
                 "Missing key in 'write_file' statement: 'contents'")
 
+        # TODO: check the rest of the elements for valid subfield attribute
         base = contents_var.split(".")[0]
         if base not in self.var_defs_:
             raise UndefinedVariableReference("Reference to undefined variable: {}"

--- a/gapic/samplegen/utils.py
+++ b/gapic/samplegen/utils.py
@@ -26,12 +26,12 @@ class CallingForm(Enum):
     RequestStreamingServer = auto()
     RequestStreamingBidi = auto()
     RequestPagedAll = auto()
-    LongRunningPromise = auto()
+    LongRunningRequestPromise = auto()
 
     @classmethod
     def method_default(cls, m):
         if m.lro:
-            return cls.LongRunningRequestAsync
+            return cls.LongRunningRequestPromise
         if m.paged_result_field:
             return cls.RequestPagedAll
         if m.client_streaming:

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -52,9 +52,9 @@ class Proto:
 
     @classmethod
     def build(cls, file_descriptor: descriptor_pb2.FileDescriptorProto,
-            file_to_generate: bool, naming: api_naming.Naming,
-            prior_protos: Mapping[str, 'Proto'] = None,
-            ) -> 'Proto':
+              file_to_generate: bool, naming: api_naming.Naming,
+              prior_protos: Mapping[str, 'Proto'] = None,
+              ) -> 'Proto':
         """Build and return a Proto instance.
 
         Args:
@@ -68,10 +68,10 @@ class Proto:
                 These are needed to look up messages in imported protos.
         """
         return _ProtoBuilder(file_descriptor,
-            file_to_generate=file_to_generate,
-            naming=naming,
-            prior_protos=prior_protos or {},
-        ).proto
+                             file_to_generate=file_to_generate,
+                             naming=naming,
+                             prior_protos=prior_protos or {},
+                             ).proto
 
     @cached_property
     def enums(self) -> Mapping[str, wrappers.EnumType]:
@@ -179,9 +179,9 @@ class API:
 
     @classmethod
     def build(cls,
-            file_descriptors: Sequence[descriptor_pb2.FileDescriptorProto],
-            package: str = '',
-            opts: options.Options = options.Options()) -> 'API':
+              file_descriptors: Sequence[descriptor_pb2.FileDescriptorProto],
+              package: str = '',
+              opts: options.Options = options.Options()) -> 'API':
         """Build the internal API schema based on the request.
 
         Args:
@@ -218,15 +218,15 @@ class API:
     def enums(self) -> Mapping[str, wrappers.EnumType]:
         """Return a map of all enums available in the API."""
         return collections.ChainMap({},
-            *[p.all_enums for p in self.protos.values()],
-        )
+                                    *[p.all_enums for p in self.protos.values()],
+                                    )
 
     @cached_property
     def messages(self) -> Mapping[str, wrappers.MessageType]:
         """Return a map of all messages available in the API."""
         return collections.ChainMap({},
-            *[p.all_messages for p in self.protos.values()],
-        )
+                                    *[p.all_messages for p in self.protos.values()],
+                                    )
 
     @cached_property
     def protos(self) -> Mapping[str, Proto]:
@@ -246,8 +246,8 @@ class API:
     def services(self) -> Mapping[str, wrappers.Service]:
         """Return a map of all services available in the API."""
         return collections.ChainMap({},
-            *[p.services for p in self.protos.values()],
-        )
+                                    *[p.services for p in self.protos.values()],
+                                    )
 
     @cached_property
     def subpackages(self) -> Mapping[str, 'API']:
@@ -265,12 +265,13 @@ class API:
         # derivative API objects returned here.
         level = len(self.subpackage_view)
         for subpkg_name in sorted({p.meta.address.subpackage[0]
-                for p in self.protos.values()
-                if len(p.meta.address.subpackage) > level and
-                p.meta.address.subpackage[:level] == self.subpackage_view}):
+                                   for p in self.protos.values()
+                                   if len(p.meta.address.subpackage) > level and
+                                   p.meta.address.subpackage[:level] == self.subpackage_view}):
             answer[subpkg_name] = dataclasses.replace(self,
-                subpackage_view=self.subpackage_view + (subpkg_name,),
-            )
+                                                      subpackage_view=self.subpackage_view +
+                                                      (subpkg_name,),
+                                                      )
         return answer
 
 
@@ -308,7 +309,7 @@ class _ProtoBuilder:
         # detail below; this code simply shifts from a list to a dict,
         # with tuples of paths as the dictionary keys.
         self.docs: Dict[Tuple[int, ...],
-                descriptor_pb2.SourceCodeInfo.Location] = {}
+                        descriptor_pb2.SourceCodeInfo.Location] = {}
         for location in file_descriptor.source_code_info.location:
             self.docs[tuple(location.path)] = location
 
@@ -388,36 +389,37 @@ class _ProtoBuilder:
         # Note: The services bind to themselves, because services get their
         # own output files.
         return dataclasses.replace(naive,
-            all_enums=collections.OrderedDict([
-                (k, v.with_context(collisions=naive.names))
-                for k, v in naive.all_enums.items()
-            ]),
-            all_messages=collections.OrderedDict([
-                (k, v.with_context(collisions=naive.names))
-                for k, v in naive.all_messages.items()
-            ]),
-            services=collections.OrderedDict([
-                (k, v.with_context(collisions=v.names))
-                for k, v in naive.services.items()
-            ]),
-            meta=naive.meta.with_context(collisions=naive.names),
-        )
+                                   all_enums=collections.OrderedDict([
+                                       (k, v.with_context(collisions=naive.names))
+                                       for k, v in naive.all_enums.items()
+                                   ]),
+                                   all_messages=collections.OrderedDict([
+                                       (k, v.with_context(collisions=naive.names))
+                                       for k, v in naive.all_messages.items()
+                                   ]),
+                                   services=collections.OrderedDict([
+                                       (k, v.with_context(collisions=v.names))
+                                       for k, v in naive.services.items()
+                                   ]),
+                                   meta=naive.meta.with_context(
+                                       collisions=naive.names),
+                                   )
 
     @cached_property
     def api_enums(self) -> Mapping[str, wrappers.EnumType]:
         return collections.ChainMap({}, self.proto_enums,
-            *[p.all_enums for p in self.prior_protos.values()],
-        )
+                                    *[p.all_enums for p in self.prior_protos.values()],
+                                    )
 
     @cached_property
     def api_messages(self) -> Mapping[str, wrappers.MessageType]:
         return collections.ChainMap({}, self.proto_messages,
-            *[p.all_messages for p in self.prior_protos.values()],
-        )
+                                    *[p.all_messages for p in self.prior_protos.values()],
+                                    )
 
     def _load_children(self,
-                children: Sequence, loader: Callable, *,
-                address: metadata.Address, path: Tuple[int, ...]) -> Mapping:
+                       children: Sequence, loader: Callable, *,
+                       address: metadata.Address, path: Tuple[int, ...]) -> Mapping:
         """Return wrapped versions of arbitrary children from a Descriptor.
 
         Args:
@@ -448,9 +450,9 @@ class _ProtoBuilder:
         return answer
 
     def _get_fields(self,
-                field_pbs: Sequence[descriptor_pb2.FieldDescriptorProto],
-                address: metadata.Address, path: Tuple[int, ...],
-                ) -> Dict[str, wrappers.Field]:
+                    field_pbs: Sequence[descriptor_pb2.FieldDescriptorProto],
+                    address: metadata.Address, path: Tuple[int, ...],
+                    ) -> Dict[str, wrappers.Field]:
         """Return a dictionary of wrapped fields for the given message.
 
         Args:
@@ -491,9 +493,9 @@ class _ProtoBuilder:
         return answer
 
     def _get_methods(self,
-            methods: Sequence[descriptor_pb2.MethodDescriptorProto],
-            address: metadata.Address, path: Tuple[int, ...],
-            ) -> Mapping[str, wrappers.Method]:
+                     methods: Sequence[descriptor_pb2.MethodDescriptorProto],
+                     address: metadata.Address, path: Tuple[int, ...],
+                     ) -> Mapping[str, wrappers.Method]:
         """Return a dictionary of wrapped methods for the given service.
 
         Args:
@@ -548,10 +550,10 @@ class _ProtoBuilder:
         return answer
 
     def _load_message(self,
-            message_pb: descriptor_pb2.DescriptorProto,
-            address: metadata.Address,
-            path: Tuple[int],
-            ) -> wrappers.MessageType:
+                      message_pb: descriptor_pb2.DescriptorProto,
+                      address: metadata.Address,
+                      path: Tuple[int],
+                      ) -> wrappers.MessageType:
         """Load message descriptions from DescriptorProtos."""
         address = address.child(message_pb.name, path)
 
@@ -603,10 +605,10 @@ class _ProtoBuilder:
         return self.proto_messages[address.proto]
 
     def _load_enum(self,
-            enum: descriptor_pb2.EnumDescriptorProto,
-            address: metadata.Address,
-            path: Tuple[int],
-            ) -> wrappers.EnumType:
+                   enum: descriptor_pb2.EnumDescriptorProto,
+                   address: metadata.Address,
+                   path: Tuple[int],
+                   ) -> wrappers.EnumType:
         """Load enum descriptions from EnumDescriptorProtos."""
         address = address.child(enum.name, path)
 
@@ -633,10 +635,10 @@ class _ProtoBuilder:
         return self.proto_enums[address.proto]
 
     def _load_service(self,
-            service: descriptor_pb2.ServiceDescriptorProto,
-            address: metadata.Address,
-            path: Tuple[int],
-            ) -> wrappers.Service:
+                      service: descriptor_pb2.ServiceDescriptorProto,
+                      address: metadata.Address,
+                      path: Tuple[int],
+                      ) -> wrappers.Service:
         """Load comments for a service and its methods."""
         address = address.child(service.name, path)
 

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -25,13 +25,45 @@ There is a little, but not enough for it to be important because
 
 {# response handling macros #}
 
+{% macro licenseSection(fileHeader, sample, callingForm) %}
+# -*- coding: utf-8 -*-
+#
+{% for line in fileHeader["copyrightLines"] -%}
+# {{ line }}
+{% endfor -%}
+#
+{% for line in fileHeader["licenseLines"] -%}
+# {{ line }}
+{% endfor -%}
+#
+# DO NOT EDIT! This is a generated sample ("{{ callingForm }}",  "{{ sample.region_tag }}")
+#
+# To install the latest published package dependency, execute the following:
+#   pip3 install TODO
+{% endmacro %}
+
+{% macro printInputParams(requests) %}
+{% with input_parameters = [] %}
+{% for request in requests %}
+  {% for element in request.body %}
+    {% if "input_parameter" in element %}
+      {% do input_parameters.append(element["input_parameter"]) %}
+    {% endif %}
+  {% endfor %}
+{% endfor %}
+{{ input_parameters|join(", ") -}}
+{% endwith %}
+{% endmacro %}
+
 {% macro renderPrint(elts) %}
   {# First elment is a format string, remaining elements are the format string parameters #}
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
   {% with fmtStr = ('\"' + elts[0] + '\"') |replace("%s", "{}") %}
-print({{ ([fmtStr] + elts[1:])|join(', ') }})
-  {% endwith -%}
+  {% with params = elts[1:]|map("replace","$resp", "response")|list %}
+print({{ ([fmtStr] + params)|join(', ') }})
+{% endwith -%}
+{% endwith -%}
 {% endmacro %}
 
 {% macro renderComment(elts) %}
@@ -39,30 +71,32 @@ print({{ ([fmtStr] + elts[1:])|join(', ') }})
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
   {% with fmtStr = elts[0] %}
-# {{ fmtStr|format(*elts[1:]) }}
-  {% endwith %}
+  {% with params = elts[1:]|map("replace", "$resp", "response")|list %}
+# {{ fmtStr|format(*params) }}
+{% endwith %}
+{% endwith %}
 {% endmacro %}
 
 {% macro renderDefine(statement) %}
 {# Python code already verified the form, no need to check #}
 {% with lvalue, rvalue = statement.split("=") %}
-{{ lvalue }} = {{ rvalue }}
+{{ lvalue }} = {{ rvalue|replace("$resp", "response") }}
 {% endwith %}
 {% endmacro %}
 
 {% macro renderCollectionLoop(statement) %}
-for {{ statement.variable }} in {{ statement.collection }}:
+for {{ statement.variable }} in {{ statement.collection|replace("$resp", "response") }}:
     {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
 {% macro renderMapLoop(statement) %}
  {# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
-for {{ statement.value }} in {{ statement.map }}.values():
+for {{ statement.value }} in {{ statement.map|replace("$resp", "response") }}.values():
 {% elif "value" not in statement %}
-for {{ statement.key }} in {{ statement.map }}.keys():
+for {{ statement.key }} in {{ statement.map|replace("$resp", "response") }}.keys():
 {% else %}
-for {{statement.key }}, {{ statement.value }} in {{ statement.map }}.items():
+for {{statement.key }}, {{ statement.value }} in {{ statement.map|replace("$resp", "response") }}.items():
 {% endif %}
     {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
@@ -111,6 +145,61 @@ with open({{ attr.input_parameter }}, "rb") as f:
   {% endfor %}
 {% endmacro %}
 
+{% macro renderMethodCall(sample, callingForm, callingFormEnum) %}
+{# Note: this doesn't deal with enums or unions #}
+{% if callingForm not in [callingFormEnum.RequestStreamingBidi,
+callingFormEnum.RequestStreamingClient] %}
+client.{{ sample.rpc }}({{ sample.request|map(attribute="base")|join(", ") }})
+{% else %}
+{# TODO: set up client streaming once some questions are answered #}
+client.{{ sample.rpc }}([{{ sample.request|map(attribute="base")|join("") }}])
+{% endif %}
+{% endmacro %}
+
+{# Setting up the method invocation is the responsibility of the caller: #}
+{# it's just easier to set up client side streamin and other things from outside this macro. #}
+{% macro renderCallingForm(methodInvocationText, callingForm, callingFormEnum, responseStatements ) %}
+{% if callingForm == callingFormEnum.Request %}
+response = {{ methodInvocationText }}
+{% for statement in responseStatements %}
+{{ dispatchStatement(statement ) }}
+{% endfor %}
+{% elif callingForm == callingFormEnum.RequestPagedAll %}
+page_result = {{ methodInvocationText }}
+for response in page_result:
+  {% for statement in responseStatements %}
+    {{ dispatchStatement(statement ) }}
+  {% endfor %}
+{% elif callingForm == callingFormEnum.RequestPaged %}
+page_result = {{ methodInvocationText }}
+for page in page_result.pages():
+    for response in page:
+  {% for statement in responseStatements %}
+        {{ dispatchStatement(statement ) }}
+  {% endfor %}
+{% elif callingForm in [callingFormEnum.RequestStreamingServer,
+callingFormEnum.RequestStreamingBidi] %}
+stream = {{ methodInvocationText }}
+for response in stream:
+  {% for statement in responseStatements %}
+    {{ dispatchStatement(statement ) }}
+  {% endfor %}
+{% elif callingForm == callingFormEnum.LongRunningRequestPromise %}
+operation = {{ methodInvocationText }}
+
+print("Waiting for operation to complete...")
+
+response = operation.result()
+{% for statement in responseStatements %}
+{{ dispatchStatement(statement ) }}
+{% endfor %}
+{% endif %}
+{% endmacro %}
+
+{% macro renderMethodName(methodName) %}
+{{ methodName|snake_case -}}
+{% endmacro %}
+
 {% macro renderMainBlock(methodName, requestBlock) %}
 def main():
     import argparse
@@ -125,7 +214,7 @@ def main():
 {% endfor %}
     args = parser.parse_args()
 
-    sample_{{ methodName|snake_case }}({{ arg_list|join(", ") }})
+    sample_{{ renderMethodName(methodName) }}({{ arg_list|join(", ") }})
 
 
 if __name__ == "__main__":

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -157,7 +157,7 @@ client.{{ sample.rpc }}([{{ sample.request|map(attribute="base")|join("") }}])
 {% endmacro %}
 
 {# Setting up the method invocation is the responsibility of the caller: #}
-{# it's just easier to set up client side streamin and other things from outside this macro. #}
+{# it's just easier to set up client side streaming and other things from outside this macro. #}
 {% macro renderCallingForm(methodInvocationText, callingForm, callingFormEnum, responseStatements ) %}
 {% if callingForm == callingFormEnum.Request %}
 response = {{ methodInvocationText }}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -28,11 +28,11 @@ There is a little, but not enough for it to be important because
 {% macro licenseSection(fileHeader, sample, callingForm) %}
 # -*- coding: utf-8 -*-
 #
-{% for line in fileHeader["copyrightLines"] -%}
+{% for line in fileHeader["copyrightLines"].split("\n") -%}
 # {{ line }}
 {% endfor -%}
 #
-{% for line in fileHeader["licenseLines"] -%}
+{% for line in fileHeader["licenseLines"].split("\n") -%}
 # {{ line }}
 {% endfor -%}
 #
@@ -149,10 +149,10 @@ with open({{ attr.input_parameter }}, "rb") as f:
 {# Note: this doesn't deal with enums or unions #}
 {% if callingForm not in [callingFormEnum.RequestStreamingBidi,
 callingFormEnum.RequestStreamingClient] %}
-client.{{ sample.rpc }}({{ sample.request|map(attribute="base")|join(", ") }})
+client.{{ sample.rpc|snake_case }}({{ sample.request|map(attribute="base")|join(", ") }})
 {% else %}
 {# TODO: set up client streaming once some questions are answered #}
-client.{{ sample.rpc }}([{{ sample.request|map(attribute="base")|join("") }}])
+client.{{ sample.rpc|snake_case }}([{{ sample.request|map(attribute="base")|join("") }}])
 {% endif %}
 {% endmacro %}
 
@@ -178,7 +178,7 @@ for page in page_result.pages():
         {{ dispatchStatement(statement ) }}
   {% endfor %}
 {% elif callingForm in [callingFormEnum.RequestStreamingServer,
-callingFormEnum.RequestStreamingBidi] %}
+                        callingFormEnum.RequestStreamingBidi] %}
 stream = {{ methodInvocationText }}
 for response in stream:
   {% for statement in responseStatements %}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -36,7 +36,7 @@ There is a little, but not enough for it to be important because
 # {{ line }}
 {% endfor -%}
 #
-# DO NOT EDIT! This is a generated sample ("{{ callingForm }}",  "{{ sample.region_tag }}")
+# DO NOT EDIT! This is a generated sample ("{{ callingForm }}",  "{{ sample.id }}")
 #
 # To install the latest published package dependency, execute the following:
 #   pip3 install TODO
@@ -60,7 +60,7 @@ There is a little, but not enough for it to be important because
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
   {% with fmtStr = ('\"' + elts[0] + '\"') |replace("%s", "{}") %}
-  {% with params = elts[1:]|map("replace","$resp", "response")|list %}
+  {% with params = elts[1:]|map("resp_to_response")|list %}
 print({{ ([fmtStr] + params)|join(', ') }})
 {% endwith -%}
 {% endwith -%}
@@ -71,7 +71,7 @@ print({{ ([fmtStr] + params)|join(', ') }})
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
   {% with fmtStr = elts[0] %}
-  {% with params = elts[1:]|map("replace", "$resp", "response")|list %}
+  {% with params = elts[1:]|map("resp_to_response")|list %}
 # {{ fmtStr|format(*params) }}
 {% endwith %}
 {% endwith %}
@@ -80,23 +80,23 @@ print({{ ([fmtStr] + params)|join(', ') }})
 {% macro renderDefine(statement) %}
 {# Python code already verified the form, no need to check #}
 {% with lvalue, rvalue = statement.split("=") %}
-{{ lvalue }} = {{ rvalue|replace("$resp", "response") }}
+{{ lvalue }} = {{ rvalue|resp_to_response }}
 {% endwith %}
 {% endmacro %}
 
 {% macro renderCollectionLoop(statement) %}
-for {{ statement.variable }} in {{ statement.collection|replace("$resp", "response") }}:
+for {{ statement.variable }} in {{ statement.collection|resp_to_response }}:
     {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
 {% macro renderMapLoop(statement) %}
  {# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
-for {{ statement.value }} in {{ statement.map|replace("$resp", "response") }}.values():
+for {{ statement.value }} in {{ statement.map|resp_to_response }}.values():
 {% elif "value" not in statement %}
-for {{ statement.key }} in {{ statement.map|replace("$resp", "response") }}.keys():
+for {{ statement.key }} in {{ statement.map|resp_to_response }}.keys():
 {% else %}
-for {{statement.key }}, {{ statement.value }} in {{ statement.map|replace("$resp", "response") }}.items():
+for {{statement.key }}, {{ statement.value }} in {{ statement.map|resp_to_response }}.items():
 {% endif %}
     {{ dispatchStatement(statement.body) -}}
 {% endmacro %}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -25,21 +25,12 @@ There is a little, but not enough for it to be important because
 
 {# response handling macros #}
 
-{% macro licenseSection(fileHeader, sample, callingForm) %}
-# -*- coding: utf-8 -*-
-#
-{% for line in fileHeader["copyrightLines"].split("\n") -%}
-# {{ line }}
-{% endfor -%}
-#
-{% for line in fileHeader["licenseLines"].split("\n") -%}
-# {{ line }}
-{% endfor -%}
+{% macro sample_header(fileHeader, sample, callingForm) %}
 #
 # DO NOT EDIT! This is a generated sample ("{{ callingForm }}",  "{{ sample.id }}")
 #
 # To install the latest published package dependency, execute the following:
-#   pip3 install TODO
+#   pip3 install {{ sample.package_name }}
 {% endmacro %}
 
 {% macro printInputParams(requests) %}
@@ -60,7 +51,7 @@ There is a little, but not enough for it to be important because
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
   {% with fmtStr = ('\"' + elts[0] + '\"') |replace("%s", "{}") %}
-  {% with params = elts[1:]|map("resp_to_response")|list %}
+  {% with params = elts[1:]|map("coerce_variable_name")|list %}
 print({{ ([fmtStr] + params)|join(', ') }})
 {% endwith -%}
 {% endwith -%}
@@ -71,7 +62,7 @@ print({{ ([fmtStr] + params)|join(', ') }})
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
   {% with fmtStr = elts[0] %}
-  {% with params = elts[1:]|map("resp_to_response")|list %}
+  {% with params = elts[1:]|map("coerce_variable_name")|list %}
 # {{ fmtStr|format(*params) }}
 {% endwith %}
 {% endwith %}
@@ -80,23 +71,23 @@ print({{ ([fmtStr] + params)|join(', ') }})
 {% macro renderDefine(statement) %}
 {# Python code already verified the form, no need to check #}
 {% with lvalue, rvalue = statement.split("=") %}
-{{ lvalue }} = {{ rvalue|resp_to_response }}
+{{ lvalue }} = {{ rvalue|coerce_variable_name }}
 {% endwith %}
 {% endmacro %}
 
 {% macro renderCollectionLoop(statement) %}
-for {{ statement.variable }} in {{ statement.collection|resp_to_response }}:
+for {{ statement.variable }} in {{ statement.collection|coerce_variable_name }}:
     {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
 {% macro renderMapLoop(statement) %}
  {# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
-for {{ statement.value }} in {{ statement.map|resp_to_response }}.values():
+for {{ statement.value }} in {{ statement.map|coerce_variable_name }}.values():
 {% elif "value" not in statement %}
-for {{ statement.key }} in {{ statement.map|resp_to_response }}.keys():
+for {{ statement.key }} in {{ statement.map|coerce_variable_name }}.keys():
 {% else %}
-for {{statement.key }}, {{ statement.value }} in {{ statement.map|resp_to_response }}.items():
+for {{statement.key }}, {{ statement.value }} in {{ statement.map|coerce_variable_name }}.items():
 {% endif %}
     {{ dispatchStatement(statement.body) -}}
 {% endmacro %}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -26,11 +26,25 @@ There is a little, but not enough for it to be important because
 {# response handling macros #}
 
 {% macro sample_header(fileHeader, sample, callingForm) %}
+{% for line in fileHeader["copyright"].split("\n") %}
+# {{ line }}
+{% endfor %}
+{% for line in fileHeader["license"].split("\n") %}
+# {{ line }}
+{% endfor %}
 #
 # DO NOT EDIT! This is a generated sample ("{{ callingForm }}",  "{{ sample.id }}")
 #
 # To install the latest published package dependency, execute the following:
 #   pip3 install {{ sample.package_name }}
+{% endmacro %}
+
+{% macro print_string_formatting(string_list) %}
+{% if string_list|length == 1 %}
+"{{ string_list[0]|replace("%s", "{}") }}"
+{% else %}
+"{{ string_list[0]|replace("%s", "{}") }}".format({{ string_list[1:]|map("coerce_response_name")|join(", ") }})
+{% endif %}
 {% endmacro %}
 
 {% macro printInputParams(requests) %}
@@ -50,11 +64,7 @@ There is a little, but not enough for it to be important because
   {# First elment is a format string, remaining elements are the format string parameters #}
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
-  {% with fmtStr = ('\"' + elts[0] + '\"') |replace("%s", "{}") %}
-  {% with params = elts[1:]|map("coerce_variable_name")|list %}
-print({{ ([fmtStr] + params)|join(', ') }})
-{% endwith -%}
-{% endwith -%}
+print({{ print_string_formatting(elts)|trim }})
 {% endmacro %}
 
 {% macro renderComment(elts) %}
@@ -62,7 +72,7 @@ print({{ ([fmtStr] + params)|join(', ') }})
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
   {% with fmtStr = elts[0] %}
-  {% with params = elts[1:]|map("coerce_variable_name")|list %}
+  {% with params = elts[1:]|map("coerce_response_name")|list %}
 # {{ fmtStr|format(*params) }}
 {% endwith %}
 {% endwith %}
@@ -71,25 +81,33 @@ print({{ ([fmtStr] + params)|join(', ') }})
 {% macro renderDefine(statement) %}
 {# Python code already verified the form, no need to check #}
 {% with lvalue, rvalue = statement.split("=") %}
-{{ lvalue }} = {{ rvalue|coerce_variable_name }}
+{{ lvalue }} = {{ rvalue|coerce_response_name }}
 {% endwith %}
 {% endmacro %}
 
 {% macro renderCollectionLoop(statement) %}
-for {{ statement.variable }} in {{ statement.collection|coerce_variable_name }}:
+for {{ statement.variable }} in {{ statement.collection|coerce_response_name }}:
     {{ dispatchStatement(statement.body) -}}
 {% endmacro %}
 
 {% macro renderMapLoop(statement) %}
  {# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
-for {{ statement.value }} in {{ statement.map|coerce_variable_name }}.values():
+for {{ statement.value }} in {{ statement.map|coerce_response_name }}.values():
 {% elif "value" not in statement %}
-for {{ statement.key }} in {{ statement.map|coerce_variable_name }}.keys():
+for {{ statement.key }} in {{ statement.map|coerce_response_name }}.keys():
 {% else %}
-for {{statement.key }}, {{ statement.value }} in {{ statement.map|coerce_variable_name }}.items():
+for {{statement.key }}, {{ statement.value }} in {{ statement.map|coerce_response_name }}.items():
 {% endif %}
     {{ dispatchStatement(statement.body) -}}
+{% endmacro %}
+
+{% macro render_write_file(statement) %}
+  {% with contents_rval = statement["contents"]|coerce_response_name %}
+with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
+    f.write({{ contents_rval }})
+
+  {% endwith %}
 {% endmacro %}
 
 {% macro dispatchStatement(statement) %}
@@ -106,6 +124,8 @@ for {{statement.key }}, {{ statement.value }} in {{ statement.map|coerce_variabl
 {{ renderMapLoop(loop) -}}
     {% endif %}
   {% endwith %}
+{% elif "write_file" in statement %}
+{{ render_write_file(statement["write_file"]) -}}
 {% endif %}
 {% endmacro %}
 

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -41,7 +41,6 @@ def sample_{{ frags.renderMethodName(sample.rpc) }}({{ frags.printInputParams(sa
 
     {{ frags.renderRequest(sample.request)|indent }}
 
-{# Still need to set up client streaming #}
 {% with methodCall = frags.renderMethodCall(sample, callingForm, callingFormEnum) %}
     {{ frags.renderCallingForm(methodCall, callingForm, callingFormEnum, sample.response)|indent }}
 {% endwith %}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -23,7 +23,7 @@
 {% import "feature_fragments.j2" as frags %}
 {{ frags.licenseSection(fileHeader, sample, callingForm) }}
 
-# [START {{ sample.region_tag }}]
+# [START {{ sample.id }}]
 {# python code is responsible for all transformations: all we do here is render #}
 {% for importStatement in imports %}
 {{ importStatement }}
@@ -33,7 +33,7 @@
 def sample_{{ frags.renderMethodName(sample.rpc) }}({{ frags.printInputParams(sample.request) }}):
     """{{ sample.description }}"""
 
-    # [START {{ sample.region_tag }}_core]
+    # [START {{ sample.id }}_core]
 
     client = {{ sample.service.split(".")[-3:-1]|
                 map("lower")|
@@ -43,8 +43,8 @@ def sample_{{ frags.renderMethodName(sample.rpc) }}({{ frags.printInputParams(sa
 {% with methodCall = frags.renderMethodCall(sample, callingForm, callingFormEnum) %}
     {{ frags.renderCallingForm(methodCall, callingForm, callingFormEnum, sample.response)|indent }}
 {% endwith %}
-    # [END {{ sample.region_tag}}_core]
+    # [END {{ sample.id}}_core]
 
-# [END {{ sample.region_tag }}]
+# [END {{ sample.id }}]
 
 {{ frags.renderMainBlock(sample.rpc, sample.request) }}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -33,17 +33,14 @@
 def sample_{{ frags.renderMethodName(sample.rpc) }}({{ frags.printInputParams(sample.request) }}):
     """{{ sample.description }}"""
 
-    # [START {{ sample.id }}_core]
-
     client = {{ sample.service.split(".")[-3:-1]|
                 map("lower")|
                 join("_") }}.{{ sample.service.split(".")[-1] }}Client()
 
     {{ frags.renderRequest(sample.request)|indent }}
 {% with methodCall = frags.renderMethodCall(sample, callingForm, callingFormEnum) %}
-    {{ frags.renderCallingForm(methodCall, callingForm, callingFormEnum, sample.response)|indent }}
+    {{ frags.renderCallingForm(methodCall, callingForm, callingFormEnum, sample.response)|indent -}}
 {% endwith %}
-    # [END {{ sample.id}}_core]
 
 # [END {{ sample.id }}]
 

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -21,7 +21,7 @@
 {# Note: this sample template is WILDLY INACCURATE AND INCOMPLETE #}
 {# It does not correctly enums, unions, top level attributes, or various other things #}
 {% import "feature_fragments.j2" as frags %}
-{{ frags.licenseSection(fileHeader, sample, callingForm) }}
+{{ frags.sample_header(fileHeader, sample, callingForm) }}
 
 # [START {{ sample.id }}]
 {# python code is responsible for all transformations: all we do here is render #}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -40,7 +40,6 @@ def sample_{{ frags.renderMethodName(sample.rpc) }}({{ frags.printInputParams(sa
                 join("_") }}.{{ sample.service.split(".")[-1] }}Client()
 
     {{ frags.renderRequest(sample.request)|indent }}
-
 {% with methodCall = frags.renderMethodCall(sample, callingForm, callingFormEnum) %}
     {{ frags.renderCallingForm(methodCall, callingForm, callingFormEnum, sample.response)|indent }}
 {% endwith %}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -1,0 +1,52 @@
+{#
+ # Copyright (C) 2019  Google LLC
+ #
+ # Licensed under the Apache License, Version 2.0 (the "License");
+ # you may not use this file except in compliance with the License.
+ # You may obtain a copy of the License at
+ #
+ #     http://www.apache.org/licenses/LICENSE-2.0
+ #
+ # Unless required by applicable law or agreed to in writing, software
+ # distributed under the License is distributed on an "AS IS" BASIS,
+ # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ # See the License for the specific language governing permissions and
+ # limitations under the License.
+#}
+{# Input parameters: sample #}
+{#                   fileHeader#}
+{#                   imports #}
+{#                   callingForm #}
+{#                   callingFormEnum #}
+{# Note: this sample template is WILDLY INACCURATE AND INCOMPLETE #}
+{# It does not correctly enums, unions, top level attributes, or various other things #}
+{% import "feature_fragments.j2" as frags %}
+{{ frags.licenseSection(fileHeader, sample, callingForm) }}
+
+# [START {{ sample.region_tag }}]
+{# python code is responsible for all transformations: all we do here is render #}
+{% for importStatement in imports %}
+{{ importStatement }}
+{% endfor %}
+
+{# also need calling form #}
+def sample_{{ frags.renderMethodName(sample.rpc) }}({{ frags.printInputParams(sample.request) }}):
+    """{{ sample.description }}"""
+
+    # [START {{ sample.region_tag }}_core]
+
+    client = {{ sample.service.split(".")[-3:-1]|
+                map("lower")|
+                join("_") }}.{{ sample.service.split(".")[-1] }}Client()
+
+    {{ frags.renderRequest(sample.request)|indent }}
+
+{# Still need to set up client streaming #}
+{% with methodCall = frags.renderMethodCall(sample, callingForm, callingFormEnum) %}
+    {{ frags.renderCallingForm(methodCall, callingForm, callingFormEnum, sample.response)|indent }}
+{% endwith %}
+    # [END {{ sample.region_tag}}_core]
+
+# [END {{ sample.region_tag }}]
+
+{{ frags.renderMainBlock(sample.rpc, sample.request) }}

--- a/gapic/utils/__init__.py
+++ b/gapic/utils/__init__.py
@@ -15,6 +15,7 @@
 from gapic.utils.cache import cached_property
 from gapic.utils.case import to_snake_case
 from gapic.utils.code import empty
+from gapic.utils.code import partition
 from gapic.utils.doc import doc
 from gapic.utils.filename import to_valid_filename
 from gapic.utils.filename import to_valid_module_name
@@ -27,6 +28,7 @@ __all__ = (
     'cached_property',
     'doc',
     'empty',
+    'partition',
     'rst',
     'sort_lines',
     'to_snake_case',

--- a/gapic/utils/code.py
+++ b/gapic/utils/code.py
@@ -28,14 +28,14 @@ def empty(content: str) -> bool:
 T = TypeVar('T')
 
 
-def partition(iterator: Iterable[T],
-              predicate: Callable[[T], bool] = bool) -> Tuple[List[T], List[T]]:
+def partition(predicate: Callable[[T], bool],
+              iterator: Iterable[T]) -> Tuple[List[T], List[T]]:
     """Partitions an iterable into two lists based on a predicate
 
     Args:
-        iterator Iterable(T):           An iterable on any type.
         predicate Callable((T), bool) : A callable predicate on a single argument
                                         of whatever type is in iterator.
+        iterator Iterable(T):           An iterable on any type.
 
     Returns:
         Tuple(List(T), List(T)): The contents of iterator partitioned into two lists.

--- a/gapic/utils/code.py
+++ b/gapic/utils/code.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import (Any, Callable, Iterable, List, Tuple, TypeVar)
+
 
 def empty(content: str) -> bool:
     """Return True if this file has no Python statements, False otherwise.
@@ -23,23 +25,27 @@ def empty(content: str) -> bool:
                     for i in content.split('\n')])
 
 
-def partition(iterator, predicate=bool):
+T = TypeVar('T')
+
+
+def partition(iterator: Iterable[T],
+              predicate: Callable[[T], bool] = bool) -> Tuple[List[T], List[T]]:
     """Partitions an iterable into two lists based on a predicate
 
     Args:
-        iterator : An iterable on any type.
-        predicate: A callable predicate on a single argument
-                   of whatever type is in iterator.
+        iterator Iterable(T):           An iterable on any type.
+        predicate Callable((T), bool) : A callable predicate on a single argument
+                                        of whatever type is in iterator.
 
     Returns:
-        Tuple(List, List): The contents of iterator partitoned into two lists.
-                           The first list contains the "true" elements
-                           and the second contains the "false" elements.
+        Tuple(List(T), List(T)): The contents of iterator partitoned into two lists.
+                                 The first list contains the "true" elements
+                                 and the second contains the "false" elements.
     """
-    results = ([], [])
+    results: Tuple[List[T], List[T]] = ([], [])
 
     for i in iterator:
         results[int(predicate(i))].append(i)
 
     # Returns trueList, falseList
-    return reversed(results)
+    return results[1], results[0]

--- a/gapic/utils/code.py
+++ b/gapic/utils/code.py
@@ -33,13 +33,13 @@ def partition(predicate: Callable[[T], bool],
     """Partitions an iterable into two lists based on a predicate
 
     Args:
-        predicate (Callable((T), bool)) : A callable predicate on a single argument
+        predicate (Callable[[T], bool]) : A callable predicate on a single argument
                                           of whatever type is in iterator.
         iterator (Iterable(T)):           An iterable on any type.
 
 
     Returns:
-        Tuple(List(T), List(T)): The contents of iterator partitioned into two lists.
+        Tuple[List[T], List[T]]: The contents of iterator partitioned into two lists.
                                  The first list contains the "true" elements
                                  and the second contains the "false" elements.
     """

--- a/gapic/utils/code.py
+++ b/gapic/utils/code.py
@@ -38,7 +38,7 @@ def partition(iterator: Iterable[T],
                                         of whatever type is in iterator.
 
     Returns:
-        Tuple(List(T), List(T)): The contents of iterator partitoned into two lists.
+        Tuple(List(T), List(T)): The contents of iterator partitioned into two lists.
                                  The first list contains the "true" elements
                                  and the second contains the "false" elements.
     """

--- a/gapic/utils/code.py
+++ b/gapic/utils/code.py
@@ -33,9 +33,10 @@ def partition(predicate: Callable[[T], bool],
     """Partitions an iterable into two lists based on a predicate
 
     Args:
-        predicate Callable((T), bool) : A callable predicate on a single argument
-                                        of whatever type is in iterator.
-        iterator Iterable(T):           An iterable on any type.
+        predicate (Callable((T), bool)) : A callable predicate on a single argument
+                                          of whatever type is in iterator.
+        iterator (Iterable(T)):           An iterable on any type.
+
 
     Returns:
         Tuple(List(T), List(T)): The contents of iterator partitioned into two lists.

--- a/gapic/utils/code.py
+++ b/gapic/utils/code.py
@@ -21,3 +21,25 @@ def empty(content: str) -> bool:
     """
     return not any([i.lstrip() and not i.lstrip().startswith('#')
                     for i in content.split('\n')])
+
+
+def partition(iterator, predicate=bool):
+    """Partitions an iterable into two lists based on a predicate
+
+    Args:
+        iterator : An iterable on any type.
+        predicate: A callable predicate on a single argument
+                   of whatever type is in iterator.
+
+    Returns:
+        Tuple(List, List): The contents of iterator partitoned into two lists.
+                           The first list contains the "true" elements
+                           and the second contains the "false" elements.
+    """
+    results = ([], [])
+
+    for i in iterator:
+        results[int(predicate(i))].append(i)
+
+    # Returns trueList, falseList
+    return reversed(results)

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -45,6 +45,7 @@ env = jinja2.Environment(
     trim_blocks=True, lstrip_blocks=True
 )
 env.filters['snake_case'] = utils.to_snake_case
+env.filters['resp_to_response'] = samplegen.resp_to_response
 
 
 def test_generate_sample_basic():
@@ -58,7 +59,7 @@ def test_generate_sample_basic():
 
     sample = {"service": "animalia.mollusca.v1.Mollusc",
               "rpc": "Classify",
-              "region_tag": "mollusc_classify_sync",
+              "id": "mollusc_classify_sync",
               "description": "Determine the full taxonomy of input mollusc",
               "request": [{"field": "classify_request.video",
                            "value": "path/to/mollusc/video.mkv",

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -66,9 +66,6 @@ def test_generate_sample_basic():
     fpath, template_stream = samplegen.generate_sample(sample, env, schema)
     sample_str = "".join(iter(template_stream))
 
-    with open("/usr/local/google/home/dovs/tmp/sample.py", "w") as f:
-        f.write(sample_str)
-
     assert sample_str == '''# -*- coding: utf-8 -*-
 #
 # Copyright (C) 2019  Google LLC

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -48,7 +48,7 @@ env = jinja2.Environment(
     trim_blocks=True, lstrip_blocks=True
 )
 env.filters['snake_case'] = utils.to_snake_case
-env.filters['coerce_variable_name'] = samplegen.coerce_variable_name
+env.filters['coerce_response_name'] = samplegen.coerce_response_name
 
 
 def test_generate_sample_basic():
@@ -75,7 +75,9 @@ def test_generate_sample_basic():
     fpath, template_stream = samplegen.generate_sample(sample, env, schema)
     sample_str = "".join(iter(template_stream))
 
-    assert sample_str == '''#
+    assert sample_str == '''# TODO: add a copyright
+# TODO: add a license
+#
 # DO NOT EDIT! This is a generated sample ("CallingForm.Request",  "mollusc_classify_sync")
 #
 # To install the latest published package dependency, execute the following:
@@ -87,8 +89,6 @@ def test_generate_sample_basic():
 def sample_classify(video):
     """Determine the full taxonomy of input mollusc"""
 
-    # [START mollusc_classify_sync_core]
-
     client = mollusca_v1.MolluscClient()
 
     classify_request = {}
@@ -99,10 +99,8 @@ def sample_classify(video):
 
     response = client.classify(classify_request)
 
-    print("Mollusc is a {}", response.taxonomy)
+    print("Mollusc is a {}".format(response.taxonomy))
 
-
-    # [END mollusc_classify_sync_core]
 
 # [END mollusc_classify_sync]
 

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jinja2
+import os.path as path
+import pytest
+
+import gapic.samplegen.samplegen as samplegen
+import gapic.utils as utils
+
+from collections import namedtuple
+from textwrap import dedent
+
+# Injected dummy test types
+dummy_method_fields = ["lro",
+                       "paged_result_field",
+                       "client_streaming",
+                       "server_streaming"]
+DummyMethod = namedtuple("DummyMethod",
+                         dummy_method_fields)
+DummyMethod.__new__.__defaults__ = (False,)*len(dummy_method_fields)
+
+DummyService = namedtuple("DummyService", ["methods"])
+
+DummyApiSchema = namedtuple("DummyApiSchema", ["services"])
+
+env = jinja2.Environment(
+    loader=jinja2.FileSystemLoader(
+        searchpath=path.realpath(path.join(path.dirname(__file__),
+                                           "..", "..", "..",
+                                           "gapic", "templates", "examples"))),
+    undefined=jinja2.StrictUndefined,
+    extensions=["jinja2.ext.do"],
+    trim_blocks=True, lstrip_blocks=True
+)
+env.filters['snake_case'] = utils.to_snake_case
+
+
+def test_generate_sample_basic():
+    # Note: the sample integration tests are needfully large
+    # and difficult to eyeball parse. They
+    schema = DummyApiSchema(
+        {"animalia.mollusca.v1.Mollusc": DummyService({"Classify": DummyMethod()})})
+
+    sample = {"service": "animalia.mollusca.v1.Mollusc",
+              "rpc": "Classify",
+              "region_tag": "mollusc_classify_sync",
+              "description": "Determine the full taxonomy of input mollusc",
+              "request": [{"field": "classify_request.video",
+                           "value": "path/to/mollusc/video.mkv",
+                           "input_parameter": "video",
+                           "value_is_file": True}],
+              "response": [{"print": ["Mollusc is a %s", "$resp.taxonomy"]}]}
+
+    fpath, template_stream = samplegen.generate_sample(sample, env, schema)
+    sample_str = "".join(iter(template_stream))
+
+    with open("/usr/local/google/home/dovs/tmp/sample.py", "w") as f:
+        f.write(sample_str)
+
+    assert sample_str == '''# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#      http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# DO NOT EDIT! This is a generated sample ("CallingForm.Request",  "mollusc_classify_sync")
+#
+# To install the latest published package dependency, execute the following:
+#   pip3 install TODO
+
+
+# [START mollusc_classify_sync]
+
+def sample_classify(video):
+    """Determine the full taxonomy of input mollusc"""
+
+    # [START mollusc_classify_sync_core]
+
+    client = mollusca_v1.MolluscClient()
+
+    classify_request = {}
+    # video = "path/to/mollusc/video.mkv"
+    with open(video, "rb") as f:
+        classify_request["video"] = f.read()
+
+
+
+    response = client.Classify(classify_request)
+
+    print("Mollusc is a {}", response.taxonomy)
+
+
+    # [END mollusc_classify_sync_core]
+
+# [END mollusc_classify_sync]
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    args = parser.parse_args()
+
+    sample_classify()
+
+
+if __name__ == "__main__":
+    main()
+'''
+
+
+def test_generate_sample_service_not_found():
+    schema = DummyApiSchema({})
+    sample = {"service": "Mollusc"}
+
+    with pytest.raises(samplegen.UnknownService):
+        samplegen.generate_sample(sample, env, schema)
+
+
+def test_generate_sample_rpc_not_found():
+    schema = DummyApiSchema({"Mollusc": DummyService({})})
+    sample = {"service": "Mollusc", "rpc": "Classify"}
+
+    with pytest.raises(samplegen.RpcMethodNotFound):
+        samplegen.generate_sample(sample, env, schema)

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -49,7 +49,10 @@ env.filters['snake_case'] = utils.to_snake_case
 
 def test_generate_sample_basic():
     # Note: the sample integration tests are needfully large
-    # and difficult to eyeball parse. They
+    # and difficult to eyeball parse. They are intended to be integration tests
+    # that catch errors in behavior that is emergent from combining smaller features
+    # or in features that are sufficiently small and trivial that it doesn't make sense
+    # to have standalone tests.
     schema = DummyApiSchema(
         {"animalia.mollusca.v1.Mollusc": DummyService({"Classify": DummyMethod()})})
 

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -106,8 +106,7 @@ def sample_classify(video):
         classify_request["video"] = f.read()
 
 
-
-    response = client.Classify(classify_request)
+    response = client.classify(classify_request)
 
     print("Mollusc is a {}", response.taxonomy)
 

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -417,6 +417,14 @@ def test_validate_request_reserved_input_param():
 
 
 def test_single_request_client_streaming():
+    # Each API client method really only takes one parameter:
+    # either a single protobuf message or an iterable of protobuf messages.
+    # With unary request methods, python lets us describe attributes as positional
+    # and keyword parameters, which simplifies request construction.
+    # The 'base' in the transformed request refers to an attribute, and the
+    # 'field's refer to sub-attributes.
+    # Client streaming and bidirectional streaming methods can't use this notation,
+    # and generate an exception if there is more than one 'base'.
     with pytest.raises(samplegen.InvalidRequestSetup):
         samplegen.Validator().validate_and_transform_request(
             utils.CallingForm.RequestStreamingClient,
@@ -427,6 +435,14 @@ def test_single_request_client_streaming():
 
 
 def test_single_request_bidi_streaming():
+    # Each API client method really only takes one parameter:
+    # either a single protobuf message or an iterable of protobuf messages.
+    # With unary request methods, python lets us describe attributes as positional
+    # and keyword parameters, which simplifies request construction.
+    # The 'base' in the transformed request refers to an attribute, and the
+    # 'field's refer to sub-attributes.
+    # Client streaming and bidirectional streaming methods can't use this notation,
+    # and generate an exception if there is more than one 'base'.
     with pytest.raises(samplegen.InvalidRequestSetup):
         samplegen.Validator().validate_and_transform_request(
             utils.CallingForm.RequestStreamingBidi,

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -476,3 +476,9 @@ def test_validate_request_calling_form():
 
     assert utils.CallingForm.method_default(DummyMethod(
         False, False, True, True)) == utils.CallingForm.RequestStreamingBidi
+
+
+def test_resp_to_response():
+    # Don't really need a test, but it shuts up code coverage.
+    assert samplegen.resp_to_response("$resp.squid") == "response.squid"
+    assert samplegen.resp_to_response("mollusc.squid") == "mollusc.squid"

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -478,7 +478,7 @@ def test_validate_request_calling_form():
         False, False, True, True)) == utils.CallingForm.RequestStreamingBidi
 
 
-def test_resp_to_response():
+def test_coerce_variable_name():
     # Don't really need a test, but it shuts up code coverage.
-    assert samplegen.resp_to_response("$resp.squid") == "response.squid"
-    assert samplegen.resp_to_response("mollusc.squid") == "mollusc.squid"
+    assert samplegen.coerce_variable_name("$resp.squid") == "response.squid"
+    assert samplegen.coerce_variable_name("mollusc.squid") == "mollusc.squid"

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -335,6 +335,47 @@ def test_loop_map_redefined_value():
         samplegen.Validator().validate_response(statements)
 
 
+def test_validate_write_file():
+    samplegen.Validator().validate_response(
+        [{"write_file": {"filename": ["specimen-%s", "$resp.species"],
+                         "contents": "$resp.photo"}}])
+
+
+def test_validate_write_file_fname_fmt():
+    with pytest.raises(samplegen.MismatchedFormatSpecifier):
+        samplegen.Validator().validate_response(
+            [{"write_file": {"filename": ["specimen-%s"],
+                             "contents": "$resp.photo"}}])
+
+
+def test_validate_write_file_fname_bad_var():
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        samplegen.Validator().validate_response(
+            [{"write_file": {"filename": ["specimen-%s", "squid.species"],
+                             "contents": "$resp.photo"}}])
+
+
+def test_validate_write_file_missing_fname():
+    with pytest.raises(samplegen.InvalidStatement):
+        samplegen.Validator().validate_response(
+            [{"write_file": {"contents": "$resp.photo"}}]
+        )
+
+
+def test_validate_write_file_missing_contents():
+    with pytest.raises(samplegen.InvalidStatement):
+        samplegen.Validator().validate_response(
+            [{"write_file": {"filename": ["specimen-%s", "$resp.species"]}}]
+        )
+
+
+def test_validate_write_file_bad_contents_var():
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        samplegen.Validator().validate_response(
+            [{"write_file": {"filename": ["specimen-%s", "$resp.species"],
+                             "contents": "squid.photo"}}])
+
+
 def test_invalid_statement():
     statement = {"print": ["Name"], "comment": ["Value"]}
     with pytest.raises(samplegen.InvalidStatement):
@@ -478,7 +519,7 @@ def test_validate_request_calling_form():
         False, False, True, True)) == utils.CallingForm.RequestStreamingBidi
 
 
-def test_coerce_variable_name():
+def test_coerce_response_name():
     # Don't really need a test, but it shuts up code coverage.
-    assert samplegen.coerce_variable_name("$resp.squid") == "response.squid"
-    assert samplegen.coerce_variable_name("mollusc.squid") == "mollusc.squid"
+    assert samplegen.coerce_response_name("$resp.squid") == "response.squid"
+    assert samplegen.coerce_response_name("mollusc.squid") == "mollusc.squid"

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -44,6 +44,7 @@ def check_template(template_fragment, expected_output, **kwargs):
     )
 
     env.filters['snake_case'] = utils.to_snake_case
+    env.filters['resp_to_response'] = samplegen.resp_to_response
 
     template = env.get_template("template_fragment")
     text = template.render(**kwargs)

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -44,7 +44,7 @@ def check_template(template_fragment, expected_output, **kwargs):
     )
 
     env.filters['snake_case'] = utils.to_snake_case
-    env.filters['resp_to_response'] = samplegen.resp_to_response
+    env.filters['coerce_variable_name'] = samplegen.coerce_variable_name
 
     template = env.get_template("template_fragment")
     text = template.render(**kwargs)


### PR DESCRIPTION
Adds basic functionality and tests for end-to-end sample generation.

Includes tests for comprehensive sample generation

Conduct translation from special variable '$resp' to 'response' in
template rendering

Includes macros to set up method invocation, adds code to include
license and copyright information,

Includes minor tweaks to various names, tests, and macros.

Note: sample generation is still ignorant of method and message
      signatures, types, attributes, and so forth.
      TODOs mark these areas in the code.
      More full-featured semantic analysis will be conducted
      in subsequent PRs.