### PR TITLE
Add test and impl for request messages with primitive fields

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -284,7 +284,8 @@ class Validator:
                     # Only valid if this is the last attribute in the chain.
                     break
                 else:
-                    raise TypeError
+                    raise TypeError(
+                        f"Could not handle attribute '{attr_name}' of type: {attr.type}")
 
             if i != len(attr_chain) - 1:
                 # We broke out of the loop after processing an enum or a primitive.

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -280,14 +280,17 @@ class Validator:
                     # and requires less munging of the assigned value
                     duplicate["value"] = f"'{val}'"
                     break
+                elif attr.is_primitive:
+                    # Only valid if this is the last attribute in the chain.
+                    break
                 else:
                     raise TypeError
 
             if i != len(attr_chain) - 1:
-                # We broke out of the loop after processing an enum.
+                # We broke out of the loop after processing an enum or a primitive.
                 extra_attrs = ".".join(attr_chain[i:])
                 raise types.InvalidEnumVariant(
-                    f"Attempted to reference attributes of enum value: '{extra_attrs}'")
+                    f"Attempted to reference attributes of enum value or primitive type: '{extra_attrs}'")
 
             if len(attr_chain) > 1:
                 duplicate["field"] = ".".join(attr_chain[1:])

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -289,7 +289,7 @@ class Validator:
             if i != len(attr_chain) - 1:
                 # We broke out of the loop after processing an enum or a primitive.
                 extra_attrs = ".".join(attr_chain[i:])
-                raise types.InvalidEnumVariant(
+                raise types.NonTerminalPrimitiveOrEnum(
                     f"Attempted to reference attributes of enum value or primitive type: '{extra_attrs}'")
 
             if len(attr_chain) > 1:

--- a/gapic/samplegen_utils/types.py
+++ b/gapic/samplegen_utils/types.py
@@ -76,6 +76,10 @@ class InvalidEnumVariant(SampleError):
     pass
 
 
+class NonTerminalPrimitiveOrEnum(SampleError):
+    pass
+
+
 class InvalidSampleFpath(SampleError):
     pass
 

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -236,7 +236,7 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-{% with arg_list = [] %}
+{% with arg_list = [] -%}
 {% for request in request_block if request.body -%}
 {% for attr in request.body if attr.input_parameter %}
     parser.add_argument("--{{ attr.input_parameter }}",
@@ -244,8 +244,8 @@ def main():
                         default={{ attr.value }})
 {% do arg_list.append("args." + attr.input_parameter) -%}
 {% endfor -%}
-{% endfor %}
-{% for request in request_block if request.single and request.single.input_parameter -%}
+{% endfor -%}
+{% for request in request_block if request.single and request.single.input_parameter %}
     parser.add_argument("--{{ request.single.input_parameter }}",
                         type=str,
                         default={{ request.single.value }})

--- a/tests/unit/samplegen/common_types.py
+++ b/tests/unit/samplegen/common_types.py
@@ -41,7 +41,12 @@ DummyMessage = namedtuple("DummyMessage", ["fields", "type", "options"])
 DummyMessage.__new__.__defaults__ = (False,) * len(DummyMessage._fields)
 
 DummyField = namedtuple("DummyField",
-                        ["message", "enum", "repeated", "field_pb", "meta"])
+                        ["message",
+                         "enum",
+                         "repeated",
+                         "field_pb",
+                         "meta",
+                         "is_primitive"])
 DummyField.__new__.__defaults__ = (False,) * len(DummyField._fields)
 
 DummyService = namedtuple("DummyService", ["methods"])

--- a/tests/unit/samplegen/common_types.py
+++ b/tests/unit/samplegen/common_types.py
@@ -46,7 +46,8 @@ DummyField = namedtuple("DummyField",
                          "repeated",
                          "field_pb",
                          "meta",
-                         "is_primitive"])
+                         "is_primitive",
+                         "type"])
 DummyField.__new__.__defaults__ = (False,) * len(DummyField._fields)
 
 DummyService = namedtuple("DummyService", ["methods"])

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -1572,7 +1572,7 @@ def test_validate_request_enum_not_last_attr():
     # request_type = message_factory("mollusc.subclass", enum=enum)
     v = samplegen.Validator(DummyMethod(output=message_factory("mollusc_result"),
                                         input=request_type))
-    with pytest.raises(types.InvalidEnumVariant):
+    with pytest.raises(types.NonTerminalPrimitiveOrEnum):
         v.validate_and_transform_request(
             types.CallingForm.Request,
             [{"field": "subclass.order", "value": "COLEOIDEA"}]
@@ -1602,6 +1602,25 @@ def test_validate_request_primitive_field():
             )
         )
     ]
