### PR TITLE
Add a test and impl for map field mock value

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -204,9 +204,11 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% endif %} {# different request package #}
 
         {#- Vanilla python protobuf wrapper types cannot _set_ repeated fields #}
-        {%- for key, field in method.flattened_fields.items() if not(field.repeated and method.input.ident.package != method.ident.package) %}
+        {% if method.flattened_fields -%}
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
+        {% endif -%}
+        {%- for key, field in method.flattened_fields.items() if not(field.repeated and method.input.ident.package != method.ident.package) %}
         if {{ field.name }} is not None:
             request.{{ key }} = {{ field.name }}
         {%- endfor %}


### PR DESCRIPTION
Protobuf map fields are special: under the hood they are implemnted as a
sequence of generated type with two fields: 'key', whose type is the
map key type, and 'value', whose type is the map value type.

The user almost never wants to know about this implementation detail,
and the python proto surface allows python dictionaries as rvalues
when assigning to a mapped field.

This change uses dict literals in generated unit tests where flattened
parameters may refer to mapped fields. This allows certain generated unit tests to pass that previously wouldn't.