### PR TITLE
[fix] Generate Map fields properly.

### DIFF
--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -69,6 +69,11 @@ class Field:
         """Return True if the field is a primitive, False otherwise."""
         return isinstance(self.type, PrimitiveType)
 
+    @property
+    def map(self) -> bool:
+        """Return True if this field is a map, False otherwise."""
+        return self.repeated and self.message and self.message.map
+
     @utils.cached_property
     def mock_value(self) -> str:
         """Return a repr of a valid, usually truthy mock value."""
@@ -212,6 +217,11 @@ class MessageType:
             if field.message or field.enum:
                 answer.append(field.type)
         return tuple(answer)
+
+    @property
+    def map(self) -> bool:
+        """Return True if the given message is a map, False otherwise."""
+        return self.message_pb.options.map_entry
 
     @property
     def ident(self) -> metadata.Address:

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -72,7 +72,7 @@ class Field:
     @property
     def map(self) -> bool:
         """Return True if this field is a map, False otherwise."""
-        return self.repeated and self.message and self.message.map
+        return bool(self.repeated and self.message and self.message.map)
 
     @utils.cached_property
     def mock_value(self) -> str:

--- a/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
@@ -21,7 +21,7 @@ class {{ message.name }}({{ p }}.Message):
         {% with message = submessage %}{% filter indent %}
             {%- include '$namespace/$name_$version/$sub/types/_message.py.j2' %}
         {% endfilter %}{% endwith %}
-        {% endif -%}
+        {% endif %}
     {% endfor -%}
 
     {# Iterate over fields. -#}

--- a/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/types/_message.py.j2
@@ -17,14 +17,18 @@ class {{ message.name }}({{ p }}.Message):
 
     {# Iterate over nested messages. -#}
     {% for submessage in message.nested_messages.values() -%}
+        {% if not submessage.map -%}
         {% with message = submessage %}{% filter indent %}
             {%- include '$namespace/$name_$version/$sub/types/_message.py.j2' %}
         {% endfilter %}{% endwith %}
+        {% endif -%}
     {% endfor -%}
 
     {# Iterate over fields. -#}
     {% for field in message.fields.values() -%}
-    {{ field.name }} = {{ p }}.{% if field.repeated %}Repeated{% endif %}Field({{ p }}.{{ field.proto_type }}, number={{ field.number }}
+    {{ field.name }} = {{ p }}.{% if field.map %}Map{% elif field.repeated %}Repeated{% endif %}Field(
+        {%- if field.map %}{{ p }}.{{ field.message.fields['key'].proto_type }}, {% endif %}
+        {{- p }}.{{ field.proto_type }}, number={{ field.number }}
     {%- if field.enum or field.message %},
         {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
     {% endif %})

--- a/tests/unit/schema/wrappers/test_message.py
+++ b/tests/unit/schema/wrappers/test_message.py
@@ -124,12 +124,29 @@ def test_get_field_nonterminal_repeated_error():
         assert outer.get_field('inner', 'one') == inner_fields[1]
 
 
+def test_field_map():
+    # Create an Entry message.
+    entry_msg = make_message(
+        name='FooEntry',
+        fields=(
+            make_field(name='key', type=9),
+            make_field(name='value', type=9),
+        ),
+        options=descriptor_pb2.MessageOptions(map_entry=True),
+    )
+    entry_field = make_field('foos', message=entry_msg, repeated=True)
+    assert entry_msg.map
+    assert entry_field.map
+
+
 def make_message(name: str, package: str = 'foo.bar.v1', module: str = 'baz',
         fields: Sequence[wrappers.Field] = (), meta: metadata.Metadata = None,
+        options: descriptor_pb2.MethodOptions = None,
                  ) -> wrappers.MessageType:
     message_pb = descriptor_pb2.DescriptorProto(
         name=name,
         field=[i.field_pb for i in fields],
+        options=options,
     )
     return wrappers.MessageType(
         message_pb=message_pb,


### PR DESCRIPTION
This PR fixes a bug whereby maps got generated as their
underlying entry messages and then a repeated field.

Fixes #188.