### PR TITLE
Fix render_main_block macro and tests

### DIFF
--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -217,11 +217,13 @@ def main():
 
     parser = argparse.ArgumentParser()
 {% with arg_list = [] %}
-{% for attr in request_block if "input_parameter" in attr %}
+{% for request in request_block|map(attribute="body") -%}
+{% for attr in request if "input_parameter" in attr %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
                         default="{{ attr.value }}")
 {% do arg_list.append("args." + attr.input_parameter) -%}
+{% endfor %}
 {% endfor %}
     args = parser.parse_args()
 

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -109,9 +109,12 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--video",
+                        type=str,
+                        default="path/to/mollusc/video.mkv")
     args = parser.parse_args()
 
-    sample_classify()
+    sample_classify(args.video)
 
 
 if __name__ == "__main__":

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -535,14 +535,7 @@ def test_main_block():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_main_block("ListMolluscs", [{"field": "list_molluscs.order",
-                                                   "value": "coleoidea",
-                                                   "input_parameter": "order"},
-                                                  {"field ": "list_molluscs.mass",
-                                                   "value": "60kg",
-                                                   "input_parameter": "mass"},
-                                                  {"field": "list_molluscs.zone",
-                                                   "value": "MESOPELAGIC"},]) }}
+        {{ frags.render_main_block("ListMolluscs", request) }}
         ''',
         '''
         def main():
@@ -562,5 +555,15 @@ def test_main_block():
 
         if __name__ == "__main__":
             main()
-        '''
+        ''',
+        request=[
+            samplegen.TransformedRequest("input_params", [{"field": "list_molluscs.order",
+                                                           "value": "coleoidea",
+                                                           "input_parameter": "order"},
+                                                          {"field ": "list_molluscs.mass",
+                                                           "value": "60kg",
+                                                           "input_parameter": "mass"}]),
+            samplegen.TransformedRequest("enum_param", [{"field": "list_molluscs.zone",
+                                                         "value": "MESOPELAGIC"}])
+        ]
     )


### PR DESCRIPTION
Properly parse the input parameters using argparse and feed them into
the sample function.

These were not being handled properly due TDD with a faulty test.