### PR TITLE
fix(dependencies): require min google-api-core version of 1.21.0

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -16,7 +16,7 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.17.2, < 2.0.0dev',
+        'google-api-core[grpc] >= 1.21.0, < 2.0.0dev',
         'libcst >= 0.2.5',
         'proto-plus >= 0.4.0',
     {%- if api.requires_package(('google', 'iam', 'v1')) %}


### PR DESCRIPTION
This is the version required for credentials_file and scopes support via google-api-core. (#461)