### PR TITLE
feat: Add opt_args to py_gapic_library

### DIFF
--- a/repositories.bzl
+++ b/repositories.bzl
@@ -58,8 +58,8 @@ def gapic_generator_python():
     _maybe(
         http_archive,
         name = "com_google_api_codegen",
-        strip_prefix = "gapic-generator-b32c73219d617f90de70bfa6ff0ea0b0dd638dfe",
-        urls = ["https://github.com/googleapis/gapic-generator/archive/b32c73219d617f90de70bfa6ff0ea0b0dd638dfe.zip"],
+        strip_prefix = "gapic-generator-03abac35ec0716c6f426ffc1532f9a62f1c9e6a2",
+        urls = ["https://github.com/googleapis/gapic-generator/archive/03abac35ec0716c6f426ffc1532f9a62f1c9e6a2.zip"],
     )
 
 def gapic_generator_register_toolchains():

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ MarkupSafe==1.1.1
 protobuf==3.11.3
 pypandoc==1.5
 PyYAML==5.3.1
-dataclasses==0.7
+dataclasses==0.6

--- a/rules_python_gapic/py_gapic.bzl
+++ b/rules_python_gapic/py_gapic.bzl
@@ -14,7 +14,7 @@
 
 load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library")
 
-def py_gapic_library(name, srcs, plugin_args = [], **kwargs):
+def py_gapic_library(name, srcs, plugin_args = [], opt_args = [], **kwargs):
     #    srcjar_target_name = "%s_srcjar" % name
     srcjar_target_name = name
     srcjar_output_suffix = ".srcjar"
@@ -25,6 +25,7 @@ def py_gapic_library(name, srcs, plugin_args = [], **kwargs):
         plugin = Label("@gapic_generator_python//:gapic_plugin"),
         plugin_args = plugin_args,
         plugin_file_args = {},
+        opt_args = opt_args,
         output_type = "python_gapic",
         output_suffix = srcjar_output_suffix,
         **kwargs


### PR DESCRIPTION
This is to suport <plugin_name>_opt command line args for protoc with a <plugin>.

See https://github.com/googleapis/gapic-generator-python/issues/390 for more details.
This PR depends on https://github.com/googleapis/gapic-generator/pull/3191

Example of usage:
```bzl
py_gapic_library(
    name = "documentai_py_gapic",
    srcs = [":documentai_proto"],
    opt_args = [
        "old-naming",
        "lazy-import",
        "python-gapic-name=documentai",
        "python-gapic-templates=ads-templates",
    ],
)

```