### PR TITLE
feat: add retry config passed to bazel rule

### DIFF
--- a/rules_python_gapic/py_gapic.bzl
+++ b/rules_python_gapic/py_gapic.bzl
@@ -14,17 +14,28 @@
 
 load("@com_google_api_codegen//rules_gapic:gapic.bzl", "proto_custom_library")
 
-def py_gapic_library(name, srcs, plugin_args = [], opt_args = [], **kwargs):
+def py_gapic_library(
+        name,
+        srcs,
+        grpc_service_config = None,
+        plugin_args = [],
+        opt_args = [],
+        **kwargs):
     #    srcjar_target_name = "%s_srcjar" % name
     srcjar_target_name = name
     srcjar_output_suffix = ".srcjar"
 
+    file_args = {}
+    if grpc_service_config:
+        file_args[grpc_service_config] =  "retry-config"
+
+    proto_
     proto_custom_library(
         name = srcjar_target_name,
         deps = srcs,
         plugin = Label("@gapic_generator_python//:gapic_plugin"),
         plugin_args = plugin_args,
-        plugin_file_args = {},
+        plugin_file_args = file_args,
         opt_args = opt_args,
         output_type = "python_gapic",
         output_suffix = srcjar_output_suffix,


### PR DESCRIPTION
Note: this is almost certainly incomplete. It's not obvious how to manipulate the commandline for the actual microgenerator, nor how to verify the output.