### PR TITLE
fix: Fix namespace packages conflict issue

### DIFF
--- a/gapic/cli/generate_with_pandoc.py
+++ b/gapic/cli/generate_with_pandoc.py
@@ -3,7 +3,7 @@ import sys
 
 if __name__ == '__main__':
     os.environ['PYPANDOC_PANDOC'] = os.path.join(
-            os.path.abspath(__file__).rsplit("gapic", 1)[0], "pandoc")
+        os.path.abspath(__file__).rsplit("gapic", 1)[0], "pandoc")
     os.environ['LC_ALL'] = 'C.UTF-8'
     os.environ['PYTHONNOUSERSITE'] = 'True'
 

--- a/gapic/cli/generate_with_pandoc.py
+++ b/gapic/cli/generate_with_pandoc.py
@@ -1,9 +1,14 @@
 import os
-
-from gapic.cli import generate
+import sys
 
 if __name__ == '__main__':
     os.environ['PYPANDOC_PANDOC'] = os.path.join(
-        os.path.abspath(__file__).rsplit("gapic", 1)[0], "pandoc")
+            os.path.abspath(__file__).rsplit("gapic", 1)[0], "pandoc")
     os.environ['LC_ALL'] = 'C.UTF-8'
-    generate.generate()
+    os.environ['PYTHONNOUSERSITE'] = 'True'
+
+    entry_point_script = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "generate.py")
+    args = [sys.executable, entry_point_script] + sys.argv[1:]
+
+    os.execv(args[0], args)


### PR DESCRIPTION
This fixes the https://github.com/googleapis/gapic-generator/issues/3334 by excluding system-wide site-packages dir from python packages resolution path completely. 

It is done by simply setting `PYTHONNOUSERSITE` environment variable and then "re-running" python interpreter replacing the current process, but this time with the site packages excluded.

This pretty much implements the long-standing featrue request for rules_python https://github.com/bazelbuild/bazel/issues/4939, but only in scope of gapic-generator-python.