### PR TITLE
Fix for flattened unit tests with deeply nested request messages

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -14,7 +14,7 @@ from google.oauth2 import service_account              # type: ignore
 
 {% filter sort_lines -%}
 {% for method in service.methods.values() -%}
-{% for ref_type in method.ref_types -%}
+{% for ref_type in method.flat_ref_types -%}
 {{ ref_type.ident.python_import }}
 {% endfor -%}
 {% endfor -%}

--- a/gapic/utils/__init__.py
+++ b/gapic/utils/__init__.py
@@ -21,6 +21,7 @@ from gapic.utils.filename import to_valid_filename
 from gapic.utils.filename import to_valid_module_name
 from gapic.utils.lines import sort_lines
 from gapic.utils.lines import wrap
+from gapic.utils.reserved_names import RESERVED_NAMES
 from gapic.utils.rst import rst
 
 
@@ -29,6 +30,7 @@ __all__ = (
     'doc',
     'empty',
     'partition',
+    'RESERVED_NAMES',
     'rst',
     'sort_lines',
     'to_snake_case',

--- a/gapic/utils/reserved_names.py
+++ b/gapic/utils/reserved_names.py
@@ -1,0 +1,18 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import keyword
+
+
+RESERVED_NAMES = frozenset(keyword.kwlist)

--- a/test_utils/test_utils.py
+++ b/test_utils/test_utils.py
@@ -145,13 +145,15 @@ def get_message(dot_path: str, *,
 
 
 def make_method(
-        name: str, input_message: wrappers.MessageType = None,
+        name: str,
+        input_message: wrappers.MessageType = None,
         output_message: wrappers.MessageType = None,
         package: typing.Union[typing.Tuple[str], str] = 'foo.bar.v1',
         module: str = 'baz',
         http_rule: http_pb2.HttpRule = None,
         signatures: typing.Sequence[str] = (),
-        **kwargs) -> wrappers.Method:
+        **kwargs
+) -> wrappers.Method:
     # Use default input and output messages if they are not provided.
     input_message = input_message or make_message('MethodInput')
     output_message = output_message or make_message('MethodOutput')
@@ -229,11 +231,14 @@ def make_field(
     )
 
 
-def make_message(name: str, package: str = 'foo.bar.v1', module: str = 'baz',
-                 fields: typing.Sequence[wrappers.Field] = (),
-                 meta: metadata.Metadata = None,
-                 options: desc.MethodOptions = None,
-                 ) -> wrappers.MessageType:
+def make_message(
+    name: str,
+    package: str = 'foo.bar.v1',
+    module: str = 'baz',
+    fields: typing.Sequence[wrappers.Field] = (),
+    meta: metadata.Metadata = None,
+    options: desc.MethodOptions = None,
+) -> wrappers.MessageType:
     message_pb = desc.DescriptorProto(
         name=name,
         field=[i.field_pb for i in fields],

--- a/tests/unit/schema/wrappers/test_message.py
+++ b/tests/unit/schema/wrappers/test_message.py
@@ -73,7 +73,10 @@ def test_field_types():
     inner_msg = make_message(
         'InnerMessage',
         fields=(
-            make_field('hidden_message', message=make_message('HiddenMessage')),
+            make_field(
+                'hidden_message',
+                message=make_message('HiddenMessage'),
+            ),
         )
     )
     inner_enum = make_enum('InnerEnum')
@@ -114,8 +117,8 @@ def test_field_types_recursive():
         )
     )
 
-    actual = sorted(topmost_msg.recursive_field_types, key=lambda t: t.name)
-    expected = sorted((enumeration, innest_msg, inner_msg), key=lambda t: t.name)
+    actual = {t.name for t in topmost_msg.recursive_field_types}
+    expected = {t.name for t in (enumeration, innest_msg, inner_msg)}
     assert actual == expected
 
 

