### PR TITLE
fix: operation module is properly aliased if necessary

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -369,7 +369,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {%- if method.lro %}
 
         # Wrap the response in an operation future.
-        response = operation.from_gapic(
+        response = {{ method.client_output.ident.module_alias or method.client_output.ident.module }}.from_gapic(
             response,
             self._transport.operations_client,
             {{ method.lro.response_type.ident }},

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -240,7 +240,7 @@ class {{ service.async_client_name }}:
         {%- if method.lro %}
 
         # Wrap the response in an operation future.
-        response = operation_async.from_gapic(
+        response = {{ method.client_output.ident.module_alias or method.client_output.ident.module }}.from_gapic(
             response,
             self._client._transport.operations_client,
             {{ method.lro.response_type.ident }},

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -240,7 +240,7 @@ class {{ service.async_client_name }}:
         {%- if method.lro %}
 
         # Wrap the response in an operation future.
-        response = {{ method.client_output.ident.module_alias or method.client_output.ident.module }}.from_gapic(
+        response = {{ method.client_output_async.ident.module_alias or method.client_output_async.ident.module }}.from_gapic(
             response,
             self._client._transport.operations_client,
             {{ method.lro.response_type.ident }},

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -381,7 +381,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {%- if method.lro %}
 
         # Wrap the response in an operation future.
-        response = operation.from_gapic(
+        response = {{ method.client_output.ident.module_alias or method.client_output.ident.module }}.from_gapic(
             response,
             self._transport.operations_client,
             {{ method.lro.response_type.ident }},


### PR DESCRIPTION
Some APIs define their own module named 'operation' that naively
clashes with google.api_core.operation.
Both modules are imported with a disambiguating alias, but the alias
was not always referenced for the api_core submodule.

This change fixes that issue. Fix for #610