### PR TITLE
All response variable/attribute expressions are validated

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -525,7 +525,7 @@ class Validator:
 
         return validate_recursively(exp, self.var_defs_)
 
-    def _handle_lvalue(self, lval: str, type_=None):
+    def _handle_lvalue(self, lval: str, type_: wrappers.Field):
         """Conducts safety checks on an lvalue and adds it to the lexical scope.
 
         Raises:

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -334,7 +334,7 @@ class Validator:
             input_parameter = duplicate.get("input_parameter")
             if input_parameter:
                 self._handle_lvalue(input_parameter, wrappers.Field(
-                    field_pb=descriptor_pb2.FieldDescriptorProto(type=9)))
+                    field_pb=descriptor_pb2.FieldDescriptorProto()))
 
             attr_chain = field.split(".")
             base = self.request_type_
@@ -494,7 +494,8 @@ class Validator:
                 # See https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L496
                 # for a better understanding of how map attributes are handled in protobuf
                 if not message or not message.options.map_field:
-                    raise BadAttributeLookup(f"Badly formed mapped field: {base}")
+                    raise BadAttributeLookup(
+                        f"Badly formed mapped field: {base}")
 
                 value_field = message.fields.get("value")
                 if not value_field:
@@ -518,9 +519,9 @@ class Validator:
                 raise BadAttributeLookup(
                     f"Non-terminal attribute is not a message: {base}")
 
-            return validate_recursively(expression[first_dot+1:],
+            return validate_recursively(expression[first_dot + 1:],
                                         scope,
-                                        depth+1)
+                                        depth + 1)
 
         return validate_recursively(exp, self.var_defs_)
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -449,7 +449,6 @@ class Validator:
         Returns:
             wrappers.Field: The final field in the chain.
         """
-        # TODO: handle mapping attributes, i.e. {}
         # TODO: Add resource name handling, i.e. %
         chain_link_re = re.compile(
             r"""
@@ -551,9 +550,6 @@ class Validator:
          The number of format tokens in the string must equal the
          number of arguments, and each argument must be a defined variable.
 
-         TODO: the attributes of the variable must correspond to attributes
-               of the variable's type.
-
          Raises:
              MismatchedFormatSpecifier: If the number of format string segments ("%s") in
                                         a "print" or "comment" block does not equal the
@@ -584,11 +580,6 @@ class Validator:
              UndefinedVariableReference: If an attempted rvalue base is a previously
                                          undeclared variable.
         """
-        # TODO: Need to check the defined variables
-        #       if the rhs references a non-response variable.
-        # TODO: Need to rework the regex to allow for subfields,
-        #       indexing, and so forth.
-        #
         # Note: really checking for safety would be equivalent to
         #       re-implementing the python interpreter.
         m = re.match(r"^([a-zA-Z]\w*)=([^=]+)$", body)

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -611,12 +611,10 @@ class Validator:
     @dataclasses.dataclass(frozen=True)
     class LoopParameterField(wrappers.Field):
         # This class is a hack for assigning the iteration variable in a collection loop.
-        # The variable is assigned to the field that represents the collection,
-        # but while the collection is a repeated field, the iteration variable is not.
-        # When adding the iteration variable to the lexical scope,
-        # instead of being directly assigned to the collection variable,
-        # it is copied into an instance of this class, which has a value
-        # override for 'repeated'.
+        # In protobuf, the concept of collection<T> is manifested as a repeated
+        # field of message type T. Therefore, in order to assign the correct type
+        # to a loop iteration parameter, we copy the field that is the collection
+        # but remove 'repeated'.
         repeated: bool = False
 
     def _validate_loop(self, loop):

--- a/tests/unit/samplegen/common_types.py
+++ b/tests/unit/samplegen/common_types.py
@@ -37,10 +37,11 @@ DummyMethod = namedtuple(
 
 DummyMethod.__new__.__defaults__ = (False,) * len(DummyMethod._fields)
 
-DummyMessage = namedtuple("DummyMessage", ["fields", "type"])
+DummyMessage = namedtuple("DummyMessage", ["fields", "type", "options"])
 DummyMessage.__new__.__defaults__ = (False,) * len(DummyMessage._fields)
 
-DummyField = namedtuple("DummyField", ["message", "enum", "repeated"])
+DummyField = namedtuple("DummyField",
+                        ["message", "enum", "repeated", "field_pb", "meta"])
 DummyField.__new__.__defaults__ = (False,) * len(DummyField._fields)
 
 DummyService = namedtuple("DummyService", ["methods"])

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -46,9 +46,16 @@ def test_generate_sample_basic():
     # or in features that are sufficiently small and trivial that it doesn't make sense
     # to have standalone tests.
     schema = DummyApiSchema(
-        {"animalia.mollusca.v1.Mollusc": DummyService(
-            {"Classify": DummyMethod(
-                input=message_factory("mollusc.classify_request.video"))})},
+        {
+            "animalia.mollusca.v1.Mollusc": DummyService(
+                {
+                    "Classify": DummyMethod(
+                        input=message_factory("mollusc.classify_request.video"),
+                        output=message_factory("$resp.taxonomy")
+                    )
+                }
+            )
+        },
         DummyNaming("molluscs-v1-mollusc"))
 
     sample = {"service": "animalia.mollusca.v1.Mollusc",

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -50,7 +50,8 @@ def test_generate_sample_basic():
             "animalia.mollusca.v1.Mollusc": DummyService(
                 {
                     "Classify": DummyMethod(
-                        input=message_factory("mollusc.classify_request.video"),
+                        input=message_factory(
+                            "mollusc.classify_request.video"),
                         output=message_factory("$resp.taxonomy")
                     )
                 }

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -182,7 +182,8 @@ def test_loop_collection():
             "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
         }
     }
-    OutputType = message_factory("$resp.molluscs.class", repeated_iter=[True, False])
+    OutputType = message_factory(
+        "$resp.molluscs.class", repeated_iter=[True, False])
     v = samplegen.Validator(DummyMethod(output=OutputType))
     v.validate_response([loop])
 

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -336,6 +336,8 @@ def test_map_loop_lexical_scope_key():
                 "body": [{"define": "tmp=cls"}],
             }
         },
