### PR TITLE
Correctly find the sample template when run via protoc

### DIFF
--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -97,14 +97,18 @@ class Generator:
                                                       api_schema=api_schema,
                                                       ))
 
-        output_files.update(self._generate_samples_and_manifest(api_schema))
+        output_files.update(self._generate_samples_and_manifest(
+            api_schema,
+            self._env.get_template(sample_templates[0]),
+        ))
 
         # Return the CodeGeneratorResponse output.
         return CodeGeneratorResponse(file=[i for i in output_files.values()])
 
     def _generate_samples_and_manifest(
-        self,
-        api_schema: api.API
+            self,
+            api_schema: api.API,
+            sample_template: jinja2.Template,
     ) -> Dict[str, CodeGeneratorResponse.File]:
         """Generate samples and samplegen manifest for the API.
 
@@ -152,7 +156,12 @@ class Generator:
                         str(spec).encode('utf8')).hexdigest()[:8]
                     spec["id"] += f"_{spec_hash}"
 
-                sample = samplegen.generate_sample(spec, self._env, api_schema)
+                sample = samplegen.generate_sample(
+                    spec,
+                    self._env,
+                    api_schema,
+                    sample_template,
+                )
 
                 fpath = spec["id"] + ".py"
                 fpath_to_spec_and_rendered[os.path.join(out_dir, fpath)] = (spec,

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -158,7 +158,6 @@ class Generator:
 
                 sample = samplegen.generate_sample(
                     spec,
-                    self._env,
                     api_schema,
                     sample_template,
                 )

--- a/gapic/samplegen/manifest.py
+++ b/gapic/samplegen/manifest.py
@@ -84,7 +84,7 @@ def generate(
             yaml.Collection(
                 name="samples",
                 elements=[
-                    [  # type: ignore
+                    [
                         # Mypy doesn't correctly intuit the type of the
                         # "region_tag" conditional expression.
                         yaml.Alias(environment.anchor_name or ""),
@@ -92,7 +92,7 @@ def generate(
                         yaml.KeyVal(
                             "path", transform_path(fpath)
                         ),
-                        (yaml.KeyVal("region_tag", sample["region_tag"])
+                        (yaml.KeyVal("region_tag", sample["region_tag"])  # type: ignore
                          if "region_tag" in sample else
                          yaml.Null),
                     ]

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -481,8 +481,10 @@ class Validator:
         num_prints = fmt_str.count("%s")
         if num_prints != len(body) - 1:
             raise types.MismatchedFormatSpecifier(
-                "Expected {} expresssions in format string but received {}".format(
-                    num_prints, len(body) - 1
+                "Expected {} expresssions in format string '{}' but found {}".format(
+                    num_prints,
+                    fmt_str,
+                    len(body) - 1
                 )
             )
 
@@ -502,7 +504,7 @@ class Validator:
         """
         # Note: really checking for safety would be equivalent to
         #       re-implementing the python interpreter.
-        m = re.match(r"^([a-zA-Z]\w*)=([^=]+)$", body)
+        m = re.match(r"^([a-zA-Z_]\w*) *= *([^=]+)$", body)
         if not m:
             raise types.BadAssignment(f"Bad assignment statement: {body}")
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -654,10 +654,12 @@ class Validator:
     }
 
 
-def generate_sample(sample,
-                    env: jinja2.environment.Environment,
-                    api_schema: api.API,
-                    template_name: str = DEFAULT_TEMPLATE_NAME) -> str:
+def generate_sample(
+        sample,
+        env: jinja2.environment.Environment,
+        api_schema: api.API,
+        sample_template: jinja2.Template
+) -> str:
     """Generate a standalone, runnable sample.
 
     Rendering and writing the rendered output is left for the caller.
@@ -667,14 +669,11 @@ def generate_sample(sample,
         env (jinja2.environment.Environment): The jinja environment used to generate
                                               the filled template for the sample.
         api_schema (api.API): The schema that defines the API to which the sample belongs.
-        template_name (str): An optional override for the name of the template
-                             used to generate the sample.
+        sample_template (jinja2.Template): The template representing a generic sample.
 
     Returns:
         str: The rendered sample.
     """
