### PR TITLE
fix: fix types on server and bidi streaming callables

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -4,7 +4,7 @@
 from collections import OrderedDict
 import functools
 import re
-from typing import Dict, {% if service.any_server_streaming %}AsyncIterable, AsyncIterator, Awaitable{% endif %}Sequence, Tuple, Type, Union
+from typing import Dict, {% if service.any_server_streaming %}AsyncIterable, Awaitable, {% endif %}{% if service.any_client_streaming %}AsyncIterator, {% endif %}Sequence, Tuple, Type, Union
 import pkg_resources
 
 import google.api_core.client_options as ClientOptions # type: ignore

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -4,7 +4,7 @@
 from collections import OrderedDict
 import functools
 import re
-from typing import Dict, {% if service.any_server_streaming %}AsyncIterable, {% endif %}{% if service.any_client_streaming %}AsyncIterator, {% endif %}Sequence, Tuple, Type, Union
+from typing import Dict, {% if service.any_server_streaming %}AsyncIterable, AsyncIterator, Awaitable{% endif %}Sequence, Tuple, Type, Union
 import pkg_resources
 
 import google.api_core.client_options as ClientOptions # type: ignore
@@ -117,7 +117,7 @@ class {{ service.async_client_name }}:
             {%- if not method.server_streaming %}
             ) -> {{ method.client_output_async.ident }}:
             {%- else %}
-            ) -> AsyncIterable[{{ method.client_output_async.ident }}]:
+            ) -> Awaitable[AsyncIterable[{{ method.client_output_async.ident }}]]:
             {%- endif %}
         r"""{{ method.meta.doc|rst(width=72, indent=8) }}
 


### PR DESCRIPTION
The return type is an Awaitable that produces an AsyncIterator.