### PR TITLE
fix: resource messages in method response types generate helpers

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -460,7 +460,7 @@ class _ProtoBuilder:
             else:
                 raise TypeError(
                     f"Unknown type referenced in "
-                    "{self.file_descriptor.name}: '{key}'"
+                    f"{self.file_descriptor.name}: '{key}'"
                 )
 
         # Only generate the service if this is a target file to be generated.

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1012,7 +1012,7 @@ class Service:
     @utils.cached_property
     def resource_messages(self) -> FrozenSet[MessageType]:
         """Returns all the resource message types used in all
-        request fields in the service."""
+        request and response fields in the service."""
         def gen_resources(message):
             if message.resource_path:
                 yield message
@@ -1022,9 +1022,14 @@ class Service:
                     yield type_
 
         return frozenset(
-            resource_msg
+            msg
             for method in self.methods.values()
-            for resource_msg in gen_resources(method.input)
+            for msg in chain(
+                gen_resources(method.input),
+                gen_resources(
+                    method.lro.response_type if method.lro else method.output
+                ),
+            )
         )
 
     @utils.cached_property

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -137,6 +137,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         """Parse a {{ message.resource_type|snake_case }} path into its component segments."""
         m = re.match(r"{{ message.path_regex_str }}", path)
         return m.groupdict() if m else {}
+
     {% endfor %} {# resources #}
     {% for resource_msg in service.common_resources|sort(attribute="type_name") -%}
     @staticmethod

--- a/noxfile.py
+++ b/noxfile.py
@@ -37,13 +37,18 @@ def unit(session):
 
     session.run(
         "py.test",
-        "-vv",
-        "-n=auto",
-        "--cov=gapic",
-        "--cov-config=.coveragerc",
-        "--cov-report=term",
-        "--cov-report=html",
-        *(session.posargs or [path.join("tests", "unit")]),
+        *(
+            session.posargs
+            or [
+                "-vv",
+                "-n=auto",
+                "--cov=gapic",
+                "--cov-config=.coveragerc",
+                "--cov-report=term",
+                "--cov-report=html",
+                path.join("tests", "unit"),
+            ]
+        ),
     )
 
 


### PR DESCRIPTION
Some resource messages are only referenced in method responses, either
directly (the method returns a resource) or indirectly (the resource
is a field for some other message).
These response-resources now generate helper methods in client
classes.

Contains a minor formatting fix in the generated output, a minor fix
in an error message, and a tweak to nox.py to aid interactive debugging.

Closes #624 