### PR TITLE
Move `libcst` to `install_requires`

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -17,8 +17,8 @@ setuptools.setup(
     include_package_data=True,
     install_requires=(
         'google-api-core[grpc] >= 1.17.0, < 2.0.0dev',
-        'proto-plus >= 0.4.0',
         'libcst >= 0.2.5',
+        'proto-plus >= 0.4.0',
     {%- if api.requires_package(('google', 'iam', 'v1')) %}
         'grpc-google-iam-v1',
     {%- endif %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -18,14 +18,12 @@ setuptools.setup(
     install_requires=(
         'google-api-core[grpc] >= 1.17.0, < 2.0.0dev',
         'proto-plus >= 0.4.0',
+        'libcst >= 0.2.5',
     {%- if api.requires_package(('google', 'iam', 'v1')) %}
         'grpc-google-iam-v1',
     {%- endif %}
     ),
     python_requires='>={% if opts.lazy_import %}3.7{% else %}3.6{% endif %}',{# Lazy import requires module-level getattr #}
-    setup_requires=[
-        'libcst >= 0.2.5',
-    ],
     scripts=[
         'scripts/fixup_keywords.py',
     ],


### PR DESCRIPTION
`libcst` is required by the fixup script, not the `setup.py` itself, so I'd prefer to move it to `install_requires`. 

Use of `setup_requires` is also discouraged by setuptools

https://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=setup_requires#options
> Warning: Using setup_requires is discouraged in favor of PEP-518
>
> A string or list of strings specifying what other distributions need to be present in order for the setup script to run. 
>
> setuptools will attempt to obtain these (even going so far as to download them using EasyInstall) before processing the rest of the setup script or commands. This argument is needed if you are using distutils extensions as part of your build process; for example, extensions that process setup() arguments and turn them into EGG-INFO metadata files.
> 
> (Note: projects listed in setup_requires will NOT be automatically installed on the system where the setup script is being run. They are simply downloaded to the ./.eggs directory if they’re not locally available already. If you want them to be installed, as well as being available when the setup script is run, you should add them to install_requires and setup_requires.)
> 

