### PR TITLE
Test request setup against method request type

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -270,17 +270,20 @@ class Validator:
                                 in the request message type.
 
         """
-        base_param_to_attrs: Dict[str, List[AttributeRequestSetup]] = defaultdict(list)
+        base_param_to_attrs: Dict[str,
+                                  List[AttributeRequestSetup]] = defaultdict(list)
 
         for r in request:
             duplicate = dict(r)
             val = duplicate.get("value")
             if not val:
-                raise InvalidRequestSetup("Missing keyword in request entry: 'value'")
+                raise InvalidRequestSetup(
+                    "Missing keyword in request entry: 'value'")
 
             field = duplicate.get("field")
             if not field:
-                raise InvalidRequestSetup("Missing keyword in request entry: 'field'")
+                raise InvalidRequestSetup(
+                    "Missing keyword in request entry: 'field'")
 
             spurious_keywords = set(duplicate.keys()) - {"value",
                                                          "field",

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -61,6 +61,18 @@ TEMPLATE_NAME = "sample.py.j2"
 
 @dataclasses.dataclass(frozen=True)
 class AttributeRequestSetup:
+    """A single request-field setup description.
+
+    If 'field' is not set, this is a top level attribute, in which case the 'base'
+    parameter of the owning TransformedRequest is the attribute name.
+
+    A True 'value_is_file' indicates that 'value' is a file path,
+    and that the value of the attribute is the contents of that file.
+
+    A non-empty 'input_parameter' indicates a formal parameter to the sample function
+    that contains the value for the attribute.
+
+    """
     value: str
     field: Optional[str] = None
     value_is_file: bool = False
@@ -72,11 +84,21 @@ class AttributeRequestSetup:
 class TransformedRequest:
     """Class representing a single field in a method call.
 
-    The Optional[single]/Optional[body] is workaround for not having tagged unions;
-    each transformed request either describes an attribute with multiple fields
-    ('base' is the top level field name, 'body' contains a list of AttributeRequestSetups,
-     where each one describes how to set up a subfield) or a top level field,
-    where 'single' refers to the value of the singleton top level attribute.
+    A request block, as read in from the sample config, is a list of dicts that
+    describe field setup for the API method request.
+
+    Fields with subfields are treated as dictionaries, with subfields as keys
+    and passed, read, or hardcoded subfield values as the mapped values.
+    These field dictionaries are passed into the client method as positional arguments.
+
+    Fields _without_ subfields, aka top-level-fields, are passed into the method call
+    as keyword parameters, with their associated values assigned directly.
+
+    A TransformedRequest describes a subfield of the API request.
+    It is either a top level request, in which case the 'single' attribute is filled,
+    or it has assigned-to subfields, in which case 'body' lists assignment setups.
+
+    The Optional[single]/Optional[body] is workaround for not having tagged unions.
     """
     base: str
     single: Optional[AttributeRequestSetup]

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import itertools
 import jinja2
 import keyword
@@ -23,7 +24,7 @@ from gapic.schema import (api, wrappers)
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
 from textwrap import dedent
-from typing import (ChainMap, Dict, List, Mapping, Optional, Set, Tuple)
+from typing import (ChainMap, Dict, List, Mapping, Optional, Set, Tuple, Union)
 
 # Outstanding issues:
 # * In real sample configs, many variables are
@@ -58,7 +59,28 @@ RESERVED_WORDS = frozenset(
 TEMPLATE_NAME = "sample.py.j2"
 
 
-TransformedRequest = namedtuple("TransformedRequest", ["base", "body"])
+@dataclasses.dataclass(frozen=True)
+class AttributeRequestSetup:
+    value: str
+    field: Optional[str] = None
+    value_is_file: bool = False
+    input_parameter: Optional[str] = None
+    comment: Optional[str] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class TransformedRequest:
+    """Class representing a single field in a method call.
+
+    The Optional[single]/Optional[body] is workaround for not having tagged unions;
+    each transformed request either describes an attribute with multiple fields
+    ('base' is the top level field name, 'body' contains a list of AttributeRequestSetups,
+     where each one describes how to set up a subfield) or a top level field,
+    where 'single' refers to the value of the singleton top level attribute.
+    """
+    base: str
+    single: Optional[AttributeRequestSetup]
+    body: Optional[List[AttributeRequestSetup]]
 
 
 class SampleError(Exception):
@@ -117,6 +139,10 @@ class InvalidRequestSetup(SampleError):
     pass
 
 
+class InvalidEnumVariant(SampleError):
+    pass
+
+
 def coerce_response_name(s: str) -> str:
     # In the sample config, the "$resp" keyword is used to refer to the
     # item of interest as received by the corresponding calling form.
@@ -148,6 +174,7 @@ class Validator:
     def __init__(self, method: wrappers.Method):
         # The response ($resp) variable is special and guaranteed to exist.
         # TODO: name lookup also involes type checking
+        self.request_type_ = method.input
         response_type = method.output
         if method.paged_result_field:
             response_type = method.paged_result_field
@@ -183,15 +210,16 @@ class Validator:
            variable name, e.g. clam.shell.
 
            The only required keys in each dict are "field" and value".
-           Optional keys are "input_parameter" and "value_is_file".
-           All values in the initial request are strings
-           except for the value for "value_is_file", which is a bool.
+           Optional keys are "input_parameter", "value_is_file". and "comment".
+           All values in the initial request are strings except for the value
+           for "value_is_file", which is a bool.
 
-           The topmost dict of the return value has two keys: "base" and "body",
-           where "base" maps to a variable name, and "body" maps to a list of variable
-           assignment definitions. The only difference in the bottommost dicts
-           are that "field" maps only to the second part of a dotted variable name.
-           Other key/value combinations in the dict are unmodified for the time being.
+           The TransformedRequest structure of the return value has three fields:
+           "base", "body", and "single", where "base" maps to the top level attribute name,
+           "body" maps to a list of subfield assignment definitions, and "single"
+           maps to a singleton attribute assignment structure with no "field" value.
+           The "field" attribute in the requests in a "body" list have their prefix stripped;
+           the request in a "single" attribute has no "field" attribute.
 
            Note: gRPC API methods only take one parameter (ignoring client-side streaming).
                  The reason that GAPIC client library API methods may take multiple parameters
@@ -199,22 +227,28 @@ class Validator:
                  The different 'bases' are really attributes for the singular request parameter.
 
            TODO: properly handle subfields, indexing, and so forth.
-
-           TODO: Conduct module lookup and expansion for protobuf enums.
-                 Requires proto/method/message descriptors.
-           TODO: Permit single level field/oneof requst parameters.
-                 Requires proto/method/message descriptors.
            TODO: Add/transform to list repeated element fields.
                  Requires proto/method/message descriptors.
 
            E.g. [{"field": "clam.shell", "value": "10 kg", "input_parameter": "shell"},
                  {"field": "clam.pearls", "value": "3"},
-                 {"field": "squid.mantle", "value": "100 kg"}]
+                 {"field": "squid.mantle", "value": "100 kg"},
+                 {"field": "whelk", "value": "speckled"}]
                   ->
-                [TransformedRequest("clam",
-                  [{"field": "shell", "value": "10 kg", "input_parameter": "shell"},
-                   {"field": "pearls", "value": "3"}]),
-                 TransformedRequest("squid", [{"field": "mantle", "value": "100 kg"}])]
+                [TransformedRequest(
+                     base="clam",
+                     body=[AttributeRequestSetup(field="shell",
+                                                 value="10 kg",
+                                                 input_parameter="shell"),
+                           AttributeRequestSetup(field="pearls", value="3")],
+                     single=None),
+                 TransformedRequest(base="squid",
+                                    body=[AttributeRequestSetup(field="mantle",
+                                                                value="100 kg")],
+                                    single=None),
+                 TransformedRequest(base="whelk",
+                                    body=None,
+                                    single=AttributeRequestSetup(value="speckled))]
 
            The transformation makes it easier to set up request parameters in jinja
            because it doesn't have to engage in prefix detection, validation,
@@ -225,78 +259,101 @@ class Validator:
             request (list[dict{str:str}]): The request body from the sample config
 
         Returns:
-            list[dict{str:(str|list[dict{str:str}])}]: The transformed request block.
+            List[TransformedRequest]: The transformed request block.
 
         Raises:
-            RedefinedVariable: If an "input_parameter" attempts to redefine a
-                               previously defined variable.
-            ReservedVariableName: If an "input_parameter" value or a "base" value
-                                  is a reserved word.
-            InvalidRequestSetup: If a dict in the request lacks a "field" key
-                                 or the corresponding value is malformed.
+            InvalidRequestSetup: If a dict in the request lacks a "field" key,
+                                 a "value" key, if there is an unexpected keyword,
+                                 or if more than one base parameter is given for
+                                 a client-side streaming calling form.
+            BadAttributeLookup: If a request field refers to a non-existent field
+                                in the request message type.
+
         """