+        # 'cls' is outside the visible lexical scope according to strict
+        # samplegen rules, even though it is valid python.
         {"define": "last_cls=cls"},
     ]
     OutputType = DummyMessage(
@@ -372,10 +374,12 @@ def test_map_loop_lexical_scope_value():
                 "map": "$resp.molluscs",
                 "key": "cls",
                 "value": "mollusc",
-                "body": [{"define": "tmp=order"}],
+                "body": [{"define": "tmp=mollusc"}],
             }
         },
-        {"define": "last_order=order"},
+        # 'mollusc' is outside the visible lexical scope according to strict
+        # samplegen rules, even though it is valid python.
+        {"define": "last_mollusc=mollusc"},
     ]
     OutputType = DummyMessage(
         fields={
@@ -414,6 +418,8 @@ def test_map_loop_lexical_scope_inline():
                 "body": [{"define": "tmp=mollusc"}],
             }
         },
+        # 'tmp' is outside the visible lexical scope according to strict
+        # samplegen rules, even though it is valid python.
         {"define": "last_mollusc=tmp"},
     ]
     OutputType = DummyMessage(
@@ -446,6 +452,7 @@ def test_loop_map_reserved_key():
     loop = {
         "loop": {
             "map": "$resp.molluscs",
+            # Can't use 'class' since it's a reserved keyword
             "key": "class",
             "value": "mollusc",
             "body": [{"print": ["A %s is a %s", "mollusc", "class"]}],
@@ -483,6 +490,7 @@ def test_loop_map_reserved_val():
         "loop": {
             "map": "$resp.molluscs",
             "key": "m",
+            # Can't use 'class' since it's a reserved keyword
             "value": "class",
             "body": [{"print": ["A %s is a %s", "m", "class"]}],
         }
@@ -598,6 +606,7 @@ def test_loop_map_no_value():
 
 def test_loop_map_no_key_or_value():
     loop = {"loop": {"map": "$resp.molluscs",
+                     # Need at least one of 'key' or 'value'
                      "body": [{"print": ["Dead loop"]}]}}
     OutputType = DummyMessage(
         fields={
@@ -667,6 +676,7 @@ def test_loop_map_redefined_key():
         {
             "loop": {
                 "map": "$resp.molluscs",
+                # Can't redefine mollusc, which was defined one statement above.
                 "key": "mollusc",
                 "body": [{"print": ["Mollusc: %s", "mollusc"]}],
             }
@@ -705,6 +715,7 @@ def test_loop_map_redefined_value():
         {
             "loop": {
                 "map": "$resp.molluscs",
+                # Can't redefine 'mollusc', which was defined one statement above.
                 "value": "mollusc",
                 "body": [{"print": ["Mollusc: %s", "mollusc"]}],
             }
@@ -1390,6 +1401,8 @@ def test_validate_expression_mapped_no_map_field():
                             )
                         )},
                     type="CEPHALOPODS_TYPE",
+                    # The map_field attribute in the options indicates whether
+                    # a message type is 'really' a map or just looks like one.
                     options=namedtuple("MessageOptions", ["map_field"])(False)),
                 repeated=True,
             )
@@ -1407,6 +1420,7 @@ def test_validate_expression_mapped_no_value():
         fields={
             "cephalopods": DummyField(
                 message=DummyMessage(
+                    # Maps need 'key' AND 'value' attributes.
                     fields={"key": DummyField()},
                     type="CEPHALOPODS_TYPE",
                     options=namedtuple("MessageOptions", ["map_field"])(True)),
@@ -1428,6 +1442,7 @@ def test_validate_expression_mapped_no_message():
                 message=DummyMessage(
                     fields={
                         "key": DummyField(),
+                        # The value field needs a message.
                         "value": DummyField(),
                     },
                     type="CEPHALOPODS_TYPE",

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -1220,18 +1220,7 @@ def test_validate_expression_no_such_attr():
         v.validate_expression("$resp.nautiloidea")
 
 
-def test_validate_expression_predefined():
-    # TODO: can't remember what this test does
-    exp = "$resp.coleoidea.octopodiformes.octopus"
-    OutputType = message_factory(exp)
-    method = DummyMethod(output=OutputType)
-    v = samplegen.Validator(method)
-
-    with pytest.raises(samplegen.BadAttributeLookup):
-        v.validate_response([{"define": "nautilus=$resp.nautiloidea"}])
-
-
-def test_validate_expression_repeated_attrs():
+def test_validate_expression_non_indexed_non_terminal_repeated():
     # This is a little tricky: there's an attribute hierarchy
     # of response/coleoidea/octopodiformes, but coleoidea is a repeated field,
     # so accessing $resp.coleoidea.octopodiformes doesn't make any sense.
@@ -1380,38 +1369,6 @@ def test_validate_expression_map_lookup_terminal_lookup():
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
     v.validate_expression('$resp.cephalopods{"squid"}')
-
-
-def test_validate_expression_mapped_no_message():
-    OutputType = DummyMessage(
-        fields={
-            "cephalopods": DummyField(
-                message=DummyMessage(
-                    fields={
-                        "key": DummyField(),
-                        "value": DummyField(
-                            message=DummyMessage(
-                                fields={
-                                    "mantle": DummyField(
-                                        message=DummyMessage(type="MANTLE_TYPE",
-                                                             fields={}),
-                                    )
-                                },
-                                type="CEPHALOPOD_TYPE"
-                            )
-                        ),
-                    },
-                    type="CEPHALOPODS_TYPE",
-                    options=namedtuple("MessageOptions", ["map_field"])(False)),
-                repeated=True,
-            )
-        },
-        type="MOLLUSC_TYPE"
-    )
-    method = DummyMethod(output=OutputType)
-    v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
-        v.validate_expression('$resp.cephalopods{"squid"}.mantle')
 
 
 def test_validate_expression_mapped_no_map_field():

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -15,7 +15,7 @@
 import yaml
 import pytest
 
-from typing import (Iterable, TypeVar)
+from typing import (TypeVar)
 from collections import namedtuple
 from google.protobuf import descriptor_pb2
 
@@ -148,8 +148,9 @@ def test_comment():
 
 
 def test_comment_fmt_str():
-    comment = {"comment": ["This is a mollusc of class %s", "$resp.class"]}
-    samplegen.Validator(DummyMethod()).validate_response([comment])
+    comment = {"comment": ["This is a mollusc of class %s", "$resp.klass"]}
+    v = samplegen.Validator(DummyMethod(output=message_factory("$resp.klass")))
+    v.validate_response([comment])
 
 
 def test_comment_fmt_undefined_var():
@@ -181,8 +182,8 @@ def test_loop_collection():
             "body": [{"print": ["Mollusc of class: %s", "m.class"]}],
         }
     }
-    v = samplegen.Validator(DummyMethod(output=message_factory(
-        "$resp.molluscs", repeated_iter=[True])))
+    OutputType = message_factory("$resp.molluscs.class", repeated_iter=[True, False])
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     v.validate_response([loop])
 
 
@@ -265,7 +266,29 @@ def test_loop_map():
             "body": [{"print": ["A %s is a %s", "mollusc", "cls"]}],
         }
     }
-    samplegen.Validator(DummyMethod()).validate_response([loop])
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="MOLLUSC_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+    v = samplegen.Validator(DummyMethod(output=OutputType))
+    v.validate_response([loop])
 
 
 def test_collection_loop_lexical_scope_variable():
@@ -308,13 +331,35 @@ def test_map_loop_lexical_scope_key():
             "loop": {
                 "map": "$resp.molluscs",
                 "key": "cls",
-                "value": "order",
+                "value": "mollusc",
                 "body": [{"define": "tmp=cls"}],
             }
         },
         {"define": "last_cls=cls"},
     ]
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="MOLLUSC_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.UndefinedVariableReference):
         v.validate_response(statements)
 