-    sample_template = env.get_template(template_name)
-
     service_name = sample["service"]
     service = api_schema.services.get(service_name)
     if not service:

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -21,7 +21,7 @@ import re
 import time
 
 from gapic.samplegen_utils import types
-from gapic.schema import (wrappers)
+from gapic.schema import wrappers
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
 from typing import (ChainMap, Dict, List, Mapping, Optional, Tuple)
@@ -658,7 +658,6 @@ class Validator:
 
 def generate_sample(
         sample,
-        env: jinja2.environment.Environment,
         api_schema,
         sample_template: jinja2.Template
 ) -> str:
@@ -668,8 +667,6 @@ def generate_sample(
 
     Args:
         sample (Any): A definition for a single sample generated from parsed yaml.
-        env (jinja2.environment.Environment): The jinja environment used to generate
-                                              the filled template for the sample.
         api_schema (api.API): The schema that defines the API to which the sample belongs.
         sample_template (jinja2.Template): The template representing a generic sample.
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -139,8 +139,8 @@ class Validator:
             # and whether it's an enum or a message or a primitive type.
             # The method call response isn't a field, so construct an artificial
             # field that wraps the response.
-            {  # type: ignore
-                "$resp": MockField(response_type, False)
+            {
+                "$resp": MockField(response_type, False)  # type: ignore
             }
         )
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -21,7 +21,7 @@ import re
 import time
 
 from gapic.samplegen_utils import types
-from gapic.schema import (api, wrappers)
+from gapic.schema import (wrappers)
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
 from typing import (ChainMap, Dict, List, Mapping, Optional, Tuple)
@@ -659,7 +659,7 @@ class Validator:
 def generate_sample(
         sample,
         env: jinja2.environment.Environment,
-        api_schema: api.API,
+        api_schema,
         sample_template: jinja2.Template
 ) -> str:
     """Generate a standalone, runnable sample.

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -702,7 +702,12 @@ def generate_sample(
     return sample_template.render(
         file_header=FILE_HEADER,
         sample=sample,
-        imports=[],
+        imports=[
+            "from google import auth",
+            "from google.auth import credentials",
+        ],
         calling_form=calling_form,
         calling_form_enum=types.CallingForm,
+        api=api_schema,
+        service=service,
     )

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -237,15 +237,15 @@ def main():
 
     parser = argparse.ArgumentParser()
 {% with arg_list = [] %}
-  {% for request in request_block if request.body -%}
-      {% for attr in request.body if attr.input_parameter %}
+{% for request in request_block if request.body -%}
+{% for attr in request.body if attr.input_parameter %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
                         default="{{ attr.value }}")
 {% do arg_list.append("args." + attr.input_parameter) -%}
 {% endfor -%}
 {% endfor %}
-{% for request in request_block if request.single and request.single.input_parameter -%}
+{% for request in request_block if request.single and request.single.input_parameter %}
     parser.add_argument("-- {{ request.single.input_parameter }}",
                         type=str,
                         default="{{ request.single.value }}")

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -191,18 +191,18 @@ client.{{ sample.rpc|snake_case }}({{ render_request_params(sample.request) }})
 {# it's just easier to set up client side streaming and other things from outside this macro. #}
 {% macro render_calling_form(method_invocation_text, calling_form, calling_form_enum, response_statements ) %}
 {% if calling_form == calling_form_enum.Request %}
-response = {{ method_invocation_text }}
+response = {{ method_invocation_text|trim }}
 {% for statement in response_statements %}
 {{ dispatch_statement(statement)|trim }}
 {% endfor %}
 {% elif calling_form == calling_form_enum.RequestPagedAll %}
-page_result = {{ method_invocation_text }}
+page_result = {{ method_invocation_text|trim }}
 for response in page_result:
   {% for statement in response_statements %}
     {{ dispatch_statement(statement)|trim }}
   {% endfor %}
 {% elif calling_form == calling_form_enum.RequestPaged %}
-page_result = {{ method_invocation_text}}
+page_result = {{ method_invocation_text|trim }}
 for page in page_result.pages():
     for response in page:
   {% for statement in response_statements %}
@@ -210,13 +210,13 @@ for page in page_result.pages():
   {% endfor %}
 {% elif calling_form in [calling_form_enum.RequestStreamingServer,
                         calling_form_enum.RequestStreamingBidi] %}
-stream = {{ method_invocation_text }}
+stream = {{ method_invocation_text|trim }}
 for response in stream:
   {% for statement in response_statements %}
     {{ dispatch_statement(statement)|trim }}
   {% endfor %}
 {% elif calling_form == calling_form_enum.LongRunningRequestPromise %}
-operation = {{ method_invocation_text }}
+operation = {{ method_invocation_text|trim }}
 
 print("Waiting for operation to complete...")
 

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -28,14 +28,16 @@
 {% for import_statement in imports %}
 {{ import_statement }}
 {% endfor %}
+from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.name }}
 
 {# also need calling form #}
 def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input_params(sample.request)|trim -}}):
     """{{ sample.description }}"""
 
-    client = {{ sample.service.split(".")[-3:-1]|
-                map("lower")|
-                join("_") }}.{{ sample.service.split(".")[-1] }}Client()
+    client = {{ service.name }}(
+        credentials=credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
 
     {{ frags.render_request_setup(sample.request)|indent }}
 {% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -20,7 +20,7 @@
 {#                   callingFormEnum #}
 {# Note: this sample template is WILDLY INACCURATE AND INCOMPLETE #}
 {# It does not correctly enums, unions, top level attributes, or various other things #}
-{% import "feature_fragments.j2" as frags %}
+{% import "examples/feature_fragments.j2" as frags %}
 {{ frags.sample_header(file_header, sample, calling_form) }}
 
 # [START {{ sample.id }}]

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -102,7 +102,6 @@ def test_generate_sample_basic():
 
     sample_str = samplegen.generate_sample(
         sample,
-        env,
         schema,
         env.get_template('examples/sample.py.j2')
     )
@@ -173,7 +172,6 @@ def test_generate_sample_service_not_found():
     with pytest.raises(types.UnknownService):
         samplegen.generate_sample(
             sample,
-            env,
             schema,
             env.get_template('examples/sample.py.j2'),
         )
@@ -187,7 +185,6 @@ def test_generate_sample_rpc_not_found():
     with pytest.raises(types.RpcMethodNotFound):
         list(samplegen.generate_sample(
             sample,
-            env,
             schema,
             env.get_template('examples/sample.py.j2')),
         )

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -103,7 +103,6 @@ def sample_classify(video):
 
 
     response = client.classify(classify_request)
-
     print("Mollusc is a {}".format(response.taxonomy))
 
 # [END %s]

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -49,7 +49,8 @@ def test_generate_sample_basic():
     # that catch errors in behavior that is emergent from combining smaller features
     # or in features that are sufficiently small and trivial that it doesn't make sense
     # to have standalone tests.
-    api_naming = naming.Naming(name="MolluscClient", namespace=("molluscs", "v1"))
+    api_naming = naming.Naming(
+        name="MolluscClient", namespace=("molluscs", "v1"))
     service = wrappers.Service(
         service_pb=namedtuple('service_pb', ['name'])('MolluscClient'),
         methods={

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -20,6 +20,7 @@ import gapic.utils as utils
 
 from gapic.samplegen import samplegen
 from gapic.samplegen_utils import (types, utils as gapic_utils)
+from gapic.schema import (naming, wrappers)
 
 from common_types import (DummyMethod, DummyService,
                           DummyApiSchema, DummyNaming, message_factory, enum_factory)
@@ -48,19 +49,22 @@ def test_generate_sample_basic():
     # that catch errors in behavior that is emergent from combining smaller features
     # or in features that are sufficiently small and trivial that it doesn't make sense
     # to have standalone tests.
-    schema = DummyApiSchema(
-        {
-            "animalia.mollusca.v1.Mollusc": DummyService(
-                {
-                    "Classify": DummyMethod(
-                        input=message_factory(
-                            "mollusc.classify_request.video"),
-                        output=message_factory("$resp.taxonomy")
-                    )
-                }
+    api_naming = naming.Naming(name="MolluscClient", namespace=("molluscs", "v1"))
+    service = wrappers.Service(
+        service_pb=namedtuple('service_pb', ['name'])('MolluscClient'),
+        methods={
+            "Classify": DummyMethod(
+                input=message_factory(
+                    "mollusc.classify_request.video"),
+                output=message_factory("$resp.taxonomy")
             )
-        },
-        DummyNaming("molluscs-v1-mollusc"))
+        }
+    )
+
+    schema = DummyApiSchema(
+        services={"animalia.mollusca.v1.Mollusc": service},
+        naming=api_naming,
+    )
 
     sample = {"service": "animalia.mollusca.v1.Mollusc",
               "rpc": "Classify",
@@ -86,15 +90,21 @@ def test_generate_sample_basic():
 # DO NOT EDIT! This is a generated sample ("request",  "%s")
 #
 # To install the latest published package dependency, execute the following:
-#   pip3 install molluscs-v1-mollusc
+#   pip3 install molluscs-v1-molluscclient
 
 
 # [START %s]
+from google import auth
+from google.auth import credentials
+from molluscs.v1.molluscclient.services.mollusc_client import MolluscClient
 
 def sample_classify(video):
     """Determine the full taxonomy of input mollusc"""
 
-    client = mollusca_v1.MolluscClient()
+    client = MolluscClient(
+        credentials=credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
 
     classify_request = {}
     # video = "path/to/mollusc/video.mkv"

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -32,7 +32,8 @@ env = jinja2.Environment(
     loader=jinja2.FileSystemLoader(
         searchpath=path.realpath(path.join(path.dirname(__file__),
                                            "..", "..", "..",
-                                           "gapic", "templates", "examples"))),
+                                           "gapic", "templates")
+                                 )),
     undefined=jinja2.StrictUndefined,
     extensions=["jinja2.ext.do"],
     trim_blocks=True, lstrip_blocks=True
@@ -75,7 +76,7 @@ def test_generate_sample_basic():
         sample,
         env,
         schema,
-        env.get_template('sample.py.j2')
+        env.get_template('examples/sample.py.j2')
     )
 
     sample_id = ("mollusc_classify_sync")
@@ -135,7 +136,7 @@ def test_generate_sample_service_not_found():
             sample,
             env,
             schema,
-            env.get_template('sample.py.j2'),
+            env.get_template('examples/sample.py.j2'),
         )
 
 
@@ -149,7 +150,7 @@ def test_generate_sample_rpc_not_found():
             sample,
             env,
             schema,
-            env.get_template('sample.py.j2')),
+            env.get_template('examples/sample.py.j2')),
         )
 
 

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -72,7 +72,11 @@ def test_generate_sample_basic():
               "response": [{"print": ["Mollusc is a %s", "$resp.taxonomy"]}]}
 
     sample_str = samplegen.generate_sample(
-        sample, env, schema)
+        sample,
+        env,
+        schema,
+        env.get_template('sample.py.j2')
+    )
 
     sample_id = ("mollusc_classify_sync")
     expected_str = '''# TODO: add a copyright
@@ -127,7 +131,12 @@ def test_generate_sample_service_not_found():
     sample = {"service": "Mollusc"}
 
     with pytest.raises(types.UnknownService):
-        samplegen.generate_sample(sample, env, schema)
+        samplegen.generate_sample(
+            sample,
+            env,
+            schema,
+            env.get_template('sample.py.j2'),
+        )
 
 
 def test_generate_sample_rpc_not_found():
@@ -136,7 +145,12 @@ def test_generate_sample_rpc_not_found():
     sample = {"service": "Mollusc", "rpc": "Classify"}
 
     with pytest.raises(types.RpcMethodNotFound):
-        list(samplegen.generate_sample(sample, env, schema))
+        list(samplegen.generate_sample(
+            sample,
+            env,
+            schema,
+            env.get_template('sample.py.j2')),
+        )
 
 
 def test_generate_sample_config_fpaths(fs):


### PR DESCRIPTION
Add a sample_template parameter to sample generation; this is just an internal parameter, not a CLI visible parameter, and it solves a problem I ran into when manually testing sample generation via the protoc plugin.

Adjust tests to pass the parameter

Quick and dirty test invoking the microgenerator via protoc plugin indicates that the template is now findable.