### PR TITLE
Tests and impl for samplegen flattening awareness of unary methods

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -21,11 +21,13 @@ import os
 import re
 import time
 
+from gapic import utils
+
 from gapic.samplegen_utils import types
 from gapic.schema import wrappers
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
-from typing import (ChainMap, Dict, List, Mapping, Optional, Tuple)
+from typing import (ChainMap, Dict, List, Mapping, Optional, Set, Tuple)
 
 # There is no library stub file for this module, so ignore it.
 from google.api import resource_pb2  # type: ignore
@@ -193,6 +195,12 @@ class RequestEntry:
         default_factory=list)
 
 
+@dataclasses.dataclass(frozen=True)
+class FullRequest:
+    request_list: List[TransformedRequest]
+    flattenable: bool = False
+
+
 class Validator:
     """Class that validates a sample.
 
@@ -222,6 +230,7 @@ class Validator:
     # TODO(dovs): make the schema a required param.
     def __init__(self, method: wrappers.Method, api_schema=None):
             # The response ($resp) variable is special and guaranteed to exist.
+        self.method = method
         self.request_type_ = method.input
         response_type = method.output
         if method.paged_result_field:
@@ -258,6 +267,12 @@ class Validator:
         """
         sample["package_name"] = api_schema.naming.warehouse_package_name
         sample.setdefault("response", [{"print": ["%s", "$resp"]}])
+
+    @utils.cached_property
+    def flattenable_fields(self) -> Set[str]:
+        return set(
+            field.name for field in self.method.flattened_fields.values()
+        )
 
     def var_field(self, var_name: str) -> Optional[wrappers.Field]:
         return self.var_defs_.get(var_name)
@@ -338,7 +353,7 @@ class Validator:
 
     def validate_and_transform_request(self,
                                        calling_form: types.CallingForm,
-                                       request: List[Mapping[str, str]]) -> List[TransformedRequest]:
+                                       request: List[Mapping[str, str]]) -> FullRequest:
         """Validates and transforms the "request" block from a sample config.
 
            In the initial request, each dict has a "field" key that maps to a dotted
@@ -477,16 +492,22 @@ class Validator:
             raise types.InvalidRequestSetup(
                 "Too many base parameters for client side streaming form")
 
-        return [
-            TransformedRequest.build(
-                self.request_type_,
-                self.api_schema_,
-                key,
-                val.attrs,
-                val.is_resource_request
-            )
-            for key, val in base_param_to_attrs.items()
-        ]
+        # We can only flatten a collection of request parameters if they're a
+        # subset of the flattened fields of the method.
+        flattenable = self.flattenable_fields >= set(base_param_to_attrs.keys())
+        return FullRequest(
+            request_list=[
+                TransformedRequest.build(
+                    self.request_type_,
+                    self.api_schema_,
+                    key,
+                    val.attrs,
+                    val.is_resource_request
+                )
+                for key, val in base_param_to_attrs.items()
+            ],
+            flattenable=flattenable
+        )
 
     def validate_response(self, response):
         """Validates a "response" block from a sample config.

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -27,7 +27,7 @@ from gapic.samplegen_utils import types
 from gapic.schema import wrappers
 
 from collections import (defaultdict, namedtuple, ChainMap as chainmap)
-from typing import (ChainMap, Dict, List, Mapping, Optional, Set, Tuple)
+from typing import (ChainMap, Dict, FrozenSet, List, Mapping, Optional, Tuple)
 
 # There is no library stub file for this module, so ignore it.
 from google.api import resource_pb2  # type: ignore
@@ -269,8 +269,8 @@ class Validator:
         sample.setdefault("response", [{"print": ["%s", "$resp"]}])
 
     @utils.cached_property
