### PR TITLE
fix: ignore types for imports generated from 'google.api_core'

### DIFF
--- a/gapic/schema/imp.py
+++ b/gapic/schema/imp.py
@@ -31,6 +31,6 @@ class Import:
             answer = f"from {'.'.join(self.package)} {answer}"
         if self.alias:
             answer += f' as {self.alias}'
-        if self.module.endswith('_pb2'):
+        if self.module.endswith('_pb2') or 'api_core' in self.package:
             answer += '  # type: ignore'
         return answer

--- a/tests/unit/schema/test_imp.py
+++ b/tests/unit/schema/test_imp.py
@@ -35,6 +35,11 @@ def test_str_untyped_pb2():
     assert str(i) == 'from foo.bar import baz_pb2 as bacon  # type: ignore'
 
 
+def test_str_untyped_api_core():
+    i = imp.Import(package=('foo', 'api_core'), module='baz', alias='bacon')
+    assert str(i) == 'from foo.api_core import baz as bacon  # type: ignore'
+
+
 def test_str_eq():
     i1 = imp.Import(package=('foo', 'bar'), module='baz')
     i2 = imp.Import(package=('foo', 'bar'), module='baz')


### PR DESCRIPTION
Closes #596.