### PR TITLE
Whitespace cleanup and correct rendering of nested loops

### DIFF
--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -87,14 +87,14 @@ print({{ print_string_formatting(elts)|trim }})
 {% endwith %}
 {% endmacro %}
 
-{% macro render_collection_loop(statement) %}
+{% macro render_collection_loop(statement, indentation=0) %}
 for {{ statement.variable }} in {{ statement.collection|coerce_response_name }}:
   {% for s in statement.body %}
-    {{ dispatch_statement(s) }}
+{{ dispatch_statement(s, indentation) }}
   {% endfor %}
 {% endmacro %}
 
-{% macro render_map_loop(statement) %}
+{% macro render_map_loop(statement, indentation=0) %}
  {# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
 for {{ statement.value }} in {{ statement.map|coerce_response_name }}.values():
@@ -104,7 +104,7 @@ for {{ statement.key }} in {{ statement.map|coerce_response_name }}.keys():
 for {{statement.key }}, {{ statement.value }} in {{ statement.map|coerce_response_name }}.items():
 {% endif %}
 {% for s in statement.body %}
-    {{ dispatch_statement(s) }}
+{{ dispatch_statement(s, indentation) }}
 {% endfor %}
 {% endmacro %}
 
@@ -115,24 +115,24 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
   {% endwith %}
 {% endmacro %}
 
-{% macro dispatch_statement(statement) %}
+{% macro dispatch_statement(statement, indentation=0) %}
 {# Each statement is a dict with a single key/value pair #}
 {% if "print" in statement -%}
-{{ render_print(statement["print"]) }}
+{{ render_print(statement["print"])|indent(width=indentation, first=True) }}
 {% elif "define" in statement -%}
-{{ render_define(statement["define"]) }}
+{{ render_define(statement["define"])|indent(width=indentation, first=True) }}
 {% elif "comment" in statement -%}
-{{ render_comment(statement["comment"]) }}
+{{ render_comment(statement["comment"])|indent(width=indentation, first=True) }}
 {% elif "loop" in statement -%}
   {% with loop = statement["loop"] -%}
     {% if "collection" in loop -%}
-{{ render_collection_loop(loop) }}
+{{ render_collection_loop(loop, 4)|indent(width=indentation, first=True) }}
     {% else -%}
-{{ render_map_loop(loop) }}
+{{ render_map_loop(loop, 4)|indent(width=indentation, first=True) }}
     {% endif -%}
   {% endwith -%}
 {% elif "write_file" in statement -%}
-{{ render_write_file(statement["write_file"]) }}
+{{ render_write_file(statement["write_file"])|indent(indentation, first=True) }}
 {% endif %}
 {% endmacro %}
 
@@ -193,27 +193,27 @@ client.{{ sample.rpc|snake_case }}({{ render_request_params(sample.request) }})
 {% if calling_form == calling_form_enum.Request %}
 response = {{ method_invocation_text }}
 {% for statement in response_statements %}
-{{ dispatch_statement(statement ) }}
+{{ dispatch_statement(statement)|trim }}
 {% endfor %}
 {% elif calling_form == calling_form_enum.RequestPagedAll %}
 page_result = {{ method_invocation_text }}
 for response in page_result:
   {% for statement in response_statements %}
-    {{ dispatch_statement(statement ) }}
+    {{ dispatch_statement(statement)|trim }}
   {% endfor %}
 {% elif calling_form == calling_form_enum.RequestPaged %}
-page_result = {{ method_invocation_text }}
+page_result = {{ method_invocation_text}}
 for page in page_result.pages():
     for response in page:
   {% for statement in response_statements %}
-        {{ dispatch_statement(statement ) }}
+        {{ dispatch_statement(statement)|trim }}
   {% endfor %}
 {% elif calling_form in [calling_form_enum.RequestStreamingServer,
                         calling_form_enum.RequestStreamingBidi] %}
 stream = {{ method_invocation_text }}
 for response in stream:
   {% for statement in response_statements %}
-    {{ dispatch_statement(statement ) }}
+    {{ dispatch_statement(statement)|trim }}
   {% endfor %}
 {% elif calling_form == calling_form_enum.LongRunningRequestPromise %}
 operation = {{ method_invocation_text }}
@@ -222,7 +222,7 @@ print("Waiting for operation to complete...")
 
 response = operation.result()
 {% for statement in response_statements %}
-{{ dispatch_statement(statement) }}
+{{ dispatch_statement(statement)|trim }}
 {% endfor %}
 {% endif %}
 {% endmacro %}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -87,14 +87,14 @@ print({{ print_string_formatting(elts)|trim }})
 {% endwith %}
 {% endmacro %}
 
-{% macro render_collection_loop(statement, indentation=0) %}
+{% macro render_collection_loop(statement) %}
 for {{ statement.variable }} in {{ statement.collection|coerce_response_name }}:
   {% for s in statement.body %}
-{{ dispatch_statement(s, indentation) }}
+{{ dispatch_statement(s, 4) }}
   {% endfor %}
 {% endmacro %}
 
-{% macro render_map_loop(statement, indentation=0) %}
+{% macro render_map_loop(statement) %}
  {# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
 for {{ statement.value }} in {{ statement.map|coerce_response_name }}.values():
@@ -104,7 +104,7 @@ for {{ statement.key }} in {{ statement.map|coerce_response_name }}.keys():
 for {{statement.key }}, {{ statement.value }} in {{ statement.map|coerce_response_name }}.items():
 {% endif %}
 {% for s in statement.body %}
-{{ dispatch_statement(s, indentation) }}
+{{ dispatch_statement(s, 4) }}
 {% endfor %}
 {% endmacro %}
 
@@ -126,9 +126,9 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 {% elif "loop" in statement -%}
   {% with loop = statement["loop"] -%}
     {% if "collection" in loop -%}
-{{ render_collection_loop(loop, 4)|indent(width=indentation, first=True) }}
+{{ render_collection_loop(loop)|indent(width=indentation, first=True) }}
     {% else -%}
-{{ render_map_loop(loop, 4)|indent(width=indentation, first=True) }}
+{{ render_map_loop(loop)|indent(width=indentation, first=True) }}
     {% endif -%}
   {% endwith -%}
 {% elif "write_file" in statement -%}

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,6 @@ def unit(session):
     session.run(
         'py.test',
         '-vv',
-        # '--quiet',
         '--cov=gapic',
         '--cov-config=.coveragerc',
         '--cov-report=term',

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -91,8 +91,6 @@ def sample_classify(video):
 
     print("Mollusc is a {}".format(response.taxonomy))
 
-
-
 # [END mollusc_classify_sync]
 
 def main():

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -319,7 +319,7 @@ def test_collection_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_collection_loop(collection, 4) }}
+        {{ frags.render_collection_loop(collection) }}
         ''',
         '''
         for m in response.molluscs:
@@ -355,7 +355,7 @@ def test_map_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_map_loop(map_loop, 4)
+        {{ frags.render_map_loop(map_loop)
         }}''',
         '''
         for cls, example in response.molluscs.items():
@@ -374,7 +374,7 @@ def test_map_loop_no_key():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_map_loop(map_loop, 4)
+        {{ frags.render_map_loop(map_loop)
         }}
         ''',
         '''
@@ -393,7 +393,7 @@ def test_map_loop_no_value():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_map_loop(map_loop, 4)
+        {{ frags.render_map_loop(map_loop)
         }}
         ''',
         '''

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -113,23 +113,23 @@ def test_render_request_basic():
         cephalopod = {}
         # cephalopod_mass = "10 kg"
         cephalopod["mantle_mass"] = cephalopod_mass
-        
+
         # photo_path = "path/to/cephalopod/photo.jpg"
         with open(photo_path, "rb") as f:
             cephalopod["photo"] = f.read()
-        
+
         cephalopod["order"] = Molluscs.Cephalopoda.Coleoidea
-        
+
         gastropod = {}
         # gastropod_mass = "1 kg"
         gastropod["mantle_mass"] = gastropod_mass
-        
+
         gastropod["order"] = Molluscs.Gastropoda.Pulmonata
-        
+
         # movie_path = "path/to/gastropod/movie.mkv"
         with open(movie_path, "rb") as f:
             gastropod["movie"] = f.read()
-    
+
         ''',
         request=[samplegen.TransformedRequest(base="cephalopod",
                                               body=[
@@ -252,7 +252,7 @@ def test_dispatch_print():
         ''',
         '''
         print("Squid")
-        
+
         '''
     )
 
@@ -265,7 +265,7 @@ def test_dispatch_define():
         ''',
         '''
         squid = humboldt
-        
+
         '''
     )
 
@@ -278,7 +278,7 @@ def test_dispatch_comment():
         ''',
         '''
         # Squid
-        
+
         '''
     )
 
