### PR TITLE
Add a 'validate_expression' method (and tests) to Validator

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,7 +3,6 @@ branch = True
 omit =
   gapic/cli/*.py
   *_pb2.py
-  # Abstract methods play hob with coverage
 
 [report]
 fail_under = 100
@@ -17,3 +16,4 @@ exclude_lines =
     def __repr__
     # Abstract methods by definition are not invoked
     @abstractmethod
+    

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -357,7 +357,8 @@ class Validator:
         toks = exp.split(".")
         match = indexed_exp_re.match(toks[0])
         if not match:
-            raise BadAttributeLookup(f"Badly formatted attribute expression: {exp}")
+            raise BadAttributeLookup(
+                f"Badly formatted attribute expression: {exp}")
 
         base_tok, previous_was_indexed = (match.groupdict()["attr_name"],
                                           bool(match.groupdict()["index"]))

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -351,7 +351,8 @@ class Validator:
         """
         # TODO: handle mapping attributes, i.e. {}
         # TODO: Add resource name handling, i.e. %
-        indexed_exp_re = re.compile(r"^(?P<attr_name>\$?\w+)(?:\[(?P<index>\d+)\])?$")
+        indexed_exp_re = re.compile(
+            r"^(?P<attr_name>\$?\w+)(?:\[(?P<index>\d+)\])?$")
 
         toks = exp.split(".")
         base_tok, previous_was_indexed = indexed_exp_re.match(toks[0]).groups()

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -19,10 +19,11 @@ import re
 import time
 
 from gapic.samplegen import utils, yaml
+from gapic.schema import (api, wrappers)
 
-
-from collections import defaultdict, namedtuple
-from typing import Dict, List, Mapping, Optional, Set, Tuple
+from collections import (defaultdict, namedtuple, ChainMap as chainmap)
+from textwrap import dedent
+from typing import (Dict, List, Mapping, Optional, Set, Tuple)
 
 # Outstanding issues:
 # * In real sample configs, many variables are
@@ -96,6 +97,10 @@ class UndefinedVariableReference(SampleError):
     pass
 
 
+class BadAttributeLookup(SampleError):
+    pass
+
+
 class RedefinedVariable(SampleError):
     pass
 
@@ -127,7 +132,7 @@ def coerce_response_name(s: str) -> str:
 
 
 class Validator:
-    """Class that validates samples.
+    """Class that validates a sample.
 
     Contains methods that validate different segments of a sample and maintains
     state that's relevant to validation across different segments.
@@ -140,15 +145,43 @@ class Validator:
     VAL_KWORD = "value"
     BODY_KWORD = "body"
 
-    def __init__(self):
+    def __init__(self, method: wrappers.Method):
         # The response ($resp) variable is special and guaranteed to exist.
-        self.var_defs_: Set[str] = {"$resp"}
+        # TODO: name lookup also involes type checking
+        response_type = method.output
+        if method.paged_result_field:
+            response_type = method.paged_result_field
+        elif method.lro:
+            response_type = method.lro.response_type
 
-    # TODO: this will eventually need the method name and the proto file
-    # so that it can do the correct value transformation for enums.
-    def validate_and_transform_request(
-        self, calling_form: utils.CallingForm, request: List[Mapping[str, str]]
-    ) -> List[TransformedRequest]:
+        class FieldMocker:
+            # This is a shameless hack to work around the design of wrappers.Field
+            def __init__(self, val):
+                self.val = val
+
+            def __getattr__(self, name):
+                return self.val
+
+        # TODO: pass var_defs_ around during response verification
+        #       instead of assigning/restoring.
+        self.var_defs_: Dict[str,  wrappers.Field] = chainmap({
+            # When validating expressions we need to store the Field,
+            # not just the message type, because there are additional data we need:
+            # whether a name refers to a repeated value (or a map),
+            # and whether it's an enum or a message or a primitive type.
+            # The method call response isn't a field, so construct an artificial
+            # field that wraps the response.
+            "$resp": wrappers.Field(field_pb=FieldMocker(False),
+                                    message=response_type,
+                                    enum=None,
+                                    meta=None)})
+
+    def var_field(self, var_name: str) -> Optional[wrappers.Field]:
+        return self.var_defs_.get(var_name)
+
+    def validate_and_transform_request(self,
+                                       calling_form: utils.CallingForm,
+                                       request: List[Mapping[str, str]]) -> List[TransformedRequest]:
         """Validates and transforms the "request" block from a sample config.
 
            In the initial request, each dict has a "field" key that maps to a dotted
@@ -214,7 +247,7 @@ class Validator:
             field_assignment_copy = dict(field_assignment)
             input_param = field_assignment_copy.get("input_parameter")
             if input_param:
-                self._handle_lvalue(input_param)
+                self._handle_lvalue(input_param, str)
 
             field = field_assignment_copy.get("field")
             if not field:
@@ -272,7 +305,6 @@ class Validator:
         A full description of the response block is outside the scope of this code;
         refer to the samplegen documentation.
 
-
         Dispatches statements to sub-validators.
 
         Args:
@@ -297,7 +329,49 @@ class Validator:
 
             validater(self, body)
 
-    def _handle_lvalue(self, lval):
+    def validate_expression(self, exp: str) -> wrappers.Field:
+        """Validate an attribute chain expression.
+
+        Given a lookup expression, e.g. squid.clam.whelk,
+        recursively validate that each base has an attr with the name of the
+        next lookup lower down and that no attributes, besides possibly the final,
+        are repeated fields.
+
+        Args:
+            expr: str: The attribute expression.
+
+        Raises:
+            UndefinedVariableReference: If the root of the expression is not
+                                        a previously defined lvalue.
+            BadAttributeLookup: If an attribute other than the final is repeated OR
+                                if an attribute in the chain is not a field of its parent.
+
+        Returns:
+            wrappers.Field: The final field in the chain.
+        """
+        toks = exp.split(".")
+        base_tok = toks[0]
+        base = self.var_field(base_tok)
+        if not base:
+            raise UndefinedVariableReference(
+                "Reference to undefined variable: {}".format(base_tok))
+
+        for attr_name in toks[1:]:
+            if base.repeated:
+                raise BadAttributeLookup(
+                    "Cannot access attributes through repeated field: {}".format(attr_name))
+
+            attr = base.message.fields.get(attr_name)
+            if not attr:
+                raise BadAttributeLookup(
+                    "No such attribute in type '{}': {}".format(base, attr_name))
+
+            # TODO: handle enums, primitives, and so forth.
+            base = attr
+
+        return base
+
+    def _handle_lvalue(self, lval: str, type_=None):
         """Conducts safety checks on an lvalue and adds it to the lexical scope.
 
         Raises:
@@ -315,7 +389,7 @@ class Validator:
             raise RedefinedVariable(
                 "Tried to redefine variable: {}".format(lval))
 
-        self.var_defs_.add(lval)
+        self.var_defs_[lval] = type_
 
     def _validate_format(self, body: List[str]):
         """Validates a format string and corresponding arguments.
@@ -330,6 +404,8 @@ class Validator:
              MismatchedFormatSpecifier: If the number of format string segments ("%s") in
                                         a "print" or "comment" block does not equal the
                                         size number of strings in the block minus 1.
+             UndefinedVariableReference: If the base lvalue in an expression chain
+                                         is not a previously defined lvalue.
         """
         fmt_str = body[0]
         num_prints = fmt_str.count("%s")
@@ -358,8 +434,6 @@ class Validator:
              UndefinedVariableReference: If an attempted rvalue base is a previously
                                          undeclared variable.
         """
-        # TODO: Need to validate the attributes of the response
-        #       based on the method return type.
         # TODO: Need to check the defined variables
         #       if the rhs references a non-response variable.
         # TODO: Need to rework the regex to allow for subfields,
@@ -372,13 +446,9 @@ class Validator:
             raise BadAssignment("Bad assignment statement: {}".format(body))
 
         lval, rval = m.groups()
-        self._handle_lvalue(lval)
 
-        rval_base = rval.split(".")[0]
-        if not rval_base in self.var_defs_:
-            raise UndefinedVariableReference(
-                "Reference to undefined variable: {}".format(rval_base)
-            )
+        rval_type = self.validate_expression(rval)
+        self._handle_lvalue(lval, rval_type)
 
     def _validate_write_file(self, body):
         """Validate 'write_file' statements.
@@ -448,20 +518,20 @@ class Validator:
         #
         # is allowed, the samplegen spec requires that errors are raised
         # if strict lexical scoping is violated.
-        previous_defs = set(self.var_defs_)
+        self.var_defs_ = self.var_defs_.new_child()
 
         if {self.COLL_KWORD, self.VAR_KWORD, self.BODY_KWORD} == segments:
-            collection_name = body[self.COLL_KWORD].split(".")[0]
-            # TODO: Once proto info is being passed in, validate the
-            #       [1:] in the collection name.
+            tokens = body[self.COLL_KWORD].split(".")
+
             # TODO: resolve the implicit $resp dilemma
             # if collection_name.startswith("."):
             #     collection_name = "$resp" + collection_name
-            if collection_name not in self.var_defs_:
-                raise UndefinedVariableReference(
-                    "Reference to undefined variable: {}".format(
-                        collection_name)
-                )
+            collection_field = self.validate_expression(
+                body[self.COLL_KWORD])
+
+            if not collection_field.repeated:
+                raise BadLoop(
+                    "Tried to use a non-repeated field as a collection: {}".format(tokens[-1]))
 
             var = body[self.VAR_KWORD]
             self._handle_lvalue(var)
@@ -500,10 +570,9 @@ class Validator:
         # Restore the previous lexical scope.
         # This is stricter than python scope rules
         # because the samplegen spec mandates it.
-        self.var_defs_ = previous_defs
+        self.var_defs_ = self.var_defs_.parents
 
     # Add new statement keywords to this table.
-    # TODO: add write_file validator and entry (and tests).
     STATEMENT_DISPATCH_TABLE = {
         "define": _validate_define,
         "print": _validate_format,
@@ -513,9 +582,11 @@ class Validator:
     }
 
 
-def generate_sample(
-    sample, id_is_unique: bool, env: jinja2.environment.Environment, api_schema
-) -> Tuple[str, jinja2.environment.TemplateStream]:
+def generate_sample(sample,
+                    id_is_unique: bool,
+                    env: jinja2.environment.Environment,
+                    api_schema: api.API) -> Tuple[str, jinja2.environment.TemplateStream]:
+
     sample_template = env.get_template(TEMPLATE_NAME)
 
     service_name = sample["service"]
@@ -533,14 +604,14 @@ def generate_sample(
 
     calling_form = utils.CallingForm.method_default(rpc)
 
-    v = Validator()
-    sample["request"] = v.validate_and_transform_request(
-        calling_form, sample["request"]
-    )
+    v = Validator(rpc)
+    sample["request"] = v.validate_and_transform_request(calling_form,
+                                                         sample["request"])
     v.validate_response(sample["response"])
 
     sample_fpath = (
-        sample["id"] + (str(calling_form) if not id_is_unique else "") + ".py"
+        sample["id"] + (str(calling_form)
+                        if not id_is_unique else "") + ".py"
     )
 
     sample["package_name"] = api_schema.naming.warehouse_package_name

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -164,7 +164,7 @@ class Validator:
 
         # TODO: pass var_defs_ around during response verification
         #       instead of assigning/restoring.
-        self.var_defs_: Dict[str,  wrappers.Field] = chainmap({
+        self.var_defs_: Dict[str, wrappers.Field] = chainmap({
             # When validating expressions we need to store the Field,
             # not just the message type, because there are additional data we need:
             # whether a name refers to a repeated value (or a map),

--- a/tests/unit/samplegen/common_types.py
+++ b/tests/unit/samplegen/common_types.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import namedtuple
+
+# Injected dummy test types
+
+DummyMethod = namedtuple(
+    "DummyMethod",
+    [
+        "input",
+        "output",
+        "lro",
+        "paged_result_field",
+        "client_streaming",
+        "server_streaming",
+    ],
+)
+
+DummyMethod.__new__.__defaults__ = (False,) * len(DummyMethod._fields)
+
+DummyMessage = namedtuple("DummyMessage", ["fields", "type"])
+DummyMessage.__new__.__defaults__ = (False,) * len(DummyMessage._fields)
+
+DummyField = namedtuple("DummyField", ["message", "repeated"])
+DummyField.__new__.__defaults__ = (False,) * len(DummyField._fields)
+
+DummyService = namedtuple("DummyService", ["methods"])
+
+DummyApiSchema = namedtuple("DummyApiSchema", ["services", "naming"])
+DummyApiSchema.__new__.__defaults__ = (False,) * len(DummyApiSchema._fields)
+
+DummyNaming = namedtuple(
+    "DummyNaming", ["warehouse_package_name", "name", "version"])
+DummyNaming.__new__.__defaults__ = (False,) * len(DummyNaming._fields)

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -19,23 +19,11 @@ import pytest
 import gapic.samplegen.samplegen as samplegen
 import gapic.utils as utils
 
+from common_types import (DummyMethod, DummyService,
+                          DummyApiSchema, DummyNaming)
+
 from collections import namedtuple
 from textwrap import dedent
-
-# Injected dummy test types
-dummy_method_fields = ["lro",
-                       "paged_result_field",
-                       "client_streaming",
-                       "server_streaming"]
-DummyMethod = namedtuple("DummyMethod",
-                         dummy_method_fields)
-DummyMethod.__new__.__defaults__ = (False,) * len(dummy_method_fields)
-
-DummyService = namedtuple("DummyService", ["methods"])
-
-DummyApiSchema = namedtuple("DummyApiSchema", ["services", "naming"])
-
-DummyNaming = namedtuple("DummyNaming", ["warehouse_package_name"])
 
 
 env = jinja2.Environment(

--- a/tests/unit/samplegen/test_manifest.py
+++ b/tests/unit/samplegen/test_manifest.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import yaml
+from textwrap import dedent
+
+import gapic.samplegen.yaml as gapic_yaml
+import gapic.samplegen.samplegen as samplegen
+from common_types import DummyApiSchema, DummyNaming
+
+
+def test_generate_manifest():
+    fpath_to_dummy_sample = {
+        "squid_fpath.py": {"id": "squid_sample"},
+        "clam_fpath.py": {"id": "clam_sample",
+                          "region_tag": "giant_clam_sample"},
+    }
+
+    fname, info = samplegen.generate_manifest(
+        fpath_to_dummy_sample.items(),
+        DummyApiSchema(naming=DummyNaming(name="Mollusc", version="v1")),
+        # Empirically derived number such that the
+        # corresponding time_struct tests the zero
+        # padding in the returned filename.
+        manifest_time=4486525628
+    )
+
+    assert fname == "Mollusc.v1.python.21120304.090708.manifest.yaml"
+
+    expected_info = [
+        gapic_yaml.KeyVal("type", "manifest/samples"),
+        gapic_yaml.KeyVal("schema_version", "3"),
+        gapic_yaml.Map(name="python",
+                       anchor_name="python",
+                       elements=[
+                           gapic_yaml.KeyVal(
+                               "environment", "python"),
+                           gapic_yaml.KeyVal(
+                               "bin", "python3"),
+                           gapic_yaml.KeyVal(
+                               "base_path", "sample/base/directory"),
+                           gapic_yaml.KeyVal(
+                               "invocation", "'{bin} {path} @args'"),
+                       ]),
+        gapic_yaml.Collection(name="samples",
+                              elements=[
+                                  [
+                                      gapic_yaml.Anchor(
+                                          "python"),
+                                      gapic_yaml.KeyVal(
+                                          "sample", "squid_sample"),
+                                      gapic_yaml.KeyVal(
+                                          "path", "'{base_path}/squid_fpath.py'"),
+                                      gapic_yaml.KeyVal(
+                                          "region_tag", ""),
+                                  ],
+                                  [
+                                      gapic_yaml.Anchor("python"),
+                                      gapic_yaml.KeyVal(
+                                          "sample", "clam_sample"),
+                                      gapic_yaml.KeyVal(
+                                          "path", "'{base_path}/clam_fpath.py'"),
+                                      gapic_yaml.KeyVal(
+                                          "region_tag", "giant_clam_sample")
+                                  ],
+                              ])
+    ]
+
+    assert info == expected_info
+
+    expected_rendering = dedent("""
+                                type: manifest/samples
+                                schema_version: 3
+                                python: &python
+                                  environment: python
+                                  bin: python3
+                                  base_path: sample/base/directory
+                                  invocation: '{bin} {path} @args'
+                                samples:
+                                - <<: *python
+                                  sample: squid_sample
+                                  path: '{base_path}/squid_fpath.py'
+                                  region_tag: 
+                                - <<: *python
+                                  sample: clam_sample
+                                  path: '{base_path}/clam_fpath.py'
+                                  region_tag: giant_clam_sample""".lstrip("\n"))
+
+    rendered_yaml = "\n".join(e.render() for e in info)
+    assert rendered_yaml == expected_rendering
+
+    expected_parsed_manifest = {
+        "type": "manifest/samples",
+        "schema_version": 3,
+        "python": {
+            "environment": "python",
+            "bin": "python3",
+            "base_path": "sample/base/directory",
+            "invocation": "{bin} {path} @args",
+        },
+        "samples": [
+            {
+                "environment": "python",
+                "bin": "python3",
+                "base_path": "sample/base/directory",
+                "invocation": "{bin} {path} @args",
+                "sample": "squid_sample",
+                "path": "{base_path}/squid_fpath.py",
+                "region_tag": None,
+            },
+            {
+                "environment": "python",
+                "bin": "python3",
+                "base_path": "sample/base/directory",
+                "invocation": "{bin} {path} @args",
+                "sample": "clam_sample",
+                "path": "{base_path}/clam_fpath.py",
+                "region_tag": "giant_clam_sample",
+            },
+        ],
+    }
+
+    parsed_manifest = yaml.safe_load(rendered_yaml)
+    assert parsed_manifest == expected_parsed_manifest

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -907,3 +907,23 @@ def test_validate_expresssion_lookup_unrepeated_base():
     v = samplegen.Validator(method)
     with pytest.raises(samplegen.BadAttributeLookup):
         v.validate_response([{"define": "m=$resp[0]"}])
+
+
+def test_validate_expression_malformed_base():
+    # Note the mistype
+    exp = "r$esp.mollusc"
+    OutputType = message_factory(exp)
+    method = DummyMethod(OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression(exp)
+
+
+def test_validate_expression_malformed_attr():
+    # Note the mistype
+    exp = "$resp.mollu$c"
+    OutputType = message_factory(exp)
+    method = DummyMethod(OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression(exp)

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -872,3 +872,38 @@ def test_validate_expression_collection_error():
     # Because 'molluscs' isn't repeated
     with pytest.raises(samplegen.BadLoop):
         v.validate_response([statement])
+
+
+def test_validate_expression_repeated_lookup():
+    exp = "$resp.molluscs.mantle"
+    OutputType = message_factory(exp, [True, False])
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    v.validate_expression("$resp.molluscs[0].mantle")
+
+
+def test_validate_expression_repeated_lookup_invalid():
+    exp = "$resp.molluscs.mantle"
+    OutputType = message_factory(exp)
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression("$resp.molluscs[0].mantle")
+
+
+def test_validate_expression_base_attr_is_repeated():
+    exp = "$resp.molluscs.mantle"
+    OutputType = message_factory(exp, [True, False])
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    v.validate_response([{"define": "molluscs=$resp.molluscs"}])
+    v.validate_expression("molluscs[0].mantle")
+
+
+def test_validate_expresssion_lookup_unrepeated_base():
+    exp = "$resp.molluscs"
+    OutputType = message_factory(exp)
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_response([{"define": "m=$resp[0]"}])

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -12,70 +12,117 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
 import yaml
+import itertools
+import pytest
+
+from typing import TypeVar
 from collections import namedtuple
-from textwrap import dedent
 
-import gapic.samplegen.samplegen as samplegen
+import gapic.schema.wrappers as wrappers
 import gapic.samplegen.yaml as gapic_yaml
+import gapic.samplegen.samplegen as samplegen
 
-
+from common_types import DummyField, DummyMessage, DummyMethod
 from gapic.samplegen import utils
+
+
+def message_factory(exp: str, repeated_iter=itertools.repeat(False)) -> DummyMessage:
+    # This mimics the structure of MessageType in the wrappers module:
+    # A MessageType has a map from field names to Fields,
+    # and a Field has an (optional) MessageType.
+    # The 'exp' parameter is a dotted attribute expression
+    # used to describe the field and type hierarchy,
+    # e.g. "mollusc.cephalopod.coleoid"
+    toks = exp.split(".")
+    messages = [DummyMessage({}, tok.upper() + "_TYPE") for tok in toks]
+    for base, field, attr_name, repeated_field in zip(
+        messages, messages[1:], toks[1:], repeated_iter
+    ):
+        base.fields[attr_name] = DummyField(field, repeated=repeated_field)
+
+    return messages[0]
+
 
 # validate_response tests
 
 
 def test_define():
     define = {"define": "squid=$resp"}
-    samplegen.Validator().validate_response([define])
+
+    samplegen.Validator(
+        DummyMethod(output=message_factory("mollusc"))
+    ).validate_response([define])
 
 
 def test_define_undefined_var():
     define = {"define": "squid=humboldt"}
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response([define])
+        samplegen.Validator(
+            DummyMethod(output=message_factory("mollusc"))
+        ).validate_response([define])
 
 
 def test_define_reserved_varname():
     define = {"define": "class=$resp"}
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator().validate_response([define])
+        samplegen.Validator(
+            DummyMethod(output=message_factory("mollusc"))
+        ).validate_response([define])
 
 
 def test_define_add_var():
-    samplegen.Validator().validate_response([{"define": "squid=$resp"},
-                                             {"define": "name=squid.name"}])
+    samplegen.Validator(
+        DummyMethod(output=message_factory("mollusc.name"))
+    ).validate_response([{"define": "squid=$resp"}, {"define": "name=squid.name"}])
 
 
 def test_define_bad_form():
     define = {"define": "mollusc=$resp.squid=$resp.clam"}
     with pytest.raises(samplegen.BadAssignment):
-        samplegen.Validator().validate_response([define])
+        samplegen.Validator(
+            DummyMethod(output=message_factory("mollusc"))
+        ).validate_response([define])
 
 
 def test_define_redefinition():
-    statements = [{"define": "molluscs=$resp.molluscs"},
-                  {"define": "molluscs=$resp.molluscs"}]
+    statements = [
+        {"define": "molluscs=$resp.molluscs"},
+        {"define": "molluscs=$resp.molluscs"},
+    ]
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.molluscs", [True]))
+        ).validate_response(statements)
 
 
 def test_define_input_param():
-    validator = samplegen.Validator()
-    validator.validate_and_transform_request(utils.CallingForm.Request,
-                                             [{"field": "squid.mantle_length",
-                                               "value": "100 cm",
-                                               "input_parameter": "mantle_length"}])
+    validator = samplegen.Validator(DummyMethod())
+    validator.validate_and_transform_request(
+        utils.CallingForm.Request,
+        [
+            {
+                "field": "squid.mantle_length",
+                "value": "100 cm",
+                "input_parameter": "mantle_length",
+            }
+        ],
+    )
     validator.validate_response([{"define": "length=mantle_length"}])
 
 
 def test_define_input_param_redefinition():
-    validator = samplegen.Validator()
-    validator.validate_and_transform_request(utils.CallingForm.Request,
-                                             [{"field": "squid.mantle_length",
-                                               "value": "100 cm",
-                                               "input_parameter": "mantle_length"}])
+    validator = samplegen.Validator(DummyMethod())
+    validator.validate_and_transform_request(
+        utils.CallingForm.Request,
+        [
+            {
+                "field": "squid.mantle_length",
+                "value": "100 cm",
+                "input_parameter": "mantle_length",
+            }
+        ],
+    )
     with pytest.raises(samplegen.RedefinedVariable):
         validator.validate_response(
             [{"define": "mantle_length=mantle_length"}])
@@ -83,382 +130,552 @@ def test_define_input_param_redefinition():
 
 def test_print_basic():
     print_statement = {"print": ["This is a squid"]}
-    samplegen.Validator().validate_response([print_statement])
+    samplegen.Validator(DummyMethod()).validate_response([print_statement])
 
 
 def test_print_fmt_str():
     print_statement = {"print": ["This is a squid named %s", "$resp.name"]}
-    samplegen.Validator().validate_response([print_statement])
+    samplegen.Validator(
+        DummyMethod(output=message_factory("$resp.name"))
+    ).validate_response([print_statement])
 
 
 def test_print_fmt_mismatch():
     print_statement = {"print": ["This is a squid named %s"]}
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator().validate_response([print_statement])
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.name"))
+        ).validate_response([print_statement])
 
 
 def test_print_fmt_mismatch2():
     print_statement = {"print": ["This is a squid", "$resp.name"]}
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator().validate_response([print_statement])
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.name"))
+        ).validate_response([print_statement])
 
 
 def test_print_undefined_var():
     print_statement = {"print": ["This mollusc is a %s", "mollusc.type"]}
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response([print_statement])
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.type"))
+        ).validate_response([print_statement])
 
 
 def test_comment():
     comment = {"comment": ["This is a mollusc"]}
-    samplegen.Validator().validate_response([comment])
+    samplegen.Validator(DummyMethod()).validate_response([comment])
 
 
 def test_comment_fmt_str():
     comment = {"comment": ["This is a mollusc of class %s", "$resp.class"]}
-    samplegen.Validator().validate_response([comment])
+    samplegen.Validator(DummyMethod()).validate_response([comment])
 
 
 def test_comment_fmt_undefined_var():
     comment = {"comment": ["This is a mollusc of class %s", "cephalopod"]}
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response([comment])
+        samplegen.Validator(DummyMethod()).validate_response([comment])
 
 
 def test_comment_fmt_mismatch():
     comment = {"comment": ["This is a mollusc of class %s"]}
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator().validate_response([comment])
+        samplegen.Validator(DummyMethod()).validate_response([comment])
 
 
 def test_comment_fmt_mismatch2():
     comment = {"comment": ["This is a mollusc of class ", "$resp.class"]}
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator().validate_response([comment])
+        samplegen.Validator(DummyMethod()).validate_response([comment])
 
 
 def test_loop_collection():
-    loop = {"loop": {"collection": "$resp.molluscs",
-                     "variable": "m",
-                     "body": [{"print":
-                               ["Mollusc of class: %s", "m.class"]}]}}
-    samplegen.Validator().validate_response([loop])
+    loop = {
+        "loop": {
+            "collection": "$resp.molluscs",
+            "variable": "m",
+            "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
+        }
+    }
+    samplegen.Validator(
+        DummyMethod(output=message_factory("$resp.molluscs", [True]))
+    ).validate_response([loop])
 
 
 def test_loop_collection_redefinition():
-    statements = [{"define": "m=$resp.molluscs"},
-                  {"loop": {"collection": "$resp.molluscs",
-                            "variable": "m",
-                            "body": [{"print": ["Mollusc of class: %s",
-                                                "m.class"]}]}}]
+    statements = [
+        {"define": "m=$resp.molluscs"},
+        {
+            "loop": {
+                "collection": "$resp.molluscs",
+                "variable": "m",
+                "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
+            }
+        },
+    ]
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.molluscs", [True]))
+        ).validate_response(statements)
 
 
 def test_loop_undefined_collection():
-    loop = {"loop": {"collection": "squid",
-                     "variable": "s",
-                     "body": [{"print":
-                               ["Squid: %s", "s"]}]}}
+    loop = {
+        "loop": {
+            "collection": "squid",
+            "variable": "s",
+            "body": [{"print": ["Squid: %s", "s"]}],
+        }
+    }
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_collection_extra_kword():
-    loop = {"loop": {"collection": "$resp.molluscs",
-                     "squid": "$resp.squids",
-                     "variable": "m",
-                     "body": [{"print":
-                               ["Mollusc of class: %s", "m.class"]}]}}
+    loop = {
+        "loop": {
+            "collection": "$resp.molluscs",
+            "squid": "$resp.squids",
+            "variable": "m",
+            "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
+        }
+    }
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_collection_missing_kword():
-    loop = {"loop": {"collection": "$resp.molluscs",
-                     "body": [{"print":
-                               ["Mollusc of class: %s", "m.class"]}]}}
+    loop = {
+        "loop": {
+            "collection": "$resp.molluscs",
+            "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
+        }
+    }
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_collection_reserved_loop_var():
-    loop = {"loop": {"collection": "$resp.molluscs",
-                     "variable": "class",
-                     "body": [{"print":
-                               ["Mollusc: %s", "class.name"]}]}}
+    loop = {
+        "loop": {
+            "collection": "$resp.molluscs",
+            "variable": "class",
+            "body": [{"print": ["Mollusc: %s", "class.name"]}],
+        }
+    }
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.molluscs", [True]))
+        ).validate_response([loop])
 
 
 def test_loop_map():
-    loop = {"loop": {"map": "$resp.molluscs",
-                     "key": "cls",
-                     "value": "mollusc",
-                     "body": [{"print": ["A %s is a %s", "mollusc", "cls"]}]}}
-    samplegen.Validator().validate_response([loop])
+    loop = {
+        "loop": {
+            "map": "$resp.molluscs",
+            "key": "cls",
+            "value": "mollusc",
+            "body": [{"print": ["A %s is a %s", "mollusc", "cls"]}],
+        }
+    }
+    samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_collection_loop_lexical_scope_variable():
-    statements = [{"loop": {"collection": "$resp.molluscs",
-                            "variable": "m",
-                            "body": [{"define": "squid=m"}]}},
-                  {"define": "cephalopod=m"}]
+    statements = [
+        {
+            "loop": {
+                "collection": "$resp.molluscs",
+                "variable": "m",
+                "body": [{"define": "squid=m"}],
+            }
+        },
+        {"define": "cephalopod=m"},
+    ]
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.molluscs", [True]))
+        ).validate_response(statements)
 
 
 def test_collection_loop_lexical_scope_inline():
-    statements = [{"loop": {"collection": "$resp.molluscs",
-                            "variable": "m",
-                            "body": [{"define": "squid=m"}]}},
-                  {"define": "cephalopod=squid"}]
+    statements = [
+        {
+            "loop": {
+                "collection": "$resp.molluscs",
+                "variable": "m",
+                "body": [{"define": "squid=m"}],
+            }
+        },
+        {"define": "cephalopod=squid"},
+    ]
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(
+            DummyMethod(output=message_factory("$resp.molluscs", [True]))
+        ).validate_response(statements)
 
 
 def test_map_loop_lexical_scope_key():
-    statements = [{"loop": {"map": "$resp.molluscs",
-                            "key": "cls",
-                            "value": "order",
-                            "body": [{"define": "tmp=cls"}]}},
-                  {"define": "last_cls=cls"}]
+    statements = [
+        {
+            "loop": {
+                "map": "$resp.molluscs",
+                "key": "cls",
+                "value": "order",
+                "body": [{"define": "tmp=cls"}],
+            }
+        },
+        {"define": "last_cls=cls"},
+    ]
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(DummyMethod()).validate_response(statements)
 
 
 def test_map_loop_lexical_scope_value():
-    statements = [{"loop": {"map": "$resp.molluscs",
-                            "key": "cls",
-                            "value": "order",
-                            "body": [{"define": "tmp=order"}]}},
-                  {"define": "last_order=order"}]
+    statements = [
+        {
+            "loop": {
+                "map": "$resp.molluscs",
+                "key": "cls",
+                "value": "order",
+                "body": [{"define": "tmp=order"}],
+            }
+        },
+        {"define": "last_order=order"},
+    ]
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(DummyMethod()).validate_response(statements)
 
 
 def test_map_loop_lexical_scope_inline():
-    statements = [{"loop": {"map": "$resp.molluscs",
-                            "key": "cls",
-                            "value": "order",
-                            "body": [{"define": "tmp=order"}]}},
-                  {"define": "last_order=tmp"}]
+    statements = [
+        {
+            "loop": {
+                "map": "$resp.molluscs",
+                "key": "cls",
+                "value": "order",
+                "body": [{"define": "tmp=order"}],
+            }
+        },
+        {"define": "last_order=tmp"},
+    ]
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(DummyMethod()).validate_response(statements)
 
 
 def test_loop_map_reserved_key():
-    loop = {"loop": {"map": "$resp.molluscs",
-                     "key": "class",
-                     "value": "mollusc",
-                     "body": [{"print": ["A %s is a %s", "mollusc", "class"]}]}}
+    loop = {
+        "loop": {
+            "map": "$resp.molluscs",
+            "key": "class",
+            "value": "mollusc",
+            "body": [{"print": ["A %s is a %s", "mollusc", "class"]}],
+        }
+    }
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_reserved_val():
-    loop = {"loop": {"map": "$resp.molluscs",
-                     "key": "m",
-                     "value": "class",
-                     "body": [{"print": ["A %s is a %s", "m", "class"]}]}}
+    loop = {
+        "loop": {
+            "map": "$resp.molluscs",
+            "key": "m",
+            "value": "class",
+            "body": [{"print": ["A %s is a %s", "m", "class"]}],
+        }
+    }
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_undefined():
-    loop = {"loop": {"map": "molluscs",
-                     "key": "name",
-                     "value": "mollusc",
-                     "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+    loop = {
+        "loop": {
+            "map": "molluscs",
+            "key": "name",
+            "value": "mollusc",
+            "body": [{"print": ["A %s is a %s", "mollusc", "name"]}],
+        }
+    }
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_no_key():
-    loop = {"loop": {"map": "$resp.molluscs",
-                     "value": "mollusc",
-                     "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
-    samplegen.Validator().validate_response([loop])
+    loop = {
+        "loop": {
+            "map": "$resp.molluscs",
+            "value": "mollusc",
+            "body": [{"print": ["Mollusc: %s", "mollusc"]}],
+        }
+    }
+    samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_no_value():
-    loop = {"loop": {"map": "$resp.molluscs",
-                     "key": "mollusc",
-                     "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}
-    samplegen.Validator().validate_response([loop])
+    loop = {
+        "loop": {
+            "map": "$resp.molluscs",
+            "key": "mollusc",
+            "body": [{"print": ["Mollusc: %s", "mollusc"]}],
+        }
+    }
+    samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_no_key_or_value():
     loop = {"loop": {"map": "$resp.molluscs",
                      "body": [{"print": ["Dead loop"]}]}}
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_no_map():
-    loop = {"loop": {"key": "name",
-                     "value": "mollusc",
-                     "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+    loop = {
+        "loop": {
+            "key": "name",
+            "value": "mollusc",
+            "body": [{"print": ["A %s is a %s", "mollusc", "name"]}],
+        }
+    }
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_no_body():
-    loop = {"loop": {"map": "$resp.molluscs",
-                     "key": "name",
-                     "value": "mollusc"}}
+    loop = {"loop": {"map": "$resp.molluscs", "key": "name", "value": "mollusc"}}
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_extra_kword():
-    loop = {"loop": {"map": "$resp.molluscs",
-                     "key": "name",
-                     "value": "mollusc",
-                     "phylum": "$resp.phylum",
-                     "body": [{"print": ["A %s is a %s", "mollusc", "name"]}]}}
+    loop = {
+        "loop": {
+            "map": "$resp.molluscs",
+            "key": "name",
+            "value": "mollusc",
+            "phylum": "$resp.phylum",
+            "body": [{"print": ["A %s is a %s", "mollusc", "name"]}],
+        }
+    }
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator().validate_response([loop])
+        samplegen.Validator(DummyMethod()).validate_response([loop])
 
 
 def test_loop_map_redefined_key():
-    statements = [{"define": "mollusc=$resp.molluscs"},
-                  {"loop": {"map": "$resp.molluscs",
-                            "key": "mollusc",
-                            "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}]
+    statements = [
+        {"define": "mollusc=$resp.molluscs"},
+        {
+            "loop": {
+                "map": "$resp.molluscs",
+                "key": "mollusc",
+                "body": [{"print": ["Mollusc: %s", "mollusc"]}],
+            }
+        },
+    ]
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(
+            DummyMethod(output=message_factory("mollusc.molluscs"))
+        ).validate_response(statements)
 
 
 def test_loop_map_redefined_value():
-    statements = [{"define": "mollusc=$resp.molluscs"},
-                  {"loop": {"map": "$resp.molluscs",
-                            "value": "mollusc",
-                            "body": [{"print": ["Mollusc: %s", "mollusc"]}]}}]
+    statements = [
+        {"define": "mollusc=$resp.molluscs"},
+        {
+            "loop": {
+                "map": "$resp.molluscs",
+                "value": "mollusc",
+                "body": [{"print": ["Mollusc: %s", "mollusc"]}],
+            }
+        },
+    ]
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator().validate_response(statements)
+        samplegen.Validator(
+            DummyMethod(output=message_factory("mollusc.molluscs"))
+        ).validate_response(statements)
 
 
 def test_validate_write_file():
-    samplegen.Validator().validate_response(
-        [{"write_file": {"filename": ["specimen-%s", "$resp.species"],
-                         "contents": "$resp.photo"}}])
+    samplegen.Validator(DummyMethod()).validate_response(
+        [
+            {
+                "write_file": {
+                    "filename": ["specimen-%s", "$resp.species"],
+                    "contents": "$resp.photo",
+                }
+            }
+        ]
+    )
 
 
 def test_validate_write_file_fname_fmt():
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator().validate_response(
-            [{"write_file": {"filename": ["specimen-%s"],
-                             "contents": "$resp.photo"}}])
+        samplegen.Validator(DummyMethod()).validate_response(
+            [{"write_file": {"filename": ["specimen-%s"], "contents": "$resp.photo"}}]
+        )
 
 
 def test_validate_write_file_fname_bad_var():
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response(
-            [{"write_file": {"filename": ["specimen-%s", "squid.species"],
-                             "contents": "$resp.photo"}}])
+        samplegen.Validator(DummyMethod()).validate_response(
+            [
+                {
+                    "write_file": {
+                        "filename": ["specimen-%s", "squid.species"],
+                        "contents": "$resp.photo",
+                    }
+                }
+            ]
+        )
 
 
 def test_validate_write_file_missing_fname():
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator().validate_response(
+        samplegen.Validator(DummyMethod()).validate_response(
             [{"write_file": {"contents": "$resp.photo"}}]
         )
 
 
 def test_validate_write_file_missing_contents():
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator().validate_response(
+        samplegen.Validator(DummyMethod()).validate_response(
             [{"write_file": {"filename": ["specimen-%s", "$resp.species"]}}]
         )
 
 
 def test_validate_write_file_bad_contents_var():
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator().validate_response(
-            [{"write_file": {"filename": ["specimen-%s", "$resp.species"],
-                             "contents": "squid.photo"}}])
+        samplegen.Validator(DummyMethod()).validate_response(
+            [
+                {
+                    "write_file": {
+                        "filename": ["specimen-%s", "$resp.species"],
+                        "contents": "squid.photo",
+                    }
+                }
+            ]
+        )
 
 
 def test_invalid_statement():
     statement = {"print": ["Name"], "comment": ["Value"]}
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator().validate_response([statement])
+        samplegen.Validator(DummyMethod()).validate_response([statement])
 
 
 def test_invalid_statement2():
     statement = {"squidify": ["Statement body"]}
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator().validate_response([statement])
+        samplegen.Validator(DummyMethod()).validate_response([statement])
 
 
 # validate_and_transform_request tests
 def test_validate_request_basic():
-    assert samplegen.Validator().validate_and_transform_request(utils.CallingForm.Request,
-                                                                [{"field": "squid.mantle_length",
-                                                                  "value": "100 cm"},
-                                                                 {"field": "squid.mantle_mass",
-                                                                  "value": "10 kg"}]) == [
-        samplegen.TransformedRequest("squid",
-                                     [{"field": "mantle_length",
-                                       "value": "100 cm"},
-                                      {"field": "mantle_mass",
-                                       "value": "10 kg"}])]
+    assert samplegen.Validator(DummyMethod()).validate_and_transform_request(
+        utils.CallingForm.Request,
+        [
+            {"field": "squid.mantle_length", "value": "100 cm"},
+            {"field": "squid.mantle_mass", "value": "10 kg"},
+        ],
+    ) == [
+        samplegen.TransformedRequest(
+            "squid",
+            [
+                {"field": "mantle_length", "value": "100 cm"},
+                {"field": "mantle_mass", "value": "10 kg"},
+            ],
+        )
+    ]
 
 
 def test_validate_request_no_field_parameter():
     with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator().validate_and_transform_request(utils.CallingForm.Request,
-                                                             [{"squid": "humboldt"}])
+        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+            utils.CallingForm.Request, [{"squid": "humboldt"}]
+        )
 
 
 def test_validate_request_malformed_field_attr():
     with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator().validate_and_transform_request(utils.CallingForm.Request,
-                                                             [{"field": "squid"}])
+        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+            utils.CallingForm.Request, [{"field": "squid"}]
+        )
 
 
 def test_validate_request_multiple_arguments():
-    assert samplegen.Validator().validate_and_transform_request(utils.CallingForm.Request,
-                                                                [{"field": "squid.mantle_length",
-                                                                  "value": "100 cm",
-                                                                  "value_is_file": True},
-                                                                 {"field": "clam.shell_mass",
-                                                                  "value": "100 kg",
-                                                                  "comment": "Clams can be large"}]) == [
-        samplegen.TransformedRequest("squid",
-                                     [{"field": "mantle_length",
-                                       "value": "100 cm",
-                                       "value_is_file": True}]),
-        samplegen.TransformedRequest("clam",
-                                     [{"field": "shell_mass",
-                                       "value": "100 kg",
-                                       "comment": "Clams can be large"}])]
+    assert samplegen.Validator(DummyMethod()).validate_and_transform_request(
+        utils.CallingForm.Request,
+        [
+            {"field": "squid.mantle_length",
+                "value": "100 cm", "value_is_file": True},
+            {
+                "field": "clam.shell_mass",
+                "value": "100 kg",
+                "comment": "Clams can be large",
+            },
+        ],
+    ) == [
+        samplegen.TransformedRequest(
+            "squid",
+            [{"field": "mantle_length", "value": "100 cm", "value_is_file": True}],
+        ),
+        samplegen.TransformedRequest(
+            "clam",
+            [
+                {
+                    "field": "shell_mass",
+                    "value": "100 kg",
+                    "comment": "Clams can be large",
+                }
+            ],
+        ),
+    ]
 
 
 def test_validate_request_reserved_request_name():
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator().validate_and_transform_request(utils.CallingForm.Request,
-                                                             [{"field": "class.order", "value": "coleoidea"}])
+        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+            utils.CallingForm.Request, [
+                {"field": "class.order", "value": "coleoidea"}]
+        )
 
 
 def test_validate_request_duplicate_input_param():
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator().validate_and_transform_request(utils.CallingForm.Request,
-                                                             [{"field": "squid.mantle_mass",
-                                                               "value": "10 kg",
-                                                               "input_parameter": "mantle_mass"},
-                                                              {"field": "clam.mantle_mass",
-                                                               "value": "1 kg",
-                                                               "input_parameter": "mantle_mass"}])
+        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+            utils.CallingForm.Request,
+            [
+                {
+                    "field": "squid.mantle_mass",
+                    "value": "10 kg",
+                    "input_parameter": "mantle_mass",
+                },
+                {
+                    "field": "clam.mantle_mass",
+                    "value": "1 kg",
+                    "input_parameter": "mantle_mass",
+                },
+            ],
+        )
 
 
 def test_validate_request_reserved_input_param():
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator().validate_and_transform_request(utils.CallingForm.Request,
-                                                             [{"field": "mollusc.class",
-                                                               "value": "cephalopoda",
-                                                               "input_parameter": "class"}])
+        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+            utils.CallingForm.Request,
+            [
+                {
+                    "field": "mollusc.class",
+                    "value": "cephalopoda",
+                    "input_parameter": "class",
+                }
+            ],
+        )
 
 
 def test_single_request_client_streaming():
@@ -471,12 +688,13 @@ def test_single_request_client_streaming():
     # Client streaming and bidirectional streaming methods can't use this notation,
     # and generate an exception if there is more than one 'base'.
     with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator().validate_and_transform_request(
+        samplegen.Validator(DummyMethod()).validate_and_transform_request(
             utils.CallingForm.RequestStreamingClient,
-            [{"field": "cephalopod.order",
-              "value": "cephalopoda"},
-             {"field": "gastropod.order",
-              "value": "pulmonata"}])
+            [
+                {"field": "cephalopod.order", "value": "cephalopoda"},
+                {"field": "gastropod.order", "value": "pulmonata"},
+            ],
+        )
 
 
 def test_single_request_bidi_streaming():
@@ -489,38 +707,45 @@ def test_single_request_bidi_streaming():
     # Client streaming and bidirectional streaming methods can't use this notation,
     # and generate an exception if there is more than one 'base'.
     with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator().validate_and_transform_request(
+        samplegen.Validator(DummyMethod()).validate_and_transform_request(
             utils.CallingForm.RequestStreamingBidi,
-            [{"field": "cephalopod.order",
-              "value": "cephalopoda"},
-             {"field": "gastropod.order",
-              "value": "pulmonata"}])
+            [
+                {"field": "cephalopod.order", "value": "cephalopoda"},
+                {"field": "gastropod.order", "value": "pulmonata"},
+            ],
+        )
 
 
 def test_validate_request_calling_form():
-    DummyMethod = namedtuple("DummyMethod",
-                             ["lro",
-                              "paged_result_field",
-                              "client_streaming",
-                              "server_streaming"])
+    assert (
+        utils.CallingForm.method_default(DummyMethod(lro=True))
+        == utils.CallingForm.LongRunningRequestPromise
+    )
 
-    assert utils.CallingForm.method_default(DummyMethod(
-        True, False, False, False)) == utils.CallingForm.LongRunningRequestPromise
+    assert (
+        utils.CallingForm.method_default(DummyMethod(paged_result_field=True))
+        == utils.CallingForm.RequestPagedAll
+    )
 
-    assert utils.CallingForm.method_default(DummyMethod(
-        False, True, False, False)) == utils.CallingForm.RequestPagedAll
+    assert (
+        utils.CallingForm.method_default(DummyMethod(client_streaming=True))
+        == utils.CallingForm.RequestStreamingClient
+    )
 
-    assert utils.CallingForm.method_default(DummyMethod(
-        False, False, True, False)) == utils.CallingForm.RequestStreamingClient
+    assert (
+        utils.CallingForm.method_default(DummyMethod(server_streaming=True))
+        == utils.CallingForm.RequestStreamingServer
+    )
 
-    assert utils.CallingForm.method_default(DummyMethod(
-        False, False, False, True)) == utils.CallingForm.RequestStreamingServer
+    assert utils.CallingForm.method_default(
+        DummyMethod()) == utils.CallingForm.Request
 
-    assert utils.CallingForm.method_default(DummyMethod(
-        False, False, False, False)) == utils.CallingForm.Request
-
-    assert utils.CallingForm.method_default(DummyMethod(
-        False, False, True, True)) == utils.CallingForm.RequestStreamingBidi
+    assert (
+        utils.CallingForm.method_default(
+            DummyMethod(client_streaming=True, server_streaming=True)
+        )
+        == utils.CallingForm.RequestStreamingBidi
+    )
 
 
 def test_coerce_response_name():
@@ -529,119 +754,121 @@ def test_coerce_response_name():
     assert samplegen.coerce_response_name("mollusc.squid") == "mollusc.squid"
 
 
-def test_generate_manifest():
-    DummyNaming = namedtuple("DummyNaming", ["name", "version"])
-    DummyApiSchema = namedtuple("DummyApiSchema", ["naming"])
+def test_regular_response_type():
+    OutputType = TypeVar("OutputType")
+    method = DummyMethod(output=OutputType)
 
-    fpath_to_dummy_sample = {
-        "squid_fpath.py": {"id": "squid_sample"},
-        "clam_fpath.py": {"id": "clam_sample",
-                          "region_tag": "giant_clam_sample"},
-    }
+    v = samplegen.Validator(method)
+    assert v.var_field("$resp").message == OutputType
 
-    fname, info = samplegen.generate_manifest(
-        fpath_to_dummy_sample.items(),
-        DummyApiSchema(DummyNaming("Mollusc", "v1")),
-        # Empirically derived number such that the
-        # corresponding time_struct tests the zero
-        # padding in the returned filename.
-        manifest_time=4486525628
+
+def test_paged_response_type():
+    OutputType = TypeVar("OutputType")
+    PagedType = TypeVar("PagedType")
+    method = DummyMethod(output=OutputType, paged_result_field=PagedType)
+
+    v = samplegen.Validator(method)
+    assert v.var_field("$resp").message == PagedType
+
+
+def test_lro_response_type():
+    OutputType = TypeVar("OutputType")
+    LroType = TypeVar("LroType")
+    method = DummyMethod(
+        output=OutputType, lro=namedtuple(
+            "operation", ["response_type"])(LroType)
     )
 
-    assert fname == "Mollusc.v1.python.21120304.090708.manifest.yaml"
+    v = samplegen.Validator(method)
+    assert v.var_field("$resp").message == LroType
 
-    expected_info = [
-        gapic_yaml.KeyVal("type", "manifest/samples"),
-        gapic_yaml.KeyVal("schema_version", "3"),
-        gapic_yaml.Map(name="python",
-                       anchor_name="python",
-                       elements=[
-                           gapic_yaml.KeyVal(
-                               "environment", "python"),
-                           gapic_yaml.KeyVal(
-                               "bin", "python3"),
-                           gapic_yaml.KeyVal(
-                               "base_path", "sample/base/directory"),
-                           gapic_yaml.KeyVal(
-                               "invocation", "'{bin} {path} @args'"),
-                       ]),
-        gapic_yaml.Collection(name="samples",
-                              elements=[
-                                  [
-                                      gapic_yaml.Anchor(
-                                          "python"),
-                                      gapic_yaml.KeyVal(
-                                          "sample", "squid_sample"),
-                                      gapic_yaml.KeyVal(
-                                          "path", "'{base_path}/squid_fpath.py'"),
-                                      gapic_yaml.KeyVal(
-                                          "region_tag", ""),
-                                  ],
-                                  [
-                                      gapic_yaml.Anchor("python"),
-                                      gapic_yaml.KeyVal(
-                                          "sample", "clam_sample"),
-                                      gapic_yaml.KeyVal(
-                                          "path", "'{base_path}/clam_fpath.py'"),
-                                      gapic_yaml.KeyVal(
-                                          "region_tag", "giant_clam_sample")
-                                  ],
-                              ])
-    ]
 
-    assert info == expected_info
+def test_validate_expression():
+    exp = "$resp.coleoidea.octopodiformes.octopus"
+    OutputType = message_factory(exp)
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
 
-    expected_rendering = dedent("""
-                                type: manifest/samples
-                                schema_version: 3
-                                python: &python
-                                  environment: python
-                                  bin: python3
-                                  base_path: sample/base/directory
-                                  invocation: '{bin} {path} @args'
-                                samples:
-                                - <<: *python
-                                  sample: squid_sample
-                                  path: '{base_path}/squid_fpath.py'
-                                  region_tag: 
-                                - <<: *python
-                                  sample: clam_sample
-                                  path: '{base_path}/clam_fpath.py'
-                                  region_tag: giant_clam_sample""".lstrip("\n"))
+    exp_type = v.validate_expression(exp)
+    assert exp_type.message.type == "OCTOPUS_TYPE"
 
-    rendered_yaml = "\n".join(e.render() for e in info)
-    assert rendered_yaml == expected_rendering
 
-    expected_parsed_manifest = {
-        "type": "manifest/samples",
-        "schema_version": 3,
-        "python": {
-            "environment": "python",
-            "bin": "python3",
-            "base_path": "sample/base/directory",
-            "invocation": "{bin} {path} @args",
-        },
-        "samples": [
+def test_validate_expression_undefined_base():
+    exp = "$resp.coleoidea.octopodiformes.octopus"
+    OutputType = message_factory(exp)
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+
+    with pytest.raises(samplegen.UndefinedVariableReference):
+        v.validate_expression("mollusc")
+
+
+def test_validate_expression_no_such_attr():
+    OutputType = message_factory("$resp.coleoidea")
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression("$resp.nautiloidea")
+
+
+def test_validate_expression_predefined():
+    exp = "$resp.coleoidea.octopodiformes.octopus"
+    OutputType = message_factory(exp)
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_response([{"define": "nautilus=$resp.nautiloidea"}])
+
+
+def test_validate_expression_repeated_attrs():
+    # This is a little tricky: there's an attribute hierarchy
+    # of response/coleoidea/octopodiformes, but coleoidea is a repeated field,
+    # so accessing $resp.coleoidea.octopodiformes doesn't make any sense.
+    exp = "$resp.coleoidea.octopodiformes"
+    OutputType = message_factory(exp, [True, False])
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_response(
+            [{"define": "octopus=$resp.coleoidea.octopodiformes"}])
+
+
+def test_validate_expression_collection():
+    exp = "$resp.molluscs"
+    OutputType = message_factory(exp, [True])
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    v.validate_response(
+        [
             {
-                "environment": "python",
-                "bin": "python3",
-                "base_path": "sample/base/directory",
-                "invocation": "{bin} {path} @args",
-                "sample": "squid_sample",
-                "path": "{base_path}/squid_fpath.py",
-                "region_tag": None,
-            },
-            {
-                "environment": "python",
-                "bin": "python3",
-                "base_path": "sample/base/directory",
-                "invocation": "{bin} {path} @args",
-                "sample": "clam_sample",
-                "path": "{base_path}/clam_fpath.py",
-                "region_tag": "giant_clam_sample",
-            },
-        ],
+                "loop": {
+                    "collection": "$resp.molluscs",
+                    "variable": "m",
+                    "body": [{"print": ["%s", "m"]}],
+                }
+            }
+        ]
+    )
+
+
+def test_validate_expression_collection_error():
+    exp = "$resp.molluscs.mollusc"
+    OutputType = message_factory(exp)
+    method = DummyMethod(output=OutputType)
+
+    statement = {
+        "loop": {
+            "collection": "$resp.molluscs",
+            "variable": "m",
+            "body": [{"print": ["%s", "m"]}],
+        }
     }
 
-    parsed_manifest = yaml.safe_load(rendered_yaml)
-    assert parsed_manifest == expected_parsed_manifest
+    v = samplegen.Validator(method)
+
+    # Because 'molluscs' isn't repeated
+    with pytest.raises(samplegen.BadLoop):
+        v.validate_response([statement])


### PR DESCRIPTION
The 'validate_expression' method validates that a dotted attribute expression, 
e.g. "squid.clam.whelk",
references a defined variable, and that each attribute in the chain is
valid, i.e. 'squid' is a defined variable, and its type has a 'clam'
attribute, whose type has a 'whelk' attribute.

Also, do initial attribute checking
**NOTE**: not all validation methods check expressions yet. 
This is a deliberate decision because
*) Determining whether an attribute is a map (and what the types of the key and value are) is non trivial and requires additional work.
*) This review was getting large as is.

All "attribute expressions", e.g. mollusc.cephalopod.squid, are
checked to make sure that the chain of attributes is valid.
Validity includes:
*) Only the final attribute may be repeated
*) The type of an attribute at position n in the chain has a field
   with the name of the attribute at position n+1.

Defines check that repeated fields can only come at the end of an expression.
Loop statements now check that the collection is a repeated field.

Also, move the manifest test into its own file because it got large.
