### PR TITLE
Disambiguate Python-keyword-named modules

### DIFF
--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -142,6 +142,28 @@ def test_proto_names():
     assert proto.disambiguate('foo') == '_foo'
 
 
+def test_proto_keyword_fname():
+    # Protos with filenames that happen to be python keywords
+    # cannot be directly imported.
+    # Check that the file names are unspecialized when building the API object.
+    fd = (
+        make_file_pb2(
+            name='import.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='ImportRequest', fields=()),),
+        ),
+        make_file_pb2(
+            name='import_.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='ImportUnderRequest', fields=()),),
+        ),
+    )
+
+    # We can't create new collisions, so check that renames cascade.
+    api_schema = api.API.build(fd, package='google.keywords.v1')
+    assert set(api_schema.protos.keys()) == {'import_.proto', 'import__.proto'}
+
+
 def test_proto_names_import_collision():
     # Put together a couple of minimal protos.
     fd = (

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -157,11 +157,26 @@ def test_proto_keyword_fname():
             package='google.keywords.v1',
             messages=(make_message_pb2(name='ImportUnderRequest', fields=()),),
         ),
+        make_file_pb2(
+            name='class_.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='ClassUnderRequest', fields=()),),
+        ),
+        make_file_pb2(
+            name='class.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='ClassRequest', fields=()),),
+        )
     )
 
     # We can't create new collisions, so check that renames cascade.
     api_schema = api.API.build(fd, package='google.keywords.v1')
-    assert set(api_schema.protos.keys()) == {'import_.proto', 'import__.proto'}
+    assert set(api_schema.protos.keys()) == {
+        'import_.proto',
+        'import__.proto',
+        'class_.proto',
+        'class__.proto',
+    }
 
 
 def test_proto_names_import_collision():


### PR DESCRIPTION
E.g. import.proto turns into import_.py, not import.py
This allows the module to be imported via the normal import mechanisms.

This allows recommendationengine to run generated tests.