### PR TITLE
Test and impl for end-to-end sample and manifest generation

### DIFF
--- a/gapic/cli/generate.py
+++ b/gapic/cli/generate.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
 import os
 import sys
 import typing

--- a/gapic/cli/generate.py
+++ b/gapic/cli/generate.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import os
 import sys
 import typing

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -147,7 +147,8 @@ class Generator:
                 # The ID is used to generate the file name and by sample tester
                 # to link filenames to invoked samples. It must be globally unique.
                 if not id_is_unique:
-                    spec_hash = sha256(str(spec).encode('utf8')).hexdigest()[:8]
+                    spec_hash = sha256(
+                        str(spec).encode('utf8')).hexdigest()[:8]
                     spec["id"] += f"_{spec_hash}"
 
                 sample = samplegen.generate_sample(spec, self._env, api_schema)

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import warnings
-import os
-import dataclasses
-from typing import DefaultDict, List, Tuple
 from collections import defaultdict
+from typing import DefaultDict, List, Tuple
+
+import dataclasses
+import os
+import warnings
 
 from gapic.samplegen_utils import utils as samplegen_utils
 
@@ -33,13 +34,10 @@ class Options:
     namespace: Tuple[str, ...] = dataclasses.field(default=())
     sample_configs: Tuple[str, ...] = dataclasses.field(default=())
     name: str = ''
-    sample_out_dir: str = ''
 
     # Class constants
-    SAMPLES_OPT: str = 'gapic_samples'
-    SAMPLE_OUT_DIR_OPT: str = 'gapic_sample_out_dir'
+    SAMPLES_OPT: str = 'samples'
     PYTHON_GAPIC_PREFIX: str = 'python-gapic-'
-    SAMPLE_OUT_DIR_DEFAULT: str = '{api}/samples/{version}'
 
     @classmethod
     def build(cls, opt_string: str) -> 'Options':
@@ -65,9 +63,6 @@ class Options:
 
             if opt == cls.SAMPLES_OPT:
                 opts[cls.SAMPLES_OPT].append(value)
-
-            if opt == cls.SAMPLE_OUT_DIR_OPT:
-                opts[cls.SAMPLE_OUT_DIR_OPT].append(value)
 
             # Throw away other options not meant for us.
             if not opt.startswith(cls.PYTHON_GAPIC_PREFIX):
@@ -98,11 +93,6 @@ class Options:
                 for s in opts.pop(cls.SAMPLES_OPT, [])
                 for cfg_path in samplegen_utils.generate_all_sample_fpaths(s)
             ),
-            # If the user passed in a sample out dir, use the last one they defined.
-            # Otherwise, use the default: 'samples'
-            sample_out_dir=next(
-                reversed(opts.pop(cls.SAMPLE_OUT_DIR_OPT, [])),
-                cls.SAMPLE_OUT_DIR_DEFAULT),
         )
 
         # If there are any options remaining, then we failed to recognize

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -99,7 +99,8 @@ class Options:
             ),
             # If the user passed in a sample out dir, use the last one they defined.
             # Otherwise, use the default: 'samples'
-            sample_out_dir=next(reversed(opts.pop(cls.SAMPLE_OUT_DIR_OPT, [])), 'samples'),
+            sample_out_dir=next(
+                reversed(opts.pop(cls.SAMPLE_OUT_DIR_OPT, [])), 'samples'),
         )
 
         # If there are any options remaining, then we failed to recognize

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -33,12 +33,13 @@ class Options:
     namespace: Tuple[str, ...] = dataclasses.field(default=())
     sample_configs: Tuple[str, ...] = dataclasses.field(default=())
     name: str = ''
-    sample_out_dir: str = 'samples'
+    sample_out_dir: str = ''
 
     # Class constants
-    SAMPLES_OPT: str = 'samples'
-    SAMPLE_OUT_DIR_OPT: str = 'sample_outdir'
+    SAMPLES_OPT: str = 'gapic_samples'
+    SAMPLE_OUT_DIR_OPT: str = 'gapic_sample_out_dir'
     PYTHON_GAPIC_PREFIX: str = 'python-gapic-'
+    SAMPLE_OUT_DIR_DEFAULT: str = '{api}/samples/{version}'
 
     @classmethod
     def build(cls, opt_string: str) -> 'Options':
@@ -100,7 +101,8 @@ class Options:
             # If the user passed in a sample out dir, use the last one they defined.
             # Otherwise, use the default: 'samples'
             sample_out_dir=next(
-                reversed(opts.pop(cls.SAMPLE_OUT_DIR_OPT, [])), 'samples'),
+                reversed(opts.pop(cls.SAMPLE_OUT_DIR_OPT, [])),
+                cls.SAMPLE_OUT_DIR_DEFAULT),
         )
 
         # If there are any options remaining, then we failed to recognize

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -16,15 +16,17 @@ import dataclasses
 import itertools
 import jinja2
 import keyword
+import os
 import re
 import time
 
-from gapic.samplegen import utils, yaml
+from gapic.samplegen_utils import (types, yaml)
 from gapic.schema import (api, wrappers)
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
 from textwrap import dedent
-from typing import (ChainMap, Dict, List, Mapping, Optional, Set, Tuple, Union)
+from typing import (ChainMap, Dict, Generator, List,
+                    Mapping, Optional, Set, Tuple, Union)
 
 from google.protobuf import descriptor_pb2
 
@@ -32,9 +34,6 @@ from google.protobuf import descriptor_pb2
 # * In real sample configs, many variables are
 #   defined with an _implicit_ $resp variable.
 
-MIN_SCHEMA_VERSION = (1, 2, 0)
-
-VALID_CONFIG_TYPE = "com.google.api.codegen.SampleConfigProto"
 
 # TODO: read in copyright and license from files.
 FILE_HEADER: Dict[str, str] = {
@@ -58,6 +57,8 @@ RESERVED_WORDS = frozenset(
     )
 )
 
+# TODO: configure the base template name so that
+#       e.g. other languages can use the same machinery.
 TEMPLATE_NAME = "sample.py.j2"
 
 
@@ -107,66 +108,6 @@ class TransformedRequest:
     body: Optional[List[AttributeRequestSetup]]
 
 
-class SampleError(Exception):
-    pass
-
-
-class ReservedVariableName(SampleError):
-    pass
-
-
-class RpcMethodNotFound(SampleError):
-    pass
-
-
-class UnknownService(SampleError):
-    pass
-
-
-class InvalidConfig(SampleError):
-    pass
-
-
-class InvalidStatement(SampleError):
-    pass
-
-
-class BadLoop(SampleError):
-    pass
-
-
-class MismatchedFormatSpecifier(SampleError):
-    pass
-
-
-class UndefinedVariableReference(SampleError):
-    pass
-
-
-class BadAttributeLookup(SampleError):
-    pass
-
-
-class RedefinedVariable(SampleError):
-    pass
-
-
-class BadAssignment(SampleError):
-    pass
-
-
-class InconsistentRequestName(SampleError):
-    pass
-
-
-class InvalidRequestSetup(SampleError):
-    pass
-
-
-class InvalidEnumVariant(SampleError):
-    pass
-
-
 def coerce_response_name(s: str) -> str:
     # In the sample config, the "$resp" keyword is used to refer to the
     # item of interest as received by the corresponding calling form.
@@ -197,7 +138,6 @@ class Validator:
 
     def __init__(self, method: wrappers.Method):
         # The response ($resp) variable is special and guaranteed to exist.
-        # TODO: name lookup also involes type checking
         self.request_type_ = method.input
         response_type = method.output
         if method.paged_result_field:
