### PR TITLE
fix: expose transport property for clients

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -118,6 +118,15 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
     from_service_account_json = from_service_account_file
 
+    @property
+    def transport(self) -> {{ service.name }}Transport:
+        """Return the transport used by the client instance.
+
+        Returns:
+            {{ service.name }}Transport: The transport used by the client instance.
+        """
+        return self._transport
+
 
     {% for message in service.resource_messages|sort(attribute="resource_type") -%}
     @staticmethod
@@ -143,7 +152,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         """Parse a {{ resource_msg.message_type.resource_type|snake_case }} path into its component segments."""
         m = re.match(r"{{ resource_msg.message_type.path_regex_str }}", path)
         return m.groupdict() if m else {}
-      
+
     {% endfor %} {# common resources #}
 
     def __init__(self, *,
@@ -179,12 +188,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 not provided, the default SSL client certificate will be used if
                 present. If GOOGLE_API_USE_CLIENT_CERTIFICATE is "false" or not
                 set, no client certificate will be used.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
-                The client info used to send a user-agent string along with	
-                API requests. If ``None``, then default info will be used.	
-                Generally, you only need to set this if you're developing	
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
                 your own client library.
-                
+
         Raises:
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS transport
                 creation failed for any reason.
@@ -193,10 +202,10 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             client_options = client_options_lib.from_dict(client_options)
         if client_options is None:
             client_options = client_options_lib.ClientOptions()
-        
+
         # Create SSL credentials for mutual TLS if needed.
         use_client_cert = bool(util.strtobool(os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false")))
-        
+
         ssl_credentials = None
         is_mtls = False
         if use_client_cert:

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -66,12 +66,12 @@ def test_{{ service.client_name|snake_case }}_from_service_account_file():
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:
         factory.return_value = creds
         client = {{ service.client_name }}.from_service_account_file("dummy/file/path.json")
-        assert client._transport._credentials == creds
+        assert client.transport._credentials == creds
 
         client = {{ service.client_name }}.from_service_account_json("dummy/file/path.json")
-        assert client._transport._credentials == creds
+        assert client.transport._credentials == creds
 
-        {% if service.host %}assert client._transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
+        {% if service.host %}assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
 
 
 def test_{{ service.client_name|snake_case }}_get_transport_class():
@@ -170,7 +170,7 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(use_client_cert_env)
                 else:
                     expected_ssl_channel_creds = ssl_channel_creds
                     expected_host = client.DEFAULT_MTLS_ENDPOINT
-                
+
                 grpc_transport.assert_called_once_with(
                     ssl_channel_credentials=expected_ssl_channel_creds,
                     credentials=None,
@@ -182,9 +182,9 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(use_client_cert_env)
     # GOOGLE_API_USE_CLIENT_CERTIFICATE value.
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}):
         with mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}GrpcTransport.__init__') as grpc_transport:
-            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):                
+            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):
                 with mock.patch('google.auth.transport.grpc.SslCredentials.is_mtls', new_callable=mock.PropertyMock) as is_mtls_mock:
-                    with mock.patch('google.auth.transport.grpc.SslCredentials.ssl_credentials', new_callable=mock.PropertyMock) as ssl_credentials_mock: 
+                    with mock.patch('google.auth.transport.grpc.SslCredentials.ssl_credentials', new_callable=mock.PropertyMock) as ssl_credentials_mock:
                         if use_client_cert_env == "false":
                             is_mtls_mock.return_value = False
                             ssl_credentials_mock.return_value = None
@@ -195,7 +195,7 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(use_client_cert_env)
                             ssl_credentials_mock.return_value = mock.Mock()
                             expected_host = client.DEFAULT_MTLS_ENDPOINT
                             expected_ssl_channel_creds = ssl_credentials_mock.return_value
