### PR TITLE
Fix for #224

### DIFF
--- a/gapic/samplegen_utils/utils.py
+++ b/gapic/samplegen_utils/utils.py
@@ -25,7 +25,7 @@ from gapic.samplegen_utils import types
 
 MIN_SCHEMA_VERSION = (1, 2, 0)
 
-VALID_CONFIG_TYPE = "com.google.api.codegen.SampleConfigProto"
+VALID_CONFIG_TYPE = "com.google.api.codegen.samplegen.v1p2.SampleConfigProto"
 
 
 def coerce_response_name(s: str) -> str:

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -278,7 +278,7 @@ def test_parse_sample_paths(fs):
         contents=dedent(
             '''
             ---
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
@@ -318,7 +318,7 @@ def test_samplegen_config_to_output_files(
         contents=dedent(
             '''
             ---
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.2.0
             samples:
             - id: squid_sample
@@ -406,7 +406,7 @@ def test_samplegen_id_disambiguation(mock_gmtime, mock_generate_sample, fs):
         contents=dedent(
             '''
             ---
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.2.0
             samples:
             - id: squid_sample
@@ -478,7 +478,7 @@ def test_generator_duplicate_samples(fs):
         contents=dedent(
             '''
             # Note: the samples are duplicates.
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.2.0
             samples:
             - id: squid_sample

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -197,7 +197,7 @@ def test_generate_sample_config_fpaths(fs):
         contents=dedent(
             '''
             ---
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
@@ -243,7 +243,7 @@ def test_generate_sample_config_fpaths_bad_contents_old(fs):
         contents=dedent(
             '''
             ---
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.1.0
             samples:
             - service: google.cloud.language.v1.LanguageService
@@ -258,7 +258,7 @@ def test_generate_sample_config_fpaths_bad_contents_no_samples(fs):
         contents=dedent(
             '''
             ---
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.2.0
             '''
         )
@@ -274,13 +274,13 @@ def test_generate_sample_config_partial_config(fs):
             '''
             ---
             # Note: not a valid config because of the type.
-            type: com.google.api.codegen.SampleConfigPronto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigPronto
             schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService
             ---
             # Note: this one IS a valid config
-            type: com.google.api.codegen.SampleConfigProto
+            type: com.google.api.codegen.samplegen.v1p2.SampleConfigProto
             schema_version: 1.2.0
             samples:
             - service: google.cloud.language.v1.LanguageService


### PR DESCRIPTION
The valid config type of a sample is now `com.google.api.codegen.samplegen.v1p2.SampleConfigProto`