### PR TITLE
Fix the autogenerated from_service_account_file test

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -14,7 +14,7 @@ from google.oauth2 import service_account              # type: ignore
 
 {% filter sort_lines -%}
 {% for method in service.methods.values() -%}
-{% for ref_type in method.ref_types_legacy -%}
+{% for ref_type in method.ref_types -%}
 {{ ref_type.ident.python_import }}
 {% endfor -%}
 {% endfor -%}

--- a/gapic/templates/tests/unit/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/%name_%version/%sub/test_%service.py.j2
@@ -40,7 +40,7 @@ def test_{{ service.client_name|snake_case }}_from_service_account_file():
         client = {{ service.client_name }}.from_service_account_json("dummy/file/path.json")
         assert client._transport._credentials == creds
 
-        {% if service.host %}assert client._transport._host == '{{ service.host }}'{% endif %}
+        {% if service.host %}assert client._transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
 
 
 def test_{{ service.client_name|snake_case }}_client_options():


### PR DESCRIPTION
If no port number is provided in the service host, include the default
of 443 when checking the transport's host.

Includes a minor fix such that a method's output type's fields can
yield import statements for the generated unit tests.

Includes minor refactors undertaken during debugging to improve code clarity.