### PR TITLE
Broad, shallow cleanup

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -506,8 +506,8 @@ def generate_sample(sample,
 
     sample["package_name"] = api_schema.naming.warehouse_package_name
 
-    return sample_fpath, sample_template.stream(fileHeader=FILE_HEADER,
+    return sample_fpath, sample_template.stream(file_header=FILE_HEADER,
                                                 sample=sample,
                                                 imports=[],
-                                                callingForm=calling_form,
-                                                callingFormEnum=utils.CallingForm)
+                                                calling_form=calling_form,
+                                                calling_form_enum=utils.CallingForm)

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -25,15 +25,15 @@ There is a little, but not enough for it to be important because
 
 {# response handling macros #}
 
-{% macro sample_header(fileHeader, sample, callingForm) %}
-{% for line in fileHeader["copyright"].split("\n") %}
+{% macro sample_header(file_header, sample, calling_form) %}
+{% for line in file_header["copyright"].split("\n") %}
 # {{ line }}
 {% endfor %}
-{% for line in fileHeader["license"].split("\n") %}
+{% for line in file_header["license"].split("\n") %}
 # {{ line }}
 {% endfor %}
 #
-# DO NOT EDIT! This is a generated sample ("{{ callingForm }}",  "{{ sample.id }}")
+# DO NOT EDIT! This is a generated sample ("{{ calling_form }}",  "{{ sample.id }}")
 #
 # To install the latest published package dependency, execute the following:
 #   pip3 install {{ sample.package_name }}
@@ -47,7 +47,7 @@ There is a little, but not enough for it to be important because
 {% endif %}
 {% endmacro %}
 
-{% macro printInputParams(requests) %}
+{% macro print_input_params(requests) %}
 {% with input_parameters = [] %}
 {% for request in requests %}
   {% for element in request.body %}
@@ -60,14 +60,14 @@ There is a little, but not enough for it to be important because
 {% endwith %}
 {% endmacro %}
 
-{% macro renderPrint(elts) %}
+{% macro render_print(elts) %}
   {# First elment is a format string, remaining elements are the format string parameters #}
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
 print({{ print_string_formatting(elts)|trim }})
 {% endmacro %}
 
-{% macro renderComment(elts) %}
+{% macro render_comment(elts) %}
   {# First elment is a format string, remaining elements are the format string parameters #}
   {# Validating that the number of format params equals #}
   {# the number of remaining params is handled by real python code #}
@@ -78,19 +78,19 @@ print({{ print_string_formatting(elts)|trim }})
 {% endwith %}
 {% endmacro %}
 
-{% macro renderDefine(statement) %}
+{% macro render_define(statement) %}
 {# Python code already verified the form, no need to check #}
 {% with lvalue, rvalue = statement.split("=") %}
 {{ lvalue }} = {{ rvalue|coerce_response_name }}
 {% endwith %}
 {% endmacro %}
 
-{% macro renderCollectionLoop(statement) %}
+{% macro render_collection_loop(statement) %}
 for {{ statement.variable }} in {{ statement.collection|coerce_response_name }}:
-    {{ dispatchStatement(statement.body) -}}
+    {{ dispatch_statement(statement.body) -}}
 {% endmacro %}
 
-{% macro renderMapLoop(statement) %}
+{% macro render_map_loop(statement) %}
  {# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
 for {{ statement.value }} in {{ statement.map|coerce_response_name }}.values():
@@ -99,7 +99,7 @@ for {{ statement.key }} in {{ statement.map|coerce_response_name }}.keys():
 {% else %}
 for {{statement.key }}, {{ statement.value }} in {{ statement.map|coerce_response_name }}.items():
 {% endif %}
-    {{ dispatchStatement(statement.body) -}}
+    {{ dispatch_statement(statement.body) -}}
 {% endmacro %}
 
 {% macro render_write_file(statement) %}
@@ -110,18 +110,18 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
   {% endwith %}
 {% endmacro %}
 
-{% macro dispatchStatement(statement) %}
+{% macro dispatch_statement(statement) %}
 {# Each statement is a dict with a single key/value pair #}
 {% if "print" in statement %}
-{{ renderPrint(statement["print"]) -}}
+{{ render_print(statement["print"]) -}}
 {% elif "comment" in statement %}
-{{ renderComment(statement["comment"]) -}}
+{{ render_comment(statement["comment"]) -}}
 {% elif "loop" in statement %}
   {% with loop = statement["loop"] %}
     {% if "collection" in loop %}
-{{ renderCollectionLoop(loop) -}}
+{{ render_collection_loop(loop) -}}
     {% else %}
-{{ renderMapLoop(loop) -}}
+{{ render_map_loop(loop) -}}
     {% endif %}
   {% endwith %}
 {% elif "write_file" in statement %}
@@ -129,7 +129,7 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 {% endif %}
 {% endmacro %}
 
-{% macro renderRequestAttr(baseName, attr) %}
+{% macro render_request_attr(base_name, attr) %}
 {# Note: python code will have manipulated the value #}
 {# to be the correct enum from the right module, if necessary. #}
 {# Python is also responsible for verifying that each input parameter is unique,#}
@@ -138,28 +138,28 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 # {{ attr.input_parameter }} = "{{ attr.value }}"
     {% if "value_is_file" in attr and attr.value_is_file %}
 with open({{ attr.input_parameter }}, "rb") as f:
-    {{ baseName }}["{{ attr.field }}"] = f.read()
+    {{ base_name }}["{{ attr.field }}"] = f.read()
     {% else %}
-{{ baseName }}["{{ attr.field }}"] = {{ attr.input_parameter }}
+{{ base_name }}["{{ attr.field }}"] = {{ attr.input_parameter }}
     {% endif %}
   {% else %}
-{{ baseName }}["{{ attr.field }}"] = {{ attr.value }}
+{{ base_name }}["{{ attr.field }}"] = {{ attr.value }}
   {% endif %}
 {% endmacro %}
 
-{% macro renderRequest(request) %}
-  {% for parameterBlock in request %}
-{{ parameterBlock.base }} = {}
-    {% for attr in parameterBlock.body %}
-{{ renderRequestAttr(parameterBlock.base, attr) }}
+{% macro render_request(request) %}
+  {% for parameter_block in request %}
+{{ parameter_block.base }} = {}
+    {% for attr in parameter_block.body %}
+{{ render_request_attr(parameter_block.base, attr) }}
     {% endfor %}
   {% endfor %}
 {% endmacro %}
 
-{% macro renderMethodCall(sample, callingForm, callingFormEnum) %}
+{% macro render_method_call(sample, calling_form, calling_form_enum) %}
 {# Note: this doesn't deal with enums or unions #}
-{% if callingForm not in [callingFormEnum.RequestStreamingBidi,
-callingFormEnum.RequestStreamingClient] %}
+{% if calling_form not in [calling_form_enum.RequestStreamingBidi,
+calling_form_enum.RequestStreamingClient] %}
 client.{{ sample.rpc|snake_case }}({{ sample.request|map(attribute="base")|join(", ") }})
 {% else %}
 {# TODO: set up client streaming once some questions are answered #}
@@ -169,55 +169,55 @@ client.{{ sample.rpc|snake_case }}([{{ sample.request|map(attribute="base")|join
 
 {# Setting up the method invocation is the responsibility of the caller: #}
 {# it's just easier to set up client side streaming and other things from outside this macro. #}
-{% macro renderCallingForm(methodInvocationText, callingForm, callingFormEnum, responseStatements ) %}
-{% if callingForm == callingFormEnum.Request %}
-response = {{ methodInvocationText }}
-{% for statement in responseStatements %}
-{{ dispatchStatement(statement ) }}
+{% macro render_calling_form(method_invocation_text, calling_form, calling_form_enum, response_statements ) %}
+{% if calling_form == calling_form_enum.Request %}
+response = {{ method_invocation_text }}
+{% for statement in response_statements %}
+{{ dispatch_statement(statement ) }}
 {% endfor %}
-{% elif callingForm == callingFormEnum.RequestPagedAll %}
-page_result = {{ methodInvocationText }}
+{% elif calling_form == calling_form_enum.RequestPagedAll %}
+page_result = {{ method_invocation_text }}
 for response in page_result:
-  {% for statement in responseStatements %}
-    {{ dispatchStatement(statement ) }}
+  {% for statement in response_statements %}
+    {{ dispatch_statement(statement ) }}
   {% endfor %}
-{% elif callingForm == callingFormEnum.RequestPaged %}
-page_result = {{ methodInvocationText }}
+{% elif calling_form == calling_form_enum.RequestPaged %}
+page_result = {{ method_invocation_text }}
 for page in page_result.pages():
     for response in page:
-  {% for statement in responseStatements %}
-        {{ dispatchStatement(statement ) }}
+  {% for statement in response_statements %}
+        {{ dispatch_statement(statement ) }}
   {% endfor %}
-{% elif callingForm in [callingFormEnum.RequestStreamingServer,
-                        callingFormEnum.RequestStreamingBidi] %}
-stream = {{ methodInvocationText }}
+{% elif calling_form in [calling_form_enum.RequestStreamingServer,
+                        calling_form_enum.RequestStreamingBidi] %}
+stream = {{ method_invocation_text }}
 for response in stream:
-  {% for statement in responseStatements %}
-    {{ dispatchStatement(statement ) }}
+  {% for statement in response_statements %}
+    {{ dispatch_statement(statement ) }}
   {% endfor %}
-{% elif callingForm == callingFormEnum.LongRunningRequestPromise %}
-operation = {{ methodInvocationText }}
+{% elif calling_form == calling_form_enum.LongRunningRequestPromise %}
+operation = {{ method_invocation_text }}
 
 print("Waiting for operation to complete...")
 
 response = operation.result()
-{% for statement in responseStatements %}
-{{ dispatchStatement(statement ) }}
+{% for statement in response_statements %}
+{{ dispatch_statement(statement ) }}
 {% endfor %}
 {% endif %}
 {% endmacro %}
 
-{% macro renderMethodName(methodName) %}
-{{ methodName|snake_case -}}
+{% macro render_method_name(method_name) %}
+{{ method_name|snake_case -}}
 {% endmacro %}
 
-{% macro renderMainBlock(methodName, requestBlock) %}
+{% macro render_main_block(method_name, request_block) %}
 def main():
     import argparse
 
     parser = argparse.ArgumentParser()
 {% with arg_list = [] %}
-{% for attr in requestBlock if "input_parameter" in attr %}
+{% for attr in request_block if "input_parameter" in attr %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
                         default="{{ attr.value }}")
@@ -225,10 +225,11 @@ def main():
 {% endfor %}
     args = parser.parse_args()
 
-    sample_{{ renderMethodName(methodName) }}({{ arg_list|join(", ") }})
+    sample_{{ render_method_name(method_name) }}({{ arg_list|join(", ") }})
 
 
 if __name__ == "__main__":
     main()
 {% endwith %}
 {% endmacro %}
+<br>

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -21,27 +21,27 @@
 {# Note: this sample template is WILDLY INACCURATE AND INCOMPLETE #}
 {# It does not correctly enums, unions, top level attributes, or various other things #}
 {% import "feature_fragments.j2" as frags %}
-{{ frags.sample_header(fileHeader, sample, callingForm) }}
+{{ frags.sample_header(file_header, sample, calling_form) }}
 
 # [START {{ sample.id }}]
 {# python code is responsible for all transformations: all we do here is render #}
-{% for importStatement in imports %}
-{{ importStatement }}
+{% for import_statement in imports %}
+{{ import_statement }}
 {% endfor %}
 
 {# also need calling form #}
-def sample_{{ frags.renderMethodName(sample.rpc) }}({{ frags.printInputParams(sample.request) }}):
+def sample_{{ frags.render_method_name(sample.rpc) }}({{ frags.print_input_params(sample.request) }}):
     """{{ sample.description }}"""
 
     client = {{ sample.service.split(".")[-3:-1]|
                 map("lower")|
                 join("_") }}.{{ sample.service.split(".")[-1] }}Client()
 
-    {{ frags.renderRequest(sample.request)|indent }}
-{% with methodCall = frags.renderMethodCall(sample, callingForm, callingFormEnum) %}
-    {{ frags.renderCallingForm(methodCall, callingForm, callingFormEnum, sample.response)|indent -}}
+    {{ frags.render_request(sample.request)|indent }}
+{% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %}
+    {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response)|indent -}}
 {% endwith %}
 
 # [END {{ sample.id }}]
 
-{{ frags.renderMainBlock(sample.rpc, sample.request) }}
+{{ frags.render_main_block(sample.rpc, sample.request) }}

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -55,7 +55,7 @@ def test_render_attr_value():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderRequestAttr("mollusc",
+        {{ frags.render_request_attr("mollusc",
                                    {"field": "order",
                                     "value": "Molluscs.Cephalopoda.Coleoidea"}) }}
         ''',
@@ -69,7 +69,7 @@ def test_render_attr_input_parameter():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderRequestAttr("squid", {"field": "species",
+        {{ frags.render_request_attr("squid", {"field": "species",
                                              "value": "Humboldt",
                                              "input_parameter": "species"}) }}
         ''',
@@ -82,17 +82,17 @@ def test_render_attr_input_parameter():
 def test_render_attr_file():
     check_template(
         '''
-            {% import "feature_fragments.j2" as frags %}
-            {{ frags.renderRequestAttr("classify_mollusc_request",
-                                       {"field": "mollusc_video",
-                                        "value": "path/to/mollusc/video.mkv",
-                                        "input_parameter" : "mollusc_video_path",
-                                        "value_is_file": True}) }}
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.render_request_attr("classify_mollusc_request",
+                                   {"field": "mollusc_video",
+                                    "value": "path/to/mollusc/video.mkv",
+                                    "input_parameter" : "mollusc_video_path",
+                                    "value_is_file": True}) }}
         ''',
         '''
-            # mollusc_video_path = "path/to/mollusc/video.mkv"
-            with open(mollusc_video_path, "rb") as f:
-                classify_mollusc_request["mollusc_video"] = f.read()
+        # mollusc_video_path = "path/to/mollusc/video.mkv"
+        with open(mollusc_video_path, "rb") as f:
+            classify_mollusc_request["mollusc_video"] = f.read()
         ''')
 
 
@@ -100,7 +100,7 @@ def test_render_request_basic():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderRequest([{"base": "cephalopod",
+        {{ frags.render_request([{"base": "cephalopod",
                                  "body": [{"field": "mantle_mass",
                                            "value": "10 kg",
                                            "input_parameter": "cephalopod_mass"},
@@ -150,9 +150,11 @@ def test_render_print():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderPrint(["Mollusc"]) }}
+        {{ frags.render_print(["Mollusc"]) }}
         ''',
-        '\nprint("Mollusc")\n'
+        '''
+        print("Mollusc")
+        '''
     )
 
 
@@ -160,9 +162,11 @@ def test_render_print_args():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderPrint(["$resp %s %s", "$resp.squids", "$resp.clams"]) }}
+        {{ frags.render_print(["$resp %s %s", "$resp.squids", "$resp.clams"]) }}
         ''',
-        '\nprint("$resp {} {}".format(response.squids, response.clams))\n'
+        '''
+        print("$resp {} {}".format(response.squids, response.clams))
+        '''
     )
 
 
@@ -170,9 +174,11 @@ def test_render_comment():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderComment(["Mollusc"]) }}
+        {{ frags.render_comment(["Mollusc"]) }}
         ''',
-        '\n# Mollusc\n'
+        '''
+        # Mollusc
+        '''
     )
 
 
@@ -180,9 +186,11 @@ def test_render_comment_args():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderComment(["$resp %s %s", "$resp.squids", "$resp.clams"]) }}
+        {{ frags.render_comment(["$resp %s %s", "$resp.squids", "$resp.clams"]) }}
         ''',
-        '\n# $resp response.squids response.clams\n'
+        '''
+        # $resp response.squids response.clams
+        '''
     )
 
 
@@ -190,9 +198,11 @@ def test_define():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderDefine("squid=humboldt") }}
+        {{ frags.render_define("squid=humboldt") }}
         ''',
-        '\nsquid = humboldt\n'
+        '''
+        squid = humboldt
+        '''
     )
 
 
@@ -200,9 +210,11 @@ def test_define_resp():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderDefine("squid=$resp.squid") }}
+        {{ frags.render_define("squid=$resp.squid") }}
         ''',
-        '\nsquid = response.squid\n'
+        '''
+        squid = response.squid
+        '''
     )
 
 
@@ -210,9 +222,11 @@ def test_dispatch_print():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatchStatement({"print" : ["Squid"] }) }}
-''',
-        '\nprint("Squid")\n'
+        {{ frags.dispatch_statement({"print" : ["Squid"] }) }}
+        ''',
+        '''
+        print("Squid")
+        '''
     )
 
 
@@ -220,9 +234,11 @@ def test_dispatch_comment():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatchStatement({"comment" : ["Squid"] }) }}
+        {{ frags.dispatch_statement({"comment" : ["Squid"] }) }}
         ''',
-        '\n# Squid\n'
+        '''
+        # Squid
+        '''
     )
 
 
@@ -246,7 +262,7 @@ def test_dispatch_write_file():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatchStatement({"write_file": 
+        {{ frags.dispatch_statement({"write_file": 
                                        {"filename": ["specimen-%s",
                                                      "$resp.species"],
                                         "contents": "$resp.photo"}})}}
@@ -263,7 +279,7 @@ def test_collection_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderCollectionLoop({"collection": "$resp.molluscs",
+        {{ frags.render_collection_loop({"collection": "$resp.molluscs",
                                        "variable": "m",
                                        "body": {"print": ["Mollusc: %s", "m"]}})}}
         ''',
@@ -278,7 +294,7 @@ def test_dispatch_collection_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatchStatement({"loop": {"collection": "molluscs",
+        {{ frags.dispatch_statement({"loop": {"collection": "molluscs",
                                     "variable": "m",
                                     "body": {"print": ["Mollusc: %s", "m"]}}}) }}''',
         '''
@@ -292,7 +308,7 @@ def test_map_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderMapLoop({"map": "$resp.molluscs",
+        {{ frags.render_map_loop({"map": "$resp.molluscs",
                                 "key":"cls",
                                 "value":"example",
                                 "body": {"print": ["A %s is a %s", "example", "cls"] }})
@@ -308,10 +324,11 @@ def test_map_loop_no_key():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderMapLoop({"map": "$resp.molluscs",
+        {{ frags.render_map_loop({"map": "$resp.molluscs",
                                 "value":"example",
                                 "body": {"print": ["A %s is a mollusc", "example"] }})
-        }}''',
+        }}
+        ''',
         '''
         for example in response.molluscs.values():
             print("A {} is a mollusc".format(example))
@@ -323,10 +340,11 @@ def test_map_loop_no_value():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderMapLoop({"map": "$resp.molluscs",
+        {{ frags.render_map_loop({"map": "$resp.molluscs",
                                 "key":"cls",
                                 "body": {"print": ["A %s is a mollusc", "cls"] }})
-        }}''',
+        }}
+        ''',
         '''
         for cls in response.molluscs.keys():
             print("A {} is a mollusc".format(cls))
@@ -338,7 +356,7 @@ def test_dispatch_map_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatchStatement({"loop":{"map": "molluscs",
+        {{ frags.dispatch_statement({"loop":{"map": "molluscs",
                                             "key":"cls",
                                             "value":"example",
                                             "body": {
@@ -356,7 +374,7 @@ def test_print_input_params():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.printInputParams([{"base": "squid",
+        {{ frags.print_input_params([{"base": "squid",
                                     "body": [{"field": "mass",
                                               "value": "10 kg",
                                               "input_parameter": "mass"},
@@ -372,14 +390,15 @@ def test_print_input_params():
                                                "input_parameter": "color"}]},
                                     ]) }}
         ''',
-        "\nmass, length, color"
+        '''
+        mass, length, color'''
     )
 
 
 CALLING_FORM_TEMPLATE_TEST_STR = '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderCallingForm("TEST_INVOCATION_TXT", callingForm,
-                                   callingFormEnum,
+        {{ frags.render_calling_form("TEST_INVOCATION_TXT", calling_form,
+                                   calling_form_enum,
                                    [{"print": ["Test print statement"]}]) }}
         '''
 
@@ -391,8 +410,8 @@ def test_render_calling_form_request():
                    print("Test print statement")
                    
                    ''',
-                   callingFormEnum=CallingForm,
-                   callingForm=CallingForm.Request)
+                   calling_form_enum=CallingForm,
+                   calling_form=CallingForm.Request)
 
 
 def test_render_calling_form_paged_all():
@@ -403,8 +422,8 @@ def test_render_calling_form_paged_all():
                        print("Test print statement")
 
                    ''',
-                   callingFormEnum=CallingForm,
-                   callingForm=CallingForm.RequestPagedAll)
+                   calling_form_enum=CallingForm,
+                   calling_form=CallingForm.RequestPagedAll)
 
 
 def test_render_calling_form_paged():
@@ -416,8 +435,8 @@ def test_render_calling_form_paged():
                             print("Test print statement")
 
                     ''',
-                   callingFormEnum=CallingForm,
-                   callingForm=CallingForm.RequestPaged)
+                   calling_form_enum=CallingForm,
+                   calling_form=CallingForm.RequestPaged)
 
 
 def test_render_calling_form_streaming_server():
@@ -428,8 +447,8 @@ def test_render_calling_form_streaming_server():
                        print("Test print statement")
                    
                    ''',
-                   callingFormEnum=CallingForm,
-                   callingForm=CallingForm.RequestStreamingServer)
+                   calling_form_enum=CallingForm,
+                   calling_form=CallingForm.RequestStreamingServer)
 
 
 def test_render_calling_form_streaming_bidi():
@@ -440,8 +459,8 @@ def test_render_calling_form_streaming_bidi():
                        print("Test print statement")
                    
                    ''',
-                   callingFormEnum=CallingForm,
-                   callingForm=CallingForm.RequestStreamingBidi)
+                   calling_form_enum=CallingForm,
+                   calling_form=CallingForm.RequestStreamingBidi)
 
 
 def test_render_calling_form_longrunning():
@@ -455,8 +474,8 @@ def test_render_calling_form_longrunning():
                    print("Test print statement")
                    
                    ''',
-                   callingFormEnum=CallingForm,
-                   callingForm=CallingForm.LongRunningRequestPromise)
+                   calling_form_enum=CallingForm,
+                   calling_form=CallingForm.LongRunningRequestPromise)
 
 
 def test_render_method_call_basic():
@@ -465,16 +484,16 @@ def test_render_method_call_basic():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderMethodCall({"rpc": "CategorizeMollusc", "request": [{"base": "video"},
+        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": [{"base": "video"},
                                                                     {"base": "audio"},
                                                                     {"base": "guess"}]},
-                                  callingForm, callingFormEnum) }}
+                                  calling_form, calling_form_enum) }}
         ''',
         '''
         client.categorize_mollusc(video, audio, guess)
         ''',
-        callingFormEnum=CallingForm,
-        callingForm=CallingForm.Request
+        calling_form_enum=CallingForm,
+        calling_form=CallingForm.Request
     )
 
 
@@ -484,14 +503,14 @@ def test_render_method_call_bidi():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderMethodCall({"rpc": "CategorizeMollusc", "request": [{"base": "video"}]},
-                                  callingForm, callingFormEnum) }}
+        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": [{"base": "video"}]},
+                                  calling_form, calling_form_enum) }}
         ''',
         '''
         client.categorize_mollusc([video])
         ''',
-        callingFormEnum=CallingForm,
-        callingForm=CallingForm.RequestStreamingBidi
+        calling_form_enum=CallingForm,
+        calling_form=CallingForm.RequestStreamingBidi
     )
 
 
@@ -501,14 +520,14 @@ def test_render_method_call_client():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderMethodCall({"rpc": "CategorizeMollusc", "request": [{"base": "video"}]},
-        callingForm, callingFormEnum) }}
+        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": [{"base": "video"}]},
+        calling_form, calling_form_enum) }}
         ''',
         '''
         client.categorize_mollusc([video])
         ''',
-        callingFormEnum=CallingForm,
-        callingForm=CallingForm.RequestStreamingClient
+        calling_form_enum=CallingForm,
+        calling_form=CallingForm.RequestStreamingClient
     )
 
 
@@ -516,7 +535,7 @@ def test_main_block():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.renderMainBlock("ListMolluscs", [{"field": "list_molluscs.order",
+        {{ frags.render_main_block("ListMolluscs", [{"field": "list_molluscs.order",
                                                    "value": "coleoidea",
                                                    "input_parameter": "order"},
                                                   {"field ": "list_molluscs.mass",


### PR DESCRIPTION
All variables, functions, and macros are now snake_case instead of smallCamelCase.
In unit tests, all comparison strings are triple quoted instead of using explicit newlines.
Fix for #144 