### PR TITLE
[fix] Convert return docstring to RST.

### DIFF
--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -117,7 +117,7 @@ class {{ service.name }}(metaclass={{ service.name }}Meta):
 
         Returns:
             {{ method.client_output.ident.sphinx }}:
-                {{ method.client_output.meta.doc|wrap(width=72, indent=16) }}
+                {{ method.client_output.meta.doc|rst(width=72, indent=16) }}
         {%- endif %}
         """
         {% if method.flattened_fields -%}


### PR DESCRIPTION
It turns out the return type docstring was being wrapped but
not RST converted, which could cause some weird issues when
rendering.

Fixes #170.