@@ -226,7 +166,7 @@ class Validator:
         return self.var_defs_.get(var_name)
 
     def validate_and_transform_request(self,
-                                       calling_form: utils.CallingForm,
+                                       calling_form: types.CallingForm,
                                        request: List[Mapping[str, str]]) -> List[TransformedRequest]:
         """Validates and transforms the "request" block from a sample config.
 
@@ -301,12 +241,12 @@ class Validator:
             duplicate = dict(r)
             val = duplicate.get("value")
             if not val:
-                raise InvalidRequestSetup(
+                raise types.InvalidRequestSetup(
                     "Missing keyword in request entry: 'value'")
 
             field = duplicate.get("field")
             if not field:
-                raise InvalidRequestSetup(
+                raise types.InvalidRequestSetup(
                     "Missing keyword in request entry: 'field'")
 
             spurious_keywords = set(duplicate.keys()) - {"value",
@@ -315,7 +255,7 @@ class Validator:
                                                          "input_parameter",
                                                          "comment"}
             if spurious_keywords:
-                raise InvalidRequestSetup(
+                raise types.InvalidRequestSetup(
                     "Spurious keyword(s) in request entry: {}".format(
                         ", ".join(f"'{kword}'" for kword in spurious_keywords)))
 
@@ -329,7 +269,7 @@ class Validator:
             for i, attr_name in enumerate(attr_chain):
                 attr = base.fields.get(attr_name)
                 if not attr:
-                    raise BadAttributeLookup(
+                    raise types.BadAttributeLookup(
                         "Method request type {} has no attribute: '{}'".format(
                             self.request_type_.type, attr_name))
 
@@ -340,7 +280,7 @@ class Validator:
                     # way to verify that the value is a valid enum variant.
                     witness = any(e.name == val for e in attr.enum.values)
                     if not witness:
-                        raise InvalidEnumVariant(
+                        raise types.InvalidEnumVariant(
                             "Invalid variant for enum {}: '{}'".format(attr, val))
                     # Python code can set protobuf enums from strings.
                     # This is preferable to adding the necessary import statement
@@ -353,7 +293,7 @@ class Validator:
             if i != len(attr_chain) - 1:
                 # We broke out of the loop after processing an enum.
                 extra_attrs = ".".join(attr_chain[i:])
-                raise InvalidEnumVariant(
+                raise types.InvalidEnumVariant(
                     f"Attempted to reference attributes of enum value: '{extra_attrs}'")
 
             if len(attr_chain) > 1:
@@ -363,7 +303,7 @@ class Validator:
                 # there can't be duplicates.
                 # This is admittedly a bit of a hack.
                 if attr_chain[0] in base_param_to_attrs:
-                    raise InvalidRequestSetup(
+                    raise types.InvalidRequestSetup(
                         "Duplicated top level field in request block: '{}'".format(
                             attr_chain[0]))
                 del duplicate["field"]
@@ -374,12 +314,12 @@ class Validator:
                 AttributeRequestSetup(**duplicate))  # type: ignore
 
         client_streaming_forms = {
-            utils.CallingForm.RequestStreamingClient,
-            utils.CallingForm.RequestStreamingBidi,
+            types.CallingForm.RequestStreamingClient,
+            types.CallingForm.RequestStreamingBidi,
         }
 
         if len(base_param_to_attrs) > 1 and calling_form in client_streaming_forms:
-            raise InvalidRequestSetup(
+            raise types.InvalidRequestSetup(
                 "Too many base parameters for client side streaming form")
 
         return [
@@ -407,13 +347,13 @@ class Validator:
 
         for statement in response:
             if len(statement) != 1:
-                raise InvalidStatement(
+                raise types.InvalidStatement(
                     "Invalid statement: {}".format(statement))
 
             keyword, body = next(iter(statement.items()))
             validater = self.STATEMENT_DISPATCH_TABLE.get(keyword)
             if not validater:
-                raise InvalidStatement(
+                raise types.InvalidStatement(
                     "Invalid statement keyword: {}".format(keyword))
 
             validater(self, body)
@@ -448,7 +388,7 @@ class Validator:
             base = expression[:first_dot] if first_dot > 0 else expression
             match = chain_link_re.match(base)
             if not match:
-                raise BadAttributeLookup(
+                raise types.BadAttributeLookup(
                     f"Badly formed attribute expression: {expression}")
 
             name, idxed, mapped = (match.groupdict()["attr_name"],
@@ -456,19 +396,19 @@ class Validator:
                                    bool(match.groupdict()["key"]))
             field = scope.get(name)
             if not field:
-                exception_class = (BadAttributeLookup if depth else
-                                   UndefinedVariableReference)
+                exception_class = (types.BadAttributeLookup if depth else
+                                   types.UndefinedVariableReference)
                 raise exception_class(f"No such variable or attribute: {name}")
 
             # Invalid input
             if (idxed or mapped) and not field.repeated:
-                raise BadAttributeLookup(
+                raise types.BadAttributeLookup(
                     f"Collection lookup on non-repeated field: {base}")
 
             # Can only ignore indexing or mapping in an indexed (or mapped) field
             # if it is the terminal point in the expression.
             if field.repeated and not (idxed or mapped) and first_dot != -1:
-                raise BadAttributeLookup(
+                raise types.BadAttributeLookup(
                     ("Accessing attribute on a non-terminal collection without"
                      f"indexing into the collection: {base}")
                 )
@@ -480,17 +420,17 @@ class Validator:
                 # See https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L496
                 # for a better understanding of how map attributes are handled in protobuf
                 if not message or not message.options.map_field:
-                    raise BadAttributeLookup(
+                    raise types.BadAttributeLookup(
                         f"Badly formed mapped field: {base}")
 
                 value_field = message.fields.get("value")
                 if not value_field:
-                    raise BadAttributeLookup(
+                    raise types.BadAttributeLookup(
                         f"Mapped attribute has no value field: {base}")
 
                 value_message = value_field.message
                 if not value_message:
-                    raise BadAttributeLookup(
+                    raise types.BadAttributeLookup(
                         f"Mapped value field is not a message: {base}")
 
                 if first_dot != -1:
@@ -502,7 +442,7 @@ class Validator:
 
             # Enums and primitives are only allowed at the tail of an expression.
             if not message:
-                raise BadAttributeLookup(
+                raise types.BadAttributeLookup(
                     f"Non-terminal attribute is not a message: {base}")
 
             return validate_recursively(expression[first_dot + 1:],
@@ -518,7 +458,7 @@ class Validator:
             ReservedVariableName: If an attempted lvalue is a reserved keyword.
         """
         if lval in RESERVED_WORDS:
