### PR TITLE
Update header copyright year to 2020

### DIFF
--- a/gapic/templates/_license.j2
+++ b/gapic/templates/_license.j2
@@ -1,4 +1,4 @@
-# Copyright (C) 2019  Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -111,7 +111,7 @@ def test_generate_sample_basic():
 
     sample_id = ("mollusc_classify_sync")
     expected_str = '''# -*- coding: utf-8 -*-
-# Copyright (C) 2019  Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -247,7 +247,7 @@ def test_generate_sample_basic_unflattenable():
 
     sample_id = ("mollusc_classify_sync")
     expected_str = '''# -*- coding: utf-8 -*-
-# Copyright (C) 2019  Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Bumps the year to 2020 in the templates. Also tweaked the formatting slightly (copied from go/copyright).