### PR TITLE
fix: raise for rest transport http error

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -199,6 +199,9 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
             json=body,
             {%- endif %}
         )
+
+        # Raise requests.exceptions.HTTPError if the status code is >= 400
+        response.raise_for_status()
         {%- if not method.void %}
 
         # Return the response


### PR DESCRIPTION
fix #730 

raise error for error status code using the `response.raise_for_status()` api.

https://github.com/psf/requests/blob/4f6c0187150af09d085c03096504934eb91c7a9e/requests/models.py#L920