### PR TITLE
First pass template for a keyword cst transformer utility

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -120,11 +120,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     {% for method in service.methods.values() -%}
     def {{ method.name|snake_case }}(self,
             {% for field in method.legacy_flattened_fields.values() -%}
-            {% if field.required -%}
-            {{ field.name }}: {{ field.ident }},
-            {% else -%}
             {{ field.name }}: {{ field.ident }} = None,
-            {% endif -%}
             {% endfor -%}
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -141,8 +137,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             {{ field.name }} (:class:`{{ field.ident.sphinx }}`):
                 {{ field.meta.doc|rst(width=72, indent=16, nl=False) }}
                 This corresponds to the ``{{ key }}`` field
-                on the ``request`` instance; if ``request`` is provided, this
-                should not be set.
+                on the ``request`` instance.
             {% endfor -%}
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.

--- a/gapic/templates/scripts/fixup_%service_keywords.py.j2
+++ b/gapic/templates/scripts/fixup_%service_keywords.py.j2
@@ -1,0 +1,92 @@
+{% extends '_base.py.j2' %}
+{% block content %}
+import argparse
+import os
+import libcst as cst
+from typing import (Any, Callable, Dict, List, Sequence, Tuple)
+
+
+def partition(
+    predicate: Callable[[Any], bool],
+    iterator: Sequence[Any]
+) -> Tuple[List[Any], List[Any]]:
+    """A stable, out-of-place partition."""
+    results = ([], [])
+
+    for i in iterator:
+        results[int(predicate(i))].append(i)
+
+    # Returns trueList, falseList
+    return results[1], results[0]
+
+
+class {{ service.client_name }}CallTransformer(cst.CSTTransformer):
+    METHOD_TO_PARAMS: Dict[str, Tuple[str]] = {
+        {% for method in service.methods.values() -%}
+          '{{ method.name|snake_case }}': ({% for field in method.legacy_flattened_fields.values() %}'{{ field.name }}', {% endfor %}'retry', 'timeout', 'metadata'),
+        {% endfor -%}
+    }
+
+    def leave_Call(self, original: cst.Call, updated: cst.Call) -> cst.CSTNode:
+        try:
+            key = original.func.attr.value
+            kword_params = self.METHOD_TO_PARAMS[key]
+        except (AttributeError, KeyError):
+            # Either not a method from the API or too convoluted to be sure.
+            return updated
+
+        # If the existing code is valid, keyword args come after positional args.
+        # Therefore, all positional args must map to the first parameters.
+        args, kwargs = partition(lambda a: not bool(a.keyword), updated.args)
+        return updated.with_changes(
+            args=[cst.Arg(value=a.value, keyword=cst.Name(value=k))
+                  for a, k in zip(args, kword_params)] + kwargs
+        )
+
+
+def fix_files(
+    dirs: Sequence[str],
+    *,
+    transformer={{ service.client_name }}CallTransformer(),
+):
+    pyfile_gen = (os.path.join(root, f)
+                  for d in dirs
+                  for root, _, files in os.walk(d)
+                  for f in files if os.path.splitext(f)[1] == ".py")
+
+    for fpath in pyfile_gen:
+        with open(fpath, 'r+') as f:
+            src = f.read()
+            tree = cst.parse_module(src)
+            updated = tree.visit(transformer)
+            f.seek(0)
+            f.truncate()
+            f.write(updated.code)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="""Fix up source that uses the {{ service.name }} client library.
+
+Note: This tool operates at a best-effort level at converting positional
+      parameters in client method calls to keyword based parameters.
+      Cases where it WILL FAIL include
+      A) * or ** expansion in a method call.
+      B) Calls via function or method alias (includes free function calls)
+      C) Indirect or dispatched calls (e.g. the method is looked up dynamically)
+
+      These all constitute false negatives. The tool will also detect false
+      positives when an API method shares a name with another method.
+
+      Be sure to back up your source files before running this tool and to compare the diffs.
+""")
+    parser.add_argument(
+        '-d',
+        metavar='dir',
+        dest='dirs',
+        action='append',
+        help='a directory to walk for python files to fix up'
+    )
+    args = parser.parse_args()
+    fix_files(args.dirs or ['.'])
+{% endblock %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -31,6 +31,14 @@ setuptools.setup(
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],
+    scripts=[
+        {% for service in api.services.values() -%}
+        'scripts/fixup_{{ service.module_name }}_keywords.py',
+        {% endfor -%}
+    ],
+    setup_requires=[
+        'libcst == 0.2.4',
+    ],
     zip_safe=False,
 )
 {% endblock %}


### PR DESCRIPTION
Manual testing on samples insert keywords correctly, preserve comments, and (mostly) maintain formatting. 

TODO:
* Be better at preserving whitespace and formatting
* Remove the space between introduced keywords, the =, and the value
* Add a dry-run option
* Add some tests for the scripts
* Package them properly in the generated setup.py