-        base_param_to_attrs: Mapping[str,
-                                     List[Mapping[str, str]]] = defaultdict(list)
+        base_param_to_attrs: Dict[str, List[AttributeRequestSetup]] = defaultdict(list)
 
-        for field_assignment in request:
-            field_assignment_copy = dict(field_assignment)
-            input_param = field_assignment_copy.get("input_parameter")
-            if input_param:
-                # We use str as the input type because
-                # validate_expression just needs to know
-                # that the input_parameter isn't a MessageType of any kind.
-                # TODO: write a test about that.
-                # TODO: handle enums
-                self._handle_lvalue(input_param, str)
+        for r in request:
+            duplicate = dict(r)
+            val = duplicate.get("value")
+            if not val:
+                raise InvalidRequestSetup("Missing keyword in request entry: 'value'")
 
-            field = field_assignment_copy.get("field")
+            field = duplicate.get("field")
             if not field:
+                raise InvalidRequestSetup("Missing keyword in request entry: 'field'")
+
+            spurious_keywords = set(duplicate.keys()) - {"value",
+                                                         "field",
+                                                         "value_is_file",
+                                                         "input_parameter",
+                                                         "comment"}
+            if spurious_keywords:
                 raise InvalidRequestSetup(
-                    "No field attribute found in request setup assignment: {}".format(
-                        field_assignment_copy
-                    )
-                )
+                    "Spurious keyword(s) in request entry: {}".format(
+                        ", ".join(f"'{kword}'" for kword in spurious_keywords)))
 
-            # TODO: properly handle top level fields
-            # E.g.
-            #
-            #  -field: edition
-            #   comment: The edition of the series.
-            #   value: '123'
-            #   input_parameter: edition
-            m = re.match(r"^([a-zA-Z]\w*)\.([a-zA-Z]\w*)$", field)
-            if not m:
-                raise InvalidRequestSetup(
-                    "Malformed request attribute description: {}".format(field)
-                )
+            input_parameter = duplicate.get("input_parameter")
+            if input_parameter:
+                self._handle_lvalue(input_parameter, str)
 
-            base, attr = m.groups()
-            if base in RESERVED_WORDS:
-                raise ReservedVariableName(
-                    "Tried to define '{}', which is a reserved name".format(
-                        base)
-                )
+            attr_chain = field.split(".")
+            base = self.request_type_
+            for attr_name in attr_chain:
+                attr = base.fields.get(attr_name)
+                if not attr:
+                    raise BadAttributeLookup(
+                        "Method request type {} has no attribute: '{}'".format(
+                            self.request_type_.type, attr_name))
 
-            field_assignment_copy["field"] = attr
-            base_param_to_attrs[base].append(field_assignment_copy)
+                if attr.message:
+                    base = attr.message
 
-        if (
-            calling_form
-            in {
-                utils.CallingForm.RequestStreamingClient,
-                utils.CallingForm.RequestStreamingBidi,
-            }
-            and len(base_param_to_attrs) > 1
-        ):
+                else:
+                    raise TypeError
+
+                # TODO: uncomment this when handling enums
+                # if attr.enum:
+                #     # A little bit hacky, but 'values' is a list, and this is the easiest
+                #     # way to verify that the value is a valid enum variant.
+                #     witness = next((e.name for e in attr.enum.values if e.name == val), None)
+                #     if not witness:
+                #         raise InvalidEnumVariant
+                #     # Python code can set protobuf enums from strings.
+                #     # This is preferable to adding the necessary import statement
+                #     # and requires less munging of the assigned value
+                #     duplicate["value"] = f"'{witness}'"
+
+            # TODO: what if there's more stuff in the chain?
+            if len(attr_chain) > 1:
+                duplicate["field"] = ".".join(attr_chain[1:])
+            else:
+                # Because of the way top level attrs get rendered,
+                # there can't be duplicates.
+                # This is admittedly a bit of a hack.
+                if attr_chain[0] in base_param_to_attrs:
+                    raise InvalidRequestSetup(
+                        "Duplicated top level field in request block: '{}'".format(
+                            attr_chain[0]))
+                del duplicate["field"]
+
+            # Mypy isn't smart enough to handle dictionary unpacking,
+            # so disable it for the AttributeRequestSetup ctor call.
+            base_param_to_attrs[attr_chain[0]].append(
+                AttributeRequestSetup(**duplicate))  # type: ignore
+
+        client_streaming_forms = {
+            utils.CallingForm.RequestStreamingClient,
+            utils.CallingForm.RequestStreamingBidi,
+        }
+
+        if len(base_param_to_attrs) > 1 and calling_form in client_streaming_forms:
             raise InvalidRequestSetup(
-                (
-                    "There can be at most 1 base request in a sample"
-                    " for a method with client side streaming"
-                )
-            )
+                "Too many base parameters for client side streaming form")
 
         return [
-            TransformedRequest(base, body) for base, body in base_param_to_attrs.items()
+            (TransformedRequest(base=key, body=val, single=None) if val[0].field
+             else TransformedRequest(base=key, body=None, single=val[0]))
+            for key, val in base_param_to_attrs.items()
         ]
 
     def validate_response(self, response):

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -217,11 +217,13 @@ def main():
 
     parser = argparse.ArgumentParser()
 {% with arg_list = [] %}
-{% for attr in request_block if "input_parameter" in attr %}
+{% for request in request_block|map(attribute="body") -%}
+{% for attr in request if "input_parameter" in attr %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
                         default="{{ attr.value }}")
 {% do arg_list.append("args." + attr.input_parameter) -%}
+{% endfor %}
 {% endfor %}
     args = parser.parse_args()
 

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -51,17 +51,14 @@ There is a little, but not enough for it to be important because
 {% with input_parameters = [] %}
   {% for request in requests %}
     {% if request.body %}
-      {% for element in request.body %}
-        {% if element.input_parameter %}
-          {% do input_parameters.append(element.input_parameter) %}
-        {% endif %}
+      {% for element in request.body if element.input_parameter %}
+        {% do input_parameters.append(element.input_parameter) %}
       {% endfor %}
     {% elif request.single and request.single.input_parameter %}
       {% do input_parameters.append(request.single.input_parameter) %}
     {% endif %}
   {% endfor %}
