### PR TITLE
Use latest version of api-common-protos in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/*
 
 # Add protoc and our common protos.
-COPY --from=gcr.io/gapic-images/api-common-protos:0.1.0 /usr/local/bin/protoc /usr/local/bin/protoc
-COPY --from=gcr.io/gapic-images/api-common-protos:0.1.0 /protos/ /protos/
+COPY --from=gcr.io/gapic-images/api-common-protos:latest /usr/local/bin/protoc /usr/local/bin/protoc
+COPY --from=gcr.io/gapic-images/api-common-protos:latest /protos/ /protos/
 
 # Add our code to the Docker image.
 ADD . /usr/src/gapic-generator-python/


### PR DESCRIPTION
Strongly suspect this will close #405. 

I looked into using the tagged 1.50.0, but that version is too old to work with the bigquery connections API. If you have concerns about pinning this to latest I can use the SHA or add a new tag.  

https://gcr.io/gapic-images/api-common-protos

Please cut a release when this is merged. Thank you! 🙏 