@@ -325,13 +370,35 @@ def test_map_loop_lexical_scope_value():
             "loop": {
                 "map": "$resp.molluscs",
                 "key": "cls",
-                "value": "order",
+                "value": "mollusc",
                 "body": [{"define": "tmp=order"}],
             }
         },
         {"define": "last_order=order"},
     ]
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="MOLLUSC_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.UndefinedVariableReference):
         v.validate_response(statements)
 
@@ -342,13 +409,34 @@ def test_map_loop_lexical_scope_inline():
             "loop": {
                 "map": "$resp.molluscs",
                 "key": "cls",
-                "value": "order",
-                "body": [{"define": "tmp=order"}],
+                "value": "mollusc",
+                "body": [{"define": "tmp=mollusc"}],
             }
         },
-        {"define": "last_order=tmp"},
+        {"define": "last_mollusc=tmp"},
     ]
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="MOLLUSC_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.UndefinedVariableReference):
         v.validate_response(statements)
 
@@ -362,7 +450,29 @@ def test_loop_map_reserved_key():
             "body": [{"print": ["A %s is a %s", "mollusc", "class"]}],
         }
     }
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="MOLLUSC_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.ReservedVariableName):
         v.validate_response([loop])
 
@@ -376,7 +486,29 @@ def test_loop_map_reserved_val():
             "body": [{"print": ["A %s is a %s", "m", "class"]}],
         }
     }
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="CLASS_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.ReservedVariableName):
         v.validate_response([loop])
 
