### PR TITLE
perf: collisions don't contain reserved names by default

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -35,3 +35,5 @@ permissionRules:
     permission: admin
   - team: yoshi-python
     permission: push
+  - team: actools-python
+    permission: push

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -49,9 +49,6 @@ class Address:
     )
     collisions: FrozenSet[str] = dataclasses.field(default_factory=frozenset)
 
-    def __post_init__(self):
-        super().__setattr__("collisions", self.collisions | RESERVED_NAMES)
-
     def __eq__(self, other) -> bool:
         return all([getattr(self, i) == getattr(other, i) for i
                     in ('name', 'module', 'module_path', 'package', 'parent')])
@@ -114,7 +111,7 @@ class Address:
         while still providing names that are fundamentally readable
         to users (albeit looking auto-generated).
         """
-        if self.module in self.collisions:
+        if self.module in self.collisions | RESERVED_NAMES:
             return '_'.join(
                 (
                     ''.join(
@@ -283,7 +280,7 @@ class Address:
         ``Address`` object aliases module names to avoid naming collisions in
         the file being written.
         """
-        return dataclasses.replace(self, collisions=frozenset(collisions))
+        return dataclasses.replace(self, collisions=collisions)
 
 
 @dataclasses.dataclass(frozen=True)


### PR DESCRIPTION
The 'collisions' set does NOT contain RESERVED_NAMES; they are
combined at runtime when needed.
    
For a large real-world, this results in an order of magnitude
reduction in memory usage.
I'm not joking: Google Ads v5 uses 2.45 GB peak before this change
and 223 MB after.

Also contains changes to add `__slots__` attributes to Metadata and Address. These are ancillary, optional, and open to negotiation.
In the above scenario, they reduce memory usage from 223 MB to 177 MB. If other people feel that the reduction in readability does not warrant the reduction in memory usage I am absolutely open to dropping that particular commit.

Includes other minor memory usage optimizations that collectively shave about 5 MB.