### PR TITLE
fix: module names can no longer collide with keywords or builtins

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -19,6 +19,7 @@ through an :class:`~.API` object.
 
 import collections
 import dataclasses
+import keyword
 import os
 import sys
 from typing import Callable, Container, Dict, FrozenSet, Mapping, Optional, Sequence, Set, Tuple
@@ -229,7 +230,7 @@ class API:
                 visited_names: Container[str]) -> str:
             path, fname = os.path.split(full_path)
             name, ext = os.path.splitext(fname)
-            if name in RESERVED_NAMES or full_path in visited_names:
+            if name in keyword.kwlist or full_path in visited_names:
                 name += "_"
                 full_path = os.path.join(path, name + ext)
                 if full_path in visited_names:

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -34,6 +34,7 @@ from google.protobuf import descriptor_pb2
 from gapic.schema import imp
 from gapic.schema import naming
 from gapic.utils import cached_property
+from gapic.utils import RESERVED_NAMES
 
 
 @dataclasses.dataclass(frozen=True)
@@ -47,6 +48,9 @@ class Address:
         default_factory=naming.NewNaming,
     )
     collisions: FrozenSet[str] = dataclasses.field(default_factory=frozenset)
+
+    def __post_init__(self):
+        super().__setattr__("collisions", self.collisions | RESERVED_NAMES)
 
     def __eq__(self, other) -> bool:
         return all([getattr(self, i) == getattr(other, i) for i

--- a/gapic/utils/reserved_names.py
+++ b/gapic/utils/reserved_names.py
@@ -12,7 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import builtins
+import itertools
 import keyword
 
 
-RESERVED_NAMES = frozenset(keyword.kwlist)
+# The filter and map builtins are a historical artifact;
+# they are not used in modern, idiomatic python,
+# nor are they used in the gapic surface.
+# They are too useful to reserve.
+RESERVED_NAMES = frozenset(
+    itertools.chain(
+        keyword.kwlist,
+        set(dir(builtins)) - {"filter", "map"},
+    )
+)

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -20,6 +20,7 @@ from test_utils.test_utils import make_doc_meta
 
 from gapic.schema import metadata
 from gapic.schema import naming
+from gapic.utils import RESERVED_NAMES
 
 
 def test_address_str():
@@ -160,11 +161,31 @@ def test_address_subpackage_empty():
 
 def test_metadata_with_context():
     meta = metadata.Metadata()
-    assert meta.with_context(
+    collisions = meta.with_context(
         collisions={'foo', 'bar'},
-    ).address.collisions == {'foo', 'bar'}
+    ).address.collisions - RESERVED_NAMES
+    assert collisions == {'foo', 'bar'}
 
 
+
+def test_address_name_builtin_keyword():
+    addr_builtin = metadata.Address(
+        name="Any",
+        module="any",
+        package=("google", "protobuf"),
+        api_naming=naming.NewNaming(proto_package="foo.bar.baz.v1"),
+    )
+    assert addr_builtin.module_alias == "gp_any"
+
+    addr_kword = metadata.Address(
+        name="Class",
+        module="class",
+        package=("google", "protobuf"),
+        api_naming=naming.NewNaming(proto_package="foo.bar.baz.v1"),
+    )
+    assert addr_kword.module_alias == "gp_class"
+    
+    
 def test_doc_nothing():
     meta = metadata.Metadata()
     assert meta.doc == ''

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -167,7 +167,6 @@ def test_metadata_with_context():
     assert collisions == {'foo', 'bar'}
 
 
-
 def test_address_name_builtin_keyword():
     addr_builtin = metadata.Address(
         name="Any",
@@ -184,8 +183,8 @@ def test_address_name_builtin_keyword():
         api_naming=naming.NewNaming(proto_package="foo.bar.baz.v1"),
     )
     assert addr_kword.module_alias == "gp_class"
-    
-    
+
+
 def test_doc_nothing():
     meta = metadata.Metadata()
     assert meta.doc == ''


### PR DESCRIPTION
E.g. protobuf/any.proto will be imported as

from google.protobuf import any_pb2 as gp_any # Was previously 'as any'