### PR TITLE
fix: unknown resources do not cause a generator crash

### DIFF
--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1064,11 +1064,12 @@ class Service:
                 resource = field.options.Extensions[
                     resource_pb2.resource_reference]
                 resource_type = resource.type or resource.child_type
-                # The common resources are defined (and rendered) explicitly
-                # by separate logic, and the resource definitions are never
-                # visible in any of the APIs file descriptor protos.
-                if resource_type and resource_type not in self.common_resources:
-                    yield self.visible_resources[resource_type]
+                # The resource may not be visible if the resource type is one of
+                # the common_resources (see the class var in class definition)
+                # or if it's something unhelpful like '*'.
+                resource = self.visible_resources.get(resource_type)
+                if resource:
+                    yield resource
 
         return frozenset(
             msg

--- a/tests/unit/schema/wrappers/test_service.py
+++ b/tests/unit/schema/wrappers/test_service.py
@@ -248,6 +248,30 @@ def test_resource_messages():
     assert expected == actual
 
 
+def test_service_unknown_resource_reference():
+    # This happens occasionally.
+    opts = descriptor_pb2.FieldOptions()
+    res_ref = opts.Extensions[resource_pb2.resource_reference]
+    res_ref.type = "*"
+    squid_request = make_message(
+        "CreateSquid",
+        fields=(
+            make_field("parent", type="TYPE_STRING", options=opts,),
+        ),
+    )
+    squid_service = make_service(
+        "SquidService",
+        methods=(
+            make_method(
+                "CreateSquid",
+                input_message=squid_request,
+            ),
+        ),
+    )
+
+    assert not squid_service.resource_messages
+
+
 def test_service_any_streaming():
     for client, server in itertools.product((True, False), (True, False)):
         service = make_service(


### PR DESCRIPTION
Some resource references do not map to actual known resource types,
e.g. from the Logging API
string destination = 3 [
    (google.api.resource_reference) = {
        type: "*"
    }
];

It's easiest to just ignore invalid resource types.