### PR TITLE
fix: retriable exceptions are deterministically ordered in GAPICs

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
@@ -89,11 +89,9 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
                     {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
                     {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                     predicate=retries.if_exception_type(
-                        {%- filter sort_lines %}
-                        {%- for ex in method.retry.retryable_exceptions %}
+                        {%- for ex in method.retry.retryable_exceptions|sort(attribute='__name__) %}
                         exceptions.{{ ex.__name__ }},
                         {%- endfor %}
-                        {%- endfilter %}
                     ),
                 ),
                 {%- endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -199,11 +199,9 @@ class {{ service.async_client_name }}:
                 {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
                 {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                 predicate=retries.if_exception_type(
-                    {%- filter sort_lines %}
-                    {%- for ex in method.retry.retryable_exceptions %}
+                    {%- for ex in method.retry.retryable_exceptions|sort(attribue='__name__') %}
                     exceptions.{{ ex.__name__ }},
                     {%- endfor %}
-                    {%- endfilter %}
                 ),
             ),
             {%- endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -114,11 +114,9 @@ class {{ service.name }}Transport(abc.ABC):
                     {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
                     {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                     predicate=retries.if_exception_type(
-                        {%- filter sort_lines %}
-                        {%- for ex in method.retry.retryable_exceptions %}
+                        {%- for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
                         exceptions.{{ ex.__name__ }},
                         {%- endfor %}
-                        {%- endfilter %}
                     ),
                 ),
                 {%- endif %}


### PR DESCRIPTION
Certain code patterns in the generated surface are created by
iteration over data collections. This iteration order should be
deterministic in order to prevent spurious deltas in the generated surface.