### PR TITLE
Fix for #169: unused imports

### DIFF
--- a/gapic/templates/tests/unit/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/%name_%version/%sub/test_%service.py.j2
@@ -21,7 +21,9 @@ from google.api_core import operations_v1
 from google.longrunning import operations_pb2
 {% endif -%}
 {% for method in service.methods.values() -%}
-{% for ref_type in method.ref_types -%}
+{% for ref_type in method.ref_types
+   if not ((ref_type.ident.python_import.package == ('google', 'api_core') and ref_type.ident.python_import.module == 'operation')
+           or ref_type.ident.python_import.package == ('google', 'protobuf') and ref_type.ident.python_import.module == 'empty_pb2') -%}
 {{ ref_type.ident.python_import }}
 {% endfor -%}
 {% endfor -%}


### PR DESCRIPTION
Fix the unused import of api_core.operation and protobuf.empty_pb2 in
generated unit tests.

The fix is hacky, gross, and specific, but presumably it should generalize.