-    def flattenable_fields(self) -> Set[str]:
-        return set(
+    def flattenable_fields(self) -> FrozenSet[str]:
+        return frozenset(
             field.name for field in self.method.flattened_fields.values()
         )
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -494,7 +494,7 @@ class Validator:
 
         # We can only flatten a collection of request parameters if they're a
         # subset of the flattened fields of the method.
-        flattenable = self.flattenable_fields >= set(base_param_to_attrs.keys())
+        flattenable = self.flattenable_fields >= set(base_param_to_attrs)
         return FullRequest(
             request_list=[
                 TransformedRequest.build(

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -41,9 +41,9 @@ There is a little, but not enough for it to be important because
 {% endif %}
 {% endmacro %}
 
-{% macro print_input_params(requests) %}
+{% macro print_input_params(full_request) %}
 {% with input_parameters = [] %}
-  {% for request in requests %}
+  {% for request in full_request.request_list %}
     {% if request.body %}
       {% for element in request.body if element.input_parameter %}
         {% do input_parameters.append(element.input_parameter) %}
@@ -148,8 +148,8 @@ with open({{ attr.input_parameter }}, "rb") as f:
   {% endif %}
 {% endmacro %}
 
-{% macro render_request_setup(request) %}
-{% for parameter_block in request if parameter_block.body %}
+{% macro render_request_setup(full_request) %}
+{% for parameter_block in full_request.request_list if parameter_block.body %}
 {% if parameter_block.pattern -%}
 {# This is a resource-name patterned lookup parameter #}
 {% with formals = [] -%} 
@@ -158,13 +158,20 @@ with open({{ attr.input_parameter }}, "rb") as f:
 {% endfor -%} 
 {{ parameter_block.base }} = "{{parameter_block.pattern }}".format({{ formals|join(", ") }})
 {% endwith -%}  
-{% else -%}
+{% else -%} {# End resource name construction #}
 {{ parameter_block.base }} = {}
 {% for attr in parameter_block.body %}
 {{ render_request_attr(parameter_block.base, attr) }}
 {% endfor %}
 {% endif -%}
 {% endfor %}
+{% if not full_request.flattenable -%}
+request = {
+{% for parameter in full_request.request_list %}
+    '{{ parameter.base  }}': {{ parameter.base if parameter.body else parameter.single }},
+{% endfor -%}
+}
+{% endif -%}
 {% endmacro %}
 
 {% macro render_request_params(request) %}
@@ -180,14 +187,29 @@ with open({{ attr.input_parameter }}, "rb") as f:
   {% endwith -%}
 {% endmacro %}
 
+{% macro render_request_params_unary(request) %}
+  {# Provide the top level parameters last and as keyword params #}
+  {% if request.flattenable -%}
+  {% with params = [] -%}
+    {% for r in request.request_list -%}
+      {% do params.append("%s=%s"|format(r.base, r.single.value if r.single else r.base)) -%}
+    {% endfor -%}
+{{ params|join(", ") -}}
+  {% endwith -%}
+  {% else -%}
+request=request
+  {% endif -%}
+{% endmacro %}
+
+
 {% macro render_method_call(sample, calling_form, calling_form_enum) %}
   {# Note: this doesn't deal with enums or unions #}
 {% if calling_form in [calling_form_enum.RequestStreamingBidi,
                        calling_form_enum.RequestStreamingClient] -%}
-client.{{ sample.rpc|snake_case }}([{{ render_request_params(sample.request)|trim -}}])
-{% else -%}
+client.{{ sample.rpc|snake_case }}([{{ render_request_params(sample.request.request_list)|trim -}}])
+{% else -%} {# TODO: deal with flattening #}
 {# TODO: set up client streaming once some questions are answered #}
-client.{{ sample.rpc|snake_case }}({{ render_request_params(sample.request)|trim -}})
+client.{{ sample.rpc|snake_case }}({{ render_request_params_unary(sample.request)|trim -}})
 {% endif -%}
 {% endmacro %}
 
@@ -235,13 +257,13 @@ response = operation.result()
 {{ method_name|snake_case }}
 {% endmacro %}
 
-{% macro render_main_block(method_name, request_block) %}
+{% macro render_main_block(method_name, full_request) %}
 def main():
     import argparse
 
     parser = argparse.ArgumentParser()
 {% with arg_list = [] -%}
-{% for request in request_block if request.body -%}
+{% for request in full_request.request_list if request.body -%}
 {% for attr in request.body if attr.input_parameter %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
@@ -249,7 +271,7 @@ def main():
 {% do arg_list.append("args." + attr.input_parameter) -%}
 {% endfor -%}
 {% endfor -%}
-{% for request in request_block if request.single and request.single.input_parameter %}
+{% for request in full_request.request_list if request.single and request.single.input_parameter %}
     parser.add_argument("--{{ request.single.input_parameter }}",
                         type=str,
                         default={{ request.single.value }})

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -37,12 +37,12 @@ def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input
         transport="grpc",
     )
 
-    {{ frags.render_request_setup(sample.request)|indent }}
-{% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %}
-    {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response)|indent -}}
-{% endwith %}
+    {{ frags.render_request_setup(sample.request)|indent }} 
+{% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %} 
+    {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response, )|indent -}} 
+{% endwith %} 
 
 # [END {{ sample.id }}]
 
-{{ frags.render_main_block(sample.rpc, sample.request) }}
+{{ frags.render_main_block(sample.rpc, sample.request) }} 
 {%- endblock %}

--- a/tests/unit/samplegen/common_types.py
+++ b/tests/unit/samplegen/common_types.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 import itertools
 
 from collections import namedtuple
-from typing import(Iterable, Optional)
+from typing import(Any, Dict, Iterable, Optional)
 
 from google.protobuf import descriptor_pb2
 
@@ -23,19 +24,17 @@ from gapic.schema import wrappers
 
 # Injected dummy test types
 
-DummyMethod = namedtuple(
-    "DummyMethod",
-    [
-        "input",
-        "output",
-        "lro",
-        "paged_result_field",
-        "client_streaming",
-        "server_streaming",
-    ],
-)
 
-DummyMethod.__new__.__defaults__ = (False,) * len(DummyMethod._fields)
+@dataclasses.dataclass(frozen=True)
+class DummyMethod:
+    input: bool = False
+    output: bool = False
+    lro: bool = False
+    paged_result_field: bool = False
+    client_streaming: bool = False
+    server_streaming: bool = False
+    flattened_fields: Dict[str, Any] = dataclasses.field(default_factory=dict)
+
 
 DummyMessage = namedtuple("DummyMessage", ["fields", "type", "options"])
 DummyMessage.__new__.__defaults__ = (False,) * len(DummyMessage._fields)
@@ -43,6 +42,7 @@ DummyMessage.__new__.__defaults__ = (False,) * len(DummyMessage._fields)
 DummyField = namedtuple("DummyField",
                         ["message",
                          "enum",
+                         "name",
                          "repeated",
                          "field_pb",
                          "meta",

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -52,7 +52,7 @@ def test_generate_sample_basic():
     input_type = DummyMessage(
         type="REQUEST TYPE",
         fields={
-            "classify_request": DummyField(
+            "classify_target": DummyField(
                 message=DummyMessage(
                     type="CLASSIFY TYPE",
                     fields={
@@ -75,7 +75,8 @@ def test_generate_sample_basic():
         methods={
             "Classify": DummyMethod(
                 input=input_type,
-                output=message_factory("$resp.taxonomy")
+                output=message_factory("$resp.taxonomy"),
+                flattened_fields={"classify_target": DummyField(name="classify_target")}
             )
         }
     )
@@ -90,11 +91,11 @@ def test_generate_sample_basic():
               "id": "mollusc_classify_sync",
               "description": "Determine the full taxonomy of input mollusc",
               "request": [
-                  {"field": "classify_request.video",
+                  {"field": "classify_target.video",
                    "value": "path/to/mollusc/video.mkv",
                    "input_parameter": "video",
                    "value_is_file": True},
-                  {"field": "classify_request.location_annotation",
+                  {"field": "classify_target.location_annotation",
                    "value": "New Zealand",
                    "input_parameter": "location"}
               ],
@@ -141,17 +142,158 @@ def sample_classify(video, location):
         transport="grpc",
     )
 
-    classify_request = {}
+    classify_target = {}
     # video = "path/to/mollusc/video.mkv"
     with open(video, "rb") as f:
-        classify_request["video"] = f.read()
+        classify_target["video"] = f.read()
 
     # location = "New Zealand"
-    classify_request["location_annotation"] = location
+    classify_target["location_annotation"] = location
 
-
-    response = client.classify(classify_request)
+ 
+ 
+    response = client.classify(classify_target=classify_target)
     print("Mollusc is a \\"{}\\"".format(response.taxonomy))
+ 
+
+# [END %s]
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--video",
+                        type=str,
+                        default="path/to/mollusc/video.mkv")
+    parser.add_argument("--location",
+                        type=str,
+                        default="New Zealand")
+    args = parser.parse_args()
+
+    sample_classify(args.video, args.location)
+
+
+if __name__ == "__main__":
+    main()
+''' % (sample_id, sample_id, sample_id)
+
+    assert sample_str == expected_str
+
+
+def test_generate_sample_basic_unflattenable():
+    # Note: the sample integration tests are needfully large
+    # and difficult to eyeball parse. They are intended to be integration tests
+    # that catch errors in behavior that is emergent from combining smaller features
+    # or in features that are sufficiently small and trivial that it doesn't make sense
+    # to have standalone tests.
+    input_type = DummyMessage(
+        type="REQUEST TYPE",
+        fields={
+            "classify_target": DummyField(
+                message=DummyMessage(
+                    type="CLASSIFY TYPE",
+                    fields={
+                        "video": DummyField(
+                            message=DummyMessage(type="VIDEO TYPE"),
+                        ),
+                        "location_annotation": DummyField(
+                            message=DummyMessage(type="LOCATION TYPE"),
+                        )
+                    },
+                )
+            )
+        }
+    )
+
+    api_naming = naming.Naming(
+        name="MolluscClient", namespace=("molluscs", "v1"))
+    service = wrappers.Service(
+        service_pb=namedtuple('service_pb', ['name'])('MolluscService'),
+        methods={
+            "Classify": DummyMethod(
+                input=input_type,
+                output=message_factory("$resp.taxonomy"),
+            )
+        }
+    )
+
+    schema = DummyApiSchema(
+        services={"animalia.mollusca.v1.Mollusc": service},
+        naming=api_naming,
+    )
+
+    sample = {"service": "animalia.mollusca.v1.Mollusc",
+              "rpc": "Classify",
+              "id": "mollusc_classify_sync",
+              "description": "Determine the full taxonomy of input mollusc",
+              "request": [
+                  {"field": "classify_target.video",
+                   "value": "path/to/mollusc/video.mkv",
+                   "input_parameter": "video",
+                   "value_is_file": True},
+                  {"field": "classify_target.location_annotation",
+                   "value": "New Zealand",
+                   "input_parameter": "location"}
+              ],
+              "response": [{"print": ['Mollusc is a "%s"', "$resp.taxonomy"]}]}
+
+    sample_str = samplegen.generate_sample(
+        sample,
+        schema,
+        env.get_template('examples/sample.py.j2')
+    )
+
+    sample_id = ("mollusc_classify_sync")
+    expected_str = '''# -*- coding: utf-8 -*-
+# Copyright (C) 2019  Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# DO NOT EDIT! This is a generated sample ("request",  "%s")
+#
+# To install the latest published package dependency, execute the following:
+#   pip3 install molluscs-v1-molluscclient
+
+
+# [START %s]
+from google import auth
+from google.auth import credentials
+from molluscs.v1.molluscclient.services.mollusc_service import MolluscServiceClient
+
+def sample_classify(video, location):
+    """Determine the full taxonomy of input mollusc"""
+
+    client = MolluscServiceClient(
+        credentials=credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    classify_target = {}
+    # video = "path/to/mollusc/video.mkv"
+    with open(video, "rb") as f:
+        classify_target["video"] = f.read()
+
+    # location = "New Zealand"
+    classify_target["location_annotation"] = location
+
+    request = {
+        'classify_target': classify_target,
+    }
+ 
+ 
+    response = client.classify(request=request)
+    print("Mollusc is a \\"{}\\"".format(response.taxonomy))
+ 
 
 # [END %s]
 

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -76,7 +76,9 @@ def test_generate_sample_basic():
             "Classify": DummyMethod(
                 input=input_type,
                 output=message_factory("$resp.taxonomy"),
-                flattened_fields={"classify_target": DummyField(name="classify_target")}
+                flattened_fields={
+                    "classify_target": DummyField(name="classify_target")
+                }
             )
         }
     )

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -899,18 +899,22 @@ def test_validate_request_basic():
             {"field": "squid.num_tentacles", "value": 10},
         ],
     )
-    expected = [samplegen.TransformedRequest(
-        base="squid",
-        body=[
-            samplegen.AttributeRequestSetup(field="mantle_length",
-                                            value='"100 \\"cm"'),
-            samplegen.AttributeRequestSetup(field="mantle_mass",
-                                            value='"10 kg"'),
-            samplegen.AttributeRequestSetup(field="num_tentacles",
-                                            value=10)
-        ],
-        single=None
-    )]
+    expected = samplegen.FullRequest(
+        request_list=[
+            samplegen.TransformedRequest(
+                base="squid",
+                body=[
+                    samplegen.AttributeRequestSetup(field="mantle_length",
+                                                    value='"100 \\"cm"'),
+                    samplegen.AttributeRequestSetup(field="mantle_mass",
+                                                    value='"10 kg"'),
+                    samplegen.AttributeRequestSetup(field="num_tentacles",
+                                                    value=10)
+                ],
+                single=None
+            )
+        ]
+    )
 
     assert actual == expected
 
@@ -943,13 +947,15 @@ def test_validate_request_top_level_field():
         [{"field": "squid", "value": "humboldt"}]
     )
 
-    expected = [
-        samplegen.TransformedRequest(base="squid",
-                                     body=None,
-                                     single=samplegen.AttributeRequestSetup(
-                                         value='"humboldt"'
-                                     ))
-    ]
+    expected = samplegen.FullRequest(
+        request_list=[
+            samplegen.TransformedRequest(base="squid",
+                                         body=None,
+                                         single=samplegen.AttributeRequestSetup(
+                                             value='"humboldt"'
+                                         ))
+        ]
+    )
 
     assert actual == expected
 
@@ -1035,24 +1041,26 @@ def test_validate_request_multiple_arguments():
             },
         ],
     )
-    expected = [
-        samplegen.TransformedRequest(
-            base="squid",
-            body=[samplegen.AttributeRequestSetup(
-                field="mantle_length",
-                value='"100 cm"',
-                value_is_file=True)],
-            single=None
-        ),
-        samplegen.TransformedRequest(
-            base="clam",
-            body=[samplegen.AttributeRequestSetup(
-                field="shell_mass",
-                value='"100 kg"',
-                comment="Clams can be large")],
-            single=None
-        ),
-    ]
+    expected = samplegen.FullRequest(
+        request_list=[
+            samplegen.TransformedRequest(
+                base="squid",
+                body=[samplegen.AttributeRequestSetup(
+                    field="mantle_length",
+                    value='"100 cm"',
+                    value_is_file=True)],
+                single=None
+            ),
+            samplegen.TransformedRequest(
+                base="clam",
+                body=[samplegen.AttributeRequestSetup(
+                    field="shell_mass",
+                    value='"100 kg"',
+                    comment="Clams can be large")],
+                single=None
+            ),
+        ]
+    )
 
     assert actual == expected
 
@@ -1524,11 +1532,16 @@ def test_validate_request_enum():
         types.CallingForm.Request,
         [{"field": "cephalopod.subclass", "value": "COLEOIDEA"}]
     )
-    expected = [samplegen.TransformedRequest(
-        "cephalopod",
-        body=[samplegen.AttributeRequestSetup(field="subclass",
-                                              value='"COLEOIDEA"')],
-        single=None)]
+    expected = samplegen.FullRequest(
+        request_list=[
+            samplegen.TransformedRequest(
+                "cephalopod",
+                body=[samplegen.AttributeRequestSetup(field="subclass",
+                                                      value='"COLEOIDEA"')],
+                single=None
+            )
+        ]
+    )
     assert actual == expected
 
 
@@ -1541,10 +1554,10 @@ def test_validate_request_enum_top_level():
         types.CallingForm.Request,
         [{"field": "subclass", "value": "COLEOIDEA"}]
     )
-    expected = [samplegen.TransformedRequest(
+    expected = samplegen.FullRequest(request_list=[samplegen.TransformedRequest(
         "subclass",
         single=samplegen.AttributeRequestSetup(value='"COLEOIDEA"'),
-        body=None)]
+        body=None)])
     assert actual == expected
 
 
@@ -1627,24 +1640,26 @@ def test_validate_request_resource_name():
         request
     )
 
-    expected = [
-        samplegen.TransformedRequest(
-            base="taxon",
-            pattern="kingdom/{kingdom}/phylum/{phylum}",
-            single=None,
-            body=[
-                samplegen.AttributeRequestSetup(
-                    field="kingdom",
-                    value="animalia",
-                ),
-                samplegen.AttributeRequestSetup(
-                    field="phylum",
-                    value="mollusca",
-                    input_parameter="phylum",
-                ),
-            ]
-        )
-    ]
+    expected = samplegen.FullRequest(
+        request_list=[
+            samplegen.TransformedRequest(
+                base="taxon",
+                pattern="kingdom/{kingdom}/phylum/{phylum}",
+                single=None,
+                body=[
+                    samplegen.AttributeRequestSetup(
+                        field="kingdom",
+                        value="animalia",
+                    ),
+                    samplegen.AttributeRequestSetup(
+                        field="phylum",
+                        value="mollusca",
+                        input_parameter="phylum",
+                    ),
+                ]
+            )
+        ]
+    )
 
     assert actual == expected
 
@@ -1663,15 +1678,17 @@ def test_validate_request_primitive_field():
 
     actual = v.validate_and_transform_request(types.CallingForm.Request,
                                               request)
-    expected = [
-        samplegen.TransformedRequest(
-            base="species",
-            body=None,
-            single=samplegen.AttributeRequestSetup(
-                value='"Architeuthis dux"'
+    expected = samplegen.FullRequest(
+        request_list=[
+            samplegen.TransformedRequest(
+                base="species",
+                body=None,
+                single=samplegen.AttributeRequestSetup(
+                    value='"Architeuthis dux"'
+                )
             )
-        )
-    ]
+        ]
+    )
 
     assert actual == expected
 


### PR DESCRIPTION
Request setup segments that are flattenable (the fields are a subset
of the flattenable fields of the method) are flattened.
Requests that do not meet this requirement are not flattened.