### PR TITLE
fix: Make gapic-generator-python compatible with protobuf 3.14.0 (native namespace package)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -57,8 +57,8 @@ py_binary(
     python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [
-        "@com_google_protobuf//:protobuf_python",
         "@com_github_grpc_grpc//src/python/grpcio/grpc:grpcio",
+        requirement("protobuf"),
         requirement("click"),
         requirement("google-api-core"),
         requirement("googleapis-common-protos"),

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -44,11 +44,9 @@ load("@com_github_grpc_grpc//bazel:grpc_deps.bzl", "grpc_deps")
 
 grpc_deps()
 
-load("@upb//bazel:repository_defs.bzl", "bazel_version_repository")
+load("@com_github_grpc_grpc//bazel:grpc_extra_deps.bzl", "grpc_extra_deps")
 
-bazel_version_repository(
-    name = "bazel_version",
-)
+grpc_extra_deps()
 
 load("@build_bazel_rules_apple//apple:repositories.bzl", "apple_rules_dependencies")
 

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -15,7 +15,7 @@ def gapic_generator_python():
         requirements = "@gapic_generator_python//:requirements.txt",
     )
 
-    _protobuf_version = "3.13.0"
+    _protobuf_version = "3.14.0"
     _protobuf_version_in_link = "v%s" % _protobuf_version
     _maybe(
         http_archive,


### PR DESCRIPTION
More details about Python namespace packaging here: https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages

The protobuf changes, which made this fix necessary are here:
https://github.com/protocolbuffers/protobuf/pull/7902
https://github.com/protocolbuffers/protobuf/pull/7908

The tracking bug for this issue (probably not the only one) https://github.com/googleapis/gapic-generator/issues/3334

This is only part of the fix, for the proper fix other google-namespaced python packages must be migrated to [pkgutil-style-namespace-packages](https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages) and make sure they **do not** have `namespace_packages` in their `setup.py` file (an artifact from the legacy `pkg_resources-style`packages)