### PR TITLE
fix: consolidate dependencies in setup.py

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -16,10 +16,7 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-auth >= 1.14.0',
-        'google-api-core >= 1.17.0, < 2.0.0dev',
-        'googleapis-common-protos >= 1.5.8',
-        'grpcio >= 1.10.0',
+        'google-api-core[grpc] >= 1.17.0, < 2.0.0dev',
         'proto-plus >= 0.4.0',
     {%- if api.requires_package(('google', 'iam', 'v1')) %}
         'grpc-google-iam-v1',


### PR DESCRIPTION
`google-auth`, `googleapis-common-protos`, and `grpcio` are required by `google-api-core`.

https://github.com/googleapis/python-api-core/blob/335c1097b4d697f93ed1088c581981850a66239e/setup.py#L32-L45