### PR TITLE
Add a license to the generated gapic and samples

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -36,12 +36,6 @@ from google.protobuf import descriptor_pb2
 #   defined with an _implicit_ $resp variable.
 
 
-# TODO: read in copyright and license from files.
-FILE_HEADER: Dict[str, str] = {
-    "copyright": "TODO: add a copyright",
-    "license": "TODO: add a license",
-}
-
 RESERVED_WORDS = frozenset(
     itertools.chain(
         keyword.kwlist,
@@ -864,7 +858,6 @@ def generate_sample(
     v.validate_response(sample["response"])
 
     return sample_template.render(
-        file_header=FILE_HEADER,
         sample=sample,
         imports=[
             "from google import auth",

--- a/gapic/templates/_base.py.j2
+++ b/gapic/templates/_base.py.j2
@@ -1,3 +1,6 @@
 # -*- coding: utf-8 -*-
+{% block license %}
+{% include "_license.j2" %}
+{% endblock %}
 {%- block content %}
 {% endblock %}

--- a/gapic/templates/_license.j2
+++ b/gapic/templates/_license.j2
@@ -1,0 +1,14 @@
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -25,14 +25,8 @@ There is a little, but not enough for it to be important because
 
 {# response handling macros #}
 
-{% macro sample_header(file_header, sample, calling_form) %}
-{% for line in file_header["copyright"].split("\n") %}
-# {{ line }}
-{% endfor %}
-{% for line in file_header["license"].split("\n") %}
-# {{ line }}
-{% endfor %}
-#
+{% macro sample_header(sample, calling_form) %}
+
 # DO NOT EDIT! This is a generated sample ("{{ calling_form }}",  "{{ sample.id }}")
 #
 # To install the latest published package dependency, execute the following:

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -13,15 +13,13 @@
  # See the License for the specific language governing permissions and
  # limitations under the License.
 #}
+{% extends "_base.py.j2" %}
+
+{% block content %}
 {# Input parameters: sample #}
-{#                   fileHeader#}
-{#                   imports #}
 {#                   callingForm #}
-{#                   callingFormEnum #}
-{# Note: this sample template is WILDLY INACCURATE AND INCOMPLETE #}
-{# It does not correctly enums, unions, top level attributes, or various other things #}
 {% import "examples/feature_fragments.j2" as frags %}
-{{ frags.sample_header(file_header, sample, calling_form) }}
+{{ frags.sample_header(sample, calling_form) }}
 
 # [START {{ sample.id }}]
 {# python code is responsible for all transformations: all we do here is render #}
@@ -47,3 +45,4 @@ def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input
 # [END {{ sample.id }}]
 
 {{ frags.render_main_block(sample.rpc, sample.request) }}
+{%- endblock %}

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -107,8 +107,20 @@ def test_generate_sample_basic():
     )
 
     sample_id = ("mollusc_classify_sync")
-    expected_str = '''# TODO: add a copyright
-# TODO: add a license
+    expected_str = '''# -*- coding: utf-8 -*-
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # DO NOT EDIT! This is a generated sample ("request",  "%s")
 #


### PR DESCRIPTION
Fix for #229 and #230 
Manual tests show the expected license is generated in the client library files.