-                        
+
                         grpc_transport.return_value = None
                         client = {{ service.client_name }}()
                         grpc_transport.assert_called_once_with(
@@ -208,7 +208,7 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(use_client_cert_env)
     # Check the case client_cert_source and ADC client cert are not provided.
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}):
         with mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}GrpcTransport.__init__') as grpc_transport:
-            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):                
+            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):
                 with mock.patch('google.auth.transport.grpc.SslCredentials.is_mtls', new_callable=mock.PropertyMock) as is_mtls_mock:
                     is_mtls_mock.return_value = False
                     grpc_transport.return_value = None
@@ -251,7 +251,7 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -331,7 +331,7 @@ def test_{{ method.name|snake_case }}_field_headers():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         {% if method.void -%}
         call.return_value = None
@@ -367,7 +367,7 @@ def test_{{ method.name|snake_case }}_from_dict():
     )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -397,7 +397,7 @@ def test_{{ method.name|snake_case }}_flattened():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -462,7 +462,7 @@ def test_{{ method.name|snake_case }}_pager():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Set the response to a series of pages.
         call.side_effect = (
@@ -521,7 +521,7 @@ def test_{{ method.name|snake_case }}_pages():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Set the response to a series of pages.
         call.side_effect = (
@@ -580,7 +580,7 @@ def test_transport_instance():
         credentials=credentials.AnonymousCredentials(),
     )
     client = {{ service.client_name }}(transport=transport)
-    assert client._transport is transport
+    assert client.transport is transport
 
 
 def test_transport_grpc_default():
@@ -589,7 +589,7 @@ def test_transport_grpc_default():
         credentials=credentials.AnonymousCredentials(),
     )
     assert isinstance(
-        client._transport,
+        client.transport,
         transports.{{ service.name }}GrpcTransport,
     )
 
@@ -669,7 +669,7 @@ def test_{{ service.name|snake_case }}_host_no_port():
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}'),
     )
-    assert client._transport._host == '{{ host }}:443'
+    assert client.transport._host == '{{ host }}:443'
     {% endwith %}
 
 
@@ -679,7 +679,7 @@ def test_{{ service.name|snake_case }}_host_with_port():
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}:8000'),
     )
-    assert client._transport._host == '{{ host }}:8000'
+    assert client.transport._host == '{{ host }}:8000'
     {% endwith %}
 
 
@@ -701,7 +701,7 @@ def test_{{ service.name|snake_case }}_grpc_lro_client():
         credentials=credentials.AnonymousCredentials(),
         transport='grpc',
     )
