### PR TITLE
Minor cleanups for generated sample manifest

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -729,6 +729,10 @@ def generate_manifest(
         Tuple[str, yaml.Doc]: The filename of the manifest and the manifest data as a dictionary.
 
     """
+    def region_tag_helper(sample) -> yaml.Element:
+        return (yaml.KeyVal("region_tag", sample["region_tag"])
+                if "region_tag" in sample
+                else yaml.Null)
 
     doc = yaml.Doc(
         [
@@ -755,9 +759,7 @@ def generate_manifest(
                         yaml.KeyVal("path",
                                     "'{base_path}/%s'" % os.path.relpath(fpath,
                                                                          base_path)),
-                        (yaml.KeyVal("region_tag", sample["region_tag"])
-                         if "region_tag" in sample
-                         else yaml.Null),
+                        region_tag_helper(sample),
                     ]
                     for fpath, sample in fpaths_and_samples
                 ],

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -748,6 +748,9 @@ def generate_manifest(
             ),
             yaml.Collection(
                 name="samples",
+                # Mypy doesn't correctly intuit the type of the
+                # "region_tag" conditional expression.
+                # type: ignore
                 elements=[
                     [
                         yaml.Alias("python"),
@@ -755,9 +758,6 @@ def generate_manifest(
                         yaml.KeyVal("path",
                                     "'{base_path}/%s'" % os.path.relpath(fpath,
                                                                          base_path)),
-                        # Mypy doesn't correctly intuit the
-                        # type of the conditional assignment.
-                        # type: ignore
                         (yaml.KeyVal("region_tag", sample["region_tag"])
                          if "region_tag" in sample else
                          yaml.Null),

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -749,10 +749,9 @@ def generate_manifest(
             yaml.Collection(
                 name="samples",
                 elements=[
-                    [
+                    [   # type: ignore
                         # Mypy doesn't correctly intuit the type of the
                         # "region_tag" conditional expression.
-                        # type: ignore
                         yaml.Alias("python"),
                         yaml.KeyVal("sample", sample["id"]),
                         yaml.KeyVal("path",

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -748,18 +748,19 @@ def generate_manifest(
             ),
             yaml.Collection(
                 name="samples",
-                # Mypy doesn't correctly intuit the type of the
-                # "region_tag" conditional expression.
                 elements=[
                     [
+                        # Mypy doesn't correctly intuit the type of the
+                        # "region_tag" conditional expression.
+                        # type: ignore
                         yaml.Alias("python"),
                         yaml.KeyVal("sample", sample["id"]),
                         yaml.KeyVal("path",
                                     "'{base_path}/%s'" % os.path.relpath(fpath,
                                                                          base_path)),
-                        (yaml.KeyVal("region_tag", sample["region_tag"])  # type: ignore
-                         if "region_tag" in sample else                   # type: ignore
-                         yaml.Null),                                      # type: ignore
+                        (yaml.KeyVal("region_tag", sample["region_tag"])
+                         if "region_tag" in sample else
+                         yaml.Null),
 
                     ]
                     for fpath, sample in fpaths_and_samples

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -750,7 +750,6 @@ def generate_manifest(
                 name="samples",
                 # Mypy doesn't correctly intuit the type of the
                 # "region_tag" conditional expression.
-                # type: ignore
                 elements=[
                     [
                         yaml.Alias("python"),
@@ -758,9 +757,10 @@ def generate_manifest(
                         yaml.KeyVal("path",
                                     "'{base_path}/%s'" % os.path.relpath(fpath,
                                                                          base_path)),
-                        (yaml.KeyVal("region_tag", sample["region_tag"])
-                         if "region_tag" in sample else
-                         yaml.Null),
+                        (yaml.KeyVal("region_tag", sample["region_tag"])  # type: ignore
+                         if "region_tag" in sample else                   # type: ignore
+                         yaml.Null),                                      # type: ignore
+
                     ]
                     for fpath, sample in fpaths_and_samples
                 ],

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -729,10 +729,6 @@ def generate_manifest(
         Tuple[str, yaml.Doc]: The filename of the manifest and the manifest data as a dictionary.
 
     """
-    def region_tag_helper(sample) -> yaml.Element:
-        return (yaml.KeyVal("region_tag", sample["region_tag"])
-                if "region_tag" in sample
-                else yaml.Null)
 
     doc = yaml.Doc(
         [
@@ -759,7 +755,12 @@ def generate_manifest(
                         yaml.KeyVal("path",
                                     "'{base_path}/%s'" % os.path.relpath(fpath,
                                                                          base_path)),
-                        region_tag_helper(sample),
+                        # Mypy doesn't correctly intuit the
+                        # type of the conditional assignment.
+                        # type: ignore
+                        (yaml.KeyVal("region_tag", sample["region_tag"])
+                         if "region_tag" in sample else
+                         yaml.Null),
                     ]
                     for fpath, sample in fpaths_and_samples
                 ],

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -729,6 +729,7 @@ def generate_manifest(
         Tuple[str, yaml.Doc]: The filename of the manifest and the manifest data as a dictionary.
 
     """
+
     doc = yaml.Doc(
         [
             yaml.KeyVal("type", "manifest/samples"),
@@ -754,8 +755,9 @@ def generate_manifest(
                         yaml.KeyVal("path",
                                     "'{base_path}/%s'" % os.path.relpath(fpath,
                                                                          base_path)),
-                        yaml.KeyVal("region_tag",
-                                    sample.get("region_tag", "")),
+                        (yaml.KeyVal("region_tag", sample["region_tag"])
+                         if "region_tag" in sample
+                         else yaml.Null),
                     ]
                     for fpath, sample in fpaths_and_samples
                 ],

--- a/gapic/samplegen_utils/yaml.py
+++ b/gapic/samplegen_utils/yaml.py
@@ -36,6 +36,12 @@ class Element(ABC):
 
 
 @dataclasses.dataclass(frozen=True)
+class Null(Element):
+    def render(self, spaces: int = 0) -> str:
+        return ""
+
+
+@dataclasses.dataclass(frozen=True)
 class KeyVal(Element):
     """A single key/value entry."""
     key: str
@@ -65,9 +71,11 @@ class Collection(Element):
         return f"{self.name}:\n" + "\n".join(
             indent(
                 "-"
-                + "\n".join(e.render(spaces=spaces + self.INDENT_SPACES) for e in l)[
-                    1:
-                ],
+                + "\n".join(
+                    r
+                    for r in (e.render(spaces + self.INDENT_SPACES) for e in l)
+                    if r
+                )[1:],
                 " " * (spaces),
             )
             for l in self.elements
@@ -106,4 +114,4 @@ class Doc(Element):
     elements: List[Element]
 
     def render(self):
-        return "---\n{}".format("\n".join(e.render() for e in self.elements))
+        return "---\n{}\n".format("\n".join(e.render() for e in self.elements))

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -356,7 +356,7 @@ def test_samplegen_config_to_output_files(mock_gmtime, mock_generate_sample, fs)
                   sample: clam_sample
                   path: '{base_path}/clam_sample.py'
                   region_tag: clam_sample
-                """.rstrip()),
+                """),
             )
         ]
     )
@@ -446,7 +446,7 @@ def test_samplegen_id_disambiguation(mock_gmtime, mock_generate_sample, fs):
                 - <<: *python
                   sample: 157884ee
                   path: '{base_path}/157884ee.py'
-                  region_tag: """)
+                """)
             ),
         ]
     )

--- a/tests/unit/samplegen/test_manifest.py
+++ b/tests/unit/samplegen/test_manifest.py
@@ -63,8 +63,7 @@ def test_generate_manifest():
                                           "sample", "squid_sample"),
                                       gapic_yaml.KeyVal(
                                           "path", "'{base_path}/squid_fpath.py'"),
-                                      gapic_yaml.KeyVal(
-                                          "region_tag", ""),
+                                      gapic_yaml.Null,
                                   ],
                                   [
                                       gapic_yaml.Alias("python"),
@@ -80,24 +79,25 @@ def test_generate_manifest():
 
     assert info == doc
 
-    expected_rendering = dedent("""
-                                ---
-                                type: manifest/samples
-                                schema_version: 3
-                                python: &python
-                                  environment: python
-                                  bin: python3
-                                  base_path: samples/
-                                  invocation: '{bin} {path} @args'
-                                samples:
-                                - <<: *python
-                                  sample: squid_sample
-                                  path: '{base_path}/squid_fpath.py'
-                                  region_tag: 
-                                - <<: *python
-                                  sample: clam_sample
-                                  path: '{base_path}/clam_fpath.py'
-                                  region_tag: giant_clam_sample""".lstrip("\n"))
+    expected_rendering = dedent(
+        """\
+        ---
+        type: manifest/samples
+        schema_version: 3
+        python: &python
+          environment: python
+          bin: python3
+          base_path: samples/
+          invocation: '{bin} {path} @args'
+        samples:
+        - <<: *python
+          sample: squid_sample
+          path: '{base_path}/squid_fpath.py'
+        - <<: *python
+          sample: clam_sample
+          path: '{base_path}/clam_fpath.py'
+          region_tag: giant_clam_sample
+        """)
 
     rendered_yaml = doc.render()
     assert rendered_yaml == expected_rendering
@@ -119,7 +119,6 @@ def test_generate_manifest():
                 "invocation": "{bin} {path} @args",
                 "sample": "squid_sample",
                 "path": "{base_path}/squid_fpath.py",
-                "region_tag": None,
             },
             {
                 "environment": "python",


### PR DESCRIPTION
Manifest does not render empty region tags
Sample manifest ends in a newline