-{% endfor %}
-{{ input_parameters|join(", ") -}
+{{ input_parameters|join(", ") -}}
 {% endwith %}
 {% endmacro %}
 

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -49,13 +49,17 @@ There is a little, but not enough for it to be important because
 
 {% macro print_input_params(requests) %}
 {% with input_parameters = [] %}
-{% for request in requests %}
-  {% for element in request.body %}
-    {% if "input_parameter" in element %}
-      {% do input_parameters.append(element["input_parameter"]) %}
+  {% for request in requests %}
+    {% if request.body %}
+      {% for element in request.body %}
+        {% if element.input_parameter %}
+          {% do input_parameters.append(element.input_parameter) %}
+        {% endif %}
+      {% endfor %}
+    {% elif request.single and request.single.input_parameter %}
+      {% do input_parameters.append(request.single.input_parameter) %}
     {% endif %}
   {% endfor %}
-{% endfor %}
 {{ input_parameters|join(", ") -}}
 {% endwith %}
 {% endmacro %}
@@ -134,9 +138,9 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 {# to be the correct enum from the right module, if necessary. #}
 {# Python is also responsible for verifying that each input parameter is unique,#}
 {# no parameter is a reserved keyword #}
-  {% if "input_parameter" in attr %}
+  {% if attr.input_parameter %}
 # {{ attr.input_parameter }} = "{{ attr.value }}"
-    {% if "value_is_file" in attr and attr.value_is_file %}
+  {% if attr.value_is_file %}
 with open({{ attr.input_parameter }}, "rb") as f:
     {{ base_name }}["{{ attr.field }}"] = f.read()
     {% else %}
@@ -147,8 +151,8 @@ with open({{ attr.input_parameter }}, "rb") as f:
   {% endif %}
 {% endmacro %}
 
-{% macro render_request(request) %}
-  {% for parameter_block in request %}
+{% macro render_request_setup(request) %}
+  {% for parameter_block in request if parameter_block.body %}
 {{ parameter_block.base }} = {}
     {% for attr in parameter_block.body %}
 {{ render_request_attr(parameter_block.base, attr) }}
@@ -156,14 +160,27 @@ with open({{ attr.input_parameter }}, "rb") as f:
   {% endfor %}
 {% endmacro %}
 
+{% macro render_request_params(request) %}
+  {# Provide the top level parameters last and as keyword params #}
+  {% with params = [] -%}
+    {% for r in request if r.body -%}
+      {% do params.append(r.base) -%}
+    {% endfor -%}
+    {% for r in request if r.single -%}
+      {% do params.append("%s=%s"|format(r.base, r.single.value)) -%}
+    {% endfor -%}
+{{ params|join(", ") -}}
+  {% endwith -%}
+{% endmacro %}
+
 {% macro render_method_call(sample, calling_form, calling_form_enum) %}
 {# Note: this doesn't deal with enums or unions #}
-{% if calling_form not in [calling_form_enum.RequestStreamingBidi,
-calling_form_enum.RequestStreamingClient] %}
-client.{{ sample.rpc|snake_case }}({{ sample.request|map(attribute="base")|join(", ") }})
+{% if calling_form in [calling_form_enum.RequestStreamingBidi,
+                       calling_form_enum.RequestStreamingClient] %}
+client.{{ sample.rpc|snake_case }}([{{ render_request_params(sample.request) }}])
 {% else %}
 {# TODO: set up client streaming once some questions are answered #}
-client.{{ sample.rpc|snake_case }}([{{ sample.request|map(attribute="base")|join("") }}])
+client.{{ sample.rpc|snake_case }}({{ render_request_params(sample.request) }})
 {% endif %}
 {% endmacro %}
 
@@ -202,7 +219,7 @@ print("Waiting for operation to complete...")
 
 response = operation.result()
 {% for statement in response_statements %}
-{{ dispatch_statement(statement ) }}
+{{ dispatch_statement(statement) }}
 {% endfor %}
 {% endif %}
 {% endmacro %}
@@ -217,13 +234,18 @@ def main():
 
     parser = argparse.ArgumentParser()
 {% with arg_list = [] %}
-{% for request in request_block|map(attribute="body") -%}
-{% for attr in request if "input_parameter" in attr %}
+  {% for request in request_block if request.body -%}
+      {% for attr in request.body if attr.input_parameter %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
                         default="{{ attr.value }}")
 {% do arg_list.append("args." + attr.input_parameter) -%}
+{% endfor -%}
 {% endfor %}
+{% for request in request_block if request.single and request.single.input_parameter -%}
+    parser.add_argument("-- {{ request.single.input_parameter }}",
+                        type=str,
+                        default="{{ request.single.value }}")
 {% endfor %}
     args = parser.parse_args()
 

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -37,7 +37,7 @@ def sample_{{ frags.render_method_name(sample.rpc) }}({{ frags.print_input_param
                 map("lower")|
                 join("_") }}.{{ sample.service.split(".")[-1] }}Client()
 
-    {{ frags.render_request(sample.request)|indent }}
+    {{ frags.render_request_setup(sample.request)|indent }}
 {% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %}
     {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response)|indent -}}
 {% endwith %}

--- a/noxfile.py
+++ b/noxfile.py
@@ -31,7 +31,8 @@ def unit(session):
 
     session.run(
         'py.test',
-        '--quiet',
+        '-vv',
+        # '--quiet',
         '--cov=gapic',
         '--cov-config=.coveragerc',
         '--cov-report=term',
@@ -71,12 +72,12 @@ def showcase(session):
 
         # Write out a client library for Showcase.
         session.run('protoc',
-            f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
-            f'--python_gapic_out={tmp_dir}',
-            'google/showcase/v1beta1/echo.proto',
-            'google/showcase/v1beta1/identity.proto',
-            external=True,
-        )
+                    f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
+                    f'--python_gapic_out={tmp_dir}',
+                    'google/showcase/v1beta1/echo.proto',
+                    'google/showcase/v1beta1/identity.proto',
+                    external=True,
+                    )
 
         # Install the library.
         session.install(tmp_dir)
@@ -107,14 +108,14 @@ def showcase_unit(session):
 
         # Write out a client library for Showcase.
         session.run('protoc',
-            f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
-            f'--python_gapic_out={tmp_dir}',
-            'google/showcase/v1beta1/echo.proto',
-            'google/showcase/v1beta1/identity.proto',
-            'google/showcase/v1beta1/messaging.proto',
-            'google/showcase/v1beta1/testing.proto',
-            external=True,
-        )
+                    f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
+                    f'--python_gapic_out={tmp_dir}',
+                    'google/showcase/v1beta1/echo.proto',
+                    'google/showcase/v1beta1/identity.proto',
+                    'google/showcase/v1beta1/messaging.proto',
+                    'google/showcase/v1beta1/testing.proto',
+                    external=True,
+                    )
 
         # Install the library.
         session.chdir(tmp_dir)
@@ -152,14 +153,14 @@ def showcase_mypy(session):
 
         # Write out a client library for Showcase.
         session.run('protoc',
-            f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
-            f'--python_gapic_out={tmp_dir}',
-            'google/showcase/v1beta1/echo.proto',
-            'google/showcase/v1beta1/identity.proto',
-            'google/showcase/v1beta1/messaging.proto',
-            'google/showcase/v1beta1/testing.proto',
-            external=True,
-        )
+                    f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
+                    f'--python_gapic_out={tmp_dir}',
+                    'google/showcase/v1beta1/echo.proto',
+                    'google/showcase/v1beta1/identity.proto',
+                    'google/showcase/v1beta1/messaging.proto',
+                    'google/showcase/v1beta1/testing.proto',
+                    external=True,
+                    )
 
         # Install the library.
         session.chdir(tmp_dir)

--- a/tests/unit/samplegen/common_types.py
+++ b/tests/unit/samplegen/common_types.py
@@ -12,7 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import itertools
+
 from collections import namedtuple
+from typing import(Iterable, Optional)
+
+from gapic.schema import wrappers
 
 # Injected dummy test types
 
@@ -33,7 +38,7 @@ DummyMethod.__new__.__defaults__ = (False,) * len(DummyMethod._fields)
 DummyMessage = namedtuple("DummyMessage", ["fields", "type"])
 DummyMessage.__new__.__defaults__ = (False,) * len(DummyMessage._fields)
 
-DummyField = namedtuple("DummyField", ["message", "repeated"])
+DummyField = namedtuple("DummyField", ["message", "enum", "repeated"])
 DummyField.__new__.__defaults__ = (False,) * len(DummyField._fields)
 
 DummyService = namedtuple("DummyService", ["methods"])
@@ -44,3 +49,44 @@ DummyApiSchema.__new__.__defaults__ = (False,) * len(DummyApiSchema._fields)
 DummyNaming = namedtuple(
     "DummyNaming", ["warehouse_package_name", "name", "version"])
 DummyNaming.__new__.__defaults__ = (False,) * len(DummyNaming._fields)
+
+
+def message_factory(exp: str,
+                    repeated_iter=itertools.repeat(False),
+                    enum: Optional[wrappers.EnumType] = None) -> DummyMessage:
+    # This mimics the structure of MessageType in the wrappers module:
+    # A MessageType has a map from field names to Fields,
+    # and a Field has an (optional) MessageType.
+    # The 'exp' parameter is a dotted attribute expression
+    # used to describe the field and type hierarchy,
+    # e.g. "mollusc.cephalopod.coleoid"
+    toks = exp.split(".")
+    messages = [DummyMessage({}, tok.upper() + "_TYPE") for tok in toks]
+    if enum:
+        messages[-1] = enum
+
+    for base, field, attr_name, repeated_field in zip(
+        messages, messages[1:], toks[1:], repeated_iter
+    ):
+        base.fields[attr_name] = (DummyField(message=field, repeated=repeated_field)
+                                  if isinstance(field, DummyMessage)
+                                  else DummyField(enum=field))
+
+    return messages[0]
+
+
+def enum_factory(name: str, variants: Iterable[str]) -> wrappers.EnumType:
+    enum_pb = descriptor_pb2.EnumDescriptorProto(
+        name=name,
+        value=tuple(
+            descriptor_pb2.EnumValueDescriptorProto(name=v, number=i)
+            for i, v in enumerate(variants)
+        )
+    )
+
+    enum = wrappers.EnumType(
+        enum_pb=enum_pb,
+        values=[wrappers.EnumValueType(enum_value_pb=v) for v in enum_pb.value]
+    )
+
+    return enum

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -20,7 +20,7 @@ import gapic.samplegen.samplegen as samplegen
 import gapic.utils as utils
 
 from common_types import (DummyMethod, DummyService,
-                          DummyApiSchema, DummyNaming)
+                          DummyApiSchema, DummyNaming, message_factory, enum_factory)
 
 from collections import namedtuple
 from textwrap import dedent
@@ -47,7 +47,8 @@ def test_generate_sample_basic():
     # to have standalone tests.
     schema = DummyApiSchema(
         {"animalia.mollusca.v1.Mollusc": DummyService(
-            {"Classify": DummyMethod()})},
+            {"Classify": DummyMethod(
+                input=message_factory("mollusc.classify_request.video"))})},
         DummyNaming("molluscs-v1-mollusc"))
 
     sample = {"service": "animalia.mollusca.v1.Mollusc",

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -97,9 +97,12 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--video",
+                        type=str,
+                        default="path/to/mollusc/video.mkv")
     args = parser.parse_args()
 
-    sample_classify()
+    sample_classify(args.video)
 
 
 if __name__ == "__main__":

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -13,35 +13,18 @@
 # limitations under the License.
 
 import yaml
-import itertools
 import pytest
 
-from typing import TypeVar
+from typing import (Iterable, TypeVar)
 from collections import namedtuple
+from google.protobuf import descriptor_pb2
 
 import gapic.schema.wrappers as wrappers
 import gapic.samplegen.yaml as gapic_yaml
 import gapic.samplegen.samplegen as samplegen
 
-from common_types import DummyField, DummyMessage, DummyMethod
+from common_types import (DummyField, DummyMessage, DummyMethod, message_factory)
 from gapic.samplegen import utils
-
-
-def message_factory(exp: str, repeated_iter=itertools.repeat(False)) -> DummyMessage:
-    # This mimics the structure of MessageType in the wrappers module:
-    # A MessageType has a map from field names to Fields,
-    # and a Field has an (optional) MessageType.
-    # The 'exp' parameter is a dotted attribute expression
-    # used to describe the field and type hierarchy,
-    # e.g. "mollusc.cephalopod.coleoid"
-    toks = exp.split(".")
-    messages = [DummyMessage({}, tok.upper() + "_TYPE") for tok in toks]
-    for base, field, attr_name, repeated_field in zip(
-        messages, messages[1:], toks[1:], repeated_iter
-    ):
-        base.fields[attr_name] = DummyField(field, repeated=repeated_field)
-
-    return messages[0]
 
 
 # validate_response tests
@@ -49,40 +32,34 @@ def message_factory(exp: str, repeated_iter=itertools.repeat(False)) -> DummyMes
 
 def test_define():
     define = {"define": "squid=$resp"}
-
-    samplegen.Validator(
-        DummyMethod(output=message_factory("mollusc"))
-    ).validate_response([define])
+    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc")))
+    v.validate_response([define])
 
 
 def test_define_undefined_var():
     define = {"define": "squid=humboldt"}
+    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc")))
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("mollusc"))
-        ).validate_response([define])
+        v.validate_response([define])
 
 
 def test_define_reserved_varname():
     define = {"define": "class=$resp"}
