### PR TITLE
WIP DO NOT MERGE: Lazy import feature

### DIFF
--- a/gapic/cli/generate.py
+++ b/gapic/cli/generate.py
@@ -61,7 +61,7 @@ def generate(
     # Translate into a protobuf CodeGeneratorResponse; this reads the
     # individual templates and renders them.
     # If there are issues, error out appropriately.
-    res = generator.Generator(opts).get_response(api_schema)
+    res = generator.Generator(opts).get_response(api_schema, opts)
 
     # Output the serialized response.
     output.write(res.SerializeToString())

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -61,7 +61,11 @@ class Generator:
 
         self._sample_configs = opts.sample_configs
 
-    def get_response(self, api_schema: api.API) -> CodeGeneratorResponse:
+    def get_response(
+        self,
+        api_schema: api.API,
+        opts: options.Options
+    ) -> CodeGeneratorResponse:
         """Return a :class:`~.CodeGeneratorResponse` for this library.
 
         This is a complete response to be written to (usually) stdout, and
@@ -69,6 +73,7 @@ class Generator:
 
         Args:
             api_schema (~api.API): An API schema object.
+            opts (~.options.Options): An options instance.
 
         Returns:
             ~.CodeGeneratorResponse: A response describing appropriate
@@ -93,9 +98,13 @@ class Generator:
                 continue
 
             # Append to the output files dictionary.
-            output_files.update(self._render_template(template_name,
-                                                      api_schema=api_schema,
-                                                      ))
+            output_files.update(
+                self._render_template(
+                    template_name,
+                    api_schema=api_schema,
+                    opts=opts
+                )
+            )
 
         output_files.update(self._generate_samples_and_manifest(
             api_schema,
@@ -208,6 +217,7 @@ class Generator:
             self,
             template_name: str, *,
             api_schema: api.API,
+            opts: options.Options,
     ) -> Dict[str, CodeGeneratorResponse.File]:
         """Render the requested templates.
 
@@ -240,6 +250,7 @@ class Generator:
             for subpackage in api_schema.subpackages.values():
                 answer.update(self._render_template(template_name,
                                                     api_schema=subpackage,
+                                                    opts=opts
                                                     ))
             skip_subpackages = True
 
@@ -252,7 +263,8 @@ class Generator:
                     continue
                 answer.update(self._get_file(template_name,
                                              api_schema=api_schema,
-                                             proto=proto
+                                             proto=proto,
+                                             opts=opts
                                              ))
             return answer
 
@@ -266,15 +278,19 @@ class Generator:
                 answer.update(self._get_file(template_name,
                                              api_schema=api_schema,
                                              service=service,
+                                             opts=opts,
                                              ))
             return answer
 
         # This file is not iterating over anything else; return back
         # the one applicable file.
-        answer.update(self._get_file(template_name, api_schema=api_schema))
+        answer.update(
+            self._get_file(template_name, api_schema=api_schema, opts=opts)
+        )
         return answer
 
     def _get_file(self, template_name: str, *,
+                  opts: options.Options,
                   api_schema=api.API,
                   **context: Mapping):
         """Render a template to a protobuf plugin File object."""
@@ -289,6 +305,7 @@ class Generator:
             content=formatter.fix_whitespace(
                 self._env.get_template(template_name).render(
                     api=api_schema,
+                    opts=opts,
                     **context
                 ),
             ),

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -679,6 +679,14 @@ class Service:
         return self.name + "Client"
 
     @property
+    def transport_name(self):
+        return self.name + "Transport"
+
+    @property
+    def grpc_transport_name(self):
+        return self.name + "GrpcTransport"
+
+    @property
     def has_lro(self) -> bool:
         """Return whether the service has a long-running method."""
         return any([m.lro for m in self.methods.values()])

--- a/gapic/templates/%namespace/%name/__init__.py.j2
+++ b/gapic/templates/%namespace/%name/__init__.py.j2
@@ -1,6 +1,100 @@
 {% extends '_base.py.j2' %}
-
 {% block content %}
+{% if opts.lazy_import -%} {# lazy import #}
+import importlib
+import re
+import sys
+
+from itertools import chain
+
+def to_snake_case(s: str) -> str:
+    s = re.sub(r'(?<=[a-z])([A-Z])', r'_\1', str(s))
+    s = re.sub(r'(?<=[^_])([A-Z])(?=[a-z])', r'_\1', s)
+
+    # Numbers are a weird case; the goal is to spot when they _start_
+    # some kind of name or acronym (e.g. 2FA, 3M).
+    #
+    # Find cases of a number preceded by a lower-case letter _and_
+    # followed by at least two capital letters or a single capital and
+    # end of string.
+    s = re.sub(r'(?<=[a-z])(\d)(?=[A-Z]{2})', r'_\1', s)
+    s = re.sub(r'(?<=[a-z])(\d)(?=[A-Z]$)', r'_\1', s)
+
+    return s.lower()
+
+
+def from_snake_case(s):
+    _CHARS_TO_UPCASE_RE = re.compile(r'(?:_|^)([a-z])')
+    return _CHARS_TO_UPCASE_RE.sub(lambda m: m.group().replace('_', '').upper(), s)
+
+
+if sys.version_info < (3, 7):
+    raise ImportError('This module requires Python 3.7 or later.')
+
+_lazy_name_to_package_map = {
+    'types': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.types',
+    'enums': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.enums',
+  {%- for service in api.services.values()|sort(attribute='name')|unique(attribute='name') if service.meta.address.subpackage == api.subpackage_view %}
+    '{{ service.client_name|snake_case }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client',
+    '{{ service.transport_name|snake_case }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.services.transports.base',
+    '{{ service.grpc_transport_name|snake_case }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.services.transports.grpc',
+    {%- endfor %}  {# Need to do types and enums #}
+}
+
+_lazy_type_to_package_map = {
+{%- for proto in api.protos.values() if proto.meta.address.subpackage == api.subpackage_view %}{%- for message in proto.messages.values() %}
+    '{{ message.name }}':'{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.types.{{ proto.module_name }}',
+{%- endfor %}
+{%- for enum in proto.enums.values() %}
+    '{{ enum.name }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.enums',
+{%- endfor %}{%- endfor %}
+}
+
+
+# Background on how this behaves: https://www.python.org/dev/peps/pep-0562/
+def __getattr__(name):  # Requires Python >= 3.7
+    if name == '__all__':
+        all_names = globals()['__all__'] = sorted(
+            chain(
+                (from_snake_case(k) for k in _lazy_name_to_package_map),
+                _lazy_type_to_package_map,
+            )
+        )
+        return all_names
+    elif name.endswith('Transport'):
+        module = __getattr__(to_snake_case(name))
+        sub_mod_class = getattr(module, name)
+        klass = type(name, (sub_mod_class,), {'__doc__': sub_mod_class.__doc__})
+        globals()[name] = klass
+        return klass
+    elif name.endswith('Client'):
+        module = __getattr__(to_snake_case(name))
+        sub_mod_class = getattr(module, name)
+        enums = __getattr__('enums')
+        klass = type(
+            name,
+            (sub_mod_class,),
+            {'__doc__': sub_mod_class.__doc__, 'enums': enums}
+        )
+        globals()[name] = klass
+        return klass
+    elif name in _lazy_name_to_package_map:
+        module = importlib.import_module(f'{_lazy_name_to_package_map[name]}')
+        globals()[name] = module
+        return module
+    elif name in _lazy_type_to_package_map:
+        module = importlib.import_module(f'{_lazy_type_to_package_map[name]}')
+        klass = getattr(module, name)
+        {# new_klass = type(name, (klass,), {'__doc__': klass.__doc__}) #}
+        globals()[name] = klass
+        return klass
+    else:
+        raise AttributeError(f'unknown sub-module {name!r}.')
+
+
+def __dir__():
+    return globals().get('__all__') or __getattr__('__all__')
+{% else -%}                {# do not use lazy import #}
 {#  Import subpackages. -#}
 {% filter sort_lines -%}
 {% for subpackage in api.subpackages.keys() -%}
@@ -62,4 +156,5 @@ __all__ = (
 {% endfilter -%}
 {% endfilter -%}
 )
+{% endif -%} {# lazy import #}
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -1,6 +1,101 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+{% if opts.lazy_import -%} {# lazy import #}
+import importlib
+import re
+import sys
+
+from itertools import chain
+
+def to_snake_case(s: str) -> str:
+    s = re.sub(r'(?<=[a-z])([A-Z])', r'_\1', str(s))
+    s = re.sub(r'(?<=[^_])([A-Z])(?=[a-z])', r'_\1', s)
+
+    # Numbers are a weird case; the goal is to spot when they _start_
+    # some kind of name or acronym (e.g. 2FA, 3M).
+    #
+    # Find cases of a number preceded by a lower-case letter _and_
+    # followed by at least two capital letters or a single capital and
+    # end of string.
+    s = re.sub(r'(?<=[a-z])(\d)(?=[A-Z]{2})', r'_\1', s)
+    s = re.sub(r'(?<=[a-z])(\d)(?=[A-Z]$)', r'_\1', s)
+
+    return s.lower()
+
+
+def from_snake_case(s):
+    _CHARS_TO_UPCASE_RE = re.compile(r'(?:_|^)([a-z])')
+    return _CHARS_TO_UPCASE_RE.sub(lambda m: m.group().replace('_', '').upper(), s)
+
+
+if sys.version_info < (3, 7):
+    raise ImportError('This module requires Python 3.7 or later.')
+
+_lazy_name_to_package_map = {
+    'types': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.types',
+    'enums': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.enums',
+  {%- for service in api.services.values()|sort(attribute='name')|unique(attribute='name') if service.meta.address.subpackage == api.subpackage_view %}
+    '{{ service.client_name|snake_case }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client',
+    '{{ service.transport_name|snake_case }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.services.transports.base',
+    '{{ service.grpc_transport_name|snake_case }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.services.transports.grpc',
+  {%- endfor %}  {# Need to do types and enums #}
+}
+
+_lazy_type_to_package_map = {
+{%- filter sort_lines %}
+{%- for proto in api.protos.values() if proto.meta.address.subpackage == api.subpackage_view %}{%- for message in proto.messages.values() %}
+    '{{ message.name }}':'{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.types.{{ proto.module_name }}',
+{%- endfor %}
+{%- for enum in proto.enums.values() %}
+    '{{ enum.name }}': '{% if api.naming.module_namespace %}{{ api.naming.module_namespace|join(".") }}.{% endif -%}{{ api.naming.versioned_module_name }}.enums',
+{%- endfor %}{%- endfor %}{%- endfilter %}
+}
+
+# Background on how this behaves: https://www.python.org/dev/peps/pep-0562/
+def __getattr__(name):  # Requires Python >= 3.7
+    if name == '__all__':
+        all_names = globals()['__all__'] = sorted(
+            chain(
+                (from_snake_case(k) for k in _lazy_name_to_package_map),
+                _lazy_type_to_package_map,
+            )
+        )
+        return all_names
+    elif name.endswith('Transport'):
+        module = __getattr__(to_snake_case(name))
+        sub_mod_class = getattr(module, name)
+        klass = type(name, (sub_mod_class,), {'__doc__': sub_mod_class.__doc__})
+        globals()[name] = klass
+        return klass
+    elif name.endswith('Client'):
+        module = __getattr__(to_snake_case(name))
+        sub_mod_class = getattr(module, name)
+        enums = __getattr__('enums')
+        klass = type(
+            name,
+            (sub_mod_class,),
+            {'__doc__': sub_mod_class.__doc__, 'enums': enums}
+        )
+        globals()[name] = klass
+        return klass
+    elif name in _lazy_name_to_package_map:
+        module = importlib.import_module(f'{_lazy_name_to_package_map[name]}')
+        globals()[name] = module
+        return module
+    elif name in _lazy_type_to_package_map:
+        module = importlib.import_module(f'{_lazy_type_to_package_map[name]}')
+        klass = getattr(module, name)
+        {# new_klass = type(name, (klass,), {'__doc__': klass.__doc__}) #}
+        globals()[name] = klass
+        return klass
+    else:
+        raise AttributeError(f'unknown sub-module {name!r}.')
+
+
+def __dir__():
+    return globals().get('__all__') or __getattr__('__all__')
+{% else -%}                {# do not use lazy import #}
 {#  Import subpackages. -#}
 {% for subpackage in api.subpackages.keys() -%}
 from . import {{ subpackage }}
@@ -55,4 +150,5 @@ __all__ = (
     {%- endfor %}
     {%- endfilter %}
 )
+{% endif -%} {# lazy import #}
 {% endblock %}

--- a/noxfile.py
+++ b/noxfile.py
@@ -73,6 +73,7 @@ def showcase(session):
         session.run('protoc',
                     f'--descriptor_set_in={tmp_dir}{os.path.sep}showcase.desc',
                     f'--python_gapic_out={tmp_dir}',
+                    '--python_gapic_opt=lazy-import,',
                     'google/showcase/v1beta1/echo.proto',
                     'google/showcase/v1beta1/identity.proto',
                     external=True,

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -131,7 +131,9 @@ def test_get_response_enumerates_services():
                 api_schema=make_api(make_proto(
                     descriptor_pb2.FileDescriptorProto(service=[
                         descriptor_pb2.ServiceDescriptorProto(name='Spam'),
-                        descriptor_pb2.ServiceDescriptorProto(name='EggsService'),
+                        descriptor_pb2.ServiceDescriptorProto(
+                            name='EggsService'
+                        ),
                     ]),
                 )), opts=options.Options.build(''))
     assert len(cgr.file) == 2

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -45,7 +45,10 @@ def test_get_response():
         lt.return_value = ['foo/bar/baz.py.j2', 'molluscs/squid/sample.py.j2']
         with mock.patch.object(jinja2.Environment, 'get_template') as gt:
             gt.return_value = jinja2.Template('I am a template result.')
-            cgr = g.get_response(api_schema=make_api())
+            cgr = g.get_response(
+                api_schema=make_api(),
+                opts=options.Options.build('')
+            )
     lt.assert_called_once()
     gt.assert_has_calls([
         mock.call('foo/bar/baz.py.j2'),
@@ -62,7 +65,10 @@ def test_get_response_ignores_empty_files():
         lt.return_value = ['foo/bar/baz.py.j2', 'molluscs/squid/sample.py.j2']
         with mock.patch.object(jinja2.Environment, 'get_template') as gt:
             gt.return_value = jinja2.Template('# Meaningless comment')
-            cgr = g.get_response(api_schema=make_api())
+            cgr = g.get_response(
+                api_schema=make_api(),
+                opts=options.Options.build('')
+            )
     lt.assert_called_once()
     gt.assert_has_calls([
         mock.call('foo/bar/baz.py.j2'),
@@ -81,7 +87,10 @@ def test_get_response_ignores_private_files():
         ]
         with mock.patch.object(jinja2.Environment, 'get_template') as gt:
             gt.return_value = jinja2.Template('I am a template result.')
-            cgr = g.get_response(api_schema=make_api())
+            cgr = g.get_response(
+                api_schema=make_api(),
+                opts=options.Options.build('')
+            )
     lt.assert_called_once()
     gt.assert_has_calls([
         mock.call('foo/bar/baz.py.j2'),
@@ -100,7 +109,10 @@ def test_get_response_fails_invalid_file_paths():
             'molluscs/squid/sample.py.j2',
         ]
         with pytest.raises(ValueError) as ex:
-            g.get_response(api_schema=make_api())
+            g.get_response(
+                api_schema=make_api(),
+                opts=options.Options.build('')
+            )
 
         ex_str = str(ex.value)
         assert '%proto' in ex_str and '%service' in ex_str
@@ -115,12 +127,13 @@ def test_get_response_enumerates_services():
         ]
         with mock.patch.object(jinja2.Environment, 'get_template') as gt:
             gt.return_value = jinja2.Template('Service: {{ service.name }}')
-            cgr = g.get_response(api_schema=make_api(make_proto(
-                descriptor_pb2.FileDescriptorProto(service=[
-                    descriptor_pb2.ServiceDescriptorProto(name='Spam'),
-                    descriptor_pb2.ServiceDescriptorProto(name='EggsService'),
-                ]),
-            )))
+            cgr = g.get_response(
+                api_schema=make_api(make_proto(
+                    descriptor_pb2.FileDescriptorProto(service=[
+                        descriptor_pb2.ServiceDescriptorProto(name='Spam'),
+                        descriptor_pb2.ServiceDescriptorProto(name='EggsService'),
+                    ]),
+                )), opts=options.Options.build(''))
     assert len(cgr.file) == 2
     assert {i.name for i in cgr.file} == {
         'foo/spam/baz.py',
@@ -140,7 +153,7 @@ def test_get_response_enumerates_proto():
             cgr = g.get_response(api_schema=make_api(
                 make_proto(descriptor_pb2.FileDescriptorProto(name='a.proto')),
                 make_proto(descriptor_pb2.FileDescriptorProto(name='b.proto')),
-            ))
+            ), opts=options.Options.build(''))
     assert len(cgr.file) == 2
     assert {i.name for i in cgr.file} == {'foo/a.py', 'foo/b.py'}
 
@@ -174,7 +187,10 @@ def test_get_response_divides_subpackages():
             gt.return_value = jinja2.Template("""
                 {{- '' }}Subpackage: {{ '.'.join(api.subpackage_view) }}
             """.strip())
-            cgr = g.get_response(api_schema=api_schema)
+            cgr = g.get_response(
+                api_schema=api_schema,
+                opts=options.Options.build('')
+            )
     assert len(cgr.file) == 6
     assert {i.name for i in cgr.file} == {
         'foo/types/top.py',
@@ -339,7 +355,10 @@ def test_samplegen_config_to_output_files(
     g._env.loader = jinja2.DictLoader({'sample.py.j2': ''})
 
     api_schema = make_api(naming=naming.Naming(name='Mollusc', version='v6'))
-    actual_response = g.get_response(api_schema)
+    actual_response = g.get_response(
+        api_schema,
+        opts=options.Options.build('')
+    )
     expected_response = CodeGeneratorResponse(
         file=[
             CodeGeneratorResponse.File(
@@ -425,7 +444,10 @@ def test_samplegen_id_disambiguation(mock_gmtime, mock_generate_sample, fs):
     g._env.loader = jinja2.DictLoader({'sample.py.j2': ''})
 
     api_schema = make_api(naming=naming.Naming(name='Mollusc', version='v6'))
-    actual_response = g.get_response(api_schema)
+    actual_response = g.get_response(
+        api_schema,
+        opts=options.Options.build('')
+    )
     expected_response = CodeGeneratorResponse(
         file=[
             CodeGeneratorResponse.File(
@@ -496,7 +518,10 @@ def test_generator_duplicate_samples(fs):
     api_schema = make_api(naming=naming.Naming(name='Mollusc', version='v6'))
 
     with pytest.raises(types.DuplicateSample):
-        generator.get_response(api_schema=api_schema)
+        generator.get_response(
+            api_schema=api_schema,
+            opts=options.Options.build('')
+        )
 
 
 @mock.patch(
@@ -611,7 +636,10 @@ def test_dont_generate_in_code_samples(
             )
         ]
     )
-    actual = generator.get_response(api_schema=api_schema)
+    actual = generator.get_response(
+        api_schema=api_schema,
+        opts=options.Options.build('')
+    )
     assert actual == expected
 
 

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -24,6 +24,7 @@ def test_options_empty():
     opts = options.Options.build('')
     assert len(opts.templates) == 1
     assert opts.templates[0].endswith('gapic/templates')
+    assert not opts.lazy_import
 
 
 def test_options_replace_templates():
@@ -115,3 +116,8 @@ def test_options_service_config(fs):
         ]
     }
     assert opts.retry == expected_cfg
+
+
+def test_options_lazy_import():
+    opts = options.Options.build('lazy-import')
+    assert opts.lazy_import

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -30,6 +30,8 @@ def test_service_properties():
     service = make_service(name='ThingDoer')
     assert service.name == 'ThingDoer'
     assert service.client_name == 'ThingDoerClient'
+    assert service.transport_name == 'ThingDoerTransport'
+    assert service.grpc_transport_name == 'ThingDoerGrpcTransport'
 
 
 def test_service_host():


### PR DESCRIPTION
APIs with a very large number of services may be prohibitive to import
and cause excessive delay at startup time.
For Python >= v3.7, there is now a generator option that allows lazy
imports of services, transports, enums, and types.