### PR TITLE
[fix] Remove <br> from `feature_fragments.j2`.

### DIFF
--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -232,4 +232,3 @@ if __name__ == "__main__":
     main()
 {% endwith %}
 {% endmacro %}
-<br>


### PR DESCRIPTION
It is obviously not valid Python.
Also, its presence causes the file to be generated even if there
are no samples.