+    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc")))
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("mollusc"))
-        ).validate_response([define])
+        v.validate_response([define])
 
 
 def test_define_add_var():
-    samplegen.Validator(
-        DummyMethod(output=message_factory("mollusc.name"))
-    ).validate_response([{"define": "squid=$resp"}, {"define": "name=squid.name"}])
+    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc.name")))
+    v.validate_response([{"define": "squid=$resp"}, {"define": "name=squid.name"}])
 
 
 def test_define_bad_form():
     define = {"define": "mollusc=$resp.squid=$resp.clam"}
+    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc")))
     with pytest.raises(samplegen.BadAssignment):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("mollusc"))
-        ).validate_response([define])
+        v.validate_response([define])
 
 
 def test_define_redefinition():
@@ -90,15 +67,16 @@ def test_define_redefinition():
         {"define": "molluscs=$resp.molluscs"},
         {"define": "molluscs=$resp.molluscs"},
     ]
+    v = samplegen.Validator(DummyMethod(output=message_factory("$resp.molluscs",
+                                                               repeated_iter=[True])))
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.molluscs", [True]))
-        ).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_define_input_param():
-    validator = samplegen.Validator(DummyMethod())
-    validator.validate_and_transform_request(
+    v = samplegen.Validator(
+        DummyMethod(input=message_factory("mollusc.squid.mantle_length")))
+    v.validate_and_transform_request(
         utils.CallingForm.Request,
         [
             {
@@ -108,12 +86,13 @@ def test_define_input_param():
             }
         ],
     )
-    validator.validate_response([{"define": "length=mantle_length"}])
+    v.validate_response([{"define": "length=mantle_length"}])
 
 
 def test_define_input_param_redefinition():
-    validator = samplegen.Validator(DummyMethod())
-    validator.validate_and_transform_request(
+    v = samplegen.Validator(DummyMethod(
+        input=message_factory("mollusc.squid.mantle_length")))
+    v.validate_and_transform_request(
         utils.CallingForm.Request,
         [
             {
@@ -124,7 +103,7 @@ def test_define_input_param_redefinition():
         ],
     )
     with pytest.raises(samplegen.RedefinedVariable):
-        validator.validate_response(
+        v.validate_response(
             [{"define": "mantle_length=mantle_length"}])
 
 
@@ -135,33 +114,29 @@ def test_print_basic():
 
 def test_print_fmt_str():
     print_statement = {"print": ["This is a squid named %s", "$resp.name"]}
-    samplegen.Validator(
-        DummyMethod(output=message_factory("$resp.name"))
-    ).validate_response([print_statement])
+    v = samplegen.Validator(DummyMethod(output=message_factory("$resp.name")))
+    v.validate_response([print_statement])
 
 
 def test_print_fmt_mismatch():
     print_statement = {"print": ["This is a squid named %s"]}
+    v = samplegen.Validator(DummyMethod(output=message_factory("$resp.name")))
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.name"))
-        ).validate_response([print_statement])
+        v.validate_response([print_statement])
 
 
 def test_print_fmt_mismatch2():
     print_statement = {"print": ["This is a squid", "$resp.name"]}
+    v = samplegen.Validator(DummyMethod(output=message_factory("$resp.name")))
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.name"))
-        ).validate_response([print_statement])
+        v.validate_response([print_statement])
 
 
 def test_print_undefined_var():
     print_statement = {"print": ["This mollusc is a %s", "mollusc.type"]}
+    v = samplegen.Validator(DummyMethod(output=message_factory("$resp.type")))
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.type"))
-        ).validate_response([print_statement])
+        v.validate_response([print_statement])
 
 
 def test_comment():
@@ -176,20 +151,23 @@ def test_comment_fmt_str():
 
 def test_comment_fmt_undefined_var():
     comment = {"comment": ["This is a mollusc of class %s", "cephalopod"]}
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response([comment])
+        v.validate_response([comment])
 
 
 def test_comment_fmt_mismatch():
     comment = {"comment": ["This is a mollusc of class %s"]}
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator(DummyMethod()).validate_response([comment])
+        v.validate_response([comment])
 
 
 def test_comment_fmt_mismatch2():
     comment = {"comment": ["This is a mollusc of class ", "$resp.class"]}
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator(DummyMethod()).validate_response([comment])
+        v.validate_response([comment])
 
 
 def test_loop_collection():
@@ -200,9 +178,9 @@ def test_loop_collection():
             "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
         }
     }
-    samplegen.Validator(
-        DummyMethod(output=message_factory("$resp.molluscs", [True]))
-    ).validate_response([loop])
+    v = samplegen.Validator(DummyMethod(output=message_factory(
+        "$resp.molluscs", repeated_iter=[True])))
+    v.validate_response([loop])
 
 
 def test_loop_collection_redefinition():
@@ -216,10 +194,10 @@ def test_loop_collection_redefinition():
             }
         },
     ]
+    v = samplegen.Validator(
+        DummyMethod(output=message_factory("$resp.molluscs", repeated_iter=[True])))
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.molluscs", [True]))
-        ).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_loop_undefined_collection():
@@ -230,8 +208,9 @@ def test_loop_undefined_collection():
             "body": [{"print": ["Squid: %s", "s"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_collection_extra_kword():
@@ -243,8 +222,9 @@ def test_loop_collection_extra_kword():
             "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_collection_missing_kword():
@@ -254,8 +234,9 @@ def test_loop_collection_missing_kword():
             "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_collection_reserved_loop_var():
@@ -266,10 +247,10 @@ def test_loop_collection_reserved_loop_var():
             "body": [{"print": ["Mollusc: %s", "class.name"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod(
+        output=message_factory("$resp.molluscs", repeated_iter=[True])))
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.molluscs", [True]))
-        ).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map():
@@ -295,10 +276,10 @@ def test_collection_loop_lexical_scope_variable():
         },
         {"define": "cephalopod=m"},
     ]
+    v = samplegen.Validator(DummyMethod(
+        output=message_factory("$resp.molluscs", repeated_iter=[True])))
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.molluscs", [True]))
-        ).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_collection_loop_lexical_scope_inline():
@@ -312,10 +293,10 @@ def test_collection_loop_lexical_scope_inline():
         },
         {"define": "cephalopod=squid"},
     ]
+    v = samplegen.Validator(DummyMethod(
+        output=message_factory("$resp.molluscs", repeated_iter=[True])))
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("$resp.molluscs", [True]))
-        ).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_map_loop_lexical_scope_key():
@@ -330,8 +311,9 @@ def test_map_loop_lexical_scope_key():
         },
         {"define": "last_cls=cls"},
     ]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_map_loop_lexical_scope_value():