-            raise ReservedVariableName(
+            raise types.ReservedVariableName(
                 "Tried to define a variable with reserved name: {}".format(
                     lval)
             )
@@ -526,7 +466,7 @@ class Validator:
         # Even though it's valid python to reassign variables to any rvalue,
         # the samplegen spec prohibits this.
         if lval in self.var_defs_:
-            raise RedefinedVariable(
+            raise types.RedefinedVariable(
                 "Tried to redefine variable: {}".format(lval))
 
         self.var_defs_[lval] = type_
@@ -547,7 +487,7 @@ class Validator:
         fmt_str = body[0]
         num_prints = fmt_str.count("%s")
         if num_prints != len(body) - 1:
-            raise MismatchedFormatSpecifier(
+            raise types.MismatchedFormatSpecifier(
                 "Expected {} expresssions in format string but received {}".format(
                     num_prints, len(body) - 1
                 )
@@ -571,7 +511,7 @@ class Validator:
         #       re-implementing the python interpreter.
         m = re.match(r"^([a-zA-Z]\w*)=([^=]+)$", body)
         if not m:
-            raise BadAssignment("Bad assignment statement: {}".format(body))
+            raise types.BadAssignment("Bad assignment statement: {}".format(body))
 
         lval, rval = m.groups()
 
@@ -596,14 +536,14 @@ class Validator:
 
         fname_fmt = body.get("filename")
         if not fname_fmt:
-            raise InvalidStatement(
+            raise types.InvalidStatement(
                 "Missing key in 'write_file' statement: 'filename'")
 
         self._validate_format(fname_fmt)
 
         contents_var = body.get("contents")
         if not contents_var:
-            raise InvalidStatement(
+            raise types.InvalidStatement(
                 "Missing key in 'write_file' statement: 'contents'")
 
         self.validate_expression(contents_var)
@@ -662,7 +602,7 @@ class Validator:
                 loop[self.COLL_KWORD])
 
             if not collection_field.repeated:
-                raise BadLoop(
+                raise types.BadLoop(
                     "Tried to use a non-repeated field as a collection: {}".format(
                         tokens[-1]))
 
@@ -683,7 +623,7 @@ class Validator:
             segments -= map_args
             segments -= {self.KEY_KWORD, self.VAL_KWORD}
             if segments:
-                raise BadLoop(
+                raise types.BadLoop(
                     "Unexpected keywords in loop statement: {}".format(
                         segments)
                 )
@@ -699,11 +639,11 @@ class Validator:
                 self._handle_lvalue(val, map_field.message.fields["value"])
 
             if not (key or val):
-                raise BadLoop(
+                raise types.BadLoop(
                     "Need at least one of 'key' or 'value' in a map loop")
 
         else:
-            raise BadLoop("Unexpected loop form: {}".format(segments))
+            raise types.BadLoop("Unexpected loop form: {}".format(segments))
 
         self.validate_response(loop[self.BODY_KWORD])
         # Restore the previous lexical scope.
@@ -724,24 +664,39 @@ class Validator:
 def generate_sample(sample,
                     id_is_unique: bool,
                     env: jinja2.environment.Environment,
-                    api_schema: api.API) -> Tuple[str, jinja2.environment.TemplateStream]:
+                    api_schema: api.API) -> Tuple[str, str]:
+    """Generate a standalone, runnable sample.
 
+    Rendering and writing the rendered output is left for the caller.
+
+    Args:
+        sample (Any): A definition for a single sample generated from parsed yaml.
+        id_is_unique (bool): Indicates whether sample["id"] globally unique.
+        env (jinja2.environment.Environment): The jinja environment used to generate
+                                              the filled template for the sample.
+        api_schema (api.API): The schema that defines the API to which the sample belongs.
+
+    Returns:
+        Tuple[str, jinja2.Template]: The filename of the generated sample and the
+                                     generated, filled-in jinja template to be
+                                     rendered to make the sample.
+    """
     sample_template = env.get_template(TEMPLATE_NAME)
 
     service_name = sample["service"]
     service = api_schema.services.get(service_name)
     if not service:
-        raise UnknownService("Unknown service: {}", service_name)
+        raise types.UnknownService("Unknown service: {}", service_name)
 
     rpc_name = sample["rpc"]
     rpc = service.methods.get(rpc_name)
     if not rpc:
-        raise RpcMethodNotFound(
+        raise types.RpcMethodNotFound(
             "Could not find rpc in service {}: {}".format(
                 service_name, rpc_name)
         )
 
-    calling_form = utils.CallingForm.method_default(rpc)
+    calling_form = types.CallingForm.method_default(rpc)
 
     v = Validator(rpc)
     sample["request"] = v.validate_and_transform_request(calling_form,
@@ -757,58 +712,67 @@ def generate_sample(sample,
 
     return (
         sample_fpath,
-        sample_template.stream(
+        sample_template.render(
             file_header=FILE_HEADER,
             sample=sample,
             imports=[],
             calling_form=calling_form,
-            calling_form_enum=utils.CallingForm,
+            calling_form_enum=types.CallingForm,
         ),
     )
 
 
-def generate_manifest(fpaths_and_samples, api_schema, *, manifest_time: int = None):
+def generate_manifest(
+        fpaths_and_samples,
+        base_path: str,
+        api_schema,
+        *,
+        manifest_time: int = None
+) -> Tuple[str, yaml.Doc]:
     """Generate a samplegen manifest for use by sampletest
 
     Args:
         fpaths_and_samples (Iterable[Tuple[str, Mapping[str, Any]]]):
                          The file paths and samples to be listed in the manifest
-
+        base_path (str): The base directory where the samples are generated.
         api_schema (~.api.API): An API schema object.
         manifest_time (int): Optional. An override for the timestamp in the name of the manifest filename.
                              Primarily used for testing.
 
     Returns:
-        Tuple[str, Dict[str,Any]]: The filename of the manifest and the manifest data as a dictionary.
+        Tuple[str, yaml.Doc]: The filename of the manifest and the manifest data as a dictionary.
 
     """
-    all_info = [
-        yaml.KeyVal("type", "manifest/samples"),
-        yaml.KeyVal("schema_version", "3"),
-        yaml.Map(
-            name="python",
-            anchor_name="python",
-            elements=[
-                yaml.KeyVal("environment", "python"),
-                yaml.KeyVal("bin", "python3"),
-                # TODO: make this the real sample base directory
-                yaml.KeyVal("base_path", "sample/base/directory"),
-                yaml.KeyVal("invocation", "'{bin} {path} @args'"),
-            ],
-        ),
-        yaml.Collection(
-            name="samples",
-            elements=[
-                [
-                    yaml.Alias("python"),
-                    yaml.KeyVal("sample", sample["id"]),
-                    yaml.KeyVal("path", "'{base_path}/%s'" % fpath),
-                    yaml.KeyVal("region_tag", sample.get("region_tag", "")),
-                ]
-                for fpath, sample in fpaths_and_samples
-            ],
-        ),
-    ]
+    doc = yaml.Doc(
+        [
+            yaml.KeyVal("type", "manifest/samples"),
+            yaml.KeyVal("schema_version", "3"),
+            yaml.Map(
+                name="python",
+                anchor_name="python",
+                elements=[
+                    yaml.KeyVal("environment", "python"),
+                    yaml.KeyVal("bin", "python3"),
+                    yaml.KeyVal("base_path", base_path),
+                    yaml.KeyVal("invocation", "'{bin} {path} @args'"),
+                ],
+            ),
+            yaml.Collection(
+                name="samples",
+                elements=[
+                    [
+                        yaml.Alias("python"),
+                        yaml.KeyVal("sample", sample["id"]),
+                        yaml.KeyVal("path",
+                                    "'{base_path}/%s'" % os.path.relpath(fpath,
+                                                                         base_path)),
+                        yaml.KeyVal("region_tag", sample.get("region_tag", "")),
+                    ]
+                    for fpath, sample in fpaths_and_samples
+                ],
+            ),
+        ]
+    )
 
     dt = time.gmtime(manifest_time)
     manifest_fname_template = (
@@ -829,4 +793,4 @@ def generate_manifest(fpaths_and_samples, api_schema, *, manifest_time: int = No
         second=dt.tm_sec,
     )
 
-    return manifest_fname, all_info
+    return manifest_fname, doc

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -511,7 +511,7 @@ class Validator:
         #       re-implementing the python interpreter.
         m = re.match(r"^([a-zA-Z]\w*)=([^=]+)$", body)
         if not m:
-            raise types.BadAssignment("Bad assignment statement: {}".format(body))
+            raise types.BadAssignment(f"Bad assignment statement: {body}")
 
         lval, rval = m.groups()
 
@@ -766,7 +766,8 @@ def generate_manifest(
                         yaml.KeyVal("path",
                                     "'{base_path}/%s'" % os.path.relpath(fpath,
                                                                          base_path)),
-                        yaml.KeyVal("region_tag", sample.get("region_tag", "")),
+                        yaml.KeyVal("region_tag",
+                                    sample.get("region_tag", "")),
                     ]
                     for fpath, sample in fpaths_and_samples
                 ],

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -660,7 +660,6 @@ class Validator:
 
 
 def generate_sample(sample,
-                    id_is_unique: bool,
                     env: jinja2.environment.Environment,
                     api_schema: api.API) -> str:
     """Generate a standalone, runnable sample.
@@ -669,9 +668,6 @@ def generate_sample(sample,
 
     Args:
         sample (Any): A definition for a single sample generated from parsed yaml.
-        id_is_unique (bool): Indicates whether the sample's id is unique.
-                             If it is not, sample["id"] is modified
-                             as an output parameter.
         env (jinja2.environment.Environment): The jinja environment used to generate
                                               the filled template for the sample.
         api_schema (api.API): The schema that defines the API to which the sample belongs.
@@ -695,8 +691,6 @@ def generate_sample(sample,
         )
 
     calling_form = types.CallingForm.method_default(rpc)
-    sample["id"] = (sample["id"] if id_is_unique else
-                    f'{sample["id"]}_{calling_form}')
 
     v = Validator(rpc)
     sample["request"] = v.validate_and_transform_request(calling_form,
@@ -705,7 +699,6 @@ def generate_sample(sample,
 
     sample["package_name"] = api_schema.naming.warehouse_package_name
 
-    # The onus to change the sample id based on the uniqueness
     return sample_template.render(
         file_header=FILE_HEADER,
         sample=sample,

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -24,9 +24,7 @@ from gapic.samplegen_utils import (types, yaml)
 from gapic.schema import (api, wrappers)
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
-from textwrap import dedent
-from typing import (ChainMap, Dict, Generator, List,
-                    Mapping, Optional, Set, Tuple, Union)
+from typing import (ChainMap, Dict, List, Mapping, Optional, Tuple)
 
 from google.protobuf import descriptor_pb2
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -664,20 +664,22 @@ class Validator:
 def generate_sample(sample,
                     id_is_unique: bool,
                     env: jinja2.environment.Environment,
-                    api_schema: api.API) -> Tuple[types.CallingForm, str]:
+                    api_schema: api.API) -> str:
     """Generate a standalone, runnable sample.
 
     Rendering and writing the rendered output is left for the caller.
 
     Args:
         sample (Any): A definition for a single sample generated from parsed yaml.
+        id_is_unique (bool): Indicates whether the sample's id is unique.
+                             If it is not, sample["id"] is modified
+                             as an output parameter.
         env (jinja2.environment.Environment): The jinja environment used to generate
                                               the filled template for the sample.
         api_schema (api.API): The schema that defines the API to which the sample belongs.
 
     Returns:
-        Tuple[types.CallingForm, str]: The calling form of the sample and the
-                                       rendered sample.
+        str: The rendered sample.
     """
     sample_template = env.get_template(TEMPLATE_NAME)
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -704,6 +704,7 @@ def generate_sample(sample,
     v.validate_response(sample["response"])
 
     sample_fpath = (
+        # TODO: enable configuration that allows other language samples.
         sample["id"] + (str(calling_form)
                         if not id_is_unique else "") + ".py"
     )
@@ -747,6 +748,8 @@ def generate_manifest(
         [
             yaml.KeyVal("type", "manifest/samples"),
             yaml.KeyVal("schema_version", "3"),
+            # TODO: make the environment configurable to allow other languages
+            #       to use the same basic machinery.
             yaml.Map(
                 name="python",
                 anchor_name="python",
@@ -776,6 +779,7 @@ def generate_manifest(
     )
 
     dt = time.gmtime(manifest_time)
+    # TODO: allow other language configuration
     manifest_fname_template = (
         "{api}.{version}.python."
         "{year:04d}{month:02d}{day:02d}."

--- a/gapic/samplegen_utils/__init__.py
+++ b/gapic/samplegen_utils/__init__.py
@@ -12,8 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from gapic.samplegen import samplegen
+import gapic.samplegen_utils.types
+import gapic.samplegen_utils.utils
+import gapic.samplegen_utils.yaml
 
 __all__ = (
-    'samplegen',
+    'types',
+    'utils',
+    'yaml',
 )

--- a/gapic/samplegen_utils/types.py
+++ b/gapic/samplegen_utils/types.py
@@ -12,10 +12,71 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Module containing miscellaneous utilities
-that will eventually move somewhere else (probably)."""
-
 from enum import Enum, auto
+
+
+class SampleError(Exception):
+    pass
+
+
+class ReservedVariableName(SampleError):
+    pass
+
+
+class RpcMethodNotFound(SampleError):
+    pass
+
+
+class UnknownService(SampleError):
+    pass
+
+
+class InvalidConfig(SampleError):
+    pass
+
+
+class InvalidStatement(SampleError):
+    pass
+
+
+class BadLoop(SampleError):
+    pass
+
+
+class MismatchedFormatSpecifier(SampleError):
+    pass
+
+
+class UndefinedVariableReference(SampleError):
+    pass
+
+
+class BadAttributeLookup(SampleError):
+    pass
+
+
+class RedefinedVariable(SampleError):
+    pass
+
+
+class BadAssignment(SampleError):
+    pass
+
+
+class InconsistentRequestName(SampleError):
+    pass
+
+
+class InvalidRequestSetup(SampleError):
+    pass
+
+
+class InvalidEnumVariant(SampleError):
+    pass
+
+
+class InvalidConfigFile(SampleError):
+    pass
 
 
 class CallingForm(Enum):

--- a/gapic/samplegen_utils/types.py
+++ b/gapic/samplegen_utils/types.py
@@ -76,10 +76,6 @@ class InvalidEnumVariant(SampleError):
     pass
 
 
-class InvalidConfigFile(SampleError):
-    pass
-
-
 class CallingForm(Enum):
     Request = auto()
     RequestPaged = auto()

--- a/gapic/samplegen_utils/types.py
+++ b/gapic/samplegen_utils/types.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from enum import Enum, auto
+from gapic.utils import to_snake_case
 
 
 class SampleError(Exception):
@@ -102,3 +103,6 @@ class CallingForm(Enum):
             return cls.RequestStreamingServer
 
         return cls.Request
+
+    def __str__(self):
+        return to_snake_case(super().__str__().split(".")[-1])

--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing miscellaneous utilities
+that will eventually move somewhere else (probably)."""
+
+import os
+import yaml
+
+from typing import (Generator, Tuple)
+
+from gapic.samplegen_utils import types
+
+
+MIN_SCHEMA_VERSION = (1, 2, 0)
+
+VALID_CONFIG_TYPE = "com.google.api.codegen.SampleConfigProto"
+
+
+def generate_all_sample_fpaths(path: str) -> Generator[str, None, None]:
+    def parse_version(version_str: str) -> Tuple[int, ...]:
+        return tuple(int(tok) for tok in version_str.split("."))
+
+    def is_valid_sampleconfig_p(doc) -> bool:
+        version_token = "config_schema_version"
+        return bool(
+            # Yaml may return a dict, a list, or a str
+            isinstance(doc, dict)
+            and doc.get("type") == VALID_CONFIG_TYPE
+            and parse_version(doc.get(version_token, "")) >= MIN_SCHEMA_VERSION
+            and doc.get("samples")
+        )
+
+    # If a user passes in a directory to search for sample configs,
+    # it is required to ignore any non-sample-config files so as to avoid
+    # being unhelpfully strict.
+    # Directly named files, however, should generate an error, because silently
+    # ignoring them is less helpful than failing loudly.
+    if os.path.isfile(path):
+        if not path.endswith('.yaml'):
+            raise types.InvalidConfig(f"Not a yaml file: {path}")
+
+        with open(path) as f:
+            if not all(is_valid_sampleconfig_p(doc)
+                       for doc in yaml.safe_load_all(f.read())):
+                raise types.InvalidConfig(f"Not a valid sampleconfig file: {path}")
+
+        yield path
+
+    elif os.path.isdir(path):
+        yaml_file_generator = (os.path.join(dirpath, fname)
+                               for dirpath, _, fnames in os.walk(path)
+                               for fname in fnames if fname.endswith(".yaml"))
+
+        for fullpath in yaml_file_generator:
+            with open(fullpath) as f:
+                if all(is_valid_sampleconfig_p(doc)
+                       for doc in yaml.safe_load_all(f.read())):
+                    yield fullpath
+
+    else:
+        raise types.InvalidConfig(f"No such file or directory: {path}")

--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -29,6 +29,21 @@ VALID_CONFIG_TYPE = "com.google.api.codegen.SampleConfigProto"
 
 
 def generate_all_sample_fpaths(path: str) -> Generator[str, None, None]:
+    """Given file or directory path, yield all valid sample config fpaths recursively.
+
+    Arguments:
+        path (str): The file or directory path to check
+                    for valid samplegen config files.
+                    Directories are checked recursively.
+
+    Raises:
+        types.InvalidConfig: If 'path' is an invalid sampleconfig file
+                             or 'path' is not a file or directory.
+
+    Returns:
+        Generator[str, None, None]: All valid samplegen config files
+                                    starting at 'path'.
+    """
     def parse_version(version_str: str) -> Tuple[int, ...]:
         return tuple(int(tok) for tok in version_str.split("."))
 

--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -75,7 +75,8 @@ def generate_all_sample_fpaths(path: str) -> Generator[str, None, None]:
         with open(path) as f:
             if not any(is_valid_sample_cfg(doc)
                        for doc in yaml.safe_load_all(f.read())):
-                raise types.InvalidConfig(f"No valid sample config in file: {path}")
+                raise types.InvalidConfig(
+                    f"No valid sample config in file: {path}")
 
             yield path
 

--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -33,7 +33,7 @@ def is_valid_sample_cfg(
         min_version: Tuple[int, int, int] = MIN_SCHEMA_VERSION,
         config_type: str = VALID_CONFIG_TYPE,
 ) -> bool:
-    """Takes a 
+    """Predicate that takes a parsed yaml doc checks if it is a valid sampel config.
 
     Arguments:
         doc (Any): The yaml document to be assessed

--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -33,10 +33,22 @@ def is_valid_sample_cfg(
         min_version: Tuple[int, int, int] = MIN_SCHEMA_VERSION,
         config_type: str = VALID_CONFIG_TYPE,
 ) -> bool:
+    """Takes a 
+
+    Arguments:
+        doc (Any): The yaml document to be assessed
+        min_version (Tuple[int, int, int]): (optional) The minimum valid version for
+        the sample config. Uses semantic version (major, minor, bugfix).
+        config_type (str): (optional) The valid type of the document.
+
+    Returns:
+        bool: True if doc is a valid sample config document.
+
+    """
     def parse_version(version_str: str) -> Tuple[int, ...]:
         return tuple(int(tok) for tok in version_str.split("."))
 
-    version_token = "config_schema_version"
+    version_token = "schema_version"
     return bool(
         # Yaml may return a dict, a list, or a str
         isinstance(doc, dict)

--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -54,7 +54,8 @@ def generate_all_sample_fpaths(path: str) -> Generator[str, None, None]:
         with open(path) as f:
             if not all(is_valid_sampleconfig_p(doc)
                        for doc in yaml.safe_load_all(f.read())):
-                raise types.InvalidConfig(f"Not a valid sampleconfig file: {path}")
+                raise types.InvalidConfig(
+                    f"Not a valid sampleconfig file: {path}")
 
         yield path
 

--- a/gapic/samplegen_utils/yaml.py
+++ b/gapic/samplegen_utils/yaml.py
@@ -46,7 +46,7 @@ class KeyVal(Element):
         return f"{whitespace}{self.key}: {self.val}"
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass(frozen=True)
 class Collection(Element):
     """An ordered list of subobjects."""
     name: str
@@ -75,7 +75,7 @@ class Collection(Element):
         )
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass(frozen=True)
 class Alias(Element):
     """An anchor to a map."""
     target: str
@@ -85,7 +85,7 @@ class Alias(Element):
         return f"{whitespace}<<: *{self.target}"
 
 
-@dataclasses.dataclass()
+@dataclasses.dataclass(frozen=True)
 class Map(Element):
     """A named collection with a list of attributes."""
     name: str
@@ -99,3 +99,12 @@ class Map(Element):
         )
         whitespace = " " * spaces
         return f"{whitespace}{self.name}:{maybe_anchor}\n{element_str}"
+
+
+@dataclasses.dataclass(frozen=True)
+class Doc(Element):
+    """A yaml document"""
+    elements: List[Element]
+
+    def render(self):
+        return "---\n{}".format("\n".join(e.render() for e in self.elements))

--- a/gapic/samplegen_utils/yaml.py
+++ b/gapic/samplegen_utils/yaml.py
@@ -62,7 +62,6 @@ class Collection(Element):
         # -  cephalopod: squid
         #   bivalve: clam
         #   gastropod: whelk
-        whitespace = " " * spaces
         return f"{self.name}:\n" + "\n".join(
             indent(
                 "-"

--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -15,7 +15,7 @@
 import dataclasses
 import os
 import re
-from typing import cast, List, Match, Sequence, Tuple
+from typing import cast, List, Match, Tuple
 
 from google.protobuf import descriptor_pb2
 
@@ -45,8 +45,8 @@ class Naming:
 
     @classmethod
     def build(cls,
-            *file_descriptors: descriptor_pb2.FileDescriptorProto,
-            opts: options.Options = options.Options(),
+              *file_descriptors: descriptor_pb2.FileDescriptorProto,
+              opts: options.Options = options.Options(),
               ) -> 'Naming':
         """Return a full Naming instance based on these file descriptors.
 
@@ -101,7 +101,7 @@ class Naming:
 
         # Okay, do the match
         match = cast(Match,
-            re.search(pattern=pattern, string=root_package)).groupdict()
+                     re.search(pattern=pattern, string=root_package)).groupdict()
         match['namespace'] = match['namespace'] or ''
         package_info = cls(
             name=match['name'].capitalize(),

--- a/gapic/utils/code.py
+++ b/gapic/utils/code.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import (Any, Callable, Iterable, List, Tuple, TypeVar)
+from typing import (Callable, Iterable, List, Tuple, TypeVar)
 
 
 def empty(content: str) -> bool:

--- a/noxfile.py
+++ b/noxfile.py
@@ -26,7 +26,7 @@ showcase_version = '0.2.0'
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pyfakefs')
     session.install('-e', '.')
 
     session.run(

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,9 @@ setup(
     extras_require={
         ':python_version<"3.7"': ('dataclasses >= 0.4',),
     },
+    tests_require=(
+        'pyfakefs >= 3.6',
+    ),
     classifiers=(
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -24,7 +24,7 @@ from google.protobuf.compiler.plugin_pb2 import CodeGeneratorResponse
 
 from gapic.generator import generator
 from gapic.generator import options
-from gapic.samplegen_utils import (types, yaml)
+from gapic.samplegen_utils import yaml
 from gapic.schema import api
 from gapic.schema import naming
 from gapic.schema import wrappers
@@ -260,7 +260,7 @@ def test_parse_sample_paths(fs):
                 '''
                 ---
                 type: com.google.api.codegen.SampleConfigProto
-                config_schema_version: 1.2.0
+                schema_version: 1.2.0
                 samples:
                 - service: google.cloud.language.v1.LanguageService
                 '''
@@ -288,11 +288,7 @@ def test_parse_sample_paths(fs):
 @mock.patch(
     'time.gmtime',
 )
-def test_samplegen_config_to_output_files(
-        mock_gmtime,
-        mock_generate_sample,
-        fs,
-):
+def test_samplegen_config_to_output_files(mock_gmtime, mock_generate_sample, fs):
     # These time values are nothing special,
     # they just need to be deterministic.
     returner = mock.MagicMock()
@@ -310,11 +306,13 @@ def test_samplegen_config_to_output_files(
             '''
             ---
             type: com.google.api.codegen.SampleConfigProto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             samples:
             - id: squid_sample
               region_tag: humboldt_tag
               rpc: get_squid_streaming
+            - region_tag: clam_sample
+              rpc: get_clam
             '''
         )
     )
@@ -335,6 +333,10 @@ def test_samplegen_config_to_output_files(
                 content="\n",
             ),
             CodeGeneratorResponse.File(
+                name="samples/clam_sample.py",
+                content="\n",
+            ),
+            CodeGeneratorResponse.File(
                 name="samples/Mollusc.v6.python.21120601.131313.manifest.yaml",
                 content=dedent("""                ---
                 type: manifest/samples
@@ -349,10 +351,105 @@ def test_samplegen_config_to_output_files(
                   sample: squid_sample
                   path: '{base_path}/squid_sample.py'
                   region_tag: humboldt_tag
+                - <<: *python
+                  sample: clam_sample
+                  path: '{base_path}/clam_sample.py'
+                  region_tag: clam_sample
                 """.rstrip()),
             )
         ]
     )
+
+    assert actual_response == expected_response
+
+
+@mock.patch(
+    'gapic.samplegen.samplegen.generate_sample',
+    return_value='',
+)
+@mock.patch(
+    'time.gmtime',
+)
+def test_samplegen_id_disambiguation(mock_gmtime, mock_generate_sample, fs):
+    # These time values are nothing special,
+    # they just need to be deterministic.
+    returner = mock.MagicMock()
+    returner.tm_year = 2112
+    returner.tm_mon = 6
+    returner.tm_mday = 1
+    returner.tm_hour = 13
+    returner.tm_min = 13
+    returner.tm_sec = 13
+    mock_gmtime.return_value = returner
+
+    # Note: The first two samples will have the same nominal ID, the first by
+    #       explicit naming and the second by falling back to the region_tag.
+    #       The third has no id of any kind, so the generator is required to make a
+    #       unique ID for it.
+    fs.create_file(
+        'samples.yaml',
+        contents=dedent(
+            '''
+            ---
+            type: com.google.api.codegen.SampleConfigProto
+            schema_version: 1.2.0
+            samples:
+            - id: squid_sample
+              region_tag: humboldt_tag
+              rpc: get_squid_streaming
+            # Note that this region tag collides with the id of the previous sample.
+            - region_tag: squid_sample
+              rpc: get_squid_streaming
+            # No id or region tag.
+            - rpc: get_squid_streaming
+            '''
+        )
+    )
+    g = generator.Generator(options.Options.build('samples=samples.yaml'))
+    api_schema = make_api(naming=naming.Naming(name='Mollusc', version='v6'))
+    actual_response = g.get_response(api_schema)
+    expected_response = CodeGeneratorResponse(
+        file=[
+            CodeGeneratorResponse.File(
+                name="samples/squid_sample_91a465c6.py",
+                content="\n",
+            ),
+            CodeGeneratorResponse.File(
+                name="samples/squid_sample_c8014108.py",
+                content="\n",
+            ),
+            CodeGeneratorResponse.File(
+                name="samples/157884ee.py",
+                content="\n",
+            ),
+            CodeGeneratorResponse.File(
+                name="samples/Mollusc.v6.python.21120601.131313.manifest.yaml",
+                content=dedent("""\
+                ---
+                type: manifest/samples
+                schema_version: 3
+                python: &python
+                  environment: python
+                  bin: python3
+                  base_path: samples
+                  invocation: '{bin} {path} @args'
+                samples:
+                - <<: *python
+                  sample: squid_sample_91a465c6
+                  path: '{base_path}/squid_sample_91a465c6.py'
+                  region_tag: humboldt_tag
+                - <<: *python
+                  sample: squid_sample_c8014108
+                  path: '{base_path}/squid_sample_c8014108.py'
+                  region_tag: squid_sample
+                - <<: *python
+                  sample: 157884ee
+                  path: '{base_path}/157884ee.py'
+                  region_tag: """)
+            ),
+        ]
+    )
+
     assert actual_response == expected_response
 
 

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -12,12 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pdb
 from textwrap import dedent
 from typing import Mapping
 from unittest import mock
 
-import itertools
 import jinja2
 import pytest
 

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -338,7 +338,8 @@ def test_samplegen_config_to_output_files(mock_gmtime, mock_generate_sample, fs)
             ),
             CodeGeneratorResponse.File(
                 name="samples/Mollusc.v6.python.21120601.131313.manifest.yaml",
-                content=dedent("""                ---
+                content=dedent("""\
+                ---
                 type: manifest/samples
                 schema_version: 3
                 python: &python

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -308,8 +308,10 @@ def test_samplegen_end_to_end(mock_generate_sample, mock_generate_manifest, fs):
     actual_response = g.get_response(None)
     expected_response = CodeGeneratorResponse(
         file=[
-            CodeGeneratorResponse.File(name='samples/sample.py', content="\n"),
-            CodeGeneratorResponse.File(name="samples/manifest.yaml", content="---\n")
+            CodeGeneratorResponse.File(name='samples/sample.py',
+                                       content="\n"),
+            CodeGeneratorResponse.File(name="samples/manifest.yaml",
+                                       content="---\n")
         ]
     )
     assert actual_response == expected_response

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -269,9 +269,9 @@ def test_parse_sample_paths(fs):
         )
 
     opts = options.Options.build(
-        ("samples=sample.yaml,"
-         "samples=sampledir/,"
-         "samples=other_sampledir"))
+        ("gapic_samples=sample.yaml,"
+         "gapic_samples=sampledir/,"
+         "gapic_samples=other_sampledir"))
 
     expected_configs = (
         'sample.yaml',
@@ -304,14 +304,26 @@ def test_samplegen_end_to_end(mock_generate_sample, mock_generate_manifest, fs):
         )
     )
 
-    g = generator.Generator(options.Options.build('samples=samples.yaml'))
-    actual_response = g.get_response(None)
+    g = generator.Generator(
+        options.Options.build(
+            (
+                'gapic_samples=samples.yaml,'
+                'gapic_sample_out_dir=api/{api}/version/{version}/samples'
+            )
+        )
+    )
+    api_schema = make_api(naming=naming.Naming(name='Mollusc', version='v6'))
+    actual_response = g.get_response(api_schema)
     expected_response = CodeGeneratorResponse(
         file=[
-            CodeGeneratorResponse.File(name='samples/sample.py',
-                                       content="\n"),
-            CodeGeneratorResponse.File(name="samples/manifest.yaml",
-                                       content="---\n")
+            CodeGeneratorResponse.File(
+                name='api/Mollusc/version/v6/samples/sample.py',
+                content="\n"
+            ),
+            CodeGeneratorResponse.File(
+                name="api/Mollusc/version/v6/samples/manifest.yaml",
+                content="---\n"
+            )
         ]
     )
     assert actual_response == expected_response

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 from unittest import mock
 import warnings
 
 from gapic.generator import options
+from gapic.samplegen_utils import types
 
 
 def test_options_empty():
@@ -46,3 +48,9 @@ def test_options_unrecognized_likely_typo():
     with mock.patch.object(warnings, 'warn') as warn:
         options.Options.build('go-gapic-abc=xyz')
     assert len(warn.mock_calls) == 0
+
+
+def test_options_no_valid_sample_config(fs):
+    fs.create_file("sampledir/not_a_config.yaml")
+    with pytest.raises(types.InvalidConfig):
+        options.Options.build("samples=sampledir/")

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -22,6 +22,7 @@ def test_options_empty():
     opts = options.Options.build('')
     assert len(opts.templates) == 1
     assert opts.templates[0].endswith('gapic/templates')
+    assert opts.sample_out_dir == 'samples'
 
 
 def test_options_replace_templates():
@@ -46,3 +47,8 @@ def test_options_unrecognized_likely_typo():
     with mock.patch.object(warnings, 'warn') as warn:
         options.Options.build('go-gapic-abc=xyz')
     assert len(warn.mock_calls) == 0
+
+
+def test_options_sample_out_dir():
+    opts = options.Options.build('sample_outdir=/var/tmp/samples')
+    assert opts.sample_out_dir == '/var/tmp/samples'

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -22,7 +22,6 @@ def test_options_empty():
     opts = options.Options.build('')
     assert len(opts.templates) == 1
     assert opts.templates[0].endswith('gapic/templates')
-    assert opts.sample_out_dir == '{api}/samples/{version}'
 
 
 def test_options_replace_templates():
@@ -47,8 +46,3 @@ def test_options_unrecognized_likely_typo():
     with mock.patch.object(warnings, 'warn') as warn:
         options.Options.build('go-gapic-abc=xyz')
     assert len(warn.mock_calls) == 0
-
-
-def test_options_sample_out_dir():
-    opts = options.Options.build('gapic_sample_out_dir=/var/tmp/samples')
-    assert opts.sample_out_dir == '/var/tmp/samples'

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -22,7 +22,7 @@ def test_options_empty():
     opts = options.Options.build('')
     assert len(opts.templates) == 1
     assert opts.templates[0].endswith('gapic/templates')
-    assert opts.sample_out_dir == 'samples'
+    assert opts.sample_out_dir == '{api}/samples/{version}'
 
 
 def test_options_replace_templates():
@@ -50,5 +50,5 @@ def test_options_unrecognized_likely_typo():
 
 
 def test_options_sample_out_dir():
-    opts = options.Options.build('sample_outdir=/var/tmp/samples')
+    opts = options.Options.build('gapic_sample_out_dir=/var/tmp/samples')
     assert opts.sample_out_dir == '/var/tmp/samples'

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -272,7 +272,7 @@ def test_generate_sample_config_partial_config(fs):
     expected_path = 'sample.yaml'
     fs.create_file(
         expected_path,
-        # Note the typo: SampleConfigPront
+        # Note the typo: SampleConfigPronto
         contents=dedent(
             '''
             ---

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -41,7 +41,7 @@ env.filters['snake_case'] = utils.to_snake_case
 env.filters['coerce_response_name'] = samplegen.coerce_response_name
 
 
-def test_generate_sample_basic(id_is_unique=True):
+def test_generate_sample_basic():
     # Note: the sample integration tests are needfully large
     # and difficult to eyeball parse. They are intended to be integration tests
     # that catch errors in behavior that is emergent from combining smaller features
@@ -72,10 +72,9 @@ def test_generate_sample_basic(id_is_unique=True):
               "response": [{"print": ["Mollusc is a %s", "$resp.taxonomy"]}]}
 
     sample_str = samplegen.generate_sample(
-        sample, id_is_unique, env, schema)
+        sample, env, schema)
 
-    sample_id = ("mollusc_classify_sync" if id_is_unique else
-                 "mollusc_classify_sync_request")
+    sample_id = ("mollusc_classify_sync")
     expected_str = '''# TODO: add a copyright
 # TODO: add a license
 #
@@ -123,16 +122,12 @@ if __name__ == "__main__":
     assert sample_str == expected_str
 
 
-def test_generate_sample_basic_non_unique_id():
-    test_generate_sample_basic(id_is_unique=False)
-
-
 def test_generate_sample_service_not_found():
     schema = DummyApiSchema({}, DummyNaming("pkg_name"))
     sample = {"service": "Mollusc"}
 
     with pytest.raises(types.UnknownService):
-        samplegen.generate_sample(sample, True, env, schema)
+        samplegen.generate_sample(sample, env, schema)
 
 
 def test_generate_sample_rpc_not_found():
@@ -141,7 +136,7 @@ def test_generate_sample_rpc_not_found():
     sample = {"service": "Mollusc", "rpc": "Classify"}
 
     with pytest.raises(types.RpcMethodNotFound):
-        list(samplegen.generate_sample(sample, True, env, schema))
+        list(samplegen.generate_sample(sample, env, schema))
 
 
 def test_generate_sample_config_fpaths(fs):
@@ -152,7 +147,7 @@ def test_generate_sample_config_fpaths(fs):
             '''
             ---
             type: com.google.api.codegen.SampleConfigProto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             '''
@@ -168,7 +163,7 @@ def test_generate_sample_config_fpaths_directories(fs):
         '''
         ---
         type: com.google.api.codegen.SampleConfigProto
-        config_schema_version: 1.2.0
+        schema_version: 1.2.0
         samples:
         - service: google.cloud.language.v1.LanguageService
         '''
@@ -232,7 +227,7 @@ def test_generate_sample_config_fpaths_bad_contents(
             '''
             ---
             type: com.google.api.codegen.SampleConfigPronto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             '''
@@ -252,7 +247,7 @@ def test_generate_sample_config_fpaths_bad_contents_old(fs):
             '''
             ---
             type: com.google.api.codegen.SampleConfigProto
-            config_schema_version: 1.1.0
+            schema_version: 1.1.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             '''
@@ -267,7 +262,7 @@ def test_generate_sample_config_fpaths_bad_contents_no_samples(fs):
             '''
             ---
             type: com.google.api.codegen.SampleConfigProto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             '''
         )
     )
@@ -277,18 +272,18 @@ def test_generate_sample_config_partial_config(fs):
     expected_path = 'sample.yaml'
     fs.create_file(
         expected_path,
+        # Note the typo: SampleConfigPront
         contents=dedent(
             '''
             ---
-            # Note: this one is NOT a valid config
             type: com.google.api.codegen.SampleConfigPronto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             ---
             # Note: this one IS a valid config
             type: com.google.api.codegen.SampleConfigProto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             '''
@@ -306,18 +301,19 @@ def test_generate_sample_config_partial_config_directory(fs):
     fpath = path.join(directory, 'sample.yaml')
     fs.create_file(
         fpath,
+        # Note: this one is NOT a valid config
         contents=dedent(
             '''
             ---
             # Note: this one is NOT a valid config
             type: com.google.api.codegen.SampleConfigPronto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             ---
             # Note: this one IS a valid config
             type: com.google.api.codegen.SampleConfigProto
-            config_schema_version: 1.2.0
+            schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             '''

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -16,8 +16,10 @@ import jinja2
 import os.path as path
 import pytest
 
-import gapic.samplegen.samplegen as samplegen
 import gapic.utils as utils
+
+from gapic.samplegen import samplegen
+from gapic.samplegen_utils import (types, utils as gapic_utils)
 
 from common_types import (DummyMethod, DummyService,
                           DummyApiSchema, DummyNaming, message_factory, enum_factory)
@@ -69,9 +71,8 @@ def test_generate_sample_basic():
                            "value_is_file": True}],
               "response": [{"print": ["Mollusc is a %s", "$resp.taxonomy"]}]}
 
-    fpath, template_stream = samplegen.generate_sample(
+    fpath, sample_str = samplegen.generate_sample(
         sample, True, env, schema)
-    sample_str = "".join(iter(template_stream))
 
     expected_str = '''# TODO: add a copyright
 # TODO: add a license
@@ -124,7 +125,7 @@ def test_generate_sample_service_not_found():
     schema = DummyApiSchema({}, DummyNaming("pkg_name"))
     sample = {"service": "Mollusc"}
 
-    with pytest.raises(samplegen.UnknownService):
+    with pytest.raises(types.UnknownService):
         samplegen.generate_sample(sample, True, env, schema)
 
 
@@ -133,5 +134,129 @@ def test_generate_sample_rpc_not_found():
         {"Mollusc": DummyService({})}, DummyNaming("pkg_name"))
     sample = {"service": "Mollusc", "rpc": "Classify"}
 
-    with pytest.raises(samplegen.RpcMethodNotFound):
-        samplegen.generate_sample(sample, True, env, schema)
+    with pytest.raises(types.RpcMethodNotFound):
+        list(samplegen.generate_sample(sample, True, env, schema))
+
+
+def test_generate_sample_config_fpaths(fs):
+    expected_path = 'cfgs/sample_config.yaml'
+    fs.create_file(
+        expected_path,
+        contents=dedent(
+            '''
+            ---
+            type: com.google.api.codegen.SampleConfigProto
+            config_schema_version: 1.2.0
+            samples:
+            - service: google.cloud.language.v1.LanguageService
+            '''
+        )
+    )
+    actual_paths = list(gapic_utils.generate_all_sample_fpaths(expected_path))
+
+    assert actual_paths == [expected_path]
+
+
+def test_generate_sample_config_fpaths_directories(fs):
+    good_contents = dedent(
+        '''
+        ---
+        type: com.google.api.codegen.SampleConfigProto
+        config_schema_version: 1.2.0
+        samples:
+        - service: google.cloud.language.v1.LanguageService
+        '''
+    )
+    bad_contents = 'bad contents'
+    # We need some invalid configs in the directory as well to verify that
+    # they don't cause spurious failures.
+    directory = 'sampleconfig'
+    for p in [
+            "config_1.yaml",
+            "config_2.yaml",
+            "config_notes.txt",
+            "subdir/config_3.yaml",
+            "subdir/config_4.yaml",
+            "subdir/nested/config_5.yaml",
+    ]:
+        fs.create_file(path.join(directory, p), contents=good_contents)
+
+    for p in [
+            "bad_config_1.yaml",
+            "subdir/bad_config_2.yaml",
+            "subdir/nested/bad_config_3.yaml",
+    ]:
+        fs.create_file(path.join(directory, p), contents=bad_contents)
+
+    expected_paths = [
+        "sampleconfig/config_1.yaml",
+        "sampleconfig/config_2.yaml",
+        "sampleconfig/subdir/config_3.yaml",
+        "sampleconfig/subdir/config_4.yaml",
+        "sampleconfig/subdir/nested/config_5.yaml",
+    ]
+
+    actual_paths = sorted(gapic_utils.generate_all_sample_fpaths(directory))
+
+    assert actual_paths == expected_paths
+
+
+def test_generate_sample_config_fpaths_not_yaml(fs):
+    expected_path = 'cfgs/sample_config.not_yaml'
+    fs.create_file(expected_path)
+
+    with pytest.raises(types.InvalidConfig):
+        list(gapic_utils.generate_all_sample_fpaths(expected_path))
+
+
+def test_generate_sample_config_fpaths_bad_contents(
+        fs,
+        # Note the typo: SampleConfigPronto
+        contents=dedent(
+            '''
+            ---
+            type: com.google.api.codegen.SampleConfigPronto
+            config_schema_version: 1.2.0
+            samples:
+            - service: google.cloud.language.v1.LanguageService
+            '''
+        )
+):
+    expected_path = 'cfgs/sample_config.yaml'
+    fs.create_file(expected_path, contents=contents)
+
+    with pytest.raises(types.InvalidConfig):
+        list(gapic_utils.generate_all_sample_fpaths(expected_path))
+
+
+def test_generate_sample_config_fpaths_bad_contents_old(fs):
+    test_generate_sample_config_fpaths_bad_contents(
+        fs,
+        contents=dedent(
+            '''
+            ---
+            type: com.google.api.codegen.SampleConfigProto
+            config_schema_version: 1.1.0
+            samples:
+            - service: google.cloud.language.v1.LanguageService
+            '''
+        )
+    )
+
+
+def test_generate_sample_config_fpaths_bad_contents_no_samples(fs):
+    test_generate_sample_config_fpaths_bad_contents(
+        fs,
+        contents=dedent(
+            '''
+            ---
+            type: com.google.api.codegen.SampleConfigProto
+            config_schema_version: 1.2.0
+            '''
+        )
+    )
+
+
+def test_generate_sample_config_fpaths_no_such_file(fs):
+    with pytest.raises(types.InvalidConfig):
+        list(gapic_utils.generate_all_sample_fpaths('cfgs/sample_config.yaml'))

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -301,7 +301,7 @@ def test_generate_sample_config_partial_config_directory(fs):
     fpath = path.join(directory, 'sample.yaml')
     fs.create_file(
         fpath,
-        # Note: this one is NOT a valid config
+        # Note the typo in the first sample: SampleConfigPronto
         contents=dedent(
             '''
             ---

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -19,13 +19,14 @@ from typing import (TypeVar)
 from collections import namedtuple
 from google.protobuf import descriptor_pb2
 
-import gapic.schema.wrappers as wrappers
-import gapic.samplegen.yaml as gapic_yaml
 import gapic.samplegen.samplegen as samplegen
+import gapic.samplegen_utils.types as types
+import gapic.samplegen_utils.yaml as gapic_yaml
+import gapic.schema.wrappers as wrappers
 
 from common_types import (DummyField, DummyMessage,
                           DummyMethod, message_factory, enum_factory)
-from gapic.samplegen import utils
+from gapic.samplegen_utils import utils
 
 
 # validate_response tests
@@ -40,14 +41,14 @@ def test_define():
 def test_define_undefined_var():
     define = {"define": "squid=humboldt"}
     v = samplegen.Validator(DummyMethod(output=message_factory("mollusc")))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response([define])
 
 
 def test_define_reserved_varname():
     define = {"define": "class=$resp"}
     v = samplegen.Validator(DummyMethod(output=message_factory("mollusc")))
-    with pytest.raises(samplegen.ReservedVariableName):
+    with pytest.raises(types.ReservedVariableName):
         v.validate_response([define])
 
 
@@ -61,7 +62,7 @@ def test_define_add_var():
 def test_define_bad_form():
     define = {"define": "mollusc=$resp.squid=$resp.clam"}
     v = samplegen.Validator(DummyMethod(output=message_factory("mollusc")))
-    with pytest.raises(samplegen.BadAssignment):
+    with pytest.raises(types.BadAssignment):
         v.validate_response([define])
 
 
@@ -72,7 +73,7 @@ def test_define_redefinition():
     ]
     v = samplegen.Validator(DummyMethod(output=message_factory("$resp.molluscs",
                                                                repeated_iter=[True])))
-    with pytest.raises(samplegen.RedefinedVariable):
+    with pytest.raises(types.RedefinedVariable):
         v.validate_response(statements)
 
 
@@ -80,7 +81,7 @@ def test_define_input_param():
     v = samplegen.Validator(
         DummyMethod(input=message_factory("mollusc.squid.mantle_length")))
     v.validate_and_transform_request(
-        utils.CallingForm.Request,
+        types.CallingForm.Request,
         [
             {
                 "field": "squid.mantle_length",
@@ -96,7 +97,7 @@ def test_define_input_param_redefinition():
     v = samplegen.Validator(DummyMethod(
         input=message_factory("mollusc.squid.mantle_length")))
     v.validate_and_transform_request(
-        utils.CallingForm.Request,
+        types.CallingForm.Request,
         [
             {
                 "field": "squid.mantle_length",
@@ -105,7 +106,7 @@ def test_define_input_param_redefinition():
             }
         ],
     )
-    with pytest.raises(samplegen.RedefinedVariable):
+    with pytest.raises(types.RedefinedVariable):
         v.validate_response(
             [{"define": "mantle_length=mantle_length"}])
 
@@ -124,21 +125,21 @@ def test_print_fmt_str():
 def test_print_fmt_mismatch():
     print_statement = {"print": ["This is a squid named %s"]}
     v = samplegen.Validator(DummyMethod(output=message_factory("$resp.name")))
-    with pytest.raises(samplegen.MismatchedFormatSpecifier):
+    with pytest.raises(types.MismatchedFormatSpecifier):
         v.validate_response([print_statement])
 
 
 def test_print_fmt_mismatch2():
     print_statement = {"print": ["This is a squid", "$resp.name"]}
     v = samplegen.Validator(DummyMethod(output=message_factory("$resp.name")))
-    with pytest.raises(samplegen.MismatchedFormatSpecifier):
+    with pytest.raises(types.MismatchedFormatSpecifier):
         v.validate_response([print_statement])
 
 
 def test_print_undefined_var():
     print_statement = {"print": ["This mollusc is a %s", "mollusc.type"]}
     v = samplegen.Validator(DummyMethod(output=message_factory("$resp.type")))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response([print_statement])
 
 
@@ -156,21 +157,21 @@ def test_comment_fmt_str():
 def test_comment_fmt_undefined_var():
     comment = {"comment": ["This is a mollusc of class %s", "cephalopod"]}
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response([comment])
 
 
 def test_comment_fmt_mismatch():
     comment = {"comment": ["This is a mollusc of class %s"]}
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.MismatchedFormatSpecifier):
+    with pytest.raises(types.MismatchedFormatSpecifier):
         v.validate_response([comment])
 
 
 def test_comment_fmt_mismatch2():
     comment = {"comment": ["This is a mollusc of class ", "$resp.class"]}
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.MismatchedFormatSpecifier):
+    with pytest.raises(types.MismatchedFormatSpecifier):
         v.validate_response([comment])
 
 
@@ -201,7 +202,7 @@ def test_loop_collection_redefinition():
     ]
     v = samplegen.Validator(
         DummyMethod(output=message_factory("$resp.molluscs", repeated_iter=[True])))
-    with pytest.raises(samplegen.RedefinedVariable):
+    with pytest.raises(types.RedefinedVariable):
         v.validate_response(statements)
 
 
@@ -214,7 +215,7 @@ def test_loop_undefined_collection():
         }
     }
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response([loop])
 
 
@@ -228,7 +229,7 @@ def test_loop_collection_extra_kword():
         }
     }
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.BadLoop):
+    with pytest.raises(types.BadLoop):
         v.validate_response([loop])
 
 
@@ -240,7 +241,7 @@ def test_loop_collection_missing_kword():
         }
     }
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.BadLoop):
+    with pytest.raises(types.BadLoop):
         v.validate_response([loop])
 
 
@@ -254,7 +255,7 @@ def test_loop_collection_reserved_loop_var():
     }
     v = samplegen.Validator(DummyMethod(
         output=message_factory("$resp.molluscs", repeated_iter=[True])))
-    with pytest.raises(samplegen.ReservedVariableName):
+    with pytest.raises(types.ReservedVariableName):
         v.validate_response([loop])
 
 
@@ -305,7 +306,7 @@ def test_collection_loop_lexical_scope_variable():
     ]
     v = samplegen.Validator(DummyMethod(
         output=message_factory("$resp.molluscs", repeated_iter=[True])))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response(statements)
 
 
@@ -322,7 +323,7 @@ def test_collection_loop_lexical_scope_inline():
     ]
     v = samplegen.Validator(DummyMethod(
         output=message_factory("$resp.molluscs", repeated_iter=[True])))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response(statements)
 
 
