### PR TITLE
chore: remove 3.6 tests for alternative templates

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,12 +38,6 @@ workflows:
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$/
-      - showcase-unit-alternative-templates-3.6:
-          requires:
-            - unit-3.6
-          filters:
-            tags:
-              only: /^v\d+\.\d+\.\d+$/
       - showcase-unit-alternative-templates-3.7:
           requires:
             - unit-3.7
@@ -100,7 +94,6 @@ workflows:
           requires:
             - docs
             - mypy
-            - showcase-unit-alternative-templates-3.6
             - showcase-unit-alternative-templates-3.7
             - showcase-unit-alternative-templates-3.8
             - showcase-mypy-alternative-templates
@@ -111,7 +104,6 @@ workflows:
           requires:
             - docs
             - mypy
-            - showcase-unit-alternative-templates-3.6
             - showcase-unit-alternative-templates-3.7
             - showcase-unit-alternative-templates-3.8
             - showcase-mypy-alternative-templates
@@ -424,30 +416,6 @@ jobs:
       - run:
           name: Run unit tests.
           command: nox -s showcase_unit-3.8
-  showcase-unit-alternative-templates-3.6:
-    docker:
-      - image: python:3.6-slim
-    steps:
-      - checkout
-      - run:
-          name: Install system dependencies.
-          command: |
-            apt-get update
-            apt-get install -y curl pandoc unzip gcc
-      - run:
-          name: Install protoc 3.12.1.
-          command: |
-            mkdir -p /usr/src/protoc/
-            curl --location https://github.com/google/protobuf/releases/download/v3.12.1/protoc-3.12.1-linux-x86_64.zip --output /usr/src/protoc/protoc-3.12.1.zip
-            cd /usr/src/protoc/
-            unzip protoc-3.12.1.zip
-            ln -s /usr/src/protoc/bin/protoc /usr/local/bin/protoc
-      - run:
-          name: Install nox.
-          command: pip install nox
-      - run:
-          name: Run unit tests.
-          command: nox -s showcase_unit_alternative_templates-3.6
   showcase-unit-alternative-templates-3.7:
     docker:
       - image: python:3.7-slim

--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -17,7 +17,6 @@ branchProtectionRules:
     - 'ci/circleci: showcase-unit-3.7'
     - 'ci/circleci: showcase-unit-3.8'
     - 'ci/circleci: showcase-unit-add-iam-methods'
-    - 'ci/circleci: showcase-unit-alternative-templates-3.6'
     - 'ci/circleci: showcase-unit-alternative-templates-3.7'
     - 'ci/circleci: showcase-unit-alternative-templates-3.8'
     - 'ci/circleci: style-check'

--- a/noxfile.py
+++ b/noxfile.py
@@ -176,7 +176,7 @@ def showcase_unit(
         )
 
 
-@nox.session(python=["3.6", "3.7", "3.8"])
+@nox.session(python=["3.7", "3.8"])
 def showcase_unit_alternative_templates(session):
     showcase_unit(session, templates=ADS_TEMPLATES, other_opts=("old-naming",))
 


### PR DESCRIPTION
Features in the Ads templates require Python 3.7 or later.