@@ -403,7 +535,30 @@ def test_loop_map_no_key():
             "body": [{"print": ["Mollusc: %s", "mollusc"]}],
         }
     }
-    samplegen.Validator(DummyMethod()).validate_response([loop])
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="CLASS_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
+    v.validate_response([loop])
 
 
 def test_loop_map_no_value():
@@ -414,13 +569,58 @@ def test_loop_map_no_value():
             "body": [{"print": ["Mollusc: %s", "mollusc"]}],
         }
     }
-    samplegen.Validator(DummyMethod()).validate_response([loop])
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="CLASS_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
+    v.validate_response([loop])
 
 
 def test_loop_map_no_key_or_value():
     loop = {"loop": {"map": "$resp.molluscs",
                      "body": [{"print": ["Dead loop"]}]}}
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="CLASS_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.BadLoop):
         v.validate_response([loop])
 
@@ -471,8 +671,29 @@ def test_loop_map_redefined_key():
             }
         },
     ]
-    v = samplegen.Validator(DummyMethod(
-        output=message_factory("mollusc.molluscs")))
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="CLASS_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.RedefinedVariable):
         v.validate_response(statements)
 
@@ -488,8 +709,29 @@ def test_loop_map_redefined_value():
             }
         },
     ]
-    v = samplegen.Validator(DummyMethod(
-        output=message_factory("mollusc.molluscs")))
+    OutputType = DummyMessage(
+        fields={
+            "molluscs": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={},
+                                type="CLASS_TYPE"
+                            )
+                        )
+                    },
+                    type="MOLLUSCS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)
+                ),
+                repeated=True
+            ),
+        },
+        type="RESPONSE_TYPE"
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.RedefinedVariable):
         v.validate_response(statements)
 
