### PR TITLE
Generated test and impl for client options

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -99,12 +99,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 automatically.
             client_options (ClientOptions): Custom options for the client.
         """
-        # Save or instantiate the transport.
-        # Ordinarily, we provide the transport, but allowing a custom transport
-        # instance provides an extensibility point for unusual situations.
         if isinstance(client_options, dict):
             client_options = ClientOptions.from_dict(client_options)
 
+        # Save or instantiate the transport.
+        # Ordinarily, we provide the transport, but allowing a custom transport
+        # instance provides an extensibility point for unusual situations.
         if isinstance(transport, {{ service.name }}Transport):
             if credentials:
                 raise ValueError('When providing a transport instance, '

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -5,11 +5,12 @@ from collections import OrderedDict
 from typing import Dict, Sequence, Tuple, Type, Union
 import pkg_resources
 
-from google.api_core import exceptions        # type: ignore
-from google.api_core import gapic_v1          # type: ignore
-from google.api_core import retry as retries  # type: ignore
-from google.auth import credentials           # type: ignore
-from google.oauth2 import service_account     # type: ignore
+import google.api_core.client_options as ClientOptions # type: ignore
+from google.api_core import exceptions                 # type: ignore
+from google.api_core import gapic_v1                   # type: ignore
+from google.api_core import retry as retries           # type: ignore
+from google.auth import credentials                    # type: ignore
+from google.oauth2 import service_account              # type: ignore
   
 {% filter sort_lines -%}
 {% for method in service.methods.values() -%}
@@ -56,6 +57,8 @@ class {{ service.client_name }}Meta(type):
 class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     """{{ service.meta.doc|rst(width=72, indent=4) }}"""
 
+    DEFAULT_OPTIONS = ClientOptions.ClientOptions({% if service.host %}api_endpoint='{{ service.host }}'{% endif %})
+
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
         """Creates an instance of this client using the provided credentials
@@ -79,15 +82,13 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
 
     def __init__(self, *,
-            host: str{% if service.host %} = '{{ service.host }}'{% endif %},
             credentials: credentials.Credentials = None,
-            transport: Union[str, {{ service.name }}Transport] = None
+            transport: Union[str, {{ service.name }}Transport] = None,
+            client_options: ClientOptions = DEFAULT_OPTIONS,
             ) -> None:
         """Instantiate the {{ (service.client_name|snake_case).replace('_', ' ') }}.
 
         Args:
-            host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
-                {{- ' ' }}The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -96,10 +97,14 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             transport (Union[str, ~.{{ service.name }}Transport]): The
                 transport to use. If set to None, a transport is chosen
                 automatically.
+            client_options (ClientOptions): Custom options for the client.
         """
         # Save or instantiate the transport.
         # Ordinarily, we provide the transport, but allowing a custom transport
         # instance provides an extensibility point for unusual situations.
+        if isinstance(client_options, dict):
+            client_options = ClientOptions.from_dict(client_options)
+
         if isinstance(transport, {{ service.name }}Transport):
             if credentials:
                 raise ValueError('When providing a transport instance, '
@@ -107,7 +112,10 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             self._transport = transport
         else:
             Transport = type(self).get_transport_class(transport)
-            self._transport = Transport(credentials=credentials, host=host)
+            self._transport = Transport(
+                credentials=credentials,
+                host=client_options.api_endpoint{% if service.host %} or '{{ service.host }}'{% endif %},
+            )
 
     {% for method in service.methods.values() -%}
     def {{ method.name|snake_case }}(self,

--- a/gapic/templates/tests/unit/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/%name_%version/%sub/test_%service.py.j2
@@ -14,6 +14,7 @@ from google.auth import credentials
 from google.oauth2 import service_account
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import transports
+from google.api_core import client_options
 {% if service.has_lro -%}
 from google.api_core import future
 from google.api_core import operations_v1
@@ -36,6 +37,31 @@ def test_{{ service.client_name|snake_case }}_from_service_account_file():
 
         client = {{ service.client_name }}.from_service_account_json("dummy/file/path.json")
         assert client._transport._credentials == creds
+
+        {% if service.host %}assert client._transport._host == '{{ service.host }}'{% endif %}
+
+
+def test_{{ service.client_name|snake_case }}_client_options():
+    # Check the default options have their expected values.
+    {% if service.host %}assert {{ service.client_name }}.DEFAULT_OPTIONS.api_endpoint == '{{ service.host }}'{% endif %}
+
+    # Check that options can be customized.
+    options = client_options.ClientOptions(api_endpoint="squid.clam.whelk")
+    with mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.{{ service.client_name }}.get_transport_class') as gtc:
+        transport = gtc.return_value = mock.MagicMock()
+        client = {{ service.client_name }}(
+            client_options=options
+        )
+        transport.assert_called_once_with(credentials=None, host="squid.clam.whelk")
+
+
+def test_{{ service.client_name|snake_case }}_client_options_from_dict():
+    with mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.{{ service.client_name }}.get_transport_class') as gtc:
+        transport = gtc.return_value = mock.MagicMock()
+        client = {{ service.client_name }}(
+            client_options={'api_endpoint': 'squid.clam.whelk'}
+        )
+        transport.assert_called_once_with(credentials=None, host="squid.clam.whelk")
 
 
 {% for method in service.methods.values() -%}
@@ -352,7 +378,7 @@ def test_{{ service.name|snake_case }}_host_no_port():
     {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
-        host='{{ host }}',
+        client_options=client_options.ClientOptions(api_endpoint='{{ host }}'),
         transport='grpc',
     )
     assert client._transport._host == '{{ host }}:443'
@@ -363,7 +389,7 @@ def test_{{ service.name|snake_case }}_host_with_port():
     {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
-        host='{{ host }}:8000',
+        client_options=client_options.ClientOptions(api_endpoint='{{ host }}:8000'),
         transport='grpc',
     )
     assert client._transport._host == '{{ host }}:8000'


### PR DESCRIPTION
In order to preserve the interface of legacy client construction,
client constructors take a
'google.api_core.client_options.ClientOptions' parameter.

Currently, this option only customizes the api endpoint, but other
customizations may be enabled.

Includes generated unit tests.

Implementation for #227 