### PR TITLE
fix: body encoding for rest transport

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -198,7 +198,7 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         {% if not method.void %}response = {% endif %}self._session.{{ method.http_opt['verb'] }}(
             url
             {%- if 'body' in method.http_opt %},
-            json=body,
+            data=body,
             {%- endif %}
         )
 


### PR DESCRIPTION
Basically just replace `json` argument with `data`

Apparently, the `json` parameter in `requests.Session.request()` method does not expect JSON string, but expects python dictionary instead, which is not intuitive and does not even match the documentation of the method: https://github.com/psf/requests/blob/master/requests/sessions.py#L483.

 At the same time in the Quickstart, it is explicitly said that `json` parameter was added in version `2.4.2` and expects python `dict`, while `data` argument can process raw encoded json string.