### PR TITLE
Make '-d' and '-o' required arguments in fixup script

### DIFF
--- a/gapic/templates/scripts/fixup_keywords.py.j2
+++ b/gapic/templates/scripts/fixup_keywords.py.j2
@@ -136,13 +136,17 @@ Note: This tool operates at a best-effort level at converting positional
 """)
     parser.add_argument(
         '-d',
+        '--input-directory',
+        required=True,
         dest='input_dir',
         help='the input directory to walk for python files to fix up',
     )
     parser.add_argument(
         '-o',
+        '--output-directory',
+        required=True,
         dest='output_dir',
-        help='a file to fix up via un-flattening',
+        help='the directory to output files fixed via un-flattening',
     )
     args = parser.parse_args()
     input_dir = pathlib.Path(args.input_dir)


### PR DESCRIPTION
This results in a slightly more helpful error message for anyone who tries to run `fixup_keywords.py` without the expected arguments.

I also added the more verbose flags `--input-directory` and `--output-directory`.

Before:
```
busunkim@busunkim:~/github/python-docs-samples/texttospeech$ fixup_keywords.py
Traceback (most recent call last):
  File "/usr/local/google/home/busunkim/.pyenv/versions/3.6.9/bin/fixup_keywords.py", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/usr/local/google/home/busunkim/github/googleapis/generated/google-cloud-texttospeech/scripts/fixup_keywords.py", line 151, in <module>
    input_dir = pathlib.Path(args.input_dir)
  File "/usr/local/google/home/busunkim/.pyenv/versions/3.6.9/lib/python3.6/pathlib.py", line 1001, in __new__
    self = cls._from_parts(args, init=False)
  File "/usr/local/google/home/busunkim/.pyenv/versions/3.6.9/lib/python3.6/pathlib.py", line 656, in _from_parts
    drv, root, parts = self._parse_args(args)
  File "/usr/local/google/home/busunkim/.pyenv/versions/3.6.9/lib/python3.6/pathlib.py", line 640, in _parse_args
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

After:
```
busunkim@busunkim:~/github/python-docs-samples/texttospeech$ fixup_keywords.py 
usage: fixup_keywords.py [-h] -d INPUT_DIR -o OUTPUT_DIR
fixup_keywords.py: error: the following arguments are required: -d/--input_directory, -o/--output_directory
```