@@ -346,8 +328,9 @@ def test_map_loop_lexical_scope_value():
         },
         {"define": "last_order=order"},
     ]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_map_loop_lexical_scope_inline():
@@ -362,8 +345,9 @@ def test_map_loop_lexical_scope_inline():
         },
         {"define": "last_order=tmp"},
     ]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_loop_map_reserved_key():
@@ -375,8 +359,9 @@ def test_loop_map_reserved_key():
             "body": [{"print": ["A %s is a %s", "mollusc", "class"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map_reserved_val():
@@ -388,8 +373,9 @@ def test_loop_map_reserved_val():
             "body": [{"print": ["A %s is a %s", "m", "class"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map_undefined():
@@ -401,8 +387,9 @@ def test_loop_map_undefined():
             "body": [{"print": ["A %s is a %s", "mollusc", "name"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map_no_key():
@@ -430,8 +417,9 @@ def test_loop_map_no_value():
 def test_loop_map_no_key_or_value():
     loop = {"loop": {"map": "$resp.molluscs",
                      "body": [{"print": ["Dead loop"]}]}}
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map_no_map():
@@ -442,14 +430,16 @@ def test_loop_map_no_map():
             "body": [{"print": ["A %s is a %s", "mollusc", "name"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map_no_body():
     loop = {"loop": {"map": "$resp.molluscs", "key": "name", "value": "mollusc"}}
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map_extra_kword():
@@ -462,8 +452,9 @@ def test_loop_map_extra_kword():
             "body": [{"print": ["A %s is a %s", "mollusc", "name"]}],
         }
     }
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.BadLoop):
-        samplegen.Validator(DummyMethod()).validate_response([loop])
+        v.validate_response([loop])
 
 
 def test_loop_map_redefined_key():
@@ -477,10 +468,9 @@ def test_loop_map_redefined_key():
             }
         },
     ]
+    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc.molluscs")))
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("mollusc.molluscs"))
-        ).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_loop_map_redefined_value():
@@ -494,160 +484,283 @@ def test_loop_map_redefined_value():
             }
         },
     ]
+    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc.molluscs")))
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator(
-            DummyMethod(output=message_factory("mollusc.molluscs"))
-        ).validate_response(statements)
+        v.validate_response(statements)
 
 
 def test_validate_write_file():
-    samplegen.Validator(DummyMethod()).validate_response(
-        [
-            {
-                "write_file": {
-                    "filename": ["specimen-%s", "$resp.species"],
-                    "contents": "$resp.photo",
-                }
+    statements = [
+        {
+            "write_file": {
+                "filename": ["specimen-%s", "$resp.species"],
+                "contents": "$resp.photo",
             }
-        ]
-    )
+        }
+    ]
+    samplegen.Validator(DummyMethod()).validate_response(statements)
 
 
 def test_validate_write_file_fname_fmt():
+    statements = [{"write_file":
+                   {"filename": ["specimen-%s"], "contents": "$resp.photo"}}]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.MismatchedFormatSpecifier):
-        samplegen.Validator(DummyMethod()).validate_response(
-            [{"write_file": {"filename": ["specimen-%s"], "contents": "$resp.photo"}}]
-        )
+        v.validate_response(statements)
 
 
 def test_validate_write_file_fname_bad_var():
+    statements = [{
+        "write_file": {
+            "filename": ["specimen-%s", "squid.species"],
+            "contents": "$resp.photo",
+        }
+    }]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response(
-            [
-                {
-                    "write_file": {
-                        "filename": ["specimen-%s", "squid.species"],
-                        "contents": "$resp.photo",
-                    }
-                }
-            ]
-        )
+        v.validate_response(statements)
 
 
 def test_validate_write_file_missing_fname():
+    statements = [{"write_file": {"contents": "$resp.photo"}}]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator(DummyMethod()).validate_response(
-            [{"write_file": {"contents": "$resp.photo"}}]
-        )
+        v.validate_response(statements)
 
 
 def test_validate_write_file_missing_contents():
+    statements = [{"write_file": {"filename": ["specimen-%s", "$resp.species"]}}]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator(DummyMethod()).validate_response(
-            [{"write_file": {"filename": ["specimen-%s", "$resp.species"]}}]
-        )
+        v.validate_response(statements)
 
 
 def test_validate_write_file_bad_contents_var():
+    statements = [{
+        "write_file": {
+            "filename": ["specimen-%s", "$resp.species"],
+            "contents": "squid.photo",
+        }
+    }]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.UndefinedVariableReference):
-        samplegen.Validator(DummyMethod()).validate_response(
-            [
-                {
-                    "write_file": {
-                        "filename": ["specimen-%s", "$resp.species"],
-                        "contents": "squid.photo",
-                    }
-                }
-            ]
-        )
+        v.validate_response(statements)
 
 
 def test_invalid_statement():
-    statement = {"print": ["Name"], "comment": ["Value"]}
+    statements = [{"print": ["Name"], "comment": ["Value"]}]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator(DummyMethod()).validate_response([statement])
+        v.validate_response(statements)
 
 
 def test_invalid_statement2():
-    statement = {"squidify": ["Statement body"]}
+    statements = [{"squidify": ["Statement body"]}]
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.InvalidStatement):
-        samplegen.Validator(DummyMethod()).validate_response([statement])
+        v.validate_response(statements)
 
 
 # validate_and_transform_request tests
 def test_validate_request_basic():
-    assert samplegen.Validator(DummyMethod()).validate_and_transform_request(
+    input_type = DummyMessage(
+        fields={
+            "squid": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "mantle_length": DummyField(
+                            message=DummyMessage(type="LENGTH_TYPE")),
+                        "mantle_mass": DummyField(
+                            message=DummyMessage(type="MASS_TYPE"))},
+                    type="SQUID_TYPE"
+                )
+            )
+        },
+        type="REQUEST_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(input=input_type))
+    actual = v.validate_and_transform_request(
         utils.CallingForm.Request,
         [
             {"field": "squid.mantle_length", "value": "100 cm"},
             {"field": "squid.mantle_mass", "value": "10 kg"},
         ],
-    ) == [
-        samplegen.TransformedRequest(
-            "squid",
-            [
-                {"field": "mantle_length", "value": "100 cm"},
-                {"field": "mantle_mass", "value": "10 kg"},
-            ],
-        )
-    ]
+    )
+    expected = [samplegen.TransformedRequest(
+        base="squid",
+        body=[
+                samplegen.AttributeRequestSetup(field="mantle_length",
+                                                value="100 cm"),
+                samplegen.AttributeRequestSetup(field="mantle_mass",
+                                                value="10 kg"),
+                ],
+        single=None
+    )]
+
+    assert actual == expected
 
 
 def test_validate_request_no_field_parameter():
