### PR TITLE
Unimported LRO type annotation fix

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -58,6 +58,7 @@ class Proto:
     @classmethod
     def build(cls, file_descriptor: descriptor_pb2.FileDescriptorProto,
               file_to_generate: bool, naming: api_naming.Naming,
+              opts: options.Options = options.Options(),
               prior_protos: Mapping[str, 'Proto'] = None,
               ) -> 'Proto':
         """Build and return a Proto instance.
@@ -75,6 +76,7 @@ class Proto:
         return _ProtoBuilder(file_descriptor,
                              file_to_generate=file_to_generate,
                              naming=naming,
+                             opts=opts,
                              prior_protos=prior_protos or {},
                              ).proto
 
@@ -221,16 +223,27 @@ class API:
 
         # Iterate over each FileDescriptorProto and fill out a Proto
         # object describing it, and save these to the instance.
+        # pre_protos: Dict[str, Proto] = {}
+        # for fd in file_descriptors:
+        #     fd.name = disambiguate_keyword_fname(fd.name, protos)
+        #     pre_protos[fd.name] = _ProtoBuilder(
+        #         file_descriptor=fd,
+        #         file_to_generate=fd.package.startswith(package),
+        #         naming=naming,
+        #         opts=opts,
+        #         prior_protos=pre_protos,
+        #     ).proto
+
         protos: Dict[str, Proto] = {}
         for fd in file_descriptors:
             fd.name = disambiguate_keyword_fname(fd.name, protos)
-            protos[fd.name] = _ProtoBuilder(
+            protos[fd.name] = Proto.build(
                 file_descriptor=fd,
                 file_to_generate=fd.package.startswith(package),
                 naming=naming,
                 opts=opts,
                 prior_protos=protos,
-            ).proto
+            )
 
         # Done; return the API.
         return cls(naming=naming, all_protos=protos)

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -247,7 +247,7 @@ class API:
         # type into the proto file that defines an LRO.
         # We just load all the APIs types first and then
         # load the services and methods with the full scope of types.
-        pre_protos: Dict[str, Proto] = prior_protos or {}
+        pre_protos: Dict[str, Proto] = dict(prior_protos or {})
         for fd in file_descriptors:
             fd.name = disambiguate_keyword_fname(fd.name, pre_protos)
             pre_protos[fd.name] = Proto.build(
@@ -699,7 +699,6 @@ class _ProtoBuilder:
         # Iterate over the methods and collect them into a dictionary.
         answer: Dict[str, wrappers.Method] = collections.OrderedDict()
         for i, meth_pb in enumerate(methods):
-            lro = self._maybe_get_lro(service_address, meth_pb)
             retry, timeout = self._get_retry_and_timeout(
                 service_address,
                 meth_pb
@@ -708,7 +707,7 @@ class _ProtoBuilder:
             # Create the method wrapper object.
             answer[meth_pb.name] = wrappers.Method(
                 input=self.api_messages[meth_pb.input_type.lstrip('.')],
-                lro=lro,
+                lro=self._maybe_get_lro(service_address, meth_pb),
                 method_pb=meth_pb,
                 meta=metadata.Metadata(
                     address=service_address.child(meth_pb.name, path + (i,)),


### PR DESCRIPTION
Partial fix for #318 
If a LRO returning method has a type annotation for a type that is not imported but is in the API, that is now supported. The general case where the annotated type lives in an arbitrary proto is not addressed.
Tested against the `functions` API, which now builds and passes generated unit tests.