-    transport = client._transport
+    transport = client.transport
 
     # Ensure that we have a api-core operations client.
     assert isinstance(

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -124,6 +124,15 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
     from_service_account_json = from_service_account_file
 
+    @property
+    def transport(self) -> {{ service.name }}Transport:
+        """Return the transport used by the client instance.
+
+        Returns:
+            {{ service.name }}Transport: The transport used by the client instance.
+        """
+        return self._transport
+
 
     {% for message in service.resource_messages|sort(attribute="resource_type") -%}
     @staticmethod
@@ -150,7 +159,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         """Parse a {{ resource_msg.message_type.resource_type|snake_case }} path into its component segments."""
         m = re.match(r"{{ resource_msg.message_type.path_regex_str }}", path)
         return m.groupdict() if m else {}
-      
+
     {% endfor %} {# common resources #}
 
     def __init__(self, *,
@@ -186,12 +195,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 not provided, the default SSL client certificate will be used if
                 present. If GOOGLE_API_USE_CLIENT_CERTIFICATE is "false" or not
                 set, no client certificate will be used.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
-                The client info used to send a user-agent string along with	
-                API requests. If ``None``, then default info will be used.	
-                Generally, you only need to set this if you're developing	
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
                 your own client library.
-                
+
         Raises:
             google.auth.exceptions.MutualTLSChannelError: If mutual TLS transport
                 creation failed for any reason.
@@ -200,10 +209,10 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             client_options = client_options_lib.from_dict(client_options)
         if client_options is None:
             client_options = client_options_lib.ClientOptions()
-        
+
         # Create SSL credentials for mutual TLS if needed.
         use_client_cert = bool(util.strtobool(os.getenv("GOOGLE_API_USE_CLIENT_CERTIFICATE", "false")))
-        
+
         ssl_credentials = None
         is_mtls = False
         if use_client_cert:

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -76,12 +76,12 @@ def test_{{ service.client_name|snake_case }}_from_service_account_file(client_c
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:
         factory.return_value = creds
         client = client_class.from_service_account_file("dummy/file/path.json")
-        assert client._transport._credentials == creds
+        assert client.transport._credentials == creds
 
         client = client_class.from_service_account_json("dummy/file/path.json")
-        assert client._transport._credentials == creds
+        assert client.transport._credentials == creds
 
-        {% if service.host %}assert client._transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
+        {% if service.host %}assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
 
 
 def test_{{ service.client_name|snake_case }}_get_transport_class():
@@ -164,7 +164,7 @@ def test_{{ service.client_name|snake_case }}_client_options(client_class, trans
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "Unsupported"}):
         with pytest.raises(MutualTLSChannelError):
             client = client_class()
-    
+
     # Check the case GOOGLE_API_USE_CLIENT_CERTIFICATE has unsupported value.
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": "Unsupported"}):
         with pytest.raises(ValueError):
@@ -214,7 +214,7 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(client_class, transp
                 else:
                     expected_ssl_channel_creds = ssl_channel_creds
                     expected_host = client.DEFAULT_MTLS_ENDPOINT
-                
+
                 patched.assert_called_once_with(
                     credentials=None,
                     credentials_file=None,
@@ -229,9 +229,9 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(client_class, transp
     # GOOGLE_API_USE_CLIENT_CERTIFICATE value.
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}):
         with mock.patch.object(transport_class, '__init__') as patched:
-            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):                
+            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):
                 with mock.patch('google.auth.transport.grpc.SslCredentials.is_mtls', new_callable=mock.PropertyMock) as is_mtls_mock:
-                    with mock.patch('google.auth.transport.grpc.SslCredentials.ssl_credentials', new_callable=mock.PropertyMock) as ssl_credentials_mock:  
+                    with mock.patch('google.auth.transport.grpc.SslCredentials.ssl_credentials', new_callable=mock.PropertyMock) as ssl_credentials_mock:
                         if use_client_cert_env == "false":
                             is_mtls_mock.return_value = False
                             ssl_credentials_mock.return_value = None
@@ -242,7 +242,7 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(client_class, transp
                             ssl_credentials_mock.return_value = mock.Mock()
                             expected_host = client.DEFAULT_MTLS_ENDPOINT
                             expected_ssl_channel_creds = ssl_credentials_mock.return_value
-                        
+
                         patched.return_value = None
                         client = client_class()
                         patched.assert_called_once_with(
@@ -254,11 +254,11 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(client_class, transp
                             quota_project_id=None,
                             client_info=transports.base.DEFAULT_CLIENT_INFO,
                         )
-    
+
     # Check the case client_cert_source and ADC client cert are not provided.
     with mock.patch.dict(os.environ, {"GOOGLE_API_USE_CLIENT_CERTIFICATE": use_client_cert_env}):
         with mock.patch.object(transport_class, '__init__') as patched:
-            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):                
+            with mock.patch('google.auth.transport.grpc.SslCredentials.__init__', return_value=None):
                 with mock.patch('google.auth.transport.grpc.SslCredentials.is_mtls', new_callable=mock.PropertyMock) as is_mtls_mock:
                     is_mtls_mock.return_value = False
                     patched.return_value = None
@@ -352,7 +352,7 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -432,7 +432,7 @@ async def test_{{ method.name|snake_case }}_async(transport: str = 'grpc_asyncio
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._client._transport.{{ method.name|snake_case }}),
+            type(client._client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -516,7 +516,7 @@ def test_{{ method.name|snake_case }}_field_headers():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         {% if method.void -%}
         call.return_value = None
@@ -561,7 +561,7 @@ async def test_{{ method.name|snake_case }}_field_headers_async():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._client._transport.{{ method.name|snake_case }}),
+            type(client._client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         {% if method.void -%}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
@@ -598,7 +598,7 @@ def test_{{ method.name|snake_case }}_from_dict():
     )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -628,7 +628,7 @@ def test_{{ method.name|snake_case }}_flattened():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -693,7 +693,7 @@ async def test_{{ method.name|snake_case }}_flattened_async():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._client._transport.{{ method.name|snake_case }}),
+            type(client._client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
@@ -779,7 +779,7 @@ def test_{{ method.name|snake_case }}_pager():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Set the response to a series of pages.
         call.side_effect = (
@@ -838,7 +838,7 @@ def test_{{ method.name|snake_case }}_pages():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._transport.{{ method.name|snake_case }}),
+            type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Set the response to a series of pages.
         call.side_effect = (
@@ -880,7 +880,7 @@ async def test_{{ method.name|snake_case }}_async_pager():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._client._transport.{{ method.name|snake_case }}),
+            type(client._client.transport.{{ method.name|snake_case }}),
             '__call__', new_callable=mock.AsyncMock) as call:
         # Set the response to a series of pages.
         call.side_effect = (
@@ -928,7 +928,7 @@ async def test_{{ method.name|snake_case }}_async_pages():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-            type(client._client._transport.{{ method.name|snake_case }}),
+            type(client._client.transport.{{ method.name|snake_case }}),
             '__call__', new_callable=mock.AsyncMock) as call:
         # Set the response to a series of pages.
         call.side_effect = (
@@ -1010,7 +1010,7 @@ def test_transport_instance():
         credentials=credentials.AnonymousCredentials(),
     )
     client = {{ service.client_name }}(transport=transport)
-    assert client._transport is transport
+    assert client.transport is transport
 
 
 def test_transport_get_channel():
@@ -1046,7 +1046,7 @@ def test_transport_grpc_default():
         credentials=credentials.AnonymousCredentials(),
     )
     assert isinstance(
-        client._transport,
+        client.transport,
         transports.{{ service.name }}GrpcTransport,
     )
 
@@ -1151,7 +1151,7 @@ def test_{{ service.name|snake_case }}_host_no_port():
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}'),
     )