@@ -363,7 +364,7 @@ def test_map_loop_lexical_scope_key():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response(statements)
 
 
@@ -404,7 +405,7 @@ def test_map_loop_lexical_scope_value():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response(statements)
 
 
@@ -444,7 +445,7 @@ def test_map_loop_lexical_scope_inline():
         type="RESPONSE_TYPE"
     )
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response(statements)
 
 
@@ -481,7 +482,7 @@ def test_loop_map_reserved_key():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.ReservedVariableName):
+    with pytest.raises(types.ReservedVariableName):
         v.validate_response([loop])
 
 
@@ -518,7 +519,7 @@ def test_loop_map_reserved_val():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.ReservedVariableName):
+    with pytest.raises(types.ReservedVariableName):
         v.validate_response([loop])
 
 
@@ -532,7 +533,7 @@ def test_loop_map_undefined():
         }
     }
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response([loop])
 
 
@@ -631,7 +632,7 @@ def test_loop_map_no_key_or_value():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.BadLoop):
+    with pytest.raises(types.BadLoop):
         v.validate_response([loop])
 
 
@@ -644,14 +645,14 @@ def test_loop_map_no_map():
         }
     }
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.BadLoop):
+    with pytest.raises(types.BadLoop):
         v.validate_response([loop])
 
 
 def test_loop_map_no_body():
     loop = {"loop": {"map": "$resp.molluscs", "key": "name", "value": "mollusc"}}
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.BadLoop):
+    with pytest.raises(types.BadLoop):
         v.validate_response([loop])
 
 
