### PR TITLE
Flattening and LRO module conflicts

### DIFF
--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -284,9 +284,10 @@ class Metadata:
         ``Address`` object aliases module names to avoid naming collisions in
         the file being written.
         """
-        return dataclasses.replace(self,
-                                   address=self.address.with_context(collisions=collisions),
-                                   )
+        return dataclasses.replace(
+            self,
+            address=self.address.with_context(collisions=collisions),
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -84,11 +84,16 @@ class Address:
         to users (albeit looking auto-generated).
         """
         if self.module in self.collisions:
-            return '_'.join((
-                ''.join([i[0] for i in self.package
-                         if i != self.api_naming.version]),
-                self.module,
-            ))
+            return '_'.join(
+                (
+                    ''.join(
+                        i[0]
+                        for i in self.package
+                        if i != self.api_naming.version
+                    ),
+                    self.module,
+                )
+            )
         return ''
 
     @property
@@ -162,10 +167,10 @@ class Address:
             ~.Address: The new address object.
         """
         return dataclasses.replace(self,
-            module_path=self.module_path + path,
-            name=child_name,
-            parent=self.parent + (self.name,) if self.name else self.parent,
-        )
+                                   module_path=self.module_path + path,
+                                   name=child_name,
+                                   parent=self.parent + (self.name,) if self.name else self.parent,
+                                   )
 
     def rel(self, address: 'Address') -> str:
         """Return an identifier for this type, relative to the given address.
@@ -279,7 +284,7 @@ class Metadata:
         the file being written.
         """
         return dataclasses.replace(self,
-            address=self.address.with_context(collisions=collisions),
+                                   address=self.address.with_context(collisions=collisions),
                                    )
 
 

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -166,11 +166,12 @@ class Address:
         Returns:
             ~.Address: The new address object.
         """
-        return dataclasses.replace(self,
-                                   module_path=self.module_path + path,
-                                   name=child_name,
-                                   parent=self.parent + (self.name,) if self.name else self.parent,
-                                   )
+        return dataclasses.replace(
+            self,
+            module_path=self.module_path + path,
+            name=child_name,
+            parent=self.parent + (self.name,) if self.name else self.parent,
+        )
 
     def rel(self, address: 'Address') -> str:
         """Return an identifier for this type, relative to the given address.

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -330,18 +330,19 @@ class MessageType:
         """
         return dataclasses.replace(
             self,
-            fields=collections.OrderedDict([
+            fields=collections.OrderedDict(
                 (k, v.with_context(collisions=collisions))
                 for k, v in self.fields.items()
-            ]) if not skip_fields else self.fields,
-            nested_enums=collections.OrderedDict([
+            ) if not skip_fields else self.fields,
+            nested_enums=collections.OrderedDict(
                 (k, v.with_context(collisions=collisions))
                 for k, v in self.nested_enums.items()
-            ]),
-            nested_messages=collections.OrderedDict([(k, v.with_context(
-                collisions=collisions,
-                skip_fields=skip_fields,
-            )) for k, v in self.nested_messages.items()]),
+            ),
+            nested_messages=collections.OrderedDict(
+                (k, v.with_context(
+                    collisions=collisions,
+                    skip_fields=skip_fields,))
+                for k, v in self.nested_messages.items()),
             meta=self.meta.with_context(collisions=collisions),
         )
 

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -456,6 +456,19 @@ class OperationInfo:
     response_type: MessageType
     metadata_type: MessageType
 
+    def with_context(self, *, collisions: FrozenSet[str]) -> 'OperationInfo':
+        """Return a derivative of this OperationInfo with the provided context.
+
+          This method is used to address naming collisions. The returned
+          ``OperationInfo`` object aliases module names to avoid naming collisions
+          in the file being written.
+          """
+        return dataclasses.replace(
+            self,
+            response_type=self.response_type.with_context(collisions=collisions),
+            metadata_type=self.metadata_type.with_context(collisions=collisions),
+        )
+
 
 @dataclasses.dataclass(frozen=True)
 class RetryInfo:
@@ -682,8 +695,13 @@ class Method:
         ``Method`` object aliases module names to avoid naming collisions
         in the file being written.
         """
+        maybe_lro = self.lro.with_context(
+            collisions=collisions
+        ) if self.lro else None
+
         return dataclasses.replace(
             self,
+            lro=maybe_lro,
             input=self.input.with_context(collisions=collisions),
             output=self.output.with_context(collisions=collisions),
             meta=self.meta.with_context(collisions=collisions),

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -811,9 +811,13 @@ class Service:
         """
         return dataclasses.replace(
             self,
-            methods=collections.OrderedDict([
-                (k, v.with_context(collisions=collisions))
+            methods=collections.OrderedDict(
+                (k, v.with_context(
+                    # A methodd's flattened fields create additional names
+                    # that may conflict with module imports.
+                    collisions=collisions | frozenset(v.flattened_fields.keys()))
+                 )
                 for k, v in self.methods.items()
-            ]),
+            ),
             meta=self.meta.with_context(collisions=collisions),
         )

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -465,8 +465,12 @@ class OperationInfo:
           """
         return dataclasses.replace(
             self,
-            response_type=self.response_type.with_context(collisions=collisions),
-            metadata_type=self.metadata_type.with_context(collisions=collisions),
+            response_type=self.response_type.with_context(
+                collisions=collisions
+            ),
+            metadata_type=self.metadata_type.with_context(
+                collisions=collisions
+            ),
         )
 
 


### PR DESCRIPTION
Flattened method fields generate names in client methods. Barring a central authority, any source of names generates the possibility of name collisions and requires disambiguation.
Before this fix, flattened fields could generate name collisions with imported modules. This commit adds field names to the context with which names are disambiguated and subjects LRO operation info structures to the same collision avoidance logic as other rich data types.

Unblocks autogenerated unit tests for Datalabeling API.