### PR TITLE
Pump up the mypy syntax version for generated code

### DIFF
--- a/gapic/templates/mypy.ini.j2
+++ b/gapic/templates/mypy.ini.j2
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.5
+python_version = 3.6
 namespace_packages = True


### PR DESCRIPTION
The supported version of generated code should be 3.6+. Using 3.5 as minimal syntax version prevents the usage of variable type annotation. https://www.python.org/dev/peps/pep-0526/