### PR TITLE
fix: remove client recv msg limit

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/grpc.py.j2
@@ -124,6 +124,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 ssl_credentials=ssl_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
             self._ssl_channel_credentials = ssl_credentials
         else:
@@ -138,6 +142,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 credentials=credentials,
                 ssl_credentials=ssl_channel_credentials,
                 scopes=self.AUTH_SCOPES,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
 
         self._stubs = {}  # type: Dict[str, Callable]

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/grpc.py.j2
@@ -124,10 +124,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 ssl_credentials=ssl_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
             self._ssl_channel_credentials = ssl_credentials
         else:
@@ -142,10 +142,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 credentials=credentials,
                 ssl_credentials=ssl_channel_credentials,
                 scopes=self.AUTH_SCOPES,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
 
         self._stubs = {}  # type: Dict[str, Callable]

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -748,10 +748,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                        ("grpc.max_send_message_length", -1),
+                        ("grpc.max_receive_message_length", -1),
+                ],
             )
             assert transport.grpc_channel == mock_grpc_channel
             assert transport._ssl_channel_credentials == mock_ssl_cred
@@ -791,10 +791,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
             assert transport.grpc_channel == mock_grpc_channel
 

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -748,6 +748,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
             assert transport.grpc_channel == mock_grpc_channel
             assert transport._ssl_channel_credentials == mock_ssl_cred
@@ -787,6 +791,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
             assert transport.grpc_channel == mock_grpc_channel
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -132,10 +132,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 ssl_credentials=ssl_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
             self._ssl_channel_credentials = ssl_credentials
         else:
@@ -152,10 +152,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 ssl_credentials=ssl_channel_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
 
         self._stubs = {}  # type: Dict[str, Callable]

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -132,6 +132,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 ssl_credentials=ssl_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
             self._ssl_channel_credentials = ssl_credentials
         else:
@@ -148,6 +152,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 ssl_credentials=ssl_channel_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
 
         self._stubs = {}  # type: Dict[str, Callable]

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -176,6 +176,10 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
                 ssl_credentials=ssl_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
             self._ssl_channel_credentials = ssl_credentials
         else:
@@ -192,6 +196,10 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
                 ssl_credentials=ssl_channel_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
 
         # Run the base constructor.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -176,10 +176,10 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
                 ssl_credentials=ssl_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
             self._ssl_channel_credentials = ssl_credentials
         else:
@@ -196,10 +196,10 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
                 ssl_credentials=ssl_channel_credentials,
                 scopes=scopes or self.AUTH_SCOPES,
                 quota_project_id=quota_project_id,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
 
         # Run the base constructor.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -101,10 +101,10 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
                     self._host,
                     credentials=self._credentials,
                     scopes=self.AUTH_SCOPES,
-                    options={
-                        "grpc.max_send_message_length": -1,
-                        "grpc.max_receive_message_length": -1,
-                    },
+                    options=[
+                        ("grpc.max_send_message_length", -1),
+                        ("grpc.max_receive_message_length", -1),
+                    ],
                 )
             )
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -101,6 +101,10 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
                     self._host,
                     credentials=self._credentials,
                     scopes=self.AUTH_SCOPES,
+                    options={
+                        "grpc.max_send_message_length": -1,
+                        "grpc.max_receive_message_length": -1,
+                    },
                 )
             )
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1237,10 +1237,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
             assert transport.grpc_channel == mock_grpc_channel
             assert transport._ssl_channel_credentials == mock_ssl_cred
@@ -1280,10 +1280,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
-                options={
-                    "grpc.max_send_message_length": -1,
-                    "grpc.max_receive_message_length": -1,
-                },
+                options=[
+                    ("grpc.max_send_message_length", -1),
+                    ("grpc.max_receive_message_length", -1),
+                ],
             )
             assert transport.grpc_channel == mock_grpc_channel
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1237,6 +1237,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
             assert transport.grpc_channel == mock_grpc_channel
             assert transport._ssl_channel_credentials == mock_ssl_cred
@@ -1276,6 +1280,10 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
+                options={
+                    "grpc.max_send_message_length": -1,
+                    "grpc.max_receive_message_length": -1,
+                },
             )
             assert transport.grpc_channel == mock_grpc_channel
 


### PR DESCRIPTION
Closes #669 

Replicates change made in monolithic generator to remove client side size limits. 
https://github.com/googleapis/gapic-generator/pull/2900 https://github.com/googleapis/gapic-generator/pull/2905