### PR TITLE
fix: don't use integer for enums in json encoding

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -157,11 +157,13 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         {%- if method.http_opt['body'] != '*' %}
         body = {{ method.input.fields[method.http_opt['body']].type.ident }}.to_json(
             request.{{ method.http_opt['body'] }},
-            including_default_value_fields=False
+            including_default_value_fields=False,
+            use_integers_for_enums=False
         )
         {%- else %}
         body = {{ method.input.ident }}.to_json(
-            request
+            request,
+            use_integers_for_enums=False
         )
         {%- endif %}
         {%- endif %}


### PR DESCRIPTION
Integers for enums in json encoded requests is not desired.