### PR TITLE
release 0.22.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with io.open(os.path.join(PACKAGE_ROOT, 'README.rst')) as file_obj:
 
 setup(
     name='gapic-generator',
-    version='0.22.0',
+    version='0.22.1',
     license='Apache 2.0',
     author='Dov Shlachter',
     author_email='dovs@google.com',


### PR DESCRIPTION
cut a release for https://github.com/googleapis/gapic-generator-python/pull/412