+    # May need to remeove this test because it doesn't necessarily make sense any more.
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator(DummyMethod()).validate_and_transform_request(
-            utils.CallingForm.Request, [{"squid": "humboldt"}]
+        v.validate_and_transform_request(
+            utils.CallingForm.Request, [{"squid": "humboldt", "value": "teuthida"}]
         )
 
 
-def test_validate_request_malformed_field_attr():
+def test_validate_request_no_such_attribute():
+    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid.mantle")))
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_and_transform_request(
+            utils.CallingForm.Request,
+            [{"field": "clam.shell", "value": "20"}]
+        )
+
+
+def test_validate_request_top_level_field():
+    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
+    actual = v.validate_and_transform_request(
+        utils.CallingForm.Request,
+        [{"field": "squid", "value": "humboldt"}]
+    )
+
+    expected = [
+        samplegen.TransformedRequest(base="squid",
+                                     body=None,
+                                     single=samplegen.AttributeRequestSetup(
+                                         value="humboldt"
+                                     ))
+    ]
+
+    assert actual == expected
+
+
+def test_validate_request_missing_keyword(kword="field"):
+    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
     with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator(DummyMethod()).validate_and_transform_request(
-            utils.CallingForm.Request, [{"field": "squid"}]
+        v.validate_and_transform_request(
+            utils.CallingForm.Request,
+            [{kword: "squid"}]
+        )
+
+
+def test_validate_request_missing_value():
+    test_validate_request_missing_keyword(kword="value")
+
+
+def test_validate_request_spurious_kword():
+    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
+    with pytest.raises(samplegen.InvalidRequestSetup):
+        v.validate_and_transform_request(
+            utils.CallingForm.Request,
+            [{"field": "mollusc.squid", "value": "humboldt", "order": "teuthida"}]
+        )
+
+
+def test_validate_request_unknown_field_type():
+    v = samplegen.Validator(DummyMethod(
+        input=DummyMessage(fields={"squid": DummyField()})))
+    with pytest.raises(TypeError):
+        v.validate_and_transform_request(
+            utils.CallingForm.Request,
+            [{"field": "squid", "value": "humboldt"}]
+        )
+
+
+def test_validate_request_duplicate_top_level_fields():
+    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
+    with pytest.raises(samplegen.InvalidRequestSetup):
+        v.validate_and_transform_request(
+            utils.CallingForm.Request,
+            [{"field": "squid", "value": "humboldt"},
+             {"field": "squid", "value": "bobtail"}]
         )
 
 
 def test_validate_request_multiple_arguments():
-    assert samplegen.Validator(DummyMethod()).validate_and_transform_request(
+    input_type = DummyMessage(
+        fields={
+            "squid": DummyField(
+                message=DummyMessage(
+                    fields={"mantle_length": DummyField(
+                        message=DummyMessage(type="LENGTH_TYPE"))},
+                    type="SQUID_TYPE"
+                )
+            ),
+            "clam": DummyField(
+                message=DummyMessage(
+                    fields={"shell_mass": DummyField(
+                        message=DummyMessage(type="MASS_TYPE"))},
+                    type="CLAM_TYPE"
+                )
+            ),
+        },
+        type="REQUEST_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(input=input_type))
+    actual = v.validate_and_transform_request(
         utils.CallingForm.Request,
         [
-            {"field": "squid.mantle_length",
-                "value": "100 cm", "value_is_file": True},
+            {
+                "field": "squid.mantle_length",
+                "value": "100 cm", "value_is_file": True
+            },
             {
                 "field": "clam.shell_mass",
                 "value": "100 kg",
                 "comment": "Clams can be large",
             },
         ],
-    ) == [
+    )
+    expected = [
         samplegen.TransformedRequest(
-            "squid",
-            [{"field": "mantle_length", "value": "100 cm", "value_is_file": True}],
+            base="squid",
+            body=[samplegen.AttributeRequestSetup(
+                field="mantle_length",
+                value="100 cm",
+                value_is_file=True)],
+            single=None
         ),
         samplegen.TransformedRequest(
-            "clam",
-            [
-                {
-                    "field": "shell_mass",
-                    "value": "100 kg",
-                    "comment": "Clams can be large",
-                }
-            ],
+            base="clam",
+            body=[samplegen.AttributeRequestSetup(
+                field="shell_mass",
+                value="100 kg",
+                comment="Clams can be large")],
+            single=None
         ),
     ]
 
-
-def test_validate_request_reserved_request_name():
-    with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator(DummyMethod()).validate_and_transform_request(
-            utils.CallingForm.Request, [
-                {"field": "class.order", "value": "coleoidea"}]
-        )
+    assert actual == expected
 
 
 def test_validate_request_duplicate_input_param():
+    input_type = DummyMessage(
+        fields={
+            "squid": DummyField(
+                message=DummyMessage(
+                    fields={"mantle_mass": DummyField(
+                        message=DummyMessage(type="MASS_TYPE"))},
+                    type="SQUID_TYPE"
+                )
+            ),
+            "clam": DummyField(
+                message=DummyMessage(
+                    fields={"mantle_mass": DummyField(
+                        message=DummyMessage(type="MASS_TYPE"))},
+                    type="CLAM_TYPE"
+                )
+            ),
+        },
+        type="REQUEST_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(input=input_type))
     with pytest.raises(samplegen.RedefinedVariable):
-        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+        v.validate_and_transform_request(
             utils.CallingForm.Request,
             [
                 {
@@ -665,8 +778,9 @@ def test_validate_request_duplicate_input_param():
 
 
 def test_validate_request_reserved_input_param():
+    v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.ReservedVariableName):
-        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+        v.validate_and_transform_request(
             utils.CallingForm.Request,
             [
                 {
@@ -678,7 +792,8 @@ def test_validate_request_reserved_input_param():
         )
 
 
-def test_single_request_client_streaming():
+def test_single_request_client_streaming(
+        calling_form=utils.CallingForm.RequestStreamingClient):
     # Each API client method really only takes one parameter:
     # either a single protobuf message or an iterable of protobuf messages.
     # With unary request methods, python lets us describe attributes as positional
@@ -687,8 +802,34 @@ def test_single_request_client_streaming():
     # 'field's refer to sub-attributes.
     # Client streaming and bidirectional streaming methods can't use this notation,
     # and generate an exception if there is more than one 'base'.
+    input_type = DummyMessage(
+        fields={
+            "cephalopod": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "order": DummyField(
+                            message=DummyMessage(type="ORDER_TYPE")
+                        )
+                    },
+                    type="CEPHALOPOD_TYPE"
+                )
+            ),
+            "gastropod": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "order": DummyField(
+                            message=DummyMessage(type="ORDER_TYPE")
+                        )
+                    },
+                    type="GASTROPOD_TYPE"
+                )
+            )
+        },
+        type="MOLLUSC_TYPE"
+    )
+    v = samplegen.Validator(DummyMethod(input=input_type))
     with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator(DummyMethod()).validate_and_transform_request(
+        v.validate_and_transform_request(
             utils.CallingForm.RequestStreamingClient,
             [
                 {"field": "cephalopod.order", "value": "cephalopoda"},
@@ -698,22 +839,7 @@ def test_single_request_client_streaming():
 
 
 def test_single_request_bidi_streaming():
-    # Each API client method really only takes one parameter:
-    # either a single protobuf message or an iterable of protobuf messages.
-    # With unary request methods, python lets us describe attributes as positional
-    # and keyword parameters, which simplifies request construction.
-    # The 'base' in the transformed request refers to an attribute, and the
-    # 'field's refer to sub-attributes.
-    # Client streaming and bidirectional streaming methods can't use this notation,
-    # and generate an exception if there is more than one 'base'.
-    with pytest.raises(samplegen.InvalidRequestSetup):
-        samplegen.Validator(DummyMethod()).validate_and_transform_request(
-            utils.CallingForm.RequestStreamingBidi,
-            [
-                {"field": "cephalopod.order", "value": "cephalopoda"},
-                {"field": "gastropod.order", "value": "pulmonata"},
-            ],
-        )
+    test_single_request_client_streaming(utils.CallingForm.RequestStreamingBidi)
 
 
 def test_validate_request_calling_form():
@@ -813,6 +939,7 @@ def test_validate_expression_no_such_attr():
 
 
 def test_validate_expression_predefined():
+    # TODO: can't remember what this test does
     exp = "$resp.coleoidea.octopodiformes.octopus"
     OutputType = message_factory(exp)
     method = DummyMethod(output=OutputType)
@@ -827,7 +954,7 @@ def test_validate_expression_repeated_attrs():
     # of response/coleoidea/octopodiformes, but coleoidea is a repeated field,
     # so accessing $resp.coleoidea.octopodiformes doesn't make any sense.
     exp = "$resp.coleoidea.octopodiformes"
-    OutputType = message_factory(exp, [True, False])
+    OutputType = message_factory(exp, repeated_iter=[True, False])
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
 
@@ -838,7 +965,7 @@ def test_validate_expression_repeated_attrs():
 
 def test_validate_expression_collection():
     exp = "$resp.molluscs"
-    OutputType = message_factory(exp, [True])
+    OutputType = message_factory(exp, repeated_iter=[True])
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
     v.validate_response(
@@ -876,7 +1003,7 @@ def test_validate_expression_collection_error():
 
 def test_validate_expression_repeated_lookup():
     exp = "$resp.molluscs.mantle"
-    OutputType = message_factory(exp, [True, False])
+    OutputType = message_factory(exp, repeated_iter=[True, False])
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
     v.validate_expression("$resp.molluscs[0].mantle")
@@ -893,7 +1020,7 @@ def test_validate_expression_repeated_lookup_invalid():
 
 def test_validate_expression_base_attr_is_repeated():
     exp = "$resp.molluscs.mantle"
-    OutputType = message_factory(exp, [True, False])
+    OutputType = message_factory(exp, repeated_iter=[True, False])
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
     v.validate_response([{"define": "molluscs=$resp.molluscs"}])

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -612,12 +612,14 @@ def test_validate_request_no_field_parameter():
     v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.InvalidRequestSetup):
         v.validate_and_transform_request(
-            utils.CallingForm.Request, [{"squid": "humboldt", "value": "teuthida"}]
+            utils.CallingForm.Request, [{"squid": "humboldt",
+                                         "value": "teuthida"}]
         )
 
 
 def test_validate_request_no_such_attribute():
-    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid.mantle")))
+    v = samplegen.Validator(DummyMethod(
+        input=message_factory("mollusc.squid.mantle")))
     with pytest.raises(samplegen.BadAttributeLookup):
         v.validate_and_transform_request(
             utils.CallingForm.Request,

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -488,7 +488,8 @@ def test_loop_map_redefined_value():
             }
         },
     ]
-    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc.molluscs")))
+    v = samplegen.Validator(DummyMethod(
+        output=message_factory("mollusc.molluscs")))
     with pytest.raises(samplegen.RedefinedVariable):
         v.validate_response(statements)
 
@@ -533,7 +534,8 @@ def test_validate_write_file_missing_fname():
 
 
 def test_validate_write_file_missing_contents():
-    statements = [{"write_file": {"filename": ["specimen-%s", "$resp.species"]}}]
+    statements = [{"write_file": {"filename": ["specimen-%s",
+                                               "$resp.species"]}}]
     v = samplegen.Validator(DummyMethod())
     with pytest.raises(samplegen.InvalidStatement):
         v.validate_response(statements)
@@ -624,7 +626,8 @@ def test_validate_request_no_such_attribute():
 
 
 def test_validate_request_top_level_field():
-    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
+    v = samplegen.Validator(DummyMethod(
+        input=message_factory("mollusc.squid")))
     actual = v.validate_and_transform_request(
         utils.CallingForm.Request,
         [{"field": "squid", "value": "humboldt"}]
@@ -642,7 +645,8 @@ def test_validate_request_top_level_field():
 
 
 def test_validate_request_missing_keyword(kword="field"):
-    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
+    v = samplegen.Validator(DummyMethod(
+        input=message_factory("mollusc.squid")))
     with pytest.raises(samplegen.InvalidRequestSetup):
         v.validate_and_transform_request(
             utils.CallingForm.Request,
@@ -655,7 +659,8 @@ def test_validate_request_missing_value():
 
 
 def test_validate_request_spurious_kword():
-    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
+    v = samplegen.Validator(
+        DummyMethod(input=message_factory("mollusc.squid")))
     with pytest.raises(samplegen.InvalidRequestSetup):
         v.validate_and_transform_request(
             utils.CallingForm.Request,
@@ -674,7 +679,8 @@ def test_validate_request_unknown_field_type():
 
 
 def test_validate_request_duplicate_top_level_fields():
-    v = samplegen.Validator(DummyMethod(input=message_factory("mollusc.squid")))
+    v = samplegen.Validator(DummyMethod(
+        input=message_factory("mollusc.squid")))
     with pytest.raises(samplegen.InvalidRequestSetup):
         v.validate_and_transform_request(
             utils.CallingForm.Request,
@@ -843,7 +849,8 @@ def test_single_request_client_streaming(
 
 
 def test_single_request_bidi_streaming():
-    test_single_request_client_streaming(utils.CallingForm.RequestStreamingBidi)
+    test_single_request_client_streaming(
+        utils.CallingForm.RequestStreamingBidi)
 
 
 def test_validate_request_calling_form():

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -23,7 +23,8 @@ import gapic.schema.wrappers as wrappers
 import gapic.samplegen.yaml as gapic_yaml
 import gapic.samplegen.samplegen as samplegen
 
-from common_types import (DummyField, DummyMessage, DummyMethod, message_factory)
+from common_types import (DummyField, DummyMessage,
+                          DummyMethod, message_factory)
 from gapic.samplegen import utils
 
 
@@ -51,8 +52,10 @@ def test_define_reserved_varname():
 
 
 def test_define_add_var():
-    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc.name")))
-    v.validate_response([{"define": "squid=$resp"}, {"define": "name=squid.name"}])
+    v = samplegen.Validator(DummyMethod(
+        output=message_factory("mollusc.name")))
+    v.validate_response([{"define": "squid=$resp"},
+                         {"define": "name=squid.name"}])
 
 
 def test_define_bad_form():
@@ -468,7 +471,8 @@ def test_loop_map_redefined_key():
             }
         },
     ]
-    v = samplegen.Validator(DummyMethod(output=message_factory("mollusc.molluscs")))
+    v = samplegen.Validator(DummyMethod(
+        output=message_factory("mollusc.molluscs")))
     with pytest.raises(samplegen.RedefinedVariable):
         v.validate_response(statements)
 

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -535,14 +535,7 @@ def test_main_block():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_main_block("ListMolluscs", [{"field": "list_molluscs.order",
-                                                   "value": "coleoidea",
-                                                   "input_parameter": "order"},
-                                                  {"field ": "list_molluscs.mass",
-                                                   "value": "60kg",
-                                                   "input_parameter": "mass"},
-                                                  {"field": "list_molluscs.zone",
-                                                   "value": "MESOPELAGIC"},]) }}
+        {{ frags.render_main_block("ListMolluscs", request) }}
         ''',
         '''
         def main():
@@ -562,5 +555,15 @@ def test_main_block():
 
         if __name__ == "__main__":
             main()
-        '''
+        ''',
+        request=[
+            samplegen.TransformedRequest("input_params", [{"field": "list_molluscs.order",
+                                                           "value": "coleoidea",
+                                                           "input_parameter": "order"},
+                                                          {"field ": "list_molluscs.mass",
+                                                           "value": "60kg",
+                                                           "input_parameter": "mass"}]),
+            samplegen.TransformedRequest("enum_param", [{"field": "list_molluscs.zone",
+                                                         "value": "MESOPELAGIC"}])
+        ]
     )

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -562,9 +562,15 @@ def test_render_method_call_basic():
         '''
         client.categorize_mollusc(video, audio, guess)
         ''',
-        request=[samplegen.TransformedRequest(base="video", body=True, single=None),
-                 samplegen.TransformedRequest(base="audio", body=True, single=None),
-                 samplegen.TransformedRequest(base="guess", body=True, single=None)],
+        request=[samplegen.TransformedRequest(base="video",
+                                              body=True,
+                                              single=None),
+                 samplegen.TransformedRequest(base="audio",
+                                              body=True,
+                                              single=None),
+                 samplegen.TransformedRequest(base="guess",
+                                              body=True,
+                                              single=None)],
         calling_form_enum=CallingForm,
         calling_form=CallingForm.Request
     )
@@ -580,7 +586,9 @@ def test_render_method_call_bidi():
         '''
         client.categorize_mollusc([video])
         ''',
-        request=[samplegen.TransformedRequest(base="video", body=True, single=None)],
+        request=[samplegen.TransformedRequest(base="video",
+                                              body=True,
+                                              single=None)],
         calling_form_enum=CallingForm,
         calling_form=CallingForm.RequestStreamingBidi
     )
@@ -596,7 +604,9 @@ def test_render_method_call_client():
         '''
         client.categorize_mollusc([video])
         ''',
-        request=[samplegen.TransformedRequest(base="video", body=True, single=None)],
+        request=[samplegen.TransformedRequest(base="video",
+                                              body=True,
+                                              single=None)],
         calling_form_enum=CallingForm,
         calling_form=CallingForm.RequestStreamingClient
     )

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -28,6 +28,7 @@ def check_template(template_fragment, expected_output, **kwargs):
     # and passing a FunctionLoader whose load function returns
     # a constantly reassigned string attribute) isn't any faster
     # and is less clear.
