### PR TITLE
Adopt legacy method flattening semantics

### DIFF
--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -594,8 +594,7 @@ class Method:
         # We found no repeated fields. Return None.
         return None
 
-    @utils.cached_property
-    def ref_types(self) -> Sequence[Union[MessageType, EnumType]]:
+    def _ref_types(self, use_legacy: bool = False) -> Sequence[Union[MessageType, EnumType]]:
         """Return types referenced by this method."""
         # Begin with the input (request) and output (response) messages.
         answer = [self.input]
@@ -607,7 +606,8 @@ class Method:
         #
         # This entails adding the module for any field on the signature
         # unless the field is a primitive.
-        for field in self.flattened_fields.values():
+        flattening = self.legacy_flattened_fields if use_legacy else self.flattened_fields
+        for field in flattening.values():
             if field.message or field.enum:
                 answer.append(field.type)
 
@@ -619,6 +619,14 @@ class Method:
 
         # Done; return the answer.
         return tuple(answer)
+
+    @utils.cached_property
+    def ref_types(self) -> Sequence[Union[MessageType, EnumType]]:
+        return self._ref_types()
+
+    @utils.cached_property
+    def ref_types_legacy(self) -> Sequence[Union[MessageType, EnumType]]:
+        return self._ref_types(use_legacy=True)
 
     @property
     def void(self) -> bool:

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -32,7 +32,7 @@ import dataclasses
 import re
 from itertools import chain
 from typing import (cast, Dict, FrozenSet, List, Mapping, Optional,
-        Sequence, Set, Union)
+                    Sequence, Set, Union)
 
 from google.api import annotations_pb2  # type: ignore
 from google.api import client_pb2
@@ -185,7 +185,8 @@ class Field:
         ``Field`` object aliases module names to avoid naming collisions
         in the file being written.
         """
-        return dataclasses.replace(self,
+        return dataclasses.replace(
+            self,
             message=self.message.with_context(
                 collisions=collisions,
                 skip_fields=True,
@@ -230,7 +231,7 @@ class MessageType:
         return self.meta.address
 
     def get_field(self, *field_path: str,
-            collisions: FrozenSet[str] = frozenset()) -> Field:
+                  collisions: FrozenSet[str] = frozenset()) -> Field:
         """Return a field arbitrarily deep in this message's structure.
 
         This method recursively traverses the message tree to return the
@@ -288,8 +289,8 @@ class MessageType:
         return cursor.message.get_field(*field_path[1:], collisions=collisions)
 
     def with_context(self, *,
-            collisions: FrozenSet[str],
-            skip_fields: bool = False,
+                     collisions: FrozenSet[str],
+                     skip_fields: bool = False,
                      ) -> 'MessageType':
         """Return a derivative of this message with the provided context.
 
@@ -301,7 +302,8 @@ class MessageType:
         underlying fields. This provides for an "exit" in the case of circular
         references.
         """