@@ -302,7 +302,7 @@ def test_dispatch_write_file():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatch_statement({"write_file": 
+        {{ frags.dispatch_statement({"write_file":
                                        {"filename": ["specimen-%s",
                                                      "$resp.species"],
                                         "contents": "$resp.photo"}})}}
@@ -310,7 +310,7 @@ def test_dispatch_write_file():
         '''
         with open("specimen-{}".format(response.species), "wb") as f:
             f.write(response.photo)
-      
+
         '''
     )
 
@@ -319,16 +319,17 @@ def test_collection_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_collection_loop({"collection": "$resp.molluscs",
-                                       "variable": "m",
-                                       "body": [{"print": ["Mollusc: %s", "m"]}]})}}
+        {{ frags.render_collection_loop(collection, 4) }}
         ''',
         '''
         for m in response.molluscs:
             print("Mollusc: {}".format(m))
         
         
-        '''
+        ''',
+        collection={"collection": "$resp.molluscs",
+                    "variable": "m",
+                    "body": [{"print": ["Mollusc: %s", "m"]}]}
     )
 
 
@@ -336,16 +337,17 @@ def test_dispatch_collection_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatch_statement({"loop": {"collection": "molluscs",
-                                    "variable": "m",
-                                    "body": [{"print": ["Mollusc: %s", "m"]}]}}) }}''',
+        {{ frags.dispatch_statement(statement) }}''',
         '''
         for m in molluscs:
             print("Mollusc: {}".format(m))
-        
-        
-        
-        '''
+
+
+
+        ''',
+        statement={"loop": {"collection": "molluscs",
+                            "variable": "m",
+                            "body": [{"print": ["Mollusc: %s", "m"]}]}}
     )
 
 
@@ -353,17 +355,18 @@ def test_map_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_map_loop({"map": "$resp.molluscs",
-                                "key":"cls",
-                                "value":"example",
-                                "body": [{"print": ["A %s is a %s", "example", "cls"] }]})
+        {{ frags.render_map_loop(map_loop, 4)
         }}''',
         '''
         for cls, example in response.molluscs.items():
             print("A {} is a {}".format(example, cls))
-        
-        
-        '''
+
+
+        ''',
+        map_loop={"map": "$resp.molluscs",
+                  "key": "cls",
+                  "value": "example",
+                  "body": [{"print": ["A %s is a %s", "example", "cls"]}]}
     )
 
 
@@ -371,17 +374,18 @@ def test_map_loop_no_key():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_map_loop({"map": "$resp.molluscs",
-                                "value":"example",
-                                "body": [{"print": ["A %s is a mollusc", "example"] }]})
+        {{ frags.render_map_loop(map_loop, 4)
         }}
         ''',
         '''
         for example in response.molluscs.values():
             print("A {} is a mollusc".format(example))
-        
-        
-        '''
+
+
+        ''',
+        map_loop={"map": "$resp.molluscs",
+                  "value": "example",
+                  "body": [{"print": ["A %s is a mollusc", "example"]}]}
     )
 
 
@@ -389,17 +393,18 @@ def test_map_loop_no_value():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.render_map_loop({"map": "$resp.molluscs",
-                                "key":"cls",
-                                "body": [{"print": ["A %s is a mollusc", "cls"] }]})
+        {{ frags.render_map_loop(map_loop, 4)
         }}
         ''',
         '''
         for cls in response.molluscs.keys():
             print("A {} is a mollusc".format(cls))
-        
-        
-        '''
+
+
+        ''',
+        map_loop={"map": "$resp.molluscs",
+                  "key": "cls",
+                  "body": [{"print": ["A %s is a mollusc", "cls"]}]}
     )
 
 
@@ -407,20 +412,121 @@ def test_dispatch_map_loop():
     check_template(
         '''
         {% import "feature_fragments.j2" as frags %}