+    expected_output = dedent(expected_output)
     env = jinja2.Environment(
         loader=jinja2.ChoiceLoader(
             [jinja2.FileSystemLoader(
@@ -48,20 +49,23 @@ def check_template(template_fragment, expected_output, **kwargs):
 
     template = env.get_template("template_fragment")
     text = template.render(**kwargs)
-    assert text == dedent(expected_output)
+
+    assert text == expected_output
 
 
 def test_render_attr_value():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_request_attr("mollusc",
-                                   {"field": "order",
-                                    "value": "Molluscs.Cephalopoda.Coleoidea"}) }}
+        {{ frags.render_request_attr("mollusc", request) }}
         ''',
         '''
         mollusc["order"] = Molluscs.Cephalopoda.Coleoidea
-        '''
+        ''',
+        request=samplegen.AttributeRequestSetup(
+            field="order",
+            value="Molluscs.Cephalopoda.Coleoidea"
+        )
     )
 
 
@@ -69,57 +73,40 @@ def test_render_attr_input_parameter():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_request_attr("squid", {"field": "species",
-                                             "value": "Humboldt",
-                                             "input_parameter": "species"}) }}
+        {{ frags.render_request_attr("squid", request) }}
         ''',
         '''
         # species = "Humboldt"
         squid["species"] = species
-        ''')
+        ''',
+        request=samplegen.AttributeRequestSetup(field="species",
+                                                value="Humboldt",
+                                                input_parameter="species"))
 
 
 def test_render_attr_file():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_request_attr("classify_mollusc_request",
-                                   {"field": "mollusc_video",
-                                    "value": "path/to/mollusc/video.mkv",
-                                    "input_parameter" : "mollusc_video_path",
-                                    "value_is_file": True}) }}
+        {{ frags.render_request_attr("classify_mollusc_request", request) }}
         ''',
         '''
         # mollusc_video_path = "path/to/mollusc/video.mkv"
         with open(mollusc_video_path, "rb") as f:
             classify_mollusc_request["mollusc_video"] = f.read()
