### PR TITLE
feat: allow warehouse name to be customized

### DIFF
--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -42,6 +42,7 @@ class Naming(abc.ABC):
     version: str = ''
     product_name: str = ''
     proto_package: str = ''
+    _warehouse_package_name: str = ''
 
     def __post_init__(self):
         if not self.product_name:
@@ -141,6 +142,10 @@ class Naming(abc.ABC):
                 # with ('x.y',) will become a two-tuple: ('x', 'y')
                 i.capitalize() for i in '.'.join(opts.namespace).split('.')
             ))
+        if opts.warehouse_package_name:
+            package_info = dataclasses.replace(package_info,
+                _warehouse_package_name=opts.warehouse_package_name
+            )
 
         # Done; return the naming information.
         return package_info
@@ -186,9 +191,11 @@ class Naming(abc.ABC):
     @property
     def warehouse_package_name(self) -> str:
         """Return the appropriate Python package name for Warehouse."""
-
-        # Piece the name and namespace together to come up with the
-        # proper package name.
+        # If a custom name has been set, use it
+        if self._warehouse_package_name:
+            return self._warehouse_package_name
+        # Otherwise piece the name and namespace together to come
+        # up with the proper package name.
         answer = list(self.namespace) + self.name.split(' ')
         return '-'.join(answer).lower()
 

--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -145,7 +145,7 @@ class Naming(abc.ABC):
         if opts.warehouse_package_name:
             package_info = dataclasses.replace(package_info,
                 _warehouse_package_name=opts.warehouse_package_name
-            )
+                                               )
 
         # Done; return the naming information.
         return package_info

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -54,7 +54,7 @@ class Options:
         'add-iam-methods',      # microgenerator implementation for `reroute_to_grpc_interface`
         # transport type(s) delineated by '+' (i.e. grpc, rest, custom.[something], etc?)
         'transport',
-        'warehouse-package-name' # change the package name on PyPI
+        'warehouse-package-name'  # change the package name on PyPI
     ))
 
     @classmethod
@@ -131,7 +131,8 @@ class Options:
         answer = Options(
             name=opts.pop('name', ['']).pop(),
             namespace=tuple(opts.pop('namespace', [])),
-            warehouse_package_name=opts.pop('warehouse-package-name', ['']).pop(),
+            warehouse_package_name=opts.pop(
+                'warehouse-package-name', ['']).pop(),
             retry=retry_cfg,
             sample_configs=tuple(
                 cfg_path

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -34,6 +34,7 @@ class Options:
     """
     name: str = ''
     namespace: Tuple[str, ...] = dataclasses.field(default=())
+    warehouse_package_name: str = ''
     retry: Optional[Dict[str, Any]] = None
     sample_configs: Tuple[str, ...] = dataclasses.field(default=())
     templates: Tuple[str, ...] = dataclasses.field(default=('DEFAULT',))
@@ -53,6 +54,7 @@ class Options:
         'add-iam-methods',      # microgenerator implementation for `reroute_to_grpc_interface`
         # transport type(s) delineated by '+' (i.e. grpc, rest, custom.[something], etc?)
         'transport',
+        'warehouse-package-name' # change the package name on PyPI
     ))
 
     @classmethod
@@ -129,6 +131,7 @@ class Options:
         answer = Options(
             name=opts.pop('name', ['']).pop(),
             namespace=tuple(opts.pop('namespace', [])),
+            warehouse_package_name=opts.pop('warehouse-package-name', ['']).pop(),
             retry=retry_cfg,
             sample_configs=tuple(
                 cfg_path

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -153,6 +153,7 @@ def test_options_add_iam_methods():
     opts = Options.build('add-iam-methods')
     assert opts.add_iam_methods
 
+
 def test_options_warehouse_package_name():
     opts = Options.build('warehouse-package-name')
     assert opts.warehouse_package_name

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -152,3 +152,7 @@ def test_options_old_naming():
 def test_options_add_iam_methods():
     opts = Options.build('add-iam-methods')
     assert opts.add_iam_methods
+
+def test_options_warehouse_package_name():
+    opts = Options.build('warehouse-package-name')
+    assert opts.warehouse_package_name

--- a/tests/unit/schema/test_naming.py
+++ b/tests/unit/schema/test_naming.py
@@ -217,6 +217,7 @@ def test_cli_override_name_and_namespace_versionless():
     assert n.name == 'Translate'
     assert not n.version
 
+
 def test_cli_override_warehouse_package_name():
     FileDesc = descriptor_pb2.FileDescriptorProto
     proto1 = FileDesc(package='google.translation')
@@ -225,7 +226,6 @@ def test_cli_override_warehouse_package_name():
         opts=Options(warehouse_package_name='google-cloud-foo'),
     )
     assert n.warehouse_package_name == "google-cloud-foo"
-
 
 
 def test_build_factory():

--- a/tests/unit/schema/test_naming.py
+++ b/tests/unit/schema/test_naming.py
@@ -217,6 +217,16 @@ def test_cli_override_name_and_namespace_versionless():
     assert n.name == 'Translate'
     assert not n.version
 
+def test_cli_override_warehouse_package_name():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.translation')
+    n = naming.Naming.build(
+        proto1,
+        opts=Options(warehouse_package_name='google-cloud-foo'),
+    )
+    assert n.warehouse_package_name == "google-cloud-foo"
+
+
 
 def test_build_factory():
     proto = descriptor_pb2.FileDescriptorProto(


### PR DESCRIPTION
Allow warehouse name (package name in `setup.py`) to be customized via a CLI option.

This is a pretty common reason for a `synth.py` regex replace:
- One repo has more than one API (e.g., Bigtable and Bigtable Admin) but the package name should always be `google-cloud-bigtable`
- We want an extra `-` in the repo name and package name to make it easier to read and type. (`google-cloud-binaryauthorization` -> `google-cloud-binary-authorization`)
- Package name constructed from the namespace doesn't match the `google-cloud-{API}` convention (`google-cloud-devtools-containeranalysis` -> `google-cloud-containeranalysis`)

Fixes #605 