+
+    assert actual == expected
+
+
+def test_validate_request_non_terminal_primitive_field():
+    field = make_field(name="species", type="TYPE_STRING")
+    request_type = make_message(name="request", fields=[field])
+
+    request = [{"field": "species.nomenclature", "value": "Architeuthis dux"}]
+    v = samplegen.Validator(
+        DummyMethod(
+            output=message_factory("mollusc_result"),
+            input=request_type
+        )
+    )
+
+    with pytest.raises(types.NonTerminalPrimitiveOrEnum):
+        v.validate_and_transform_request(types.CallingForm.Request,
+                                         request)
 
 
 def make_message(name: str, package: str = 'animalia.mollusca.v1', module: str = 'cephalopoda',

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -15,14 +15,14 @@
 import yaml
 import pytest
 
-from typing import (TypeVar)
-from collections import namedtuple
+from typing import (TypeVar, Sequence)
+from collections import (OrderedDict, namedtuple)
 from google.protobuf import descriptor_pb2
 
 import gapic.samplegen.samplegen as samplegen
 import gapic.samplegen_utils.types as types
 import gapic.samplegen_utils.yaml as gapic_yaml
-from gapic.schema import (api, naming)
+from gapic.schema import (api, metadata, naming)
 import gapic.schema.wrappers as wrappers
 
 from common_types import (DummyField, DummyMessage,
@@ -1555,8 +1555,21 @@ def test_validate_request_enum_invalid_value():
 
 
 def test_validate_request_enum_not_last_attr():
-    enum = enum_factory("subclass", ["AMMONOIDEA", "COLEOIDEA", "NAUTILOIDEA"])
-    request_type = message_factory("mollusc.subclass", enum=enum)
+    # enum = enum_factory("subclass", ["AMMONOIDEA", "COLEOIDEA", "NAUTILOIDEA"])
+    # field = make_field(name="subclass", enum=enum)
+    request_type = make_message(
+        name="mollusc",
+        fields=[
+            make_field(
+                name="subclass",
+                enum=enum_factory(
+                    "subclass", ["AMMONOIDEA", "COLEOIDEA", "NAUTILOIDEA"]
+                )
+            )
+        ]
+    )
+
+    # request_type = message_factory("mollusc.subclass", enum=enum)
     v = samplegen.Validator(DummyMethod(output=message_factory("mollusc_result"),
                                         input=request_type))
     with pytest.raises(types.InvalidEnumVariant):
@@ -1564,3 +1577,62 @@ def test_validate_request_enum_not_last_attr():
             types.CallingForm.Request,
             [{"field": "subclass.order", "value": "COLEOIDEA"}]
         )
+
+
+def test_validate_request_primitive_field():
+    field = make_field(name="species", type="TYPE_STRING")
+    request_type = make_message(name="request", fields=[field])
+
+    request = [{"field": "species", "value": "Architeuthis dux"}]
+    v = samplegen.Validator(
+        DummyMethod(
+            output=message_factory("mollusc_result"),
+            input=request_type
+        )
+    )
+
+    actual = v.validate_and_transform_request(types.CallingForm.Request,
+                                              request)
+    expected = [
+        samplegen.TransformedRequest(
+            base="species",
+            body=None,
+            single=samplegen.AttributeRequestSetup(
+                value="Architeuthis dux"
+            )
+        )
+    ]
+
+
+def make_message(name: str, package: str = 'animalia.mollusca.v1', module: str = 'cephalopoda',
+                 fields: Sequence[wrappers.Field] = (), meta: metadata.Metadata = None,
+                 options: descriptor_pb2.MethodOptions = None,
+                 ) -> wrappers.MessageType:
+    message_pb = descriptor_pb2.DescriptorProto(
+        name=name,
+        field=[i.field_pb for i in fields],
+        options=options,
+    )
+    return wrappers.MessageType(
+        message_pb=message_pb,
+        fields=OrderedDict((i.name, i) for i in fields),
+        nested_messages={},
+        nested_enums={},
+        meta=meta or metadata.Metadata(address=metadata.Address(
+            name=name,
+            package=tuple(package.split('.')),
+            module=module,
+        )),
+    )
+
+
+# Borrowed from test_field.py
+def make_field(*, message=None, enum=None, **kwargs) -> wrappers.Field:
+    T = descriptor_pb2.FieldDescriptorProto.Type
+    kwargs.setdefault('name', 'my_field')
+    kwargs.setdefault('number', 1)
+    kwargs.setdefault('type', T.Value('TYPE_BOOL'))
+    if isinstance(kwargs['type'], str):
+        kwargs['type'] = T.Value(kwargs['type'])
+    field_pb = descriptor_pb2.FieldDescriptorProto(**kwargs)
+    return wrappers.Field(field_pb=field_pb, message=message, enum=enum)


### PR DESCRIPTION
Fields that are strings, bools, ints, or floats are permitted.

Mismatch between the type of the assigned value and type of the field
is NOT handled by samplegen yet.

Fix for #213 