-        {{ frags.dispatch_statement({"loop":{"map": "molluscs",
-                                            "key":"cls",
-                                            "value":"example",
-                                            "body": [{
-                                              "print": ["A %s is a %s", "example", "cls"] }]}})
-        }}
+        {{ frags.dispatch_statement(statement) }}
         ''',
         '''
         for cls, example in molluscs.items():
             print("A {} is a {}".format(example, cls))
+
+
+        
+        ''',
+        statement={"loop": {"map": "molluscs",
+                            "key": "cls",
+                            "value": "example",
+                            "body": [{"print": ["A %s is a %s", "example", "cls"]}]}}
+    )
+
+
+def test_render_nested_loop_collection():
+    # Note: the vast quantity of extraneous tailing whitespace is an artifact of the
+    # recursive dispatch and indentation.
+    # The calling form macros are responsible for trimming it out.
+    statement = {
+        "loop": {
+            "collection": "$resp.molluscs",
+            "variable": "m",
+            "body": [
+                {
+                    "loop": {
+                        "collection": "m.tentacles",
+                        "variable": "t",
+                        "body": [
+                            {
+                                "loop": {
+                                    "collection": "t.suckers",
+                                    "variable": "s",
+                                    "body": [{"print": ["Sucker: %s", "s"]}],
+                                }
+                            }
+                        ],
+                    }
+                }
+            ],
+        }
+    }
+    check_template(
+        """
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.dispatch_statement(statement) }}
+        """,
+        """
+        for m in response.molluscs:
+            for t in m.tentacles:
+                for s in t.suckers:
+                    print("Sucker: {}".format(s))
+
+
         
         
         
-        '''
+        
+        
+        """,
+        statement=statement
+    )
+
+
+def test_render_nested_loop_map():
+    # Note: the vast quantity of extraneous tailing whitespace is an artifact of the
+    # recursive dispatch and indentation.
+    # The calling form macros are responsible for trimming it out.
+    statement = {
+        "loop": {
+            "map": "$resp.molluscs",
+            "key": "klass",
+            "value": "orders",
+            "body": [
+                {
+                    "loop": {
+                        "map": "orders",
+                        "key": "order",
+                        "value": "families",
+                        "body": [
+                            {
+                                "loop": {
+                                    "map": "families",
+                                    "key": "family",
+                                    "value": "ex",
+                                    "body": [{"print": ["Example: %s", "ex"]}]
+                                }
+                            }
+                        ]
+                    }
+                }
+            ]
+        }
+    }
+
+    check_template(
+        """
+        {% import "feature_fragments.j2" as frags %}
+        {{ frags.dispatch_statement(statement) }}
+        """,
+        """
+        for klass, orders in response.molluscs.items():
+            for order, families in orders.items():
+                for family, ex in families.items():
+                    print("Example: {}".format(ex))
+
+
+        
+        
+        
+        
+        
+        """,
+        statement=statement
     )
 
 
@@ -476,8 +582,6 @@ def test_render_calling_form_request():
                    '''
                    response = TEST_INVOCATION_TXT
                    print("Test print statement")
-                   
-                   
                    ''',
                    calling_form_enum=CallingForm,
                    calling_form=CallingForm.Request)
@@ -489,8 +593,6 @@ def test_render_calling_form_paged_all():
                    page_result = TEST_INVOCATION_TXT
                    for response in page_result:
                        print("Test print statement")
-                   
-                   
                    ''',
                    calling_form_enum=CallingForm,
                    calling_form=CallingForm.RequestPagedAll)
@@ -503,9 +605,7 @@ def test_render_calling_form_paged():
                     for page in page_result.pages():
                         for response in page:
                             print("Test print statement")
-                   
-                   
-                    ''',
+                   ''',
                    calling_form_enum=CallingForm,
                    calling_form=CallingForm.RequestPaged)
 
@@ -516,8 +616,6 @@ def test_render_calling_form_streaming_server():
                    stream = TEST_INVOCATION_TXT
                    for response in stream:
                        print("Test print statement")
-                   
-                   
                    ''',
                    calling_form_enum=CallingForm,
                    calling_form=CallingForm.RequestStreamingServer)
@@ -529,8 +627,6 @@ def test_render_calling_form_streaming_bidi():
                    stream = TEST_INVOCATION_TXT
                    for response in stream:
                        print("Test print statement")
-                   
-                   
                    ''',
                    calling_form_enum=CallingForm,
                    calling_form=CallingForm.RequestStreamingBidi)
@@ -540,13 +636,11 @@ def test_render_calling_form_longrunning():
     check_template(CALLING_FORM_TEMPLATE_TEST_STR,
                    '''
                    operation = TEST_INVOCATION_TXT
-                   
+
                    print("Waiting for operation to complete...")
-                   
+
                    response = operation.result()
                    print("Test print statement")
-                   
-                   
                    ''',
                    calling_form_enum=CallingForm,
                    calling_form=CallingForm.LongRunningRequestPromise)
@@ -617,7 +711,7 @@ def test_render_request_params():
         '''
         {% import "feature_fragments.j2" as frags %}
         {{ frags.render_request_params(request) }}
-        
+
         ''',
         '''
         mollusc, length_meters=16, order='TEUTHIDA'


### PR DESCRIPTION
Tests and impl for the nested loop rendering bug

Collection and map loops can now be nested arbitrarily 
deep and be rendered with the proper level of indentation throughout.