--- a/tests/unit/schema/wrappers/test_message.py
+++ b/tests/unit/schema/wrappers/test_message.py
@@ -70,7 +70,12 @@ def test_get_field():
 
 def test_field_types():
     # Create the inner message.
-    inner_msg = make_message('InnerMessage', fields=())
+    inner_msg = make_message(
+        'InnerMessage',
+        fields=(
+            make_field('hidden_message', message=make_message('HiddenMessage')),
+        )
+    )
     inner_enum = make_enum('InnerEnum')
 
     # Create the outer message, which contains an Inner as a field.
@@ -85,6 +90,33 @@ def test_field_types():
     assert len(outer.field_types) == 2
     assert inner_msg in outer.field_types
     assert inner_enum in outer.field_types
+
+
+def test_field_types_recursive():
+    enumeration = make_enum('Enumeration')
+    innest_msg = make_message(
+        'InnestMessage',
+        fields=(
+            make_field('enumeration', enum=enumeration),
+        )
+    )
+    inner_msg = make_message(
+        'InnerMessage',
+        fields=(
+            make_field('innest_message', message=innest_msg),
+        )
+    )
+    topmost_msg = make_message(
+        'TopmostMessage',
+        fields=(
+            make_field('inner_message', message=inner_msg),
+            make_field('uninteresting')
+        )
+    )
+
+    actual = sorted(topmost_msg.recursive_field_types, key=lambda t: t.name)
+    expected = sorted((enumeration, innest_msg, inner_msg), key=lambda t: t.name)
+    assert actual == expected
 
 
 def test_get_field_recursive():

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -23,6 +23,7 @@ from gapic.schema import metadata
 from gapic.schema import wrappers
 
 from test_utils.test_utils import (
+    make_enum,
     make_field,
     make_message,
     make_method,
@@ -149,6 +150,45 @@ def test_method_paged_result_ref_types():
         'ListSquidsPager',
         'Mollusc',
     }
+
+
+def test_flattened_ref_types():
+    method = make_method(
+        'IdentifyMollusc',
+        input_message=make_message(
+            'IdentifyMolluscRequest',
+            fields=(
+                make_field(
+                    'cephalopod',
+                    message=make_message(
+                        'Cephalopod',
+                        fields=(
+                            make_field('mass_kg', type='TYPE_INT32'),
+                            make_field('squid', number=2, message=make_message('Squid'),),
+                            make_field('clam', number=3, message=make_message('Clam'),),
+                        ),
+                    ),
+                ),
+                make_field(
+                    'stratum',
+                    enum=make_enum(
+                        'Stratum',
+                    )
+                ),
+            ),
+        ),
+        signatures=('cephalopod.squid,stratum',),
+        output_message=make_message('Mollusc'),
+    )
+
+    expected_flat_ref_type_names = {
+        'IdentifyMolluscRequest',
+        'Squid',
+        'Stratum',
+        'Mollusc',
+    }
+    actual_flat_ref_type_names = {t.name for t in method.flat_ref_types}
+    assert expected_flat_ref_type_names == actual_flat_ref_type_names
 
 
 def test_method_field_headers_none():

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -164,8 +164,16 @@ def test_flattened_ref_types():
                         'Cephalopod',
                         fields=(
                             make_field('mass_kg', type='TYPE_INT32'),
-                            make_field('squid', number=2, message=make_message('Squid'),),
-                            make_field('clam', number=3, message=make_message('Clam'),),
+                            make_field(
+                                'squid',
+                                number=2,
+                                message=make_message('Squid'),
+                            ),
+                            make_field(
+                                'clam',
+                                number=3,
+                                message=make_message('Clam'),
+                            ),
                         ),
                     ),
                 ),


### PR DESCRIPTION
Expands the unit-test visible method ref types to include _all_
recursive types.

Do NOT use this deep nesting in the client submodule. The client ONLY
needs to import, for each method, the request type, response type, and
the types of any flattened fields.