### PR TITLE
Fixes for reading service config

### DIFF
--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -92,12 +92,18 @@ class Options:
                 os.path.join(os.path.dirname(__file__), '..', 'templates'),
             )
 
+        retry_cfg = None
+        retry_path = opts.pop(cls.RETRY_OPT, None)
+        if retry_path:
+            with open(retry_path[-1]) as f:
+              retry_cfg = json.load(f)
+
         # Build the options instance.
         sample_paths = opts.pop(cls.SAMPLES_OPT, [])
         answer = Options(
             name=opts.pop('name', ['']).pop(),
             namespace=tuple(opts.pop('namespace', [])),
-            retry=json.loads(str(opts.pop(cls.RETRY_OPT, 'null'))),
+            retry=retry_cfg,
             sample_configs=tuple(
                 cfg_path
                 for s in sample_paths

--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -93,10 +93,11 @@ class Options:
             )
 
         retry_cfg = None
-        retry_path = opts.pop(cls.RETRY_OPT, None)
-        if retry_path:
-            with open(retry_path[-1]) as f:
-              retry_cfg = json.load(f)
+        retry_paths = opts.pop(cls.RETRY_OPT, None)
+        if retry_paths:
+            # Just use the last config specified.
+            with open(retry_paths[-1]) as f:
+                retry_cfg = json.load(f)
 
         # Build the options instance.
         sample_paths = opts.pop(cls.SAMPLES_OPT, [])

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -145,9 +145,9 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             self._transport.{{ method.name|snake_case }},
             {%- if method.retry %}
             default_retry=retries.Retry(
-                {%- if method.retry.initial_backoff %}initial={{ method.retry.initial_backoff }},{% endif %}
-                {%- if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
-                {%- if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
+                {% if method.retry.initial_backoff %}initial={{ method.retry.initial_backoff }},{% endif %}
+                {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
+                {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                 predicate=retries.if_exception_type(
                     {%- filter sort_lines %}
                     {%- for ex in method.retry.retryable_exceptions %}

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -54,3 +54,63 @@ def test_options_no_valid_sample_config(fs):
     fs.create_file("sampledir/not_a_config.yaml")
     with pytest.raises(types.InvalidConfig):
         options.Options.build("samples=sampledir/")
+
+def test_options_service_config(fs):
+    opts = options.Options.build("")
+    assert opts.retry is None
+
+    # Default of None is okay, verify build can read a config.
+    service_config_fpath = "service_config.json"
+    fs.create_file(service_config_fpath, contents="""{
+    "methodConfig": [
+        {
+            "name": [
+                {
+                  "service": "animalia.mollusca.v1beta1.Cephalopod",
+                  "method": "IdentifySquid"
+                }
+            ],
+            "retryPolicy": {
+                "maxAttempts": 5,
+                "maxBackoff": "3s",
+                "initialBackoff": "0.2s",
+                "backoffMultiplier": 2,
+                "retryableStatusCodes": [
+                    "UNAVAILABLE",
+                    "UNKNOWN"
+                ]
+            },
+            "timeout": "5s"
+        }
+      ]
+    }""")
+
+    opt_string = f"retry-config={service_config_fpath}"
+    opts = options.Options.build(opt_string)
+
+    # Verify the config was read in correctly.
+    expected_cfg = {
+        "methodConfig": [
+            {
+                "name": [
+                {
+                    "service": "animalia.mollusca.v1beta1.Cephalopod",
+                    "method":"IdentifySquid"
+                }
+                ],
+                "retryPolicy":{
+                    "maxAttempts":5,
+                    "maxBackoff":"3s",
+                    "initialBackoff":"0.2s",
+                    "backoffMultiplier":2,
+                    "retryableStatusCodes":
+                    [
+                        "UNAVAILABLE",
+                        "UNKNOWN"
+                    ]
+                },
+                "timeout":"5s"
+            }
+        ]
+    }
+    assert opts.retry == expected_cfg

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -55,6 +55,7 @@ def test_options_no_valid_sample_config(fs):
     with pytest.raises(types.InvalidConfig):
         options.Options.build("samples=sampledir/")
 
+
 def test_options_service_config(fs):
     opts = options.Options.build("")
     assert opts.retry is None

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -95,10 +95,10 @@ def test_options_service_config(fs):
                 "name": [
                     {
                         "service": "animalia.mollusca.v1beta1.Cephalopod",
-                        "method":"IdentifySquid",
+                        "method": "IdentifySquid",
                     }
                 ],
-                "retryPolicy" :{
+                "retryPolicy": {
                     "maxAttempts": 5,
                     "maxBackoff": "3s",
                     "initialBackoff": "0.2s",

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -93,16 +93,16 @@ def test_options_service_config(fs):
         "methodConfig": [
             {
                 "name": [
-                {
-                    "service": "animalia.mollusca.v1beta1.Cephalopod",
-                    "method":"IdentifySquid"
-                }
+                    {
+                        "service": "animalia.mollusca.v1beta1.Cephalopod",
+                        "method":"IdentifySquid",
+                    }
                 ],
-                "retryPolicy":{
-                    "maxAttempts":5,
-                    "maxBackoff":"3s",
-                    "initialBackoff":"0.2s",
-                    "backoffMultiplier":2,
+                "retryPolicy" :{
+                    "maxAttempts": 5,
+                    "maxBackoff": "3s",
+                    "initialBackoff": "0.2s",
+                    "backoffMultiplier": 2,
                     "retryableStatusCodes":
                     [
                         "UNAVAILABLE",


### PR DESCRIPTION
Adds fixes and a unit test for reading a service config from file.
Includes minor rendering fixes.

System tests to verify that the config percolates to method calls are in progress.