### PR TITLE
Remove trailing comma after keyword only param

### DIFF
--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -57,7 +57,7 @@ class {{ service.name }}(metaclass={{ service.name }}Meta):
     def __init__(self, *,
             host: str{% if service.host %} = '{{ service.host }}'{% endif %},
             credentials: credentials.Credentials = None,
-            transport: Union[str, {{ service.name }}Transport] = None,
+            transport: Union[str, {{ service.name }}Transport] = None
             ) -> None:
         """Instantiate the {{ (service.name|snake_case).replace('_', ' ') }}.
 


### PR DESCRIPTION
Fix for #168 : trailing comma after keyword-only args is a syntax error in python3.5