-        ''')
+        ''',
+        request=samplegen.AttributeRequestSetup(field="mollusc_video",
+                                                value="path/to/mollusc/video.mkv",
+                                                input_parameter="mollusc_video_path",
+                                                value_is_file=True)
+    )
 
 
 def test_render_request_basic():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_request([{"base": "cephalopod",
-                                 "body": [{"field": "mantle_mass",
-                                           "value": "10 kg",
-                                           "input_parameter": "cephalopod_mass"},
-                                          {"field": "photo",
-                                           "value": "path/to/cephalopod/photo.jpg",
-                                           "input_parameter": "photo_path",
-                                           "value_is_file": True},
-                                          {"field": "order",
-                                           "value": "Molluscs.Cephalopoda.Coleoidea"}, ]},
-                                {"base": "gastropod",
-                                 "body": [{"field": "mantle_mass",
-                                           "value": "1 kg",
-                                           "input_parameter": "gastropod_mass"},
-                                          {"field": "order",
-                                           "value": "Molluscs.Gastropoda.Pulmonata"},
-                                          {"field": "movie",
-                                           "value": "path/to/gastropod/movie.mkv",
-                                           "input_parameter": "movie_path",
-                                           "value_is_file": True}]}, ]) }}
+        {{ frags.render_request_setup(request) }}
         ''',
         '''
         cephalopod = {}
@@ -142,7 +129,45 @@ def test_render_request_basic():
         with open(movie_path, "rb") as f:
             gastropod["movie"] = f.read()
     
-        '''
+        ''',
+        request=[samplegen.TransformedRequest(base="cephalopod",
+                                              body=[
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="mantle_mass",
+                                                      value="10 kg",
+                                                      input_parameter="cephalopod_mass"
+                                                  ),
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="photo",
+                                                      value="path/to/cephalopod/photo.jpg",
+                                                      input_parameter="photo_path",
+                                                      value_is_file=True
+                                                  ),
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="order",
+                                                      value="Molluscs.Cephalopoda.Coleoidea"),
+                                              ],
+                                              single=None),
+                 samplegen.TransformedRequest(base="gastropod",
+                                              body=[
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="mantle_mass",
+                                                      value="1 kg",
+                                                      input_parameter="gastropod_mass"
+                                                  ),
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="order",
+                                                      value="Molluscs.Gastropoda.Pulmonata"
+                                                  ),
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="movie",
+                                                      value="path/to/gastropod/movie.mkv",
+                                                      input_parameter="movie_path",
+                                                      value_is_file=True
+                                                  )
+                                              ],
+                                              single=None),
+                 ]
     )
 
 
@@ -374,24 +399,38 @@ def test_print_input_params():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.print_input_params([{"base": "squid",
-                                    "body": [{"field": "mass",
-                                              "value": "10 kg",
-                                              "input_parameter": "mass"},
-                                             {"field": "length",
-                                              "value": "20 m",
-                                              "input_parameter": "length"}]},
-                                    {"base": "clam",
-                                     "body": [{"field": "diameter",
-                                               "value": "10 cm"}]},
-                                    {"base": "whelk",
-                                     "body": [{"field": "color",
-                                               "value": "red",
-                                               "input_parameter": "color"}]},
-                                    ]) }}
+        {{ frags.print_input_params(request) }}
+
         ''',
         '''
-        mass, length, color'''
+        mass, length, color
+        ''',
+        request=[samplegen.TransformedRequest(base="squid",
+                                              body=[
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="mass",
+                                                      value="10 kg",
+                                                      input_parameter="mass"
+                                                  ),
+                                                  samplegen.AttributeRequestSetup(
+                                                      field="length",
+                                                      value="20 m",
+                                                      input_parameter="length"
+                                                  )
+                                              ],
+                                              single=None),
+                 samplegen.TransformedRequest(base="diameter",
+                                              single=samplegen.AttributeRequestSetup(
+                                                  value="10 cm"
+                                              ),
+                                              body=None),
+                 samplegen.TransformedRequest(base="color",
+                                              single=samplegen.AttributeRequestSetup(
+                                                  value="red",
+                                                  input_parameter="color"
+                                              ),
+                                              body=None),
+                 ]
     )
 
 
@@ -479,55 +518,93 @@ def test_render_calling_form_longrunning():
 
 
 def test_render_method_call_basic():
-    # The callingForm and callingFormEnum parameters are dummies,
-    # which we can get away with because of duck typing in the template.
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": [{"base": "video"},
-                                                                    {"base": "audio"},
-                                                                    {"base": "guess"}]},
+        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": request},
                                   calling_form, calling_form_enum) }}
         ''',
         '''
         client.categorize_mollusc(video, audio, guess)
         ''',
+        request=[samplegen.TransformedRequest(base="video", body=True, single=None),
+                 samplegen.TransformedRequest(base="audio", body=True, single=None),
+                 samplegen.TransformedRequest(base="guess", body=True, single=None)],
         calling_form_enum=CallingForm,
         calling_form=CallingForm.Request
     )
 
 
 def test_render_method_call_bidi():
-    # The callingForm and callingFormEnum parameters are dummies,
-    # which we can get away with because of duck typing in the template.
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": [{"base": "video"}]},
+        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": request},
                                   calling_form, calling_form_enum) }}
         ''',
         '''
         client.categorize_mollusc([video])
         ''',
+        request=[samplegen.TransformedRequest(base="video", body=True, single=None)],
         calling_form_enum=CallingForm,
         calling_form=CallingForm.RequestStreamingBidi
     )
 
 
 def test_render_method_call_client():
-    # The callingForm and callingFormEnum parameters are dummies,
-    # which we can get away with because of duck typing in the template.
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": [{"base": "video"}]},
+        {{ frags.render_method_call({"rpc": "CategorizeMollusc", "request": request},
         calling_form, calling_form_enum) }}
         ''',
         '''
         client.categorize_mollusc([video])
         ''',
+        request=[samplegen.TransformedRequest(base="video", body=True, single=None)],
         calling_form_enum=CallingForm,
         calling_form=CallingForm.RequestStreamingClient
+    )
+
+
+def test_render_request_params():
+    check_template(
+        '''
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.render_request_params(request) }}
+        
+        ''',
+        '''
+        mollusc, length_meters=16, order='TEUTHIDA'
+        ''',
+        request=[
+            samplegen.TransformedRequest(
+                base="length_meters",
+                body=None,
+                single=samplegen.AttributeRequestSetup(value="16")
+            ),
+            samplegen.TransformedRequest(
+                base="mollusc",
+                body=[
+                    samplegen.AttributeRequestSetup(
+                        field="video",
+                        value="path/to/video.mkv"
+                    ),
+                    samplegen.AttributeRequestSetup(
+                        field="audio",
+                        value="path/to/audio.ogg"
+                    )
+                ],
+                single=None
+            ),
+            samplegen.TransformedRequest(
+                base="order",
+                body=None,
+                single=samplegen.AttributeRequestSetup(
+                    value="'TEUTHIDA'"
+                )
+            )
+        ]
     )
 
 
@@ -557,13 +634,26 @@ def test_main_block():
             main()
         ''',
         request=[
-            samplegen.TransformedRequest("input_params", [{"field": "list_molluscs.order",
-                                                           "value": "coleoidea",
-                                                           "input_parameter": "order"},
-                                                          {"field ": "list_molluscs.mass",
-                                                           "value": "60kg",
-                                                           "input_parameter": "mass"}]),
-            samplegen.TransformedRequest("enum_param", [{"field": "list_molluscs.zone",
-                                                         "value": "MESOPELAGIC"}])
+            samplegen.TransformedRequest(base="input_params",
+                                         body=[
+                                             samplegen.AttributeRequestSetup(
+                                                 field="list_molluscs.order",
+                                                 value="coleoidea",
+                                                 input_parameter="order"
+                                             ),
+                                             samplegen.AttributeRequestSetup(
+                                                 field="list_molluscs.mass",
+                                                 value="60kg",
+                                                 input_parameter="mass")
+                                         ],
+                                         single=None),
+            samplegen.TransformedRequest(base="enum_param",
+                                         body=[
+                                             samplegen.AttributeRequestSetup(
+                                                 field="list_molluscs.zone",
+                                                 value="MESOPELAGIC"
+                                             )
+                                         ],
+                                         single=None)
         ]
     )


### PR DESCRIPTION
Fields in the request are checked against the fields in the message type.

Also includes changes for properly handling and rendering top level
fields, plus associated tests.

The data model for transformed requests has changed substantially: instead of being primarily dict based, TransformedRequest now has a de-facto tagged union for a list of AttributeRequestSetup objects XOR a singleton AttributeRequestSetup. This change was made to facilitate top level fields in requests.

Also includes broad, shallow, standardizing cleanup to samplegen unit tests