### PR TITLE
Change generated client class name to have 'Client' at the end

### DIFF
--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -628,6 +628,11 @@ class Service:
         return getattr(self.service_pb, name)
 
     @property
+    def client_name(self) -> str:
+        """Returns the name of the generated client class"""
+        return self.name + "Client"
+
+    @property
     def has_lro(self) -> bool:
         """Return whether the service has a long-running method."""
         return any([m.lro for m in self.methods.values()])
@@ -672,8 +677,9 @@ class Service:
         used for imports.
         """
         # Put together a set of the service and method names.
-        answer = {self.name}.union(
-            {utils.to_snake_case(i.name) for i in self.methods.values()}
+        answer = {self.name, self.client_name}
+        answer.update(
+            utils.to_snake_case(i.name) for i in self.methods.values()
         )
 
         # Identify any import module names where the same module name is used

--- a/gapic/templates/$namespace/$name/__init__.py.j2
+++ b/gapic/templates/$namespace/$name/__init__.py.j2
@@ -11,7 +11,7 @@ from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.'
 {% for service in api.services.values()|sort(attribute='name')
         if service.meta.address.subpackage == api.subpackage_view -%}
 from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.name }}
+    {{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.client_name }}
 {% endfor -%}
 
 {#  Import messages from each proto.
@@ -36,7 +36,7 @@ __all__ = (
     {%- endfor %}
     {%- for service in api.services.values()|sort(attribute='name')
             if service.meta.address.subpackage == api.subpackage_view %}
-    '{{ service.name }}',
+    '{{ service.client_name }}',
     {%- endfor %}
     {%- for proto in api.protos.values()|sort(attribute='module_name')
             if proto.meta.address.subpackage == api.subpackage_view %}

--- a/gapic/templates/$namespace/$name_$version/$sub/__init__.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/__init__.py.j2
@@ -10,7 +10,7 @@ from . import {{ subpackage }}
 {% filter sort_lines -%}
 {% for service in api.services.values()|sort(attribute='name')
         if service.meta.address.subpackage == api.subpackage_view -%}
-from .services.{{ service.name|snake_case }} import {{ service.name }}
+from .services.{{ service.name|snake_case }} import {{ service.client_name }}
 {% endfor -%}
 {% endfilter -%}
 
@@ -42,7 +42,7 @@ __all__ = (
     {%- endfor %}
     {%- for service in api.services.values()
             if service.meta.address.subpackage == api.subpackage_view %}
-    '{{ service.name }}',
+    '{{ service.client_name }}',
     {%- endfor %}
     {%- for proto in api.protos.values()
             if proto.meta.address.subpackage == api.subpackage_view %}

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/__init__.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/__init__.py.j2
@@ -1,9 +1,9 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-from .client import {{ service.name }}
+from .client import {{ service.client_name }}
 
 __all__ = (
-    '{{ service.name }}',
+    '{{ service.client_name }}',
 )
 {% endblock %}

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -21,7 +21,7 @@ from .transports.base import {{ service.name }}Transport
 from .transports.grpc import {{ service.name }}GrpcTransport
 
 
-class {{ service.name }}Meta(type):
+class {{ service.client_name }}Meta(type):
     """Metaclass for the {{ service.name }} client.
 
     This provides class-level methods for building and retrieving
@@ -52,14 +52,14 @@ class {{ service.name }}Meta(type):
         return next(iter(cls._transport_registry.values()))
 
 
-class {{ service.name }}(metaclass={{ service.name }}Meta):
+class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     """{{ service.meta.doc|rst(width=72, indent=4) }}"""
     def __init__(self, *,
             host: str{% if service.host %} = '{{ service.host }}'{% endif %},
             credentials: credentials.Credentials = None,
             transport: Union[str, {{ service.name }}Transport] = None
             ) -> None:
-        """Instantiate the {{ (service.name|snake_case).replace('_', ' ') }}.
+        """Instantiate the {{ (service.client_name|snake_case).replace('_', ' ') }}.
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
@@ -214,6 +214,6 @@ except pkg_resources.DistributionNotFound:
 
 
 __all__ = (
-    '{{ service.name }}',
+    '{{ service.client_name }}',
 )
 {% endblock %}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -28,13 +28,13 @@
 {% for import_statement in imports %}
 {{ import_statement }}
 {% endfor %}
