### PR TITLE
Test and impl for stripping whitespace off option tokens

### DIFF
--- a/gapic/generator/options.py
+++ b/gapic/generator/options.py
@@ -70,6 +70,7 @@ class Options:
         # Parse out every option beginning with `python-gapic`
         opts: DefaultDict[str, List[str]] = defaultdict(list)
         for opt in opt_string.split(','):
+            opt = opt.strip()
             # Parse out the key and value.
             value = 'true'
             if '=' in opt:

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -52,6 +52,18 @@ def test_options_unrecognized_likely_typo():
     assert len(warn.mock_calls) == 0
 
 
+def test_options_trim_whitespace():
+    # When writing shell scripts, users may construct options strings with
+    # whitespace that needs to be trimmed after tokenizing.
+    opts = options.Options.build(
+        '''
+        python-gapic-templates=/squid/clam/whelk ,
+        python-gapic-name=mollusca ,
+        ''')
+    assert opts.templates[0] == '/squid/clam/whelk'
+    assert opts.name == 'mollusca'
+
+
 def test_options_no_valid_sample_config(fs):
     fs.create_file("sampledir/not_a_config.yaml")
     with pytest.raises(types.InvalidConfig):


### PR DESCRIPTION
Shell scripts that invoke the generator may construct the gapic
generator options via formatted string concatenation and may contain
escaped newlines.

Proper parsing includes stripping whitespace after tokenizing from a
comma-delimited string.