-    assert client._transport._host == '{{ host }}:443'
+    assert client.transport._host == '{{ host }}:443'
     {% endwith %}
 
 
@@ -1161,7 +1161,7 @@ def test_{{ service.name|snake_case }}_host_with_port():
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}:8000'),
     )
-    assert client._transport._host == '{{ host }}:8000'
+    assert client.transport._host == '{{ host }}:8000'
     {% endwith %}
 
 
@@ -1274,7 +1274,7 @@ def test_{{ service.name|snake_case }}_grpc_lro_client():
         credentials=credentials.AnonymousCredentials(),
         transport='grpc',
     )
-    transport = client._transport
+    transport = client.transport
 
     # Ensure that we have a api-core operations client.
     assert isinstance(
@@ -1291,7 +1291,7 @@ def test_{{ service.name|snake_case }}_grpc_lro_async_client():
         credentials=credentials.AnonymousCredentials(),
         transport='grpc_asyncio',
     )
-    transport = client._client._transport
+    transport = client._client.transport
 
     # Ensure that we have a api-core operations client.
     assert isinstance(
@@ -1384,7 +1384,7 @@ def test_set_iam_policy(transport: str = "grpc"):
     request = iam_policy.SetIamPolicyRequest()
 
     # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(type(client._transport.set_iam_policy), "__call__") as call:
+    with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = policy.Policy(version=774, etag=b"etag_blob",)
 
@@ -1416,7 +1416,7 @@ async def test_set_iam_policy_async(transport: str = "grpc_asyncio"):
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._client._transport.set_iam_policy), "__call__"
+        type(client._client.transport.set_iam_policy), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
@@ -1450,7 +1450,7 @@ def test_set_iam_policy_field_headers():
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(type(client._transport.set_iam_policy), "__call__") as call:
+    with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         call.return_value = policy.Policy()
 
         client.set_iam_policy(request)
