### PR TITLE
Initial part of abstracting out python specifics from sample generation

### DIFF
--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -140,7 +140,6 @@ class Generator:
                 spec["id"] = sample_id
                 id_to_samples[sample_id].append(spec)
 
-        # Interpolate the special variables in the sample_out_dir template.
         out_dir = "samples"
         fpath_to_spec_and_rendered = {}
         for samples in id_to_samples.values():
@@ -169,10 +168,9 @@ class Generator:
 
         # Only generate a manifest if we generated samples.
         if output_files:
-            manifest_fname, manifest_doc = manifest.generate_manifest(
+            manifest_fname, manifest_doc = manifest.generate(
                 ((fname, spec)
                  for fname, (spec, _) in fpath_to_spec_and_rendered.items()),
-                out_dir,
                 api_schema
             )
 

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -19,9 +19,9 @@ import os
 from typing import (Any, DefaultDict, Dict, Mapping, List)
 from hashlib import sha256
 from collections import (OrderedDict, defaultdict)
-from gapic.samplegen_utils.utils import is_valid_sample_cfg
+from gapic.samplegen_utils.utils import (coerce_response_name, is_valid_sample_cfg)
 from gapic.samplegen_utils.types import InvalidConfig
-from gapic.samplegen import samplegen
+from gapic.samplegen import (manifest, samplegen)
 from gapic.generator import options
 from gapic.generator import formatter
 from gapic.schema import api
@@ -56,7 +56,7 @@ class Generator:
         self._env.filters['snake_case'] = utils.to_snake_case
         self._env.filters['sort_lines'] = utils.sort_lines
         self._env.filters['wrap'] = utils.wrap
-        self._env.filters['coerce_response_name'] = samplegen.coerce_response_name
+        self._env.filters['coerce_response_name'] = coerce_response_name
 
         self._sample_configs = opts.sample_configs
 
@@ -76,7 +76,7 @@ class Generator:
         output_files: Dict[str, CodeGeneratorResponse.File] = OrderedDict()
 
         sample_templates, client_templates = utils.partition(
-            lambda fname: os.path.basename(fname) == samplegen.TEMPLATE_NAME,
+            lambda fname: os.path.basename(fname) == samplegen.DEFAULT_TEMPLATE_NAME,
             self._env.loader.list_templates())
 
         # Iterate over each template and add the appropriate output files
@@ -167,7 +167,7 @@ class Generator:
 
         # Only generate a manifest if we generated samples.
         if output_files:
-            manifest_fname, manifest_doc = samplegen.generate_manifest(
+            manifest_fname, manifest_doc = manifest.generate_manifest(
                 ((fname, spec)
                  for fname, (spec, _) in fpath_to_spec_and_rendered.items()),
                 out_dir,

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -19,7 +19,8 @@ import os
 from typing import (Any, DefaultDict, Dict, Mapping, List)
 from hashlib import sha256
 from collections import (OrderedDict, defaultdict)
-from gapic.samplegen_utils.utils import (coerce_response_name, is_valid_sample_cfg)
+from gapic.samplegen_utils.utils import (
+    coerce_response_name, is_valid_sample_cfg)
 from gapic.samplegen_utils.types import InvalidConfig
 from gapic.samplegen import (manifest, samplegen)
 from gapic.generator import options
@@ -76,7 +77,8 @@ class Generator:
         output_files: Dict[str, CodeGeneratorResponse.File] = OrderedDict()
 
         sample_templates, client_templates = utils.partition(
-            lambda fname: os.path.basename(fname) == samplegen.DEFAULT_TEMPLATE_NAME,
+            lambda fname: os.path.basename(
+                fname) == samplegen.DEFAULT_TEMPLATE_NAME,
             self._env.loader.list_templates())
 
         # Iterate over each template and add the appropriate output files

--- a/gapic/samplegen/__init__.py
+++ b/gapic/samplegen/__init__.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 from gapic.samplegen import samplegen
+from gapic.samplegen import manifest
 
 __all__ = (
+    'manifest',
     'samplegen',
 )

--- a/gapic/samplegen/manifest.py
+++ b/gapic/samplegen/manifest.py
@@ -84,7 +84,8 @@ def generate_manifest(
                         yaml.KeyVal("sample", sample["id"]),
                         yaml.KeyVal(
                             "path",
-                            "'{base_path}/%s'" % os.path.relpath(fpath, base_path)
+                            "'{base_path}/%s'" % os.path.relpath(
+                                fpath, base_path)
                         ),
                         (yaml.KeyVal("region_tag", sample["region_tag"])
                          if "region_tag" in sample else

--- a/gapic/samplegen/manifest.py
+++ b/gapic/samplegen/manifest.py
@@ -1,0 +1,115 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import time
+from typing import Tuple
+
+from gapic.samplegen_utils import yaml
+
+
+BASE_PATH_KEY = "base_path"
+DEFAULT_SAMPLE_DIR = "samples"
+
+PYTHON3_ENVIRONMENT = yaml.Map(
+    name="python",
+    anchor_name="python",
+    elements=[
+        yaml.KeyVal("environment", "python"),
+        yaml.KeyVal("bin", "python3"),
+        yaml.KeyVal(BASE_PATH_KEY, DEFAULT_SAMPLE_DIR),
+        yaml.KeyVal("invocation", "'{bin} {path} @args'"),
+    ],
+)
+
+
+def generate_manifest(
+        fpaths_and_samples,
+        base_path: str,
+        api_schema,
+        *,
+        environment: yaml.Map = PYTHON3_ENVIRONMENT,
+        manifest_time: int = None
+) -> Tuple[str, yaml.Doc]:
+    """Generate a samplegen manifest for use by sampletest
+
+    Args:
+        fpaths_and_samples (Iterable[Tuple[str, Mapping[str, Any]]]):
+                         The file paths and samples to be listed in the manifest
+        base_path (str): The base directory where the samples are generated.
+        api_schema (~.api.API): An API schema object.
+        environment (yaml.Map): Optional custom sample execution environment.
+                                Set this if the samples are being generated for
+                                a custom language.
+        manifest_time (int): Optional. An override for the timestamp in the name of the manifest filename.
+                             Primarily used for testing.
+
+    Returns:
+        Tuple[str, yaml.Doc]: The filename of the manifest and the manifest data as a dictionary.
+
+    """
+    # Use iter([]) instead of a generator expression due to a bug in pytest.
+    # See https://github.com/pytest-dev/pytest-cov/issues/310 for details.
+    base_path = next(
+        iter([e.val for e in environment.elements if e.key == BASE_PATH_KEY]),
+        DEFAULT_SAMPLE_DIR
+    )
+    doc = yaml.Doc(
+        [
+            yaml.KeyVal("type", "manifest/samples"),
+            yaml.KeyVal("schema_version", "3"),
+            environment,
+            yaml.Collection(
+                name="samples",
+                elements=[
+                    [  # type: ignore
+                        # Mypy doesn't correctly intuit the type of the
+                        # "region_tag" conditional expression.
+                        yaml.Alias(environment.anchor_name),
+                        yaml.KeyVal("sample", sample["id"]),
+                        yaml.KeyVal(
+                            "path",
+                            "'{base_path}/%s'" % os.path.relpath(fpath, base_path)
+                        ),
+                        (yaml.KeyVal("region_tag", sample["region_tag"])
+                         if "region_tag" in sample else
+                         yaml.Null),
+                    ]
+                    for fpath, sample in fpaths_and_samples
+                ],
+            ),
+        ]
+    )
+
+    dt = time.gmtime(manifest_time)
+    manifest_fname_template = (
+        "{api}.{version}.{language}."
+        "{year:04d}{month:02d}{day:02d}."
+        "{hour:02d}{minute:02d}{second:02d}."
+        "manifest.yaml"
+    )
+
+    manifest_fname = manifest_fname_template.format(
+        api=api_schema.naming.name,
+        version=api_schema.naming.version,
+        language=environment.name,
+        year=dt.tm_year,
+        month=dt.tm_mon,
+        day=dt.tm_mday,
+        hour=dt.tm_hour,
+        minute=dt.tm_min,
+        second=dt.tm_sec,
+    )
+
+    return manifest_fname, doc

--- a/gapic/samplegen/manifest.py
+++ b/gapic/samplegen/manifest.py
@@ -62,7 +62,11 @@ def generate_manifest(
     # Use iter([]) instead of a generator expression due to a bug in pytest.
     # See https://github.com/pytest-dev/pytest-cov/issues/310 for details.
     base_path = next(
-        iter([e.val for e in environment.elements if e.key == BASE_PATH_KEY]),
+        iter(
+            [e.val  # type: ignore
+             for e in environment.elements
+             if e.key == BASE_PATH_KEY]  # type: ignore
+        ),
         DEFAULT_SAMPLE_DIR
     )
     doc = yaml.Doc(
@@ -76,7 +80,7 @@ def generate_manifest(
                     [  # type: ignore
                         # Mypy doesn't correctly intuit the type of the
                         # "region_tag" conditional expression.
-                        yaml.Alias(environment.anchor_name),
+                        yaml.Alias(environment.anchor_name or ""),
                         yaml.KeyVal("sample", sample["id"]),
                         yaml.KeyVal(
                             "path",

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -20,7 +20,7 @@ import os
 import re
 import time
 
-from gapic.samplegen_utils import (types, yaml)
+from gapic.samplegen_utils import types
 from gapic.schema import (api, wrappers)
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
@@ -55,9 +55,7 @@ RESERVED_WORDS = frozenset(
     )
 )
 
-# TODO: configure the base template name so that
-#       e.g. other languages can use the same machinery.
-TEMPLATE_NAME = "sample.py.j2"
+DEFAULT_TEMPLATE_NAME = "sample.py.j2"
 
 
 @dataclasses.dataclass(frozen=True)
@@ -106,20 +104,6 @@ class TransformedRequest:
     body: Optional[List[AttributeRequestSetup]]
 
 
-def coerce_response_name(s: str) -> str:
-    # In the sample config, the "$resp" keyword is used to refer to the
-    # item of interest as received by the corresponding calling form.
-    # For a 'regular', i.e. unary, synchronous, non-long-running method,
-    # it's the return value; for a server-streaming method, it's the iteration
-    # variable in the for loop that iterates over the return value, and for
-    # a long running promise, the user calls result on the method return value to
-    # resolve the future.
-    #
-    # The sample schema uses '$resp' as the special variable,
-    # but in the samples the 'response' variable is used instead.
-    return s.replace("$resp", "response")
-
-
 class Validator:
     """Class that validates a sample.
 
@@ -159,6 +143,13 @@ class Validator:
                 "$resp": MockField(response_type, False)
             }
         )
+
+    @staticmethod
+    def preprocess_sample(api_schema, sample):
+        sample["package_name"] = api_schema.naming.warehouse_package_name
+        # If the sample author didn't define a response handling section,
+        # just print the response returned by the method call.
+        sample.setdefault("response", [{"print": ["%s", "$resp"]}])
 
     def var_field(self, var_name: str) -> Optional[wrappers.Field]:
         return self.var_defs_.get(var_name)
@@ -661,7 +652,8 @@ class Validator:
 
 def generate_sample(sample,
                     env: jinja2.environment.Environment,
-                    api_schema: api.API) -> str:
+                    api_schema: api.API,
+                    template_name: str = DEFAULT_TEMPLATE_NAME) -> str:
     """Generate a standalone, runnable sample.
 
     Rendering and writing the rendered output is left for the caller.
@@ -671,11 +663,13 @@ def generate_sample(sample,
         env (jinja2.environment.Environment): The jinja environment used to generate
                                               the filled template for the sample.
         api_schema (api.API): The schema that defines the API to which the sample belongs.
+        template_name (str): An optional override for the name of the template
+                             used to generate the sample.
 
     Returns:
         str: The rendered sample.
     """
-    sample_template = env.get_template(TEMPLATE_NAME)
+    sample_template = env.get_template(template_name)
 
     service_name = sample["service"]
     service = api_schema.services.get(service_name)
@@ -693,11 +687,12 @@ def generate_sample(sample,
     calling_form = types.CallingForm.method_default(rpc)
 
     v = Validator(rpc)
+    # Tweak some small aspects of the sample to set sane defaults for optional
+    # fields, add fields that are required for the template, and so forth.
+    v.preprocess_sample(api_schema, sample)
     sample["request"] = v.validate_and_transform_request(calling_form,
                                                          sample["request"])
     v.validate_response(sample["response"])
-
-    sample["package_name"] = api_schema.naming.warehouse_package_name
 
     return sample_template.render(
         file_header=FILE_HEADER,
@@ -706,86 +701,3 @@ def generate_sample(sample,
         calling_form=calling_form,
         calling_form_enum=types.CallingForm,
     )
-
-
-def generate_manifest(
-        fpaths_and_samples,
-        base_path: str,
-        api_schema,
-        *,
-        manifest_time: int = None
-) -> Tuple[str, yaml.Doc]:
-    """Generate a samplegen manifest for use by sampletest
-
-    Args:
-        fpaths_and_samples (Iterable[Tuple[str, Mapping[str, Any]]]):
-                         The file paths and samples to be listed in the manifest
-        base_path (str): The base directory where the samples are generated.
-        api_schema (~.api.API): An API schema object.
-        manifest_time (int): Optional. An override for the timestamp in the name of the manifest filename.
-                             Primarily used for testing.
-
-    Returns:
-        Tuple[str, yaml.Doc]: The filename of the manifest and the manifest data as a dictionary.
-
-    """
-
-    doc = yaml.Doc(
-        [
-            yaml.KeyVal("type", "manifest/samples"),
-            yaml.KeyVal("schema_version", "3"),
-            # TODO: make the environment configurable to allow other languages
-            #       to use the same basic machinery.
-            yaml.Map(
-                name="python",
-                anchor_name="python",
-                elements=[
-                    yaml.KeyVal("environment", "python"),
-                    yaml.KeyVal("bin", "python3"),
-                    yaml.KeyVal("base_path", base_path),
-                    yaml.KeyVal("invocation", "'{bin} {path} @args'"),
-                ],
-            ),
-            yaml.Collection(
-                name="samples",
-                elements=[
-                    [   # type: ignore
-                        # Mypy doesn't correctly intuit the type of the
-                        # "region_tag" conditional expression.
-                        yaml.Alias("python"),
-                        yaml.KeyVal("sample", sample["id"]),
-                        yaml.KeyVal("path",
-                                    "'{base_path}/%s'" % os.path.relpath(fpath,
-                                                                         base_path)),
-                        (yaml.KeyVal("region_tag", sample["region_tag"])
-                         if "region_tag" in sample else
-                         yaml.Null),
-
-                    ]
-                    for fpath, sample in fpaths_and_samples
-                ],
-            ),
-        ]
-    )
-
-    dt = time.gmtime(manifest_time)
-    # TODO: allow other language configuration
-    manifest_fname_template = (
-        "{api}.{version}.python."
-        "{year:04d}{month:02d}{day:02d}."
-        "{hour:02d}{minute:02d}{second:02d}."
-        "manifest.yaml"
-    )
-
-    manifest_fname = manifest_fname_template.format(
-        api=api_schema.naming.name,
-        version=api_schema.naming.version,
-        year=dt.tm_year,
-        month=dt.tm_mon,
-        day=dt.tm_mday,
-        hour=dt.tm_hour,
-        minute=dt.tm_min,
-        second=dt.tm_sec,
-    )
-
-    return manifest_fname, doc

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -145,10 +145,14 @@ class Validator:
         )
 
     @staticmethod
-    def preprocess_sample(api_schema, sample):
+    def preprocess_sample(sample, api_schema):
+        """Modify a sample to set default or missing fields.
+
+        Args:
+           sample (Any): A definition for a single sample generated from parsed yaml.
+           api_schema (api.API): The schema that defines the API to which the sample belongs.
+        """
         sample["package_name"] = api_schema.naming.warehouse_package_name
-        # If the sample author didn't define a response handling section,
-        # just print the response returned by the method call.
         sample.setdefault("response", [{"print": ["%s", "$resp"]}])
 
     def var_field(self, var_name: str) -> Optional[wrappers.Field]:
@@ -689,7 +693,7 @@ def generate_sample(sample,
     v = Validator(rpc)
     # Tweak some small aspects of the sample to set sane defaults for optional
     # fields, add fields that are required for the template, and so forth.
-    v.preprocess_sample(api_schema, sample)
+    v.preprocess_sample(sample, api_schema)
     sample["request"] = v.validate_and_transform_request(calling_form,
                                                          sample["request"])
     v.validate_response(sample["response"])

--- a/gapic/samplegen_utils/types.py
+++ b/gapic/samplegen_utils/types.py
@@ -76,6 +76,10 @@ class InvalidEnumVariant(SampleError):
     pass
 
 
+class InvalidSampleFpath(SampleError):
+    pass
+
+
 class CallingForm(Enum):
     Request = auto()
     RequestPaged = auto()

--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -28,6 +28,20 @@ MIN_SCHEMA_VERSION = (1, 2, 0)
 VALID_CONFIG_TYPE = "com.google.api.codegen.SampleConfigProto"
 
 
+def coerce_response_name(s: str) -> str:
+    # In the sample config, the "$resp" keyword is used to refer to the
+    # item of interest as received by the corresponding calling form.
+    # For a 'regular', i.e. unary, synchronous, non-long-running method,
+    # it's the return value; for a server-streaming method, it's the iteration
+    # variable in the for loop that iterates over the return value, and for
+    # a long running promise, the user calls result on the method return value to
+    # resolve the future.
+    #
+    # The sample schema uses '$resp' as the special variable,
+    # but in the samples the 'response' variable is used instead.
+    return s.replace("$resp", "response")
+
+
 def is_valid_sample_cfg(
         doc,
         min_version: Tuple[int, int, int] = MIN_SCHEMA_VERSION,

--- a/gapic/samplegen_utils/yaml.py
+++ b/gapic/samplegen_utils/yaml.py
@@ -107,6 +107,18 @@ class Map(Element):
         whitespace = " " * spaces
         return f"{whitespace}{self.name}:{maybe_anchor}\n{element_str}"
 
+    def get(self, key, default=None):
+        # Use iter([]) instead of a generator expression due to a bug in pytest.
+        # See https://github.com/pytest-dev/pytest-cov/issues/310 for details.
+        return next(
+            iter(
+                [e.val  # type: ignore
+                 for e in self.elements
+                 if e.key == key]  # type: ignore
+            ),
+            default
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class Doc(Element):

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -38,7 +38,7 @@ env = jinja2.Environment(
     trim_blocks=True, lstrip_blocks=True
 )
 env.filters['snake_case'] = utils.to_snake_case
-env.filters['coerce_response_name'] = samplegen.coerce_response_name
+env.filters['coerce_response_name'] = gapic_utils.coerce_response_name
 
 
 def test_generate_sample_basic():

--- a/tests/unit/samplegen/test_manifest.py
+++ b/tests/unit/samplegen/test_manifest.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
 import yaml
 from textwrap import dedent
 
 import gapic.samplegen_utils.yaml as gapic_yaml
+import gapic.samplegen_utils.types as types
 import gapic.samplegen.manifest as manifest
 from common_types import DummyApiSchema, DummyNaming
 
@@ -27,9 +29,8 @@ def test_generate_manifest():
                                   "region_tag": "giant_clam_sample"},
     }
 
-    fname, info = manifest.generate_manifest(
+    fname, info = manifest.generate(
         fpath_to_dummy_sample.items(),
-        "samples/",
         DummyApiSchema(naming=DummyNaming(name="Mollusc", version="v1")),
         # Empirically derived number such that the
         # corresponding time_struct tests the zero
@@ -134,3 +135,11 @@ def test_generate_manifest():
 
     parsed_manifest = yaml.safe_load(rendered_yaml)
     assert parsed_manifest == expected_parsed_manifest
+
+
+def test_generate_manifest_relative_path_sanity():
+    with pytest.raises(types.InvalidSampleFpath):
+        manifest.generate(
+            {"molluscs/squid.py": {"id": "squid_sample"}}.items(),
+            DummyApiSchema(naming=DummyNaming(name="Mollusc", version="v1"))
+        )

--- a/tests/unit/samplegen/test_manifest.py
+++ b/tests/unit/samplegen/test_manifest.py
@@ -16,7 +16,7 @@ import yaml
 from textwrap import dedent
 
 import gapic.samplegen_utils.yaml as gapic_yaml
-import gapic.samplegen.samplegen as samplegen
+import gapic.samplegen.manifest as manifest
 from common_types import DummyApiSchema, DummyNaming
 
 
@@ -27,7 +27,7 @@ def test_generate_manifest():
                                   "region_tag": "giant_clam_sample"},
     }
 
-    fname, info = samplegen.generate_manifest(
+    fname, info = manifest.generate_manifest(
         fpath_to_dummy_sample.items(),
         "samples/",
         DummyApiSchema(naming=DummyNaming(name="Mollusc", version="v1")),
@@ -50,7 +50,7 @@ def test_generate_manifest():
                            gapic_yaml.KeyVal(
                                "bin", "python3"),
                            gapic_yaml.KeyVal(
-                               "base_path", "samples/"),
+                               "base_path", "samples"),
                            gapic_yaml.KeyVal(
                                "invocation", "'{bin} {path} @args'"),
                        ]),
@@ -87,7 +87,7 @@ def test_generate_manifest():
         python: &python
           environment: python
           bin: python3
-          base_path: samples/
+          base_path: samples
           invocation: '{bin} {path} @args'
         samples:
         - <<: *python
@@ -108,14 +108,14 @@ def test_generate_manifest():
         "python": {
             "environment": "python",
             "bin": "python3",
-            "base_path": "samples/",
+            "base_path": "samples",
             "invocation": "{bin} {path} @args",
         },
         "samples": [
             {
                 "environment": "python",
                 "bin": "python3",
-                "base_path": "samples/",
+                "base_path": "samples",
                 "invocation": "{bin} {path} @args",
                 "sample": "squid_sample",
                 "path": "{base_path}/squid_fpath.py",
@@ -123,7 +123,7 @@ def test_generate_manifest():
             {
                 "environment": "python",
                 "bin": "python3",
-                "base_path": "samples/",
+                "base_path": "samples",
                 "invocation": "{bin} {path} @args",
                 "sample": "clam_sample",
                 "path": "{base_path}/clam_fpath.py",

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -88,7 +88,7 @@ def test_preprocess_sample():
         all_protos={},
     )
 
-    samplegen.Validator.preprocess_sample(api_schema, sample)
+    samplegen.Validator.preprocess_sample(sample, api_schema)
 
     response = sample.get("response")
     assert response == [{"print": ["%s", "$resp"]}]

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -22,6 +22,7 @@ from google.protobuf import descriptor_pb2
 import gapic.samplegen.samplegen as samplegen
 import gapic.samplegen_utils.types as types
 import gapic.samplegen_utils.yaml as gapic_yaml
+from gapic.schema import (api, naming)
 import gapic.schema.wrappers as wrappers
 
 from common_types import (DummyField, DummyMessage,
@@ -75,6 +76,25 @@ def test_define_redefinition():
                                                                repeated_iter=[True])))
     with pytest.raises(types.RedefinedVariable):
         v.validate_response(statements)
+
+
+def test_preprocess_sample():
+    # Verify that the default response is added.
+    sample = {}
+    api_schema = api.API(
+        naming.Naming(
+            namespace=("mollusc", "cephalopod", "teuthida")
+        ),
+        all_protos={},
+    )
+
+    samplegen.Validator.preprocess_sample(api_schema, sample)
+
+    response = sample.get("response")
+    assert response == [{"print": ["%s", "$resp"]}]
+
+    package_name = sample.get("package_name")
+    assert package_name == "mollusc-cephalopod-teuthida-"
 
 
 def test_define_input_param():
@@ -1170,8 +1190,8 @@ def test_validate_request_calling_form():
 
 def test_coerce_response_name():
     # Don't really need a test, but it shuts up code coverage.
-    assert samplegen.coerce_response_name("$resp.squid") == "response.squid"
-    assert samplegen.coerce_response_name("mollusc.squid") == "mollusc.squid"
+    assert utils.coerce_response_name("$resp.squid") == "response.squid"
+    assert utils.coerce_response_name("mollusc.squid") == "mollusc.squid"
 
 
 def test_regular_response_type():

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -16,6 +16,7 @@
 import jinja2
 import os.path as path
 import gapic.samplegen.samplegen as samplegen
+import gapic.samplegen_utils.utils as sample_utils
 import gapic.utils as utils
 
 from gapic.samplegen_utils.types import CallingForm
@@ -45,7 +46,7 @@ def check_template(template_fragment, expected_output, **kwargs):
     )
 
     env.filters['snake_case'] = utils.to_snake_case
-    env.filters['coerce_response_name'] = samplegen.coerce_response_name
+    env.filters['coerce_response_name'] = sample_utils.coerce_response_name
 
     template = env.get_template("template_fragment")
     text = template.render(**kwargs)


### PR DESCRIPTION
Move manifest generation to its own file
Abstract out python-specific manfiest values
Provide a default response if sample spec doesn't contain one

Move some code into utility files
Minor cleanups