### PR TITLE
Fix syntax errors in docs templates

### DIFF
--- a/gapic/templates/docs/%name_%version/services.rst.j2
+++ b/gapic/templates/docs/%name_%version/services.rst.j2
@@ -1,5 +1,5 @@
 Client for {{ api.naming.long_name }} API
-{{ '=' * (14 + api.naming.long_name|length) }}
+{{ '=' * (15 + api.naming.long_name|length) }}
 
 .. automodule:: {{ api.naming.namespace|join('.')|lower }}.{{ api.naming.versioned_module_name }}
     :members:

--- a/gapic/templates/docs/%name_%version/types.rst.j2
+++ b/gapic/templates/docs/%name_%version/types.rst.j2
@@ -1,5 +1,5 @@
 Types for {{ api.naming.long_name }} API
-{{ '=' * (13 + api.naming.long_name|length) }}
+{{ '=' * (14 + api.naming.long_name|length) }}
 
 .. automodule:: {{ api.naming.namespace|join('.')|lower }}.{{ api.naming.versioned_module_name }}.types
     :members:

--- a/gapic/templates/docs/index.rst.j2
+++ b/gapic/templates/docs/index.rst.j2
@@ -2,5 +2,6 @@ API Reference
 -------------
 .. toctree::
     :maxdepth: 2
+    
     {{ api.naming.versioned_module_name }}/services
     {{ api.naming.versioned_module_name }}/types


### PR DESCRIPTION
The underlines were both one char too short, and the toctree is particular about extra line breaks. 