@@ -1478,7 +1478,7 @@ async def test_set_iam_policy_field_headers_async():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._client._transport.set_iam_policy), "__call__"
+        type(client._client.transport.set_iam_policy), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
 
@@ -1499,7 +1499,7 @@ def test_set_iam_policy_from_dict():
         credentials=credentials.AnonymousCredentials(),
     )
     # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(type(client._transport.set_iam_policy), "__call__") as call:
+    with mock.patch.object(type(client.transport.set_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = policy.Policy()
 
@@ -1522,7 +1522,7 @@ def test_get_iam_policy(transport: str = "grpc"):
     request = iam_policy.GetIamPolicyRequest()
 
     # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(type(client._transport.get_iam_policy), "__call__") as call:
+    with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = policy.Policy(version=774, etag=b"etag_blob",)
 
@@ -1554,7 +1554,7 @@ async def test_get_iam_policy_async(transport: str = "grpc_asyncio"):
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._client._transport.get_iam_policy), "__call__"
+        type(client._client.transport.get_iam_policy), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
@@ -1588,7 +1588,7 @@ def test_get_iam_policy_field_headers():
     request.resource = "resource/value"
 
     # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(type(client._transport.get_iam_policy), "__call__") as call:
+    with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         call.return_value = policy.Policy()
 
         client.get_iam_policy(request)
@@ -1616,7 +1616,7 @@ async def test_get_iam_policy_field_headers_async():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._client._transport.get_iam_policy), "__call__"
+        type(client._client.transport.get_iam_policy), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(policy.Policy())
 
@@ -1637,7 +1637,7 @@ def test_get_iam_policy_from_dict():
         credentials=credentials.AnonymousCredentials(),
     )
     # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(type(client._transport.get_iam_policy), "__call__") as call:
+    with mock.patch.object(type(client.transport.get_iam_policy), "__call__") as call:
         # Designate an appropriate return value for the call.
         call.return_value = policy.Policy()
 
@@ -1661,7 +1661,7 @@ def test_test_iam_permissions(transport: str = "grpc"):
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._transport.test_iam_permissions), "__call__"
+        type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = iam_policy.TestIamPermissionsResponse(
@@ -1694,7 +1694,7 @@ async def test_test_iam_permissions_async(transport: str = "grpc_asyncio"):
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._client._transport.test_iam_permissions), "__call__"
+        type(client._client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
@@ -1727,7 +1727,7 @@ def test_test_iam_permissions_field_headers():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._transport.test_iam_permissions), "__call__"
+        type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         call.return_value = iam_policy.TestIamPermissionsResponse()
 
@@ -1756,7 +1756,7 @@ async def test_test_iam_permissions_field_headers_async():
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._client._transport.test_iam_permissions), "__call__"
+        type(client._client.transport.test_iam_permissions), "__call__"
     ) as call:
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             iam_policy.TestIamPermissionsResponse()
@@ -1780,7 +1780,7 @@ def test_test_iam_permissions_from_dict():
     )
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
-        type(client._transport.test_iam_permissions), "__call__"
+        type(client.transport.test_iam_permissions), "__call__"
     ) as call:
         # Designate an appropriate return value for the call.
         call.return_value = iam_policy.TestIamPermissionsResponse()


### PR DESCRIPTION
Sometimes it's useful to get a reference to the transport for a client object.

Closes #640