@@ -666,7 +667,7 @@ def test_loop_map_extra_kword():
         }
     }
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.BadLoop):
+    with pytest.raises(types.BadLoop):
         v.validate_response([loop])
 
 
@@ -705,7 +706,7 @@ def test_loop_map_redefined_key():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.RedefinedVariable):
+    with pytest.raises(types.RedefinedVariable):
         v.validate_response(statements)
 
 
@@ -744,7 +745,7 @@ def test_loop_map_redefined_value():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.RedefinedVariable):
+    with pytest.raises(types.RedefinedVariable):
         v.validate_response(statements)
 
 
@@ -771,7 +772,7 @@ def test_validate_write_file_fname_fmt():
     statements = [{"write_file":
                    {"filename": ["specimen-%s"], "contents": "$resp.photo"}}]
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.MismatchedFormatSpecifier):
+    with pytest.raises(types.MismatchedFormatSpecifier):
         v.validate_response(statements)
 
 
@@ -783,7 +784,7 @@ def test_validate_write_file_fname_bad_var():
         }
     }]
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response(statements)
 
 
@@ -796,7 +797,7 @@ def test_validate_write_file_missing_fname():
         }
     )
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.InvalidStatement):
+    with pytest.raises(types.InvalidStatement):
         v.validate_response(statements)
 
 