@@ -503,7 +745,14 @@ def test_validate_write_file():
             }
         }
     ]
-    samplegen.Validator(DummyMethod()).validate_response(statements)
+    OutputType = DummyMessage(
+        fields={
+            "species": DummyField(message=DummyMessage(fields={})),
+            "photo": DummyField(message=DummyMessage(fields={}))
+        }
+    )
+    v = samplegen.Validator(DummyMethod(output=OutputType))
+    v.validate_response(statements)
 
 
 def test_validate_write_file_fname_fmt():
@@ -528,7 +777,13 @@ def test_validate_write_file_fname_bad_var():
 
 def test_validate_write_file_missing_fname():
     statements = [{"write_file": {"contents": "$resp.photo"}}]
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "filename": DummyField(message=DummyMessage(fields={})),
+            "photo": DummyField(message=DummyMessage(fields={}))
+        }
+    )
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.InvalidStatement):
         v.validate_response(statements)
 
@@ -536,7 +791,14 @@ def test_validate_write_file_missing_fname():
 def test_validate_write_file_missing_contents():
     statements = [{"write_file": {"filename": ["specimen-%s",
                                                "$resp.species"]}}]
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "species": DummyField(message=DummyMessage(fields={})),
+            "photo": DummyField(message=DummyMessage(fields={}))
+        }
+    )
+
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.InvalidStatement):
         v.validate_response(statements)
 
@@ -548,7 +810,13 @@ def test_validate_write_file_bad_contents_var():
             "contents": "squid.photo",
         }
     }]
-    v = samplegen.Validator(DummyMethod())
+    OutputType = DummyMessage(
+        fields={
+            "species": DummyField(message=DummyMessage(fields={})),
+            "photo": DummyField(message=DummyMessage(fields={}))
+        }
+    )
+    v = samplegen.Validator(DummyMethod(output=OutputType))
     with pytest.raises(samplegen.UndefinedVariableReference):
         v.validate_response(statements)
 
@@ -596,11 +864,11 @@ def test_validate_request_basic():
     expected = [samplegen.TransformedRequest(
         base="squid",
         body=[
-                samplegen.AttributeRequestSetup(field="mantle_length",
-                                                value="100 cm"),
-                samplegen.AttributeRequestSetup(field="mantle_mass",
-                                                value="10 kg"),
-                ],
+            samplegen.AttributeRequestSetup(field="mantle_length",
+                                            value="100 cm"),
+            samplegen.AttributeRequestSetup(field="mantle_mass",
+                                            value="10 kg"),
+        ],
         single=None
     )]
 
@@ -1046,6 +1314,175 @@ def test_validate_expression_base_attr_is_repeated():
     v = samplegen.Validator(method)
     v.validate_response([{"define": "molluscs=$resp.molluscs"}])
     v.validate_expression("molluscs[0].mantle")