-        return dataclasses.replace(self,
+        return dataclasses.replace(
+            self,
             fields=collections.OrderedDict([
                 (k, v.with_context(collisions=collisions))
                 for k, v in self.fields.items()
@@ -355,7 +357,7 @@ class EnumType:
         the file being written.
         """
         return dataclasses.replace(self,
-            meta=self.meta.with_context(collisions=collisions),
+                                   meta=self.meta.with_context(collisions=collisions),
                                    )
 
 
@@ -540,6 +542,15 @@ class Method:
         # Done; return the flattened fields
         return answer
 
+    @utils.cached_property
+    def legacy_flattened_fields(self) -> Mapping[str, Field]:
+        """Return the legacy flattening interface: top level fields only,
+        required fields first"""
+        required, optional = utils.partition(lambda f: f.required,
+                                             self.input.fields.values())
+        return collections.OrderedDict((f.name, f)
+                                       for f in chain(required, optional))
+
     @property
     def grpc_stub_type(self) -> str:
         """Return the type of gRPC stub to use."""
@@ -621,11 +632,12 @@ class Method:
         ``Method`` object aliases module names to avoid naming collisions
         in the file being written.
         """
-        return dataclasses.replace(self,
+        return dataclasses.replace(
+            self,
             input=self.input.with_context(collisions=collisions),
             output=self.output.with_context(collisions=collisions),
             meta=self.meta.with_context(collisions=collisions),
-                                   )
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -670,8 +682,8 @@ class Service:
         """
         # Return the OAuth scopes, split on comma.
         return tuple([i.strip() for i in
-            self.options.Extensions[client_pb2.oauth_scopes].split(',')
-            if i])
+                      self.options.Extensions[client_pb2.oauth_scopes].split(',')
+                      if i])
 
     @property
     def module_name(self) -> str:
@@ -715,7 +727,8 @@ class Service:
         ``Service`` object aliases module names to avoid naming collisions
         in the file being written.
         """
-        return dataclasses.replace(self,
+        return dataclasses.replace(
+            self,
             methods=collections.OrderedDict([
                 (k, v.with_context(collisions=collisions))
                 for k, v in self.methods.items()

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -356,9 +356,10 @@ class EnumType:
         ``EnumType`` object aliases module names to avoid naming collisions in
         the file being written.
         """
-        return dataclasses.replace(self,
-                                   meta=self.meta.with_context(collisions=collisions),
-                                   )
+        return dataclasses.replace(
+            self,
+            meta=self.meta.with_context(collisions=collisions),
+        )
 
 
 @dataclasses.dataclass(frozen=True)
@@ -689,9 +690,11 @@ class Service:
             Sequence[str]: A sequence of OAuth scopes.
         """
         # Return the OAuth scopes, split on comma.
-        return tuple([i.strip() for i in
-                      self.options.Extensions[client_pb2.oauth_scopes].split(',')
-                      if i])
+        return tuple(
+            i.strip()
+            for i in self.options.Extensions[client_pb2.oauth_scopes].split(',')
+            if i
+        )
 
     @property
     def module_name(self) -> str:

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -124,14 +124,6 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 {{ method.client_output.meta.doc|rst(width=72, indent=16) }}
         {%- endif %}
         """
-        {# {% if method.flattened_fields -%} #}
-        {# # Sanity check: If we got a request object, we should *not* have #}
-        {# # gotten any keyword arguments that map to the request. #}
-        {# if request is not None and any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}]): #}
-        {#     raise ValueError('If the `request` argument is set, then none of ' #}
-        {#                      'the individual field arguments should be set.') #}
-
-        {# {% endif -%} #}
         # Create or coerce a protobuf request object.
         {% if method.legacy_flattened_fields -%}
         # If we have keyword arguments corresponding to fields on the

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -139,8 +139,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% endif -%}
         request = {{ method.input.ident }}()
         {%- for field in method.legacy_flattened_fields.values() %}
-        if {{ field.name }} is not None:
-            request.{{ field.name }} = {{ field.name }}
+        request.{{ field.name }} = {{ field.name }}
         {%- endfor %}
 
         # Wrap the RPC method; this adds retry and timeout information,

--- a/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
+++ b/gapic/templates/$namespace/$name_$version/$sub/services/$service/client.py.j2
@@ -12,7 +12,7 @@ from google.auth import credentials           # type: ignore
 
 {% filter sort_lines -%}
 {% for method in service.methods.values() -%}
-{% for ref_type in method.ref_types -%}
+{% for ref_type in method.ref_types_legacy -%}
 {{ ref_type.ident.python_import }}
 {% endfor -%}
 {% endfor -%}
@@ -87,10 +87,14 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
     {% for method in service.methods.values() -%}
     def {{ method.name|snake_case }}(self,
-            request: {{ method.input.ident }} = None, *,
-            {% for field in method.flattened_fields.values() -%}
+            {% for field in method.legacy_flattened_fields.values() -%}
+            {% if field.required -%}
+            {{ field.name }}: {{ field.ident }},
+            {% else -%}
             {{ field.name }}: {{ field.ident }} = None,
+            {% endif -%}
             {% endfor -%}
+            *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
@@ -120,23 +124,23 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 {{ method.client_output.meta.doc|rst(width=72, indent=16) }}
         {%- endif %}
         """
-        {% if method.flattened_fields -%}
-        # Sanity check: If we got a request object, we should *not* have
-        # gotten any keyword arguments that map to the request.
-        if request is not None and any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}]):
-            raise ValueError('If the `request` argument is set, then none of '
-                             'the individual field arguments should be set.')
+        {# {% if method.flattened_fields -%} #}
+        {# # Sanity check: If we got a request object, we should *not* have #}
+        {# # gotten any keyword arguments that map to the request. #}
+        {# if request is not None and any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}]): #}
+        {#     raise ValueError('If the `request` argument is set, then none of ' #}
+        {#                      'the individual field arguments should be set.') #}
 
-        {% endif -%}
+        {# {% endif -%} #}
         # Create or coerce a protobuf request object.
-        {% if method.flattened_fields -%}
+        {% if method.legacy_flattened_fields -%}
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
         {% endif -%}
-        request = {{ method.input.ident }}(request)
-        {%- for key, field in method.flattened_fields.items() %}
+        request = {{ method.input.ident }}()
+        {%- for field in method.legacy_flattened_fields.values() %}
         if {{ field.name }} is not None:
-            request.{{ key }} = {{ field.name }}
+            request.{{ field.name }} = {{ field.name }}
         {%- endfor %}
 
         # Wrap the RPC method; this adds retry and timeout information,

--- a/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
+++ b/gapic/templates/tests/unit/$name_$version/$sub/test_$service.py.j2
@@ -33,10 +33,6 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc'):
         transport=transport,
     )
 
-    # Everything is optional in proto3 as far as the runtime is concerned,
-    # and we are mocking out the actual API, so just send an empty request.
-    request = {{ method.input.ident }}()
-
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
             type(client._transport.{{ method.name|snake_case }}),
@@ -55,12 +51,18 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc'):
             {%- endfor %}
         )
         {% endif -%}
-        response = client.{{ method.name|snake_case }}(request)
+        # Everything is optional in proto3 as far as the runtime is concerned,
+        # and we are mocking out the actual API, so just send an empty request.
+        response = client.{{ method.name|snake_case }}(
+            {% for field in method.legacy_flattened_fields.values() -%}
+            {{ field.name }}=None,
+            {% endfor -%}
+        )
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-        assert args[0] == request
+        assert args[0] == {{ method.input.ident }}()
 
     # Establish that the response is the type that we expect.
     {% if method.void -%}
@@ -83,24 +85,27 @@ def test_{{ method.name|snake_case }}_field_headers():
         credentials=credentials.AnonymousCredentials(),
     )
 
-    # Any value that is part of the HTTP/1.1 URI should be sent as
-    # a field header. Set these to a non-empty value.
-    request = {{ method.input.ident }}(
-        {%- for field_header in method.field_headers %}
-        {{ field_header }}='{{ field_header }}/value',
-        {%- endfor %}
-    )
-
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
             type(client._transport.{{ method.name|snake_case }}),
             '__call__') as call:
         call.return_value = {{ method.output.ident }}()
-        response = client.{{ method.name|snake_case }}(request)
+        # Any value that is part of the HTTP/1.1 URI should be sent as
+        # a field header. Set these to a non-empty value.
+        response = client.{{ method.name|snake_case }}(
+        {%- for field_header in method.field_headers %}
+            {{ field_header }}='{{ field_header }}/value',
+        {%- endfor %}
+        )
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
+        request = {{ method.input.ident }}(
+        {%- for field_header in method.field_headers %}
+            {{ field_header }}='{{ field_header }}/value',
+        {%- endfor %}
+        )
         assert args[0] == request
 
     # Establish that the field header was sent.
@@ -114,58 +119,61 @@ def test_{{ method.name|snake_case }}_field_headers():
     ) in kw['metadata']
 {% endif %} {#- method.field_headers #}
 
-{% if method.flattened_fields %}
-def test_{{ method.name|snake_case }}_flattened():
-    client = {{ service.client_name }}(
-        credentials=credentials.AnonymousCredentials(),
-    )
+{# NOTE: the backwards compatibility requirements of legacy flattening make these tests no longer relevant #}
+{# If the legacy flattening is ever abandoned, these tests or something like them will be needed again. #}
+{#  #}
+{# {% if method.flattened_fields %} #}
+{# def test_{{ method.name|snake_case }}_flattened(): #}
+{#     client = {{ service.client_name }}( #}
+{#         credentials=credentials.AnonymousCredentials(), #}
+{#     ) #}
 
-    # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
-            '__call__') as call:
-        # Designate an appropriate return value for the call.
-        {% if method.void -%}
-        call.return_value = None
-        {% elif method.lro -%}
-        call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
-        call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
-        call.return_value = {{ method.output.ident }}()
-        {% endif %}
-        # Call the method with a truthy value for each flattened field,
-        # using the keyword arguments to the method.
-        response = client.{{ method.name|snake_case }}(
-            {%- for key, field in method.flattened_fields.items() %}
-            {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
-        )
+{#     # Mock the actual call within the gRPC stub, and fake the request. #}
+{#     with mock.patch.object( #}
+{#             type(client._transport.{{ method.name|snake_case }}), #}
+{#             '__call__') as call: #}
+{#         # Designate an appropriate return value for the call. #}
+{#         {% if method.void -%} #}
+{#         call.return_value = None #}
+{#         {% elif method.lro -%} #}
+{#         call.return_value = operations_pb2.Operation(name='operations/op') #}
+{#         {% elif method.server_streaming -%} #}
+{#         call.return_value = iter([{{ method.output.ident }}()]) #}
+{#         {% else -%} #}
+{#         call.return_value = {{ method.output.ident }}() #}
+{#         {% endif %} #}
+{#         # Call the method with a truthy value for each flattened field, #}
+{#         # using the keyword arguments to the method. #}
+{#         response = client.{{ method.name|snake_case }}( #}
+{#             {%- for key, field in method.flattened_fields.items() %} #}
+{#             {{ field.name }}={{ field.mock_value }}, #}
+{#             {%- endfor %} #}
+{#         ) #}
 
-        # Establish that the underlying call was made with the expected
-        # request object values.
-        assert len(call.mock_calls) == 1
-        _, args, _ = call.mock_calls[0]
-        {% for key, field in method.flattened_fields.items() -%}
-        assert args[0].{{ key }} == {{ field.mock_value }}
-        {% endfor %}
+{#         # Establish that the underlying call was made with the expected #}
+{#         # request object values. #}
+{#         assert len(call.mock_calls) == 1 #}
+{#         _, args, _ = call.mock_calls[0] #}
+{#         {% for key, field in method.flattened_fields.items() -%} #}
+{#         assert args[0].{{ key }} == {{ field.mock_value }} #}
+{#         {% endfor %} #}
 
 
-def test_{{ method.name|snake_case }}_flattened_error():
-    client = {{ service.client_name }}(
-        credentials=credentials.AnonymousCredentials(),
-    )
+{# def test_{{ method.name|snake_case }}_flattened_error(): #}
+{#     client = {{ service.client_name }}( #}
+{#         credentials=credentials.AnonymousCredentials(), #}
+{#     ) #}
 
-    # Attempting to call a method with both a request object and flattened
-    # fields is an error.
-    with pytest.raises(ValueError):
-        client.{{ method.name|snake_case }}(
-            {{ method.input.ident }}(),
-            {%- for key, field in method.flattened_fields.items() %}
-            {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
-        )
-{% endif %} {#- method.flattened_fields #}
+{#     # Attempting to call a method with both a request object and flattened #}
+{#     # fields is an error. #}
+{#     with pytest.raises(ValueError): #}
+{#         client.{{ method.name|snake_case }}( #}
+{#             {{ method.input.ident }}(), #}
+{#             {%- for key, field in method.flattened_fields.items() %} #}
+{#             {{ field.name }}={{ field.mock_value }}, #}
+{#             {%- endfor %} #}
+{#         ) #}
+{# {% endif %} {\#- method.flattened_fields #\} #}
 
 
 {% if method.paged_result_field %}
@@ -206,9 +214,7 @@ def test_{{ method.name|snake_case }}_pager():
             ),
             RuntimeError,
         )
-        results = [i for i in client.{{ method.name|snake_case }}(
-            request={},
-        )]
+        results = [i for i in client.{{ method.name|snake_case }}({% for field in method.legacy_flattened_fields.values() if field.required -%}None,{% endfor -%})]
         assert len(results) == 6
         assert all([isinstance(i, {{ method.paged_result_field.message.ident }})
                     for i in results])
@@ -250,7 +256,7 @@ def test_{{ method.name|snake_case }}_pages():
             ),
             RuntimeError,
         )
-        pages = list(client.{{ method.name|snake_case }}(request={}).pages)
+        pages = list(client.{{ method.name|snake_case }}({% for field in method.legacy_flattened_fields.values() if field.required -%}None,{% endfor -%}).pages)
         for page, token in zip(pages, ['abc','def','ghi', '']):
             assert page.raw_page.next_page_token == token
 {% elif method.lro and "next_page_token" in method.lro.response_type.fields.keys() %}
@@ -308,7 +314,7 @@ def test_{{ service.name|snake_case }}_base_transport():
     )
     for method in methods:
         with pytest.raises(NotImplementedError):
-            getattr(transport, method)(request=object())
+            getattr(transport, method)()
 
     {% if service.has_lro -%}
     # Additionally, the LRO client (a property) should

--- a/tests/system/test_grpc_lro.py
+++ b/tests/system/test_grpc_lro.py
@@ -18,12 +18,12 @@ from google import showcase_v1beta1
 
 
 def test_lro(echo):
-    wait_request = {
-        'end_time': datetime.now(tz=timezone.utc) + timedelta(seconds=1),
-        'success': {'content': 'The hail in Wales falls mainly '
-                               'on the snails...eventually.'},
-    }
-    future = echo.wait(wait_request)
+    future = echo.wait(
+        end_time=datetime.now(tz=timezone.utc) + timedelta(seconds=1),
+        success={
+            'content': 'The hail in Wales falls mainly on the snails...eventually.'
+        }
+    )
     response = future.result()
     assert isinstance(response, showcase_v1beta1.WaitResponse)
     assert response.content.endswith('the snails...eventually.')

--- a/tests/system/test_grpc_streams.py
+++ b/tests/system/test_grpc_streams.py
@@ -15,9 +15,9 @@
 
 def test_unary_stream(echo):
     content = 'The hail in Wales falls mainly on the snails.'
-    responses = echo.expand({
-        'content': content,
-    })
+    responses = echo.expand(
+        content=content,
+    )
 
     # Consume the response and ensure it matches what we expect.
     # with pytest.raises(exceptions.NotFound) as exc:

--- a/tests/system/test_grpc_unary.py
+++ b/tests/system/test_grpc_unary.py
@@ -20,27 +20,28 @@ from google.rpc import code_pb2
 from google import showcase
 
 
-def test_unary_with_request_object(echo):
-    response = echo.echo(showcase.EchoRequest(
-        content='The hail in Wales falls mainly on the snails.',
-    ))
-    assert response.content == 'The hail in Wales falls mainly on the snails.'
+def test_unary(echo):
+    content = 'The hail in Wales falls mainly on the snails.'
+    response = echo.echo(
+        content=content,
+    )
+    assert response.content == content
 
 
-def test_unary_with_dict(echo):
-    response = echo.echo({
-        'content': 'The hail in Wales falls mainly on the snails.',
-    })
-    assert response.content == 'The hail in Wales falls mainly on the snails.'
+def test_unary_positional(echo):
+    content = 'The hail in Wales falls mainly on the snails.'
+    response = echo.echo(content,)
+    assert response.content == content
 
 
 def test_unary_error(echo):
+    message = 'Bad things! Bad things!'
     with pytest.raises(exceptions.InvalidArgument) as exc:
-        echo.echo({
-            'error': {
+        echo.echo(
+            error={
                 'code': code_pb2.Code.Value('INVALID_ARGUMENT'),
-                'message': 'Bad things! Bad things!',
+                'message': message,
             },
-        })
-    assert exc.value.code == 400
-    assert exc.value.message == 'Bad things! Bad things!'
+        )
+        assert exc.value.code == 400
+        assert exc.value.message == message

--- a/tests/system/test_pagination.py
+++ b/tests/system/test_pagination.py
@@ -17,10 +17,10 @@ from google import showcase
 
 def test_pagination(echo):
     text = 'The hail in Wales falls mainly on the snails.'
-    results = [i for i in echo.paged_expand({
-        'content': text,
-        'page_size': 3,
-    })]
+    results = [i for i in echo.paged_expand(
+        content=text,
+        page_size=3,
+    )]
     assert len(results) == 9
     assert results == [showcase.EchoResponse(content=i)
                        for i in text.split(' ')]
@@ -28,10 +28,10 @@ def test_pagination(echo):
 
 def test_pagination_pages(echo):
     text = "The hail in Wales falls mainly on the snails."
-    page_results = list(echo.paged_expand({
-        'content': text,
-        'page_size': 3,
-    }).pages)
+    page_results = list(echo.paged_expand(
+        content=text,
+        page_size=3,
+    ).pages)
 
     assert len(page_results) == 3
     assert not page_results[-1].next_page_token

--- a/tests/system/test_resource_crud.py
+++ b/tests/system/test_resource_crud.py
@@ -14,34 +14,32 @@
 
 
 def test_crud_with_request(identity):
-    count = len(identity.list_users({}).users)
-    user = identity.create_user({'user': {
+    count = len(identity.list_users().users)
+    user = identity.create_user(user={
         'display_name': 'Guido van Rossum',
         'email': 'guido@guido.fake',
-    }})
+    })
     try:
         assert user.display_name == 'Guido van Rossum'
         assert user.email == 'guido@guido.fake'
-        assert len(identity.list_users({}).users) == count + 1
-        assert identity.get_user({
-            'name': user.name,
-        }).display_name == 'Guido van Rossum'
+        assert len(identity.list_users().users) == count + 1
+        assert identity.get_user(
+            name=user.name
+        ).display_name == 'Guido van Rossum'
     finally:
-        identity.delete_user({'name': user.name})
+        identity.delete_user(name=user.name)
 
 
-def test_crud_flattened(identity):
-    count = len(identity.list_users({}).users)
-    user = identity.create_user(
-        display_name='Monty Python',
-        email='monty@python.org',
-    )
+def test_crud_positional(identity):
+    count = len(identity.list_users().users)
+    user = identity.create_user({
+        'display_name': 'Monty Python',
+        'email': 'monty@python.org',
+    })
     try:
         assert user.display_name == 'Monty Python'
         assert user.email == 'monty@python.org'
-        assert len(identity.list_users({}).users) == count + 1
-        assert identity.get_user({
-            'name': user.name,
-        }).display_name == 'Monty Python'
+        assert len(identity.list_users().users) == count + 1
+        assert identity.get_user(user.name).display_name == 'Monty Python'
     finally:
-        identity.delete_user({'name': user.name})
+        identity.delete_user(user.name)

--- a/tests/system/test_retry.py
+++ b/tests/system/test_retry.py
@@ -20,9 +20,9 @@ from google.rpc import code_pb2
 
 def test_retry_bubble(echo):
     with pytest.raises(exceptions.DeadlineExceeded):
-        echo.echo({
-            'error': {
+        echo.echo(
+            error={
                 'code': code_pb2.Code.Value('DEADLINE_EXCEEDED'),
                 'message': 'This took longer than you said it should.',
             },
-        })
+        )

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -17,6 +17,7 @@ from typing import Sequence
 
 from google.api import annotations_pb2
 from google.api import client_pb2
+from google.api import field_behavior_pb2
 from google.api import http_pb2
 from google.protobuf import descriptor_pb2
 
@@ -70,8 +71,8 @@ def test_method_client_output_paged():
         make_field(name='next_page_token', type=9),  # str
     ))
     method = make_method('ListFoos',
-        input_message=input_msg,
-        output_message=output_msg,
+                         input_message=input_msg,
+                         output_message=output_msg,
                          )
     assert method.paged_result_field == paged
     assert method.client_output.ident.name == 'ListFoosPager'
@@ -89,8 +90,8 @@ def test_method_paged_result_field_not_first():
         paged,
     ))
     method = make_method('ListFoos',
-        input_message=input_msg,
-        output_message=output_msg,
+                         input_message=input_msg,
+                         output_message=output_msg,
                          )
     assert method.paged_result_field == paged
 
@@ -106,8 +107,8 @@ def test_method_paged_result_field_no_page_field():
         make_field(name='next_page_token', type=9),  # str
     ))
     method = make_method('ListFoos',
-        input_message=input_msg,
-        output_message=output_msg,
+                         input_message=input_msg,
+                         output_message=output_msg,
                          )
     assert method.paged_result_field is None
 
@@ -178,6 +179,57 @@ def test_method_ignored_flattened_fields():
     assert len(method.flattened_fields) == 0
 
 
+def test_method_legacy_flattened_fields():
+    required_options = descriptor_pb2.FieldOptions()
+    required_options.Extensions[field_behavior_pb2.field_behavior].append(
+        field_behavior_pb2.FieldBehavior.Value("REQUIRED"))
+
+    # Cephalopods are required.
+    squid = make_field(name="squid", options=required_options)
+    octopus = make_field(
+        name="octopus",
+        message=make_message(
+            name="Octopus",
+            fields=[make_field(name="mass", options=required_options)]
+        ),
+        options=required_options)
+
+    # Bivalves are optional.
+    clam = make_field(name="clam")
+    oyster = make_field(
+        name="oyster",
+        message=make_message(
+            name="Oyster",
+            fields=[make_field(name="has_pearl")]
+        )
+    )
+
+    # Interleave required and optional fields to make sure
+    # that, in the legacy flattening, required fields are always first.
+    request = make_message("request", fields=[squid, clam, octopus, oyster])
+
+    method = make_method(
+        name="CreateMolluscs",
+        input_message=request,
+        # Signatures should be ignored.
+        signatures=[
+            "squid,octopus.mass",
+            "squid,octopus,oyster.has_pearl"
+        ]
+    )
+
+    # Use a default dict because ordering is important:
+    # required fields should come first.
+    expected = collections.OrderedDict([
+        ("squid", squid),
+        ("octopus", octopus),
+        ("clam", clam),
+        ("oyster", oyster)
+    ])
+
+    assert method.legacy_flattened_fields == expected
+
+
 def make_method(
         name: str, input_message: wrappers.MessageType = None,
         output_message: wrappers.MessageType = None,
@@ -222,7 +274,7 @@ def make_method(
 
 
 def make_message(name: str, package: str = 'foo.bar.v1', module: str = 'baz',
-        fields: Sequence[wrappers.Field] = (),
+                 fields: Sequence[wrappers.Field] = (),
                  ) -> wrappers.MessageType:
     message_pb = descriptor_pb2.DescriptorProto(
         name=name,

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -218,7 +218,7 @@ def test_method_legacy_flattened_fields():
         ]
     )
 
-    # Use a default dict because ordering is important:
+    # Use an ordered dict because ordering is important:
     # required fields should come first.
     expected = collections.OrderedDict([
         ("squid", squid),

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -81,7 +81,7 @@ def test_service_python_modules():
     ))
     imports = set()
     for m in service.methods.values():
-        imports = imports.union({i.ident.python_import for i in m.ref_types})
+        imports = imports.union({i.ident.python_import for i in m.ref_types_legacy})
     assert imports == {
         imp.Import(package=('a', 'b', 'v1'), module='c'),
         imp.Import(package=('foo',), module='bacon'),
@@ -164,10 +164,10 @@ def make_service(name: str = 'Placeholder', host: str = '',
 # FIXME (lukesneeringer): This test method is convoluted and it makes these
 #                         tests difficult to understand and maintain.
 def make_service_with_method_options(*,
-        http_rule: http_pb2.HttpRule = None,
-        method_signature: str = '',
-        in_fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = ()
-        ) -> wrappers.Service:
+                                     http_rule: http_pb2.HttpRule = None,
+                                     method_signature: str = '',
+                                     in_fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = ()
+                                     ) -> wrappers.Service:
     # Declare a method with options enabled for long-running operations and
     # field headers.
     method = get_method(
@@ -192,13 +192,13 @@ def make_service_with_method_options(*,
 
 
 def get_method(name: str,
-        in_type: str,
-        out_type: str,
-        lro_response_type: str = '',
-        lro_metadata_type: str = '', *,
-        in_fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = (),
-        http_rule: http_pb2.HttpRule = None,
-        method_signature: str = '',
+               in_type: str,
+               out_type: str,
+               lro_response_type: str = '',
+               lro_metadata_type: str = '', *,
+               in_fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = (),
+               http_rule: http_pb2.HttpRule = None,
+               method_signature: str = '',
                ) -> wrappers.Method:
     input_ = get_message(in_type, fields=in_fields)
     output = get_message(out_type)
@@ -231,7 +231,7 @@ def get_method(name: str,
 
 
 def get_message(dot_path: str, *,
-        fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = (),
+                fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = (),
                 ) -> wrappers.MessageType:
     # Pass explicit None through (for lro_metadata).
     if dot_path is None:

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -79,9 +79,11 @@ def test_service_python_modules():
         get_method('Jump', 'foo.bacon.JumpRequest', 'foo.bacon.JumpResponse'),
         get_method('Yawn', 'a.b.v1.c.YawnRequest', 'x.y.v1.z.YawnResponse'),
     ))
-    imports = set()
-    for m in service.methods.values():
-        imports = imports.union({i.ident.python_import for i in m.ref_types_legacy})
+    imports = {
+        i.ident.python_import
+        for m in service.methods.values()
+        for i in m.ref_types_legacy
+    }
     assert imports == {
         imp.Import(package=('a', 'b', 'v1'), module='c'),
         imp.Import(package=('foo',), module='bacon'),
@@ -163,11 +165,12 @@ def make_service(name: str = 'Placeholder', host: str = '',
 
 # FIXME (lukesneeringer): This test method is convoluted and it makes these
 #                         tests difficult to understand and maintain.
-def make_service_with_method_options(*,
-                                     http_rule: http_pb2.HttpRule = None,
-                                     method_signature: str = '',
-                                     in_fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = ()
-                                     ) -> wrappers.Service:
+def make_service_with_method_options(
+    *,
+    http_rule: http_pb2.HttpRule = None,
+    method_signature: str = '',
+    in_fields: typing.Tuple[descriptor_pb2.FieldDescriptorProto] = ()
+) -> wrappers.Service:
     # Declare a method with options enabled for long-running operations and
     # field headers.
     method = get_method(


### PR DESCRIPTION
Tests and implementation for #241
The python microgenerator transition consensus is to minimize breaking changes for the duration of the transition and revisit any breaking UI/UX improvements after the fact. As a result, the legacy flattening interface must be restored.

Inspection of the monolith parameter transformer and template reveal that the legacy interface only flattens the fields of the request object one level deep; required fields are used first as positional parameters, followed by optional fields used as optional parameters.

Includes changes to the client template, client unit test template, and new features and associated tests in the generator logic.

Note: please ignore most of the formatting changes. They are due to an overly aggressive emacs configuration that is difficult to change.

The relevant source lines in the generator are https://github.com/googleapis/gapic-generator/blob/bcedba65bf930d3e35530fe5360f1c6f24d27abc/src/main/resources/com/google/api/codegen/py/main.snip#L321 and https://github.com/googleapis/gapic-generator/blob/bcedba65bf930d3e35530fe5360f1c6f24d27abc/src/main/java/com/google/api/codegen/transformer/py/PythonApiMethodParamTransformer.java#L43 .