### PR TITLE
test: use built-in mock module for tests

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -2,7 +2,7 @@
 
 {% block content %}
 import os
-import mock
+from unittest import mock
 
 import grpc
 from grpc.experimental import aio


### PR DESCRIPTION
Since Python 3.6+ is required, there is no need to use the mock backport.