### PR TITLE
fix: disambiguate fields whose names are reserved python words

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -621,7 +621,7 @@ class _ProtoBuilder:
                 field_pb.oneof_index
             ) if is_oneof else None
 
-            answer[field_pb.name] = wrappers.Field(
+            field = wrappers.Field(
                 field_pb=field_pb,
                 enum=self.api_enums.get(field_pb.type_name.lstrip('.')),
                 message=self.api_messages.get(field_pb.type_name.lstrip('.')),
@@ -631,6 +631,7 @@ class _ProtoBuilder:
                 ),
                 oneof=oneof_name,
             )
+            answer[field.name] = field
 
         # Done; return the answer.
         return answer

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -59,6 +59,12 @@ class Field:
     def __getattr__(self, name):
         return getattr(self.field_pb, name)
 
+    @property
+    def name(self) -> str:
+        """Used to prevent collisions with python keywords"""
+        name = self.field_pb.name
+        return name + "_" if name in utils.RESERVED_NAMES else name
+
     @utils.cached_property
     def ident(self) -> metadata.FieldIdentifier:
         """Return the identifier to be used in templates."""

--- a/tests/unit/schema/wrappers/test_field.py
+++ b/tests/unit/schema/wrappers/test_field.py
@@ -248,3 +248,15 @@ def test_mock_value_message():
         message=message,
     )
     assert field.mock_value == 'bogus.Message(foo=324)'
+
+
+def test_field_name_kword_disambiguation():
+    from_field = make_field(
+        name="from",
+    )
+    assert from_field.name == "from_"
+
+    frum_field = make_field(
+        name="frum",
+    )
+    assert frum_field.name == "frum"


### PR DESCRIPTION
Fix for #504 