### PR TITLE
docs: generated message types reference proto-plus

### DIFF
--- a/gapic/ads-templates/scripts/fixup_%name_%version_keywords.py.j2
+++ b/gapic/ads-templates/scripts/fixup_%name_%version_keywords.py.j2
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 {% extends '_base.py.j2' %}
 {% block content %}
 import argparse

--- a/gapic/templates/docs/%name_%version/types.rst.j2
+++ b/gapic/templates/docs/%name_%version/types.rst.j2
@@ -3,3 +3,4 @@ Types for {{ api.naming.long_name }} {{ api.naming.version }} API
 
 .. automodule:: {{ api.naming.namespace|join('.')|lower }}.{{ api.naming.versioned_module_name }}.types
     :members:
+    :show-inheritance:

--- a/gapic/templates/docs/conf.py.j2
+++ b/gapic/templates/docs/conf.py.j2
@@ -346,6 +346,7 @@ intersphinx_mapping = {
     "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
     "grpc": ("https://grpc.io/grpc/python/", None),
     "requests": ("http://requests.kennethreitz.org/en/stable/", None),
+    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
 }
 
 

--- a/gapic/templates/scripts/fixup_%name_%version_keywords.py.j2
+++ b/gapic/templates/scripts/fixup_%name_%version_keywords.py.j2
@@ -1,3 +1,4 @@
+#! /usr/bin/env python3
 {% extends '_base.py.j2' %}
 {% block content %}
 import argparse

--- a/noxfile.py
+++ b/noxfile.py
@@ -229,7 +229,7 @@ def showcase_mypy_alternative_templates(session):
     showcase_mypy(session, templates=ADS_TEMPLATES, other_opts=("old-naming",))
 
 
-@nox.session(python="3.6")
+@nox.session(python="3.8")
 def docs(session):
     """Build the docs."""
 


### PR DESCRIPTION
Multiple issues have been filed indicating that json marshalling has
been broken and the fix is not obvious.
This will hopefully be ameliorated by indicating the inheritance from
proto.Message, with a link to the appropriate documentation.