@@ -811,7 +812,7 @@ def test_validate_write_file_missing_contents():
     )
 
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.InvalidStatement):
+    with pytest.raises(types.InvalidStatement):
         v.validate_response(statements)
 
 
@@ -829,21 +830,21 @@ def test_validate_write_file_bad_contents_var():
         }
     )
     v = samplegen.Validator(DummyMethod(output=OutputType))
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_response(statements)
 
 
 def test_invalid_statement():
     statements = [{"print": ["Name"], "comment": ["Value"]}]
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.InvalidStatement):
+    with pytest.raises(types.InvalidStatement):
         v.validate_response(statements)
 
 
 def test_invalid_statement2():
     statements = [{"squidify": ["Statement body"]}]
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.InvalidStatement):
+    with pytest.raises(types.InvalidStatement):
         v.validate_response(statements)
 
 
@@ -867,7 +868,7 @@ def test_validate_request_basic():
 
     v = samplegen.Validator(DummyMethod(input=input_type))
     actual = v.validate_and_transform_request(
-        utils.CallingForm.Request,
+        types.CallingForm.Request,
         [
             {"field": "squid.mantle_length", "value": "100 cm"},
             {"field": "squid.mantle_mass", "value": "10 kg"},
@@ -890,9 +891,9 @@ def test_validate_request_basic():
 def test_validate_request_no_field_parameter():
     # May need to remeove this test because it doesn't necessarily make sense any more.
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.InvalidRequestSetup):
+    with pytest.raises(types.InvalidRequestSetup):
         v.validate_and_transform_request(
-            utils.CallingForm.Request, [{"squid": "humboldt",
+            types.CallingForm.Request, [{"squid": "humboldt",
                                          "value": "teuthida"}]
         )
 
@@ -900,9 +901,9 @@ def test_validate_request_no_field_parameter():
 def test_validate_request_no_such_attribute():
     v = samplegen.Validator(DummyMethod(
         input=message_factory("mollusc.squid.mantle")))
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [{"field": "clam.shell", "value": "20"}]
         )
 
@@ -911,7 +912,7 @@ def test_validate_request_top_level_field():
     v = samplegen.Validator(DummyMethod(
         input=message_factory("mollusc.squid")))
     actual = v.validate_and_transform_request(
-        utils.CallingForm.Request,
+        types.CallingForm.Request,
         [{"field": "squid", "value": "humboldt"}]
     )
 
@@ -929,9 +930,9 @@ def test_validate_request_top_level_field():
 def test_validate_request_missing_keyword(kword="field"):
     v = samplegen.Validator(DummyMethod(
         input=message_factory("mollusc.squid")))
-    with pytest.raises(samplegen.InvalidRequestSetup):
+    with pytest.raises(types.InvalidRequestSetup):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [{kword: "squid"}]
         )
 
@@ -943,9 +944,9 @@ def test_validate_request_missing_value():
 def test_validate_request_spurious_kword():
     v = samplegen.Validator(
         DummyMethod(input=message_factory("mollusc.squid")))
-    with pytest.raises(samplegen.InvalidRequestSetup):
+    with pytest.raises(types.InvalidRequestSetup):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [{"field": "mollusc.squid", "value": "humboldt", "order": "teuthida"}]
         )
 