+
+
+def test_validate_expression_map_lookup():
+    # See https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L475
+    # for details on how mapped attributes get transformed by the protoc compiler.
+    OutputType = DummyMessage(
+        fields={
+            "cephalopods": DummyField(
+                message=DummyMessage(
+                    fields={
+                        # real type is most likely str in real protos
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={
+                                    "mantle": DummyField(
+                                        message=DummyMessage(type="MANTLE_TYPE",
+                                                             fields={}),
+                                    )
+                                },
+                                type="CEPHALOPOD_TYPE"
+                            )
+                        ),
+                    },
+                    type="CEPHALOPODS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)),
+                repeated=True,
+            )
+        },
+        type="MOLLUSC_TYPE"
+    )
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    v.validate_expression('$resp.cephalopods{"squid"}.mantle')
+
+
+def test_validate_expression_map_lookup_terminal_lookup():
+    OutputType = DummyMessage(
+        fields={
+            "cephalopods": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={
+                                    "mantle": DummyField(
+                                        message=DummyMessage(type="MANTLE_TYPE",
+                                                             fields={}),
+                                    )
+                                },
+                                type="CEPHALOPOD_TYPE"
+                            )
+                        ),
+                    },
+                    type="CEPHALOPODS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)),
+                repeated=True,
+            )
+        },
+        type="MOLLUSC_TYPE"
+    )
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    v.validate_expression('$resp.cephalopods{"squid"}')
+
+
+def test_validate_expression_mapped_no_message():
+    OutputType = DummyMessage(
+        fields={
+            "cephalopods": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={
+                                    "mantle": DummyField(
+                                        message=DummyMessage(type="MANTLE_TYPE",
+                                                             fields={}),
+                                    )
+                                },
+                                type="CEPHALOPOD_TYPE"
+                            )
+                        ),
+                    },
+                    type="CEPHALOPODS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(False)),
+                repeated=True,
+            )
+        },
+        type="MOLLUSC_TYPE"
+    )
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression('$resp.cephalopods{"squid"}.mantle')
+
+
+def test_validate_expression_mapped_no_map_field():
+    OutputType = DummyMessage(
+        fields={
+            "cephalopods": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(
+                            message=DummyMessage(
+                                fields={
+                                    "mantle": DummyField(
+                                        message=DummyMessage(type="MANTLE_TYPE",
+                                                             fields={}),
+                                    )
+                                },
+                                type="CEPHALOPOD_TYPE"
+                            )
+                        )},
+                    type="CEPHALOPODS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(False)),
+                repeated=True,
+            )
+        },
+        type="MOLLUSC_TYPE"
+    )
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression('$resp.cephalopods{"squid"}.mantle')
+
+
+def test_validate_expression_mapped_no_value():
+    OutputType = DummyMessage(
+        fields={
+            "cephalopods": DummyField(
+                message=DummyMessage(
+                    fields={"key": DummyField()},
+                    type="CEPHALOPODS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)),
+                repeated=True,
+            )
+        },
+        type="MOLLUSC_TYPE"
+    )
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression('$resp.cephalopods{"squid"}.mantle')
+
+
+def test_validate_expression_mapped_no_message():
+    OutputType = DummyMessage(
+        fields={
+            "cephalopods": DummyField(
+                message=DummyMessage(
+                    fields={
+                        "key": DummyField(),
+                        "value": DummyField(),
+                    },
+                    type="CEPHALOPODS_TYPE",
+                    options=namedtuple("MessageOptions", ["map_field"])(True)),
+                repeated=True,
+            )
+        },
+        type="MOLLUSC_TYPE"
+    )
+    method = DummyMethod(output=OutputType)
+    v = samplegen.Validator(method)
+    with pytest.raises(samplegen.BadAttributeLookup):
+        v.validate_expression('$resp.cephalopods{"squid"}.mantle')
 
 
 def test_validate_expresssion_lookup_unrepeated_base():


### PR DESCRIPTION
All statements and expressions that reference the method response are validated,
e.g. {"print": ["%s", "$resp.cephalopods[0].mantle"]},
will be checked to make sure that the response message type has a
repeated "cephalopods" field, and that that type has a "mantle" field.

Includes a major refactor of Validator.validate_expression