### PR TITLE
Disable renovate updating the docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "extends": [
-    "config:base"
+      "config:base",
+      "docker:disable"
   ]
 }


### PR DESCRIPTION
The docker images as they are now give us test coverage for both
python 3.6 and 3.7; the default behavior for renovate would be to
update the images to the latest version, which defeats the point of
backwards compatibility testing.