### PR TITLE
fix: fix missing .coveragerc and the broken bazel build

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -52,7 +52,7 @@ toolchain(
 py_binary(
     name = "gapic_plugin",
     srcs = glob(["gapic/**/*.py"]),
-    data = [":pandoc_binary"] + glob(["gapic/**/*.j2"]),
+    data = [":pandoc_binary"] + glob(["gapic/**/*.j2", "gapic/**/.*.j2"]),
     main = "gapic/cli/generate_with_pandoc.py",
     python_version = "PY3",
     visibility = ["//visibility:public"],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,13 +9,9 @@ http_archive(
 
 http_archive(
     name = "rules_python",
-    strip_prefix = "rules_python-0.1.0,
+    strip_prefix = "rules_python-0.1.0",
     url = "https://github.com/bazelbuild/rules_python/archive/0.1.0.tar.gz",
 )
-
-load("@rules_python//python:repositories.bzl", "py_repositories")
-
-py_repositories()
 
 load("@rules_python//python:pip.bzl", "pip_repositories")
 
@@ -24,18 +20,15 @@ pip_repositories()
 #
 # Import gapic-generator-python specific dependencies
 #
-load("//:repositories.bzl",
+load(
+    "//:repositories.bzl",
     "gapic_generator_python",
-    "gapic_generator_register_toolchains"
+    "gapic_generator_register_toolchains",
 )
 
 gapic_generator_python()
 
 gapic_generator_register_toolchains()
-
-load("@gapic_generator_python_pip_deps//:requirements.bzl", "pip_install")
-
-pip_install()
 
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 


### PR DESCRIPTION
Fixes a typo in bazel build and https://github.com/googleapis/gapic-generator-python/issues/437