### PR TITLE
[WIP] feat: Initial draft of GAPIC Bazel Extensions gapic-generator-python

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,21 @@
+load("@gapic_generator_python_pip_deps//:requirements.bzl", "requirement")
+
+py_binary(
+    name = "gapic_generator_python",
+    srcs = glob(["gapic/**/*.py"]),
+    data = glob(["gapic/**/*.j2"]),
+    main = "gapic/cli/generate.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_protobuf//:protobuf_python",
+        requirement("click"),
+        requirement("google-api-core"),
+        requirement("googleapis-common-protos"),
+        requirement("grpcio"),
+        requirement("protobuf"),
+        requirement("jinja2"),
+        requirement("pypandoc"),
+        requirement("PyYAML"),
+    ],
+    python_version = "PY3",
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@gapic_generator_python_pip_deps//:requirements.bzl", "requirement")
 
 py_binary(
-    name = "gapic_generator_python",
+    name = "gapic_plugin",
     srcs = glob(["gapic/**/*.py"]),
     data = glob(["gapic/**/*.j2"]),
     main = "gapic/cli/generate.py",
@@ -12,7 +12,6 @@ py_binary(
         requirement("google-api-core"),
         requirement("googleapis-common-protos"),
         requirement("grpcio"),
-        requirement("protobuf"),
         requirement("jinja2"),
         requirement("pypandoc"),
         requirement("PyYAML"),

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,32 @@
+workspace(name = "gapic_generator_python")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_python",
+    url = "https://github.com/bazelbuild/rules_python/archive/748aa53d7701e71101dfd15d800e100f6ff8e5d1.zip",
+    strip_prefix = "rules_python-748aa53d7701e71101dfd15d800e100f6ff8e5d1"
+)
+load("@rules_python//python:repositories.bzl", "py_repositories")
+py_repositories()
+
+# Only needed if using the packaging rules.
+load("@rules_python//python:pip.bzl", "pip_repositories")
+pip_repositories()
+
+
+
+load("@rules_python//python:pip.bzl", "pip_import")
+
+pip_import(   # or pip3_import
+   name = "gapic_generator_python_pip_deps",
+   requirements = "@gapic_generator_python//:requirements.txt",
+   python_interpreter = "python3",
+)
+
+load("@gapic_generator_python_pip_deps//:requirements.bzl", "pip_install")
+pip_install()
+
+local_repository(
+    name = "com_google_api_codegen",
+    path = "/usr/local/google/home/vam/_/projects/github/vam-google/gapic-generator",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,7 +24,7 @@ pip_repositories()
 #
 load("//:repositories.bzl", "gapic_generator_python")
 
-gapic_generator_python();
+gapic_generator_python()
 
 load("@gapic_generator_python_pip_deps//:requirements.bzl", "pip_install")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,32 +1,35 @@
 workspace(name = "gapic_generator_python")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+#
+# Import rules_python
+#
 http_archive(
     name = "rules_python",
+    strip_prefix = "rules_python-748aa53d7701e71101dfd15d800e100f6ff8e5d1",
     url = "https://github.com/bazelbuild/rules_python/archive/748aa53d7701e71101dfd15d800e100f6ff8e5d1.zip",
-    strip_prefix = "rules_python-748aa53d7701e71101dfd15d800e100f6ff8e5d1"
 )
+
 load("@rules_python//python:repositories.bzl", "py_repositories")
+
 py_repositories()
 
-# Only needed if using the packaging rules.
 load("@rules_python//python:pip.bzl", "pip_repositories")
+
 pip_repositories()
 
+#
+# Import gapic-generator-python specific dependencies
+#
+load("//:repositories.bzl", "gapic_generator_python")
 
-
-load("@rules_python//python:pip.bzl", "pip_import")
-
-pip_import(   # or pip3_import
-   name = "gapic_generator_python_pip_deps",
-   requirements = "@gapic_generator_python//:requirements.txt",
-   python_interpreter = "python3",
-)
+gapic_generator_python();
 
 load("@gapic_generator_python_pip_deps//:requirements.bzl", "pip_install")
+
 pip_install()
 
-local_repository(
-    name = "com_google_api_codegen",
-    path = "/usr/local/google/home/vam/_/projects/github/vam-google/gapic-generator",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,0 +1,36 @@
+load("@rules_python//python:pip.bzl", "pip_import")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def com_google_protoc_java_resource_names_plugin_repositories():
+    _protobuf_version = "3.11.2"
+    _protobuf_version_in_link = "v%s" % _protobuf_version
+    _maybe(
+        http_archive,
+        name = "com_google_protobuf",
+        urls = ["https://github.com/protocolbuffers/protobuf/archive/%s.zip" % _protobuf_version_in_link],
+        strip_prefix = "protobuf-%s" % _protobuf_version,
+    )
+
+    _maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
+        strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
+        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+    )
+
+
+    pip_import(
+        name = "examples_helloworld",
+        requirements = "@rules_python//examples/helloworld:requirements.txt",
+    )
+
+
+def _maybe(repo_rule, name, strip_repo_prefix = "", **kwargs):
+    if not name.startswith(strip_repo_prefix):
+        return
+    repo_name = name[len(strip_repo_prefix):]
+    if repo_name in native.existing_rules():
+        return
+    repo_rule(name = repo_name, **kwargs)

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -1,8 +1,14 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@rules_python//python:pip.bzl", "pip_import")
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+def gapic_generator_python():
+    _maybe(
+        pip_import,
+        name = "gapic_generator_python_pip_deps",
+        python_interpreter = "python3",
+        requirements = "@gapic_generator_python//:requirements.txt",
+    )
 
-def com_google_protoc_java_resource_names_plugin_repositories():
     _protobuf_version = "3.11.2"
     _protobuf_version_in_link = "v%s" % _protobuf_version
     _maybe(
@@ -15,17 +21,16 @@ def com_google_protoc_java_resource_names_plugin_repositories():
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        sha256 = "bbccf674aa441c266df9894182d80de104cabd19be98be002f6d478aaa31574d",
         strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
         urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
     )
 
-
-    pip_import(
-        name = "examples_helloworld",
-        requirements = "@rules_python//examples/helloworld:requirements.txt",
+    _maybe(
+        http_archive,
+        name = "com_google_api_codegen",
+        strip_prefix = "gapic-generator-b32c73219d617f90de70bfa6ff0ea0b0dd638dfe",
+        urls = ["https://github.com/googleapis/gapic-generator/archive/b32c73219d617f90de70bfa6ff0ea0b0dd638dfe.zip"],
     )
-
 
 def _maybe(repo_rule, name, strip_repo_prefix = "", **kwargs):
     if not name.startswith(strip_repo_prefix):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+click >= 6.7
+google-api-core >= 1.14.3
+googleapis-common-protos >= 1.6.0
+grpcio >= 1.24.3
+jinja2 >= 2.10
+protobuf >= 3.7.1
+pypandoc >= 1.4
+PyYAML >= 5.1.1

--- a/rules_python_gapic/py_gapic.bzl
+++ b/rules_python_gapic/py_gapic.bzl
@@ -1,6 +1,6 @@
 load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library")
 
-def py_gapic_library2(name, srcs, **kwargs):
+def py_gapic_library(name, srcs, **kwargs):
 #    srcjar_target_name = "%s_srcjar" % name
     srcjar_target_name = name
     srcjar_output_suffix = ".srcjar"

--- a/rules_python_gapic/py_gapic.bzl
+++ b/rules_python_gapic/py_gapic.bzl
@@ -1,7 +1,21 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library")
 
 def py_gapic_library(name, srcs, **kwargs):
-#    srcjar_target_name = "%s_srcjar" % name
+    #    srcjar_target_name = "%s_srcjar" % name
     srcjar_target_name = name
     srcjar_output_suffix = ".srcjar"
 
@@ -15,4 +29,3 @@ def py_gapic_library(name, srcs, **kwargs):
         output_suffix = srcjar_output_suffix,
         **kwargs
     )
-

--- a/rules_python_gapic/py_gapic.bzl
+++ b/rules_python_gapic/py_gapic.bzl
@@ -8,7 +8,7 @@ def py_gapic_library2(name, srcs, **kwargs):
     proto_custom_library(
         name = srcjar_target_name,
         deps = srcs,
-        plugin = Label("@gapic_generator_python//:gapic_generator_python"),
+        plugin = Label("@gapic_generator_python//:gapic_plugin"),
         plugin_args = [],
         plugin_file_args = {},
         output_type = "python_gapic",

--- a/rules_python_gapic/py_gapic.bzl
+++ b/rules_python_gapic/py_gapic.bzl
@@ -1,0 +1,18 @@
+load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library")
+
+def py_gapic_library2(name, srcs, **kwargs):
+#    srcjar_target_name = "%s_srcjar" % name
+    srcjar_target_name = name
+    srcjar_output_suffix = ".srcjar"
+
+    proto_custom_library(
+        name = srcjar_target_name,
+        deps = srcs,
+        plugin = Label("@gapic_generator_python//:gapic_generator_python"),
+        plugin_args = [],
+        plugin_file_args = {},
+        output_type = "python_gapic",
+        output_suffix = srcjar_output_suffix,
+        **kwargs
+    )
+


### PR DESCRIPTION
This is a "minimal viable product" version of the rule, which simply call the python microgenerator to generate a client. No post and/or preprocessing is implemented. 

Successfully tested on `googleapis/google/cloud/lanugage/v1` API.


To use it from googleapis, add the following to the `# Python` in WORKSPACE file in googleapis:

```bzl
load("@rules_python//python:repositories.bzl", "py_repositories")
py_repositories()

load("@rules_python//python:pip.bzl", "pip_repositories")
pip_repositories()

# Change upstream repository once PR is merged
http_archive(
    name = "gapic_generator_python",
    urls = ["https://github.com/vam-google/gapic-generator-python/archive/77637d9bfdbfcb67b02b3d6bbbc6938de44214ce.zip"],
    strip_prefix = "gapic-generator-python-77637d9bfdbfcb67b02b3d6bbbc6938de44214ce",
)

load("@gapic_generator_python//:repositories.bzl", "gapic_generator_python")

gapic_generator_python()

load("@gapic_generator_python_pip_deps//:requirements.bzl", "pip_install")
pip_install()
```

and the following at the top of the file (needs to go to the top, because `rules_python` of older version is a transitive dependency of `grpc` rules, we need a newer version to be used in workspace, so specify it first to override the older one).

```bzl
http_archive(
    name = "rules_python",
    url = "https://github.com/bazelbuild/rules_python/archive/748aa53d7701e71101dfd15d800e100f6ff8e5d1.zip",
    strip_prefix = "rules_python-748aa53d7701e71101dfd15d800e100f6ff8e5d1"
)

```

The in `google/cloud/langugae/v1/BUILD.bazel` file in Python section add

```bzl
load("@gapic_generator_python//rules_python_gapic:py_gapic.bzl", py_gapic_library2 = "py_gapic_library")

py_gapic_library2(
    name = "language_py_gapic2",
    srcs = [":language_proto"],
)
```

and build it with:
```
bazel build //google/cloud/language/v1:language_py_gapic2
```