### PR TITLE
fix: update dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -263,7 +263,7 @@ jobs:
           name: Install system dependencies.
           command: |
             apt-get update
-            apt-get install -y curl pandoc unzip git
+            apt-get install -y curl pandoc unzip
       - run:
           name: Install protoc 3.7.1.
           command: |
@@ -287,7 +287,7 @@ jobs:
           name: Install system dependencies.
           command: |
             apt-get update
-            apt-get install -y curl pandoc unzip git
+            apt-get install -y curl pandoc unzip
       - run:
           name: Install protoc 3.7.1.
           command: |
@@ -311,7 +311,7 @@ jobs:
           name: Install system dependencies.
           command: |
             apt-get update
-            apt-get install -y curl pandoc unzip git
+            apt-get install -y curl pandoc unzip
       - run:
           name: Install protoc 3.7.1.
           command: |
@@ -335,7 +335,7 @@ jobs:
           name: Install system dependencies.
           command: |
             apt-get update
-            apt-get install -y curl pandoc unzip git
+            apt-get install -y curl pandoc unzip
       - run:
           name: Install protoc 3.7.1.
           command: |
@@ -359,7 +359,7 @@ jobs:
           name: Install system dependencies.
           command: |
             apt-get update
-            apt-get install -y curl pandoc unzip git
+            apt-get install -y curl pandoc unzip
       - run:
           name: Install protoc 3.7.1.
           command: |
@@ -383,7 +383,7 @@ jobs:
           name: Install system dependencies.
           command: |
             apt-get update
-            apt-get install -y curl pandoc unzip git
+            apt-get install -y curl pandoc unzip
       - run:
           name: Install protoc 3.7.1.
           command: |

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -16,7 +16,7 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core >= 1.8.0, < 2.0.0dev',
+        'google-api-core >= 1.17.0, < 2.0.0dev',
         'googleapis-common-protos >= 1.5.8',
         'grpcio >= 1.10.0',
         'proto-plus >= 0.4.0',

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -16,8 +16,8 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-auth >= 1.13.1',
-        'google-api-core >= 1.8.0, < 2.0.0dev',
+        'google-auth >= 1.14.0',
+        'google-api-core >= 1.17.0, < 2.0.0dev',
         'googleapis-common-protos >= 1.5.8',
         'grpcio >= 1.10.0',
         'proto-plus >= 0.4.0',

--- a/noxfile.py
+++ b/noxfile.py
@@ -118,10 +118,6 @@ def showcase_unit(
     """Run the generated unit tests against the Showcase library."""
 
     # Install pytest and gapic-generator-python
-    session.install(
-        "-e",
-        "git+https://github.com/googleapis/python-api-core.git@ca6c41cf460e505e6b228263170927270626222a#egg=google-api-core",
-    )
     session.install('coverage', 'pytest', 'pytest-cov', 'pytest-xdist',)
     session.install('.')
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 click==7.1.1
-google-api-core==1.16.0
+google-api-core==1.17.0
 googleapis-common-protos==1.51.0
 grpcio==1.28.1
 jinja2==2.11.2

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     include_package_data=True,
     install_requires=(
         'click >= 6.7',
-        'google-api-core >= 1.14.3',
+        'google-api-core >= 1.17.0',
         'googleapis-common-protos >= 1.6.0',
         'grpcio >= 1.24.3',
         'jinja2 >= 2.10',


### PR DESCRIPTION
python-auth and python-api-core are all shipped, this PR updates the dependency to use the most recent version of these 2 libraries.

For #360 