-from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.name }}
+from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
 
 {# also need calling form #}
 def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input_params(sample.request)|trim -}}):
     """{{ sample.description }}"""
 
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         transport="grpc",
     )

--- a/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
+++ b/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
@@ -222,7 +222,7 @@ def test_credentials_transport_error():
         credentials=credentials.AnonymousCredentials(),
     )
     with pytest.raises(ValueError):
-        client = {{ service.name }}(
+        client = {{ service.client_name }}(
             credentials=credentials.AnonymousCredentials(),
             transport=transport,
         )

--- a/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
+++ b/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
@@ -11,7 +11,7 @@ import pytest
 {% filter sort_lines -%}
 from google import auth
 from google.auth import credentials
-from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.name }}
+from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import transports
 {% if service.has_lro -%}
 from google.api_core import future
@@ -28,7 +28,7 @@ from google.longrunning import operations_pb2
 
 {% for method in service.methods.values() -%}
 def test_{{ method.name|snake_case }}(transport: str = 'grpc'):
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         transport=transport,
     )
@@ -79,7 +79,7 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc'):
 
 {% if method.field_headers %}
 def test_{{ method.name|snake_case }}_field_headers():
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
     )
 
@@ -116,7 +116,7 @@ def test_{{ method.name|snake_case }}_field_headers():
 
 {% if method.flattened_fields %}
 def test_{{ method.name|snake_case }}_flattened():
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
     )
 
@@ -152,7 +152,7 @@ def test_{{ method.name|snake_case }}_flattened():
 
 
 def test_{{ method.name|snake_case }}_flattened_error():
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
     )
 
@@ -170,7 +170,7 @@ def test_{{ method.name|snake_case }}_flattened_error():
 
 {% if method.paged_result_field %}
 def test_{{ method.name|snake_case }}_pager():
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials,
     )
 
@@ -233,13 +233,13 @@ def test_transport_instance():
     transport = transports.{{ service.name }}GrpcTransport(
         credentials=credentials.AnonymousCredentials(),
     )
-    client = {{ service.name }}(transport=transport)
+    client = {{ service.client_name }}(transport=transport)
     assert client._transport is transport
 
 
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
     )
     assert isinstance(
@@ -277,7 +277,7 @@ def test_{{ service.name|snake_case }}_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(auth, 'default') as adc:
         adc.return_value = (credentials.AnonymousCredentials(), None)
-        client = {{ service.name }}()
+        client = {{ service.client_name }}()
         adc.assert_called_once_with(scopes=(
             {%- for scope in service.oauth_scopes %}
             '{{ scope }}',
@@ -287,7 +287,7 @@ def test_{{ service.name|snake_case }}_auth_adc():
 
 def test_{{ service.name|snake_case }}_host_no_port():
     {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         host='{{ host }}',
         transport='grpc',
@@ -298,7 +298,7 @@ def test_{{ service.name|snake_case }}_host_no_port():
 
 def test_{{ service.name|snake_case }}_host_with_port():
     {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         host='{{ host }}:8000',
         transport='grpc',
@@ -309,7 +309,7 @@ def test_{{ service.name|snake_case }}_host_with_port():
 
 def test_{{ service.name|snake_case }}_grpc_transport_channel():
     channel = grpc.insecure_channel('http://localhost/')
-    transport = transports.{{ service.name }}GrpcTransport(
+    transport = transports.{{ service.client_name }}GrpcTransport(
         channel=channel,
     )
     assert transport.grpc_channel is channel
@@ -317,7 +317,7 @@ def test_{{ service.name|snake_case }}_grpc_transport_channel():
 
 {% if service.has_lro -%}
 def test_{{ service.name|snake_case }}_grpc_lro_client():
-    client = {{ service.name }}(
+    client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         transport='grpc',
     )

--- a/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
+++ b/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
@@ -309,7 +309,7 @@ def test_{{ service.name|snake_case }}_host_with_port():
 
 def test_{{ service.name|snake_case }}_grpc_transport_channel():
     channel = grpc.insecure_channel('http://localhost/')
-    transport = transports.{{ service.client_name }}GrpcTransport(
+    transport = transports.{{ service.name }}GrpcTransport(
         channel=channel,
     )
     assert transport.grpc_channel is channel

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -14,23 +14,23 @@
 
 import pytest
 
-from google.showcase import Echo
-from google.showcase import Identity
+from google.showcase import EchoClient
+from google.showcase import IdentityClient
 
 import grpc
 
 
 @pytest.fixture
 def echo():
-    transport = Echo.get_transport_class('grpc')(
+    transport = EchoClient.get_transport_class('grpc')(
         channel=grpc.insecure_channel('localhost:7469'),
     )
-    return Echo(transport=transport)
+    return EchoClient(transport=transport)
 
 
 @pytest.fixture
 def identity():
-    transport = Identity.get_transport_class('grpc')(
+    transport = IdentityClient.get_transport_class('grpc')(
         channel=grpc.insecure_channel('localhost:7469'),
     )
-    return Identity(transport=transport)
+    return IdentityClient(transport=transport)

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -71,7 +71,7 @@ def test_generate_sample_basic():
     api_naming = naming.Naming(
         name="MolluscClient", namespace=("molluscs", "v1"))
     service = wrappers.Service(
-        service_pb=namedtuple('service_pb', ['name'])('MolluscClient'),
+        service_pb=namedtuple('service_pb', ['name'])('MolluscService'),
         methods={
             "Classify": DummyMethod(
                 input=input_type,
@@ -119,12 +119,12 @@ def test_generate_sample_basic():
 # [START %s]
 from google import auth
 from google.auth import credentials
-from molluscs.v1.molluscclient.services.mollusc_client import MolluscClient
+from molluscs.v1.molluscclient.services.mollusc_service import MolluscServiceClient
 
 def sample_classify(video, location):
     """Determine the full taxonomy of input mollusc"""
 
-    client = MolluscClient(
+    client = MolluscServiceClient(
         credentials=credentials.AnonymousCredentials(),
         transport="grpc",
     )

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -52,7 +52,8 @@ def test_service_names():
         get_method('Jump', 'foo.bacon.JumpRequest', 'foo.bacon.JumpResponse'),
         get_method('Yawn', 'a.b.v1.c.YawnRequest', 'x.y.v1.z.YawnResponse'),
     ))
-    expected_names = {'ThingDoer', 'ThingDoerClient', 'do_thing', 'jump', 'yawn'}
+    expected_names = {'ThingDoer', 'ThingDoerClient',
+                      'do_thing', 'jump', 'yawn'}
     assert service.names == expected_names
 
 
@@ -62,7 +63,8 @@ def test_service_name_colliding_modules():
         get_method('Jump', 'bacon.bar.JumpRequest', 'bacon.bar.JumpResponse'),
         get_method('Yawn', 'a.b.v1.c.YawnRequest', 'a.b.v1.c.YawnResponse'),
     ))
-    expected_names = {'ThingDoer', 'ThingDoerClient', 'do_thing', 'jump', 'yawn', 'bar'}
+    expected_names = {'ThingDoer', 'ThingDoerClient',
+                      'do_thing', 'jump', 'yawn', 'bar'}
     assert service.names == expected_names
 
 

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -27,6 +27,7 @@ from gapic.schema import wrappers
 def test_service_properties():
     service = make_service(name='ThingDoer')
     assert service.name == 'ThingDoer'
+    assert service.client_name == 'ThingDoerClient'
 
 
 def test_service_host():
@@ -51,7 +52,8 @@ def test_service_names():
         get_method('Jump', 'foo.bacon.JumpRequest', 'foo.bacon.JumpResponse'),
         get_method('Yawn', 'a.b.v1.c.YawnRequest', 'x.y.v1.z.YawnResponse'),
     ))
-    assert service.names == {'ThingDoer', 'do_thing', 'jump', 'yawn'}
+    expected_names = {'ThingDoer', 'ThingDoerClient', 'do_thing', 'jump', 'yawn'}
+    assert service.names == expected_names
 
 
 def test_service_name_colliding_modules():
@@ -60,7 +62,8 @@ def test_service_name_colliding_modules():
         get_method('Jump', 'bacon.bar.JumpRequest', 'bacon.bar.JumpResponse'),
         get_method('Yawn', 'a.b.v1.c.YawnRequest', 'a.b.v1.c.YawnResponse'),
     ))
-    assert service.names == {'ThingDoer', 'do_thing', 'jump', 'yawn', 'bar'}
+    expected_names = {'ThingDoer', 'ThingDoerClient', 'do_thing', 'jump', 'yawn', 'bar'}
+    assert service.names == expected_names
 
 
 def test_service_no_scopes():


### PR DESCRIPTION
Fix for #221 : Client class name changes from monolith gapic