### PR TITLE
Tweak docstring references to auth and api_core

### DIFF
--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -64,7 +64,7 @@ class {{ service.name }}(metaclass={{ service.name }}Meta):
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
                 {{- ' ' }}The hostname to connect to.
-            credentials (Optional[google.auth.credentials.Credential]): The
+            credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
                 are specified, the client will attempt to ascertain the
@@ -108,7 +108,7 @@ class {{ service.name }}(metaclass={{ service.name }}Meta):
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
             {% endfor -%}
-            retry (~.retries.Retry): Designation of what errors, if any,
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be


### PR DESCRIPTION
* https://googleapis.dev/python/google-api-core/1.12.0/retry.html#google.api_core.retry.Retry
* https://google-auth.readthedocs.io/en/stable/reference/google.auth.credentials.html#google.auth.credentials.Credentials