@@ -955,7 +956,7 @@ def test_validate_request_unknown_field_type():
         input=DummyMessage(fields={"squid": DummyField()})))
     with pytest.raises(TypeError):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [{"field": "squid", "value": "humboldt"}]
         )
 
@@ -963,9 +964,9 @@ def test_validate_request_unknown_field_type():
 def test_validate_request_duplicate_top_level_fields():
     v = samplegen.Validator(DummyMethod(
         input=message_factory("mollusc.squid")))
-    with pytest.raises(samplegen.InvalidRequestSetup):
+    with pytest.raises(types.InvalidRequestSetup):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [{"field": "squid", "value": "humboldt"},
              {"field": "squid", "value": "bobtail"}]
         )
@@ -994,7 +995,7 @@ def test_validate_request_multiple_arguments():
 
     v = samplegen.Validator(DummyMethod(input=input_type))
     actual = v.validate_and_transform_request(
-        utils.CallingForm.Request,
+        types.CallingForm.Request,
         [
             {
                 "field": "squid.mantle_length",
@@ -1051,9 +1052,9 @@ def test_validate_request_duplicate_input_param():
     )
 
     v = samplegen.Validator(DummyMethod(input=input_type))
-    with pytest.raises(samplegen.RedefinedVariable):
+    with pytest.raises(types.RedefinedVariable):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [
                 {
                     "field": "squid.mantle_mass",
@@ -1071,9 +1072,9 @@ def test_validate_request_duplicate_input_param():
 
 def test_validate_request_reserved_input_param():
     v = samplegen.Validator(DummyMethod())
-    with pytest.raises(samplegen.ReservedVariableName):
+    with pytest.raises(types.ReservedVariableName):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [
                 {
                     "field": "mollusc.class",
@@ -1085,7 +1086,7 @@ def test_validate_request_reserved_input_param():
 
 
 def test_single_request_client_streaming(
-        calling_form=utils.CallingForm.RequestStreamingClient):
+        calling_form=types.CallingForm.RequestStreamingClient):
     # Each API client method really only takes one parameter:
     # either a single protobuf message or an iterable of protobuf messages.
     # With unary request methods, python lets us describe attributes as positional
@@ -1120,9 +1121,9 @@ def test_single_request_client_streaming(
         type="MOLLUSC_TYPE"
     )
     v = samplegen.Validator(DummyMethod(input=input_type))
-    with pytest.raises(samplegen.InvalidRequestSetup):
+    with pytest.raises(types.InvalidRequestSetup):
         v.validate_and_transform_request(
-            utils.CallingForm.RequestStreamingClient,
+            types.CallingForm.RequestStreamingClient,
             [
                 {"field": "cephalopod.order", "value": "cephalopoda"},
                 {"field": "gastropod.order", "value": "pulmonata"},
@@ -1132,38 +1133,38 @@ def test_single_request_client_streaming(
 
 def test_single_request_bidi_streaming():
     test_single_request_client_streaming(
-        utils.CallingForm.RequestStreamingBidi)
+        types.CallingForm.RequestStreamingBidi)
 
 
 def test_validate_request_calling_form():
     assert (
-        utils.CallingForm.method_default(DummyMethod(lro=True))
-        == utils.CallingForm.LongRunningRequestPromise
+        types.CallingForm.method_default(DummyMethod(lro=True))
+        == types.CallingForm.LongRunningRequestPromise
     )
 
     assert (
-        utils.CallingForm.method_default(DummyMethod(paged_result_field=True))
-        == utils.CallingForm.RequestPagedAll
+        types.CallingForm.method_default(DummyMethod(paged_result_field=True))
+        == types.CallingForm.RequestPagedAll
     )
 
     assert (
-        utils.CallingForm.method_default(DummyMethod(client_streaming=True))
-        == utils.CallingForm.RequestStreamingClient
+        types.CallingForm.method_default(DummyMethod(client_streaming=True))
+        == types.CallingForm.RequestStreamingClient
     )
 
     assert (
-        utils.CallingForm.method_default(DummyMethod(server_streaming=True))
-        == utils.CallingForm.RequestStreamingServer
+        types.CallingForm.method_default(DummyMethod(server_streaming=True))
+        == types.CallingForm.RequestStreamingServer
     )
 
-    assert utils.CallingForm.method_default(
-        DummyMethod()) == utils.CallingForm.Request
+    assert types.CallingForm.method_default(
+        DummyMethod()) == types.CallingForm.Request
 
     assert (
-        utils.CallingForm.method_default(
+        types.CallingForm.method_default(
             DummyMethod(client_streaming=True, server_streaming=True)
         )
-        == utils.CallingForm.RequestStreamingBidi
+        == types.CallingForm.RequestStreamingBidi
     )
 
 
@@ -1218,7 +1219,7 @@ def test_validate_expression_undefined_base():
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
 
-    with pytest.raises(samplegen.UndefinedVariableReference):
+    with pytest.raises(types.UndefinedVariableReference):
         v.validate_expression("mollusc")
 
 
@@ -1227,7 +1228,7 @@ def test_validate_expression_no_such_attr():
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
 
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_expression("$resp.nautiloidea")
 
 
@@ -1240,7 +1241,7 @@ def test_validate_expression_non_indexed_non_terminal_repeated():
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
 
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_response(
             [{"define": "octopus=$resp.coleoidea.octopodiformes"}])
 
@@ -1279,7 +1280,7 @@ def test_validate_expression_collection_error():
     v = samplegen.Validator(method)
 
     # Because 'molluscs' isn't repeated
-    with pytest.raises(samplegen.BadLoop):
+    with pytest.raises(types.BadLoop):
         v.validate_response([statement])
 
 
@@ -1304,7 +1305,7 @@ def test_validate_expression_repeated_lookup_invalid():
     OutputType = message_factory(exp)
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_expression("$resp.molluscs[0].mantle")
 
 
@@ -1411,7 +1412,7 @@ def test_validate_expression_mapped_no_map_field():
     )
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_expression('$resp.cephalopods{"squid"}.mantle')
 
 
@@ -1431,7 +1432,7 @@ def test_validate_expression_mapped_no_value():
     )
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_expression('$resp.cephalopods{"squid"}.mantle')
 
 
@@ -1454,7 +1455,7 @@ def test_validate_expression_mapped_no_message():
     )
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_expression('$resp.cephalopods{"squid"}.mantle')
 
 
@@ -1463,7 +1464,7 @@ def test_validate_expresssion_lookup_unrepeated_base():
     OutputType = message_factory(exp)
     method = DummyMethod(output=OutputType)
     v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_response([{"define": "m=$resp[0]"}])
 
 
@@ -1473,7 +1474,7 @@ def test_validate_expression_malformed_base():
     OutputType = message_factory(exp)
     method = DummyMethod(OutputType)
     v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_expression(exp)
 
 
@@ -1483,7 +1484,7 @@ def test_validate_expression_malformed_attr():
     OutputType = message_factory(exp)
     method = DummyMethod(OutputType)
     v = samplegen.Validator(method)
-    with pytest.raises(samplegen.BadAttributeLookup):
+    with pytest.raises(types.BadAttributeLookup):
         v.validate_expression(exp)
 
 
@@ -1493,7 +1494,7 @@ def test_validate_request_enum():
 
     v = samplegen.Validator(DummyMethod(input=request_type))
     actual = v.validate_and_transform_request(
-        utils.CallingForm.Request,
+        types.CallingForm.Request,
         [{"field": "cephalopod.subclass", "value": "COLEOIDEA"}]
     )
     expected = [samplegen.TransformedRequest(
@@ -1510,7 +1511,7 @@ def test_validate_request_enum_top_level():
 
     v = samplegen.Validator(DummyMethod(input=request_type))
     actual = v.validate_and_transform_request(
-        utils.CallingForm.Request,
+        types.CallingForm.Request,
         [{"field": "subclass", "value": "COLEOIDEA"}]
     )
     expected = [samplegen.TransformedRequest(
@@ -1525,9 +1526,9 @@ def test_validate_request_enum_invalid_value():
     request_type = message_factory("mollusc.cephalopod.subclass", enum=enum)
     v = samplegen.Validator(DummyMethod(output=message_factory("mollusc_result"),
                                         input=request_type))
-    with pytest.raises(samplegen.InvalidEnumVariant):
+    with pytest.raises(types.InvalidEnumVariant):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             # Heterodonta are bivalves, not cephalopods
             [{"field": "cephalopod.subclass", "value": "HETERODONTA"}]
         )
@@ -1538,8 +1539,8 @@ def test_validate_request_enum_not_last_attr():
     request_type = message_factory("mollusc.subclass", enum=enum)
     v = samplegen.Validator(DummyMethod(output=message_factory("mollusc_result"),
                                         input=request_type))
-    with pytest.raises(samplegen.InvalidEnumVariant):
+    with pytest.raises(types.InvalidEnumVariant):
         v.validate_and_transform_request(
-            utils.CallingForm.Request,
+            types.CallingForm.Request,
             [{"field": "subclass.order", "value": "COLEOIDEA"}]
         )

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -18,7 +18,7 @@ import os.path as path
 import gapic.samplegen.samplegen as samplegen
 import gapic.utils as utils
 
-from gapic.samplegen.utils import CallingForm
+from gapic.samplegen_utils.types import CallingForm
 from textwrap import dedent
 
 


### PR DESCRIPTION
The sample outdir and paths to sample config dirs and files are read
in as options; all the samples are generated, as is the manifest.

Samplegen utility code is moved into a separate module to bypass
circular imports.

Includes various other minor cleanups and tweaks.

WORK TO DO:
* Provide configuration knobs for the environment and environment name
  in the generated sample manifest.
* Provide configuration knobs for the name of the sample template.