### PR TITLE
feat: support self-signed JWT flow for service accounts

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -3,9 +3,11 @@
 {% block content %}
 import abc
 import typing
+import packaging.version
 import pkg_resources
 
 from google import auth  # type: ignore
+import google.api_core
 from google.api_core import exceptions  # type: ignore
 from google.api_core import gapic_v1    # type: ignore
 from google.api_core import retry as retries  # type: ignore
@@ -34,6 +36,17 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
+try:
+    # google.auth.__version__ was added in 1.26.0
+    _GOOGLE_AUTH_VERSION = auth.__version__
+except AttributeError:
+    try:  # try pkg_resources if it is available
+        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
+    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
+        _GOOGLE_AUTH_VERSION = None
+
+_API_CORE_VERSION = google.api_core.__version__
+
 class {{ service.name }}Transport(abc.ABC):
     """Abstract transport class for {{ service.name }}."""
 
@@ -43,12 +56,14 @@ class {{ service.name }}Transport(abc.ABC):
         {%- endfor %}
     )
 
+    DEFAULT_HOST = {% if service.host %}'{{ service.host }}'{% else %}{{ None }}{% endif %}
+
     def __init__(
             self, *,
-            host: str{% if service.host %} = '{{ service.host }}'{% endif %},
+            host: str = DEFAULT_HOST,
             credentials: credentials.Credentials = None,
             credentials_file: typing.Optional[str] = None,
-            scopes: typing.Optional[typing.Sequence[str]] = AUTH_SCOPES,
+            scopes: typing.Optional[typing.Sequence[str]] = None,
             quota_project_id: typing.Optional[str] = None,
             client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
             **kwargs,       
@@ -66,7 +81,7 @@ class {{ service.name }}Transport(abc.ABC):
             credentials_file (Optional[str]): A file with credentials that can
                 be loaded with :func:`google.auth.load_credentials_from_file`.
                 This argument is mutually exclusive with credentials.
-            scope (Optional[Sequence[str]]): A list of scopes.
+            scopes (Optional[Sequence[str]]): A list of scopes.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
             client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
@@ -83,6 +98,15 @@ class {{ service.name }}Transport(abc.ABC):
         # Save the scopes.
         self._scopes = scopes or self.AUTH_SCOPES
 
+        # TODO: Remove this if/else once google-auth >= 1.25.0 is required
+        if _GOOGLE_AUTH_VERSION and (
+            packaging.version.parse(_GOOGLE_AUTH_VERSION)
+            >= packaging.version.parse("1.25.0")
+        ):
+            scopes_kwargs = {"scopes": self._scopes, "default_scopes": self.AUTH_SCOPES}
+        else:
+            scopes_kwargs = {"scopes": self._scopes}
+
         # If no credentials are provided, then determine the appropriate
         # defaults.
         if credentials and credentials_file:
@@ -91,12 +115,12 @@ class {{ service.name }}Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = auth.load_credentials_from_file(
                                 credentials_file,
-                                scopes=self._scopes,
+                                **scopes_kwargs,
                                 quota_project_id=quota_project_id
                             )
 
         elif credentials is None:
-            credentials, _ = auth.default(scopes=self._scopes, quota_project_id=quota_project_id)
+            credentials, _ = auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
 
         # Save the credentials.
         self._credentials = credentials

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -67,7 +67,7 @@ class {{ service.name }}Transport(abc.ABC):
             scopes: Optional[Sequence[str]] = None,
             quota_project_id: Optional[str] = None,
             client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
-            **kwargs,       
+            **kwargs,
             ) -> None:
         """Instantiate the transport.
 
@@ -85,10 +85,10 @@ class {{ service.name }}Transport(abc.ABC):
             scopes (Optional[Sequence[str]]): A list of scopes.
             quota_project_id (Optional[str]): An optional project to use for billing
                 and quota.
-            client_info (google.api_core.gapic_v1.client_info.ClientInfo):	
-                The client info used to send a user-agent string along with	
-                API requests. If ``None``, then default info will be used.	
-                Generally, you only need to set this if you're developing	
+            client_info (google.api_core.gapic_v1.client_info.ClientInfo):
+                The client info used to send a user-agent string along with
+                API requests. If ``None``, then default info will be used.
+                Generally, you only need to set this if you're developing
                 your own client library.
         """
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
@@ -99,13 +99,13 @@ class {{ service.name }}Transport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes_kwargs["scopes"]
+        self._scopes = scopes or self.AUTH_SCOPES
 
         # If no credentials are provided, then determine the appropriate
         # defaults.
         if credentials and credentials_file:
             raise exceptions.DuplicateCredentialArgs("'credentials_file' and 'credentials' are mutually exclusive")
-        
+
         if credentials_file is not None:
             credentials, _ = auth.load_credentials_from_file(
                                 credentials_file,
@@ -120,19 +120,7 @@ class {{ service.name }}Transport(abc.ABC):
         self._credentials = credentials
 
 
-    @classmethod
-    def _get_user_scopes(cls, host: str, scopes: Optional[Sequence[str]]) -> Optional[Sequence[str]]:
-        if scopes is None:
-            # If a custom API endpoint is set, set user scopes to ensure the auth
-            # library does not used the self-signed JWT flow for service
-            # accounts.
-            if host.split(":")[0] != cls.DEFAULT_HOST.split(":")[0]:
-                scopes = cls.AUTH_SCOPES
-        
-        return scopes
-
-
-    # TODO(busunkim): These two class methods are in the base transport 
+    # TODO(busunkim): These two class methods are in the base transport
     # to avoid duplicating code across the transport classes. These functions
     # should be deleted once the minimum required versions of google-api-core
     # and google-auth are increased.
@@ -142,7 +130,6 @@ class {{ service.name }}Transport(abc.ABC):
     def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
         """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
 
-        scopes = cls._get_user_scopes(host, scopes)
         scopes_kwargs = {}
 
         if _GOOGLE_AUTH_VERSION and (
@@ -152,17 +139,16 @@ class {{ service.name }}Transport(abc.ABC):
             scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
         else:
             scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-        
+
         return scopes_kwargs
 
     # TODO: Remove this function once google-api-core >= 1.26.0 is required
     @classmethod
     def _get_self_signed_jwt_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Union[Optional[Sequence[str]], str]]:
         """Returns kwargs to pass to grpc_helpers.create_channel depending on the google-api-core version"""
-        scopes = cls._get_user_scopes(host, scopes)
 
         self_signed_jwt_kwargs: Dict[str, Union[Optional[Sequence[str]], str]] = {}
-        
+
         if _API_CORE_VERSION and (
             packaging.version.parse(_API_CORE_VERSION)
             >= packaging.version.parse("1.26.0")
@@ -172,7 +158,7 @@ class {{ service.name }}Transport(abc.ABC):
             self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
         else:
             self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
-        
+
         return self_signed_jwt_kwargs
 
 
@@ -251,7 +237,7 @@ class {{ service.name }}Transport(abc.ABC):
         ],
     ]:
         raise NotImplementedError()
-    {% endif %} 
+    {% endif %}
 
 __all__ = (
     '{{ service.name }}Transport',

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -2,8 +2,7 @@
 
 {% block content %}
 import abc
-import re
-import typing
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import packaging.version
 import pkg_resources
 
@@ -58,15 +57,15 @@ class {{ service.name }}Transport(abc.ABC):
         {%- endfor %}
     )
 
-    DEFAULT_HOST = {% if service.host %}'{{ service.host }}'{% else %}{{ None }}{% endif %}
+    DEFAULT_HOST: str = {% if service.host %}'{{ service.host }}'{% else %}{{ '' }}{% endif %}
 
     def __init__(
             self, *,
             host: str = DEFAULT_HOST,
             credentials: credentials.Credentials = None,
-            credentials_file: typing.Optional[str] = None,
-            scopes: typing.Optional[typing.Sequence[str]] = None,
-            quota_project_id: typing.Optional[str] = None,
+            credentials_file: Optional[str] = None,
+            scopes: Optional[Sequence[str]] = None,
+            quota_project_id: Optional[str] = None,
             client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
             **kwargs,       
             ) -> None:
@@ -97,27 +96,10 @@ class {{ service.name }}Transport(abc.ABC):
             host += ':443'
         self._host = host
 
-        # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
-        # If a custom API endpoint is set, set scopes to ensure the auth
-        # library does not used the self-signed JWT flow for service
-        # accounts
-        if (
-            host is not None
-            and self.DEFAULT_HOST is not None
-            and host.split(":")[0] != self.DEFAULT_HOST.split(":")[0]
-            and not scopes
-        ):
-            scopes = self.AUTH_SCOPES
+        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
-        # TODO: Remove this if/else once google-auth >= 1.25.0 is required
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": self._scopes, "default_scopes": self.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": self._scopes}
+        # Save the scopes.
+        self._scopes = scopes_kwargs["scopes"]
 
         # If no credentials are provided, then determine the appropriate
         # defaults.
@@ -136,6 +118,62 @@ class {{ service.name }}Transport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
+
+
+    @classmethod
+    def _get_user_scopes(cls, host: str, scopes: Optional[Sequence[str]]) -> Optional[Sequence[str]]:
+        if scopes is None:
+            # If a custom API endpoint is set, set user scopes to ensure the auth
+            # library does not used the self-signed JWT flow for service
+            # accounts.
+            if host.split(":")[0] != cls.DEFAULT_HOST.split(":")[0]:
+                scopes = cls.AUTH_SCOPES
+        
+        return scopes
+
+
+    # TODO(busunkim): These two class methods are in the base transport 
+    # to avoid duplicating code across the transport classes. These functions
+    # should be deleted once the minimum required versions of google-api-core
+    # and google-auth are increased.
+
+    # TODO: Remove this function once google-auth >= 1.25.0 is required
+    @classmethod
+    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
+        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
+
+        scopes = cls._get_user_scopes(host, scopes)
+        scopes_kwargs = {}
+
+        if _GOOGLE_AUTH_VERSION and (
+            packaging.version.parse(_GOOGLE_AUTH_VERSION)
+            >= packaging.version.parse("1.25.0")
+        ):
+            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
+        else:
+            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
+        
+        return scopes_kwargs
+
+    # TODO: Remove this function once google-api-core >= 1.26.0 is required
+    @classmethod
+    def _get_self_signed_jwt_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Union[Optional[Sequence[str]], str]]:
+        """Returns kwargs to pass to grpc_helpers.create_channel depending on the google-api-core version"""
+        scopes = cls._get_user_scopes(host, scopes)
+
+        self_signed_jwt_kwargs: Dict[str, Union[Optional[Sequence[str]], str]] = {}
+        
+        if _API_CORE_VERSION and (
+            packaging.version.parse(_API_CORE_VERSION)
+            >= packaging.version.parse("1.26.0")
+        ):
+            self_signed_jwt_kwargs["default_scopes"] = cls.AUTH_SCOPES
+            self_signed_jwt_kwargs["scopes"] = scopes
+            self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
+        else:
+            self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
+        
+        return self_signed_jwt_kwargs
 
 
     def _prep_wrapped_messages(self, client_info):
@@ -173,11 +211,11 @@ class {{ service.name }}Transport(abc.ABC):
     {%- for method in service.methods.values() %}
 
     @property
-    def {{ method.name|snake_case }}(self) -> typing.Callable[
+    def {{ method.name|snake_case }}(self) -> Callable[
             [{{ method.input.ident }}],
-            typing.Union[
+            Union[
                 {{ method.output.ident }},
-                typing.Awaitable[{{ method.output.ident }}]
+                Awaitable[{{ method.output.ident }}]
             ]]:
         raise NotImplementedError()
     {%- endfor %}
@@ -187,29 +225,29 @@ class {{ service.name }}Transport(abc.ABC):
     @property
     def set_iam_policy(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [iam_policy.SetIamPolicyRequest],
-        typing.Union[policy.Policy, typing.Awaitable[policy.Policy]],
+        Union[policy.Policy, Awaitable[policy.Policy]],
     ]:
         raise NotImplementedError()
 
     @property
     def get_iam_policy(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [iam_policy.GetIamPolicyRequest],
-        typing.Union[policy.Policy, typing.Awaitable[policy.Policy]],
+        Union[policy.Policy, Awaitable[policy.Policy]],
     ]:
         raise NotImplementedError()
 
     @property
     def test_iam_permissions(
         self,
-    ) -> typing.Callable[
+    ) -> Callable[
         [iam_policy.TestIamPermissionsRequest],
-        typing.Union[
+        Union[
             iam_policy.TestIamPermissionsResponse,
-            typing.Awaitable[iam_policy.TestIamPermissionsResponse],
+            Awaitable[iam_policy.TestIamPermissionsResponse],
         ],
     ]:
         raise NotImplementedError()

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -48,7 +48,6 @@ except AttributeError:
 
 _API_CORE_VERSION = google.api_core.__version__
 
-_HOST_RE = re.compile("(?P<host>[^:]+)(:(?P<port>\d+))?")
 
 class {{ service.name }}Transport(abc.ABC):
     """Abstract transport class for {{ service.name }}."""
@@ -104,8 +103,9 @@ class {{ service.name }}Transport(abc.ABC):
         # library does not used the self-signed JWT flow for service
         # accounts
         if (
-            _HOST_RE.match(host).group("host")
-            != _HOST_RE.match(self.DEFAULT_HOST).group("host")
+            host is not None
+            and self.DEFAULT_HOST is not None
+            and host.split(":")[0] != self.DEFAULT_HOST.split(":")[0]
             and not scopes
         ):
             scopes = self.AUTH_SCOPES

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -7,7 +7,7 @@ import packaging.version
 import pkg_resources
 
 from google import auth  # type: ignore
-import google.api_core
+import google.api_core  # type: ignore
 from google.api_core import exceptions  # type: ignore
 from google.api_core import gapic_v1    # type: ignore
 from google.api_core import retry as retries  # type: ignore

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -2,6 +2,7 @@
 
 {% block content %}
 import abc
+import re
 import typing
 import packaging.version
 import pkg_resources
@@ -46,6 +47,8 @@ except AttributeError:
         _GOOGLE_AUTH_VERSION = None
 
 _API_CORE_VERSION = google.api_core.__version__
+
+_HOST_RE = re.compile("(?P<host>[^:]+)(:(?P<port>\d+))?")
 
 class {{ service.name }}Transport(abc.ABC):
     """Abstract transport class for {{ service.name }}."""
@@ -97,6 +100,15 @@ class {{ service.name }}Transport(abc.ABC):
 
         # Save the scopes.
         self._scopes = scopes or self.AUTH_SCOPES
+        # If a custom API endpoint is set, set scopes to ensure the auth
+        # library does not used the self-signed JWT flow for service
+        # accounts
+        if (
+            _HOST_RE.match(host).group("host")
+            != _HOST_RE.match(self.DEFAULT_HOST).group("host")
+            and not scopes
+        ):
+            scopes = self.AUTH_SCOPES
 
         # TODO: Remove this if/else once google-auth >= 1.25.0 is required
         if _GOOGLE_AUTH_VERSION and (

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -28,7 +28,7 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
-from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
+from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION, _HOST_RE
 
 
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -222,7 +222,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
             self_signed_jwt_kwargs["scopes"] = scopes
             self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
         else:
-            self_signed_jwt_kwargs["scopes"] = scopes if scopes is not None else cls.AUTH_SCOPES
+            self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
 
         return grpc_helpers.create_channel(
             host,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -28,7 +28,7 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
-from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION, _HOST_RE
+from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
 
 
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
@@ -208,7 +208,12 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         # If a custom API endpoint is set, set scopes to ensure the auth
         # library does not used the self-signed JWT flow for service
         # accounts
-        if host != cls.DEFAULT_HOST and not scopes:
+        if (
+            host is not None
+            and cls.DEFAULT_HOST is not None
+            and host.split(":")[0] != cls.DEFAULT_HOST.split(":")[0]
+            and not scopes
+        ):
             scopes = cls.AUTH_SCOPES
 
         self_signed_jwt_kwargs = {}  # type: Dict[str, Union[Optional[Sequence[str]], str]]

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -4,6 +4,7 @@
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple
 
+import google.api_core
 from google.api_core import grpc_helpers   # type: ignore
 {%- if service.has_lro %}
 from google.api_core import operations_v1  # type: ignore
@@ -12,6 +13,8 @@ from google.api_core import gapic_v1       # type: ignore
 from google import auth                    # type: ignore
 from google.auth import credentials        # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
+import packaging.version
+import pkg_resources
 
 import grpc  # type: ignore
 
@@ -26,6 +29,18 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
+from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
+
+try:
+    # google.auth.__version__ was added in 1.26.0
+    _GOOGLE_AUTH_VERSION = auth.__version__
+except AttributeError:
+    try:  # try pkg_resources if it is available
+        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
+    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
+        _GOOGLE_AUTH_VERSION = None
+
+_API_CORE_VERSION = google.api_core.__version__
 
 
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
@@ -202,13 +217,31 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
             google.api_core.exceptions.DuplicateCredentialArgs: If both ``credentials``
               and ``credentials_file`` are passed.
         """
-        scopes = scopes or cls.AUTH_SCOPES
+        # If a custom API endpoint is set, set scopes to ensure the auth
+        # library does not used the self-signed JWT flow for service
+        # accounts
+        if host != cls.DEFAULT_HOST and not scopes:
+            scopes = cls.AUTH_SCOPES
+
+        self_signed_jwt_kwargs = {}
+
+        # TODO(busunkim): Remove this if/else once google-api-core >= 1.26.0 is required
+        if _API_CORE_VERSION and (
+            packaging.version.parse(_API_CORE_VERSION)
+            >= packaging.version.parse("1.26.0")
+        ):
+            self_signed_jwt_kwargs["default_scopes"] = cls.AUTH_SCOPES
+            self_signed_jwt_kwargs["scopes"] = scopes
+            self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
+        else:
+            self_signed_jwt_kwargs["scopes"] = scopes if scopes is not None else cls.AUTH_SCOPES
+
         return grpc_helpers.create_channel(
             host,
             credentials=credentials,
             credentials_file=credentials_file,
-            scopes=scopes,
             quota_project_id=quota_project_id,
+            **self_signed_jwt_kwargs,
             **kwargs
         )
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -12,8 +12,6 @@ from google.api_core import gapic_v1       # type: ignore
 from google import auth                    # type: ignore
 from google.auth import credentials        # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
-import pkg_resources
 
 import grpc  # type: ignore
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -28,7 +28,6 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
-from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
 
 
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
@@ -205,29 +204,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
             google.api_core.exceptions.DuplicateCredentialArgs: If both ``credentials``
               and ``credentials_file`` are passed.
         """
-        # If a custom API endpoint is set, set scopes to ensure the auth
-        # library does not used the self-signed JWT flow for service
-        # accounts
-        if (
-            host is not None
-            and cls.DEFAULT_HOST is not None
-            and host.split(":")[0] != cls.DEFAULT_HOST.split(":")[0]
-            and not scopes
-        ):
-            scopes = cls.AUTH_SCOPES
 
-        self_signed_jwt_kwargs = {}  # type: Dict[str, Union[Optional[Sequence[str]], str]]
-
-        # TODO(busunkim): Remove this if/else once google-api-core >= 1.26.0 is required
-        if _API_CORE_VERSION and (
-            packaging.version.parse(_API_CORE_VERSION)
-            >= packaging.version.parse("1.26.0")
-        ):
-            self_signed_jwt_kwargs["default_scopes"] = cls.AUTH_SCOPES
-            self_signed_jwt_kwargs["scopes"] = scopes
-            self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
-        else:
-            self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
+        self_signed_jwt_kwargs = cls._get_self_signed_jwt_kwargs(host, scopes)
 
         return grpc_helpers.create_channel(
             host,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -2,9 +2,8 @@
 
 {% block content %}
 import warnings
-from typing import Callable, Dict, Optional, Sequence, Tuple
+from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
-import google.api_core
 from google.api_core import grpc_helpers   # type: ignore
 {%- if service.has_lro %}
 from google.api_core import operations_v1  # type: ignore
@@ -30,17 +29,6 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
 from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
-
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
-_API_CORE_VERSION = google.api_core.__version__
 
 
 class {{ service.name }}GrpcTransport({{ service.name }}Transport):
@@ -223,7 +211,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         if host != cls.DEFAULT_HOST and not scopes:
             scopes = cls.AUTH_SCOPES
 
-        self_signed_jwt_kwargs = {}
+        self_signed_jwt_kwargs = {}  # type: Dict[str, Union[Optional[Sequence[str]], str]]
 
         # TODO(busunkim): Remove this if/else once google-api-core >= 1.26.0 is required
         if _API_CORE_VERSION and (

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -28,7 +28,7 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
-from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
+from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION, _HOST_RE
 from .grpc import {{ service.name }}GrpcTransport
 
 
@@ -80,7 +80,11 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         # If a custom API endpoint is set, set scopes to ensure the auth
         # library does not used the self-signed JWT flow for service
         # accounts
-        if host != cls.DEFAULT_HOST and not scopes:
+        if (
+            _HOST_RE.match(host).group("host")
+            != _HOST_RE.match(cls.DEFAULT_HOST).group("host")
+            and not scopes
+        ):
             scopes = cls.AUTH_SCOPES
 
         self_signed_jwt_kwargs = {}  # type: Dict[str, Union[Optional[Sequence[str]], str]]

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -28,7 +28,6 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
-from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
 from .grpc import {{ service.name }}GrpcTransport
 
 
@@ -77,29 +76,8 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         Returns:
             aio.Channel: A gRPC AsyncIO channel object.
         """
-        # If a custom API endpoint is set, set scopes to ensure the auth
-        # library does not used the self-signed JWT flow for service
-        # accounts
-        if (
-            host is not None
-            and cls.DEFAULT_HOST is not None
-            and host.split(":")[0] != cls.DEFAULT_HOST.split(":")[0]
-            and not scopes
-        ):
-            scopes = cls.AUTH_SCOPES
 
-        self_signed_jwt_kwargs = {}  # type: Dict[str, Union[Optional[Sequence[str]], str]]
-
-        # TODO(busunkim): Remove this if/else once google-api-core >= 1.26.0 is required
-        if _API_CORE_VERSION and (
-            packaging.version.parse(_API_CORE_VERSION)
-            >= packaging.version.parse("1.26.0")
-        ):
-            self_signed_jwt_kwargs["default_scopes"] = cls.AUTH_SCOPES
-            self_signed_jwt_kwargs["scopes"] = scopes
-            self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
-        else:
-            self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
+        self_signed_jwt_kwargs = cls._get_self_signed_jwt_kwargs(host, scopes)
 
         return grpc_helpers_async.create_channel(
             host,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -12,6 +12,7 @@ from google.api_core import operations_v1              # type: ignore
 from google import auth                                # type: ignore
 from google.auth import credentials                    # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
+import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore
@@ -27,7 +28,10 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
+from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
 from .grpc import {{ service.name }}GrpcTransport
+from .grpc import _API_CORE_VERSION
+from .grpc import _GOOGLE_AUTH_VERSION
 
 
 class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
@@ -75,13 +79,31 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         Returns:
             aio.Channel: A gRPC AsyncIO channel object.
         """
-        scopes = scopes or cls.AUTH_SCOPES
+        # If a custom API endpoint is set, set scopes to ensure the auth
+        # library does not used the self-signed JWT flow for service
+        # accounts
+        if host != cls.DEFAULT_HOST and not scopes:
+            scopes = cls.AUTH_SCOPES
+
+        self_signed_jwt_kwargs = {}
+
+        # TODO(busunkim): Remove this if/else once google-api-core >= 1.26.0 is required
+        if _API_CORE_VERSION and (
+            packaging.version.parse(_API_CORE_VERSION)
+            >= packaging.version.parse("1.26.0")
+        ):
+            self_signed_jwt_kwargs["default_scopes"] = cls.AUTH_SCOPES
+            self_signed_jwt_kwargs["scopes"] = scopes
+            self_signed_jwt_kwargs["default_host"] = cls.DEFAULT_HOST
+        else:
+            self_signed_jwt_kwargs["scopes"] = scopes or cls.AUTH_SCOPES
+
         return grpc_helpers_async.create_channel(
             host,
             credentials=credentials,
             credentials_file=credentials_file,
-            scopes=scopes,
             quota_project_id=quota_project_id,
+            **self_signed_jwt_kwargs,
             **kwargs
         )
 
@@ -163,7 +185,6 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
             # If a channel was explicitly provided, set it.
             self._grpc_channel = channel
             self._ssl_channel_credentials = None
-
         else:
             if api_mtls_endpoint:
                 host = api_mtls_endpoint

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -83,7 +83,7 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         if (
             host is not None
             and cls.DEFAULT_HOST is not None
-            and host.split(":")[0] != self.DEFAULT_HOST.split(":")[0]
+            and host.split(":")[0] != cls.DEFAULT_HOST.split(":")[0]
             and not scopes
         ):
             scopes = cls.AUTH_SCOPES

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -2,7 +2,7 @@
 
 {% block content %}
 import warnings
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
@@ -30,8 +30,6 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
 from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
 from .grpc import {{ service.name }}GrpcTransport
-from .grpc import _API_CORE_VERSION
-from .grpc import _GOOGLE_AUTH_VERSION
 
 
 class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
@@ -85,7 +83,7 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         if host != cls.DEFAULT_HOST and not scopes:
             scopes = cls.AUTH_SCOPES
 
-        self_signed_jwt_kwargs = {}
+        self_signed_jwt_kwargs = {}  # type: Dict[str, Union[Optional[Sequence[str]], str]]
 
         # TODO(busunkim): Remove this if/else once google-api-core >= 1.26.0 is required
         if _API_CORE_VERSION and (

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -28,7 +28,7 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
-from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION, _HOST_RE
+from .base import _GOOGLE_AUTH_VERSION, _API_CORE_VERSION
 from .grpc import {{ service.name }}GrpcTransport
 
 
@@ -81,8 +81,9 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         # library does not used the self-signed JWT flow for service
         # accounts
         if (
-            _HOST_RE.match(host).group("host")
-            != _HOST_RE.match(cls.DEFAULT_HOST).group("host")
+            host is not None
+            and cls.DEFAULT_HOST is not None
+            and host.split(":")[0] != self.DEFAULT_HOST.split(":")[0]
             and not scopes
         ):
             scopes = cls.AUTH_SCOPES

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -81,12 +81,14 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         """
         # Run the base constructor
         # TODO(yon-mg): resolve other ctor params i.e. scopes, quota, etc.
+        # When custom host (api_endpoint) can be set, `scopes` must *also* be set on the
+        # credentials object 
         super().__init__(
             host=host,
             credentials=credentials,
             client_info=client_info,
         )
-        self._session = AuthorizedSession(self._credentials)
+        self._session = AuthorizedSession(self._credentials, default_host=cls.DEFAULT_HOST)
         {%- if service.has_lro %}
         self._operations_client = None
         {%- endif %}
@@ -110,7 +112,9 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
                 grpc_helpers.create_channel(
                     self._host,
                     credentials=self._credentials,
-                    scopes=self.AUTH_SCOPES,
+                    default_scopes=self.AUTH_SCOPES,
+                    scopes=scopes,
+                    default_host=cls.DEFAULT_HOST,
                     options=[
                         ("grpc.max_send_message_length", -1),
                         ("grpc.max_receive_message_length", -1),

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -81,7 +81,7 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         """
         # Run the base constructor
         # TODO(yon-mg): resolve other ctor params i.e. scopes, quota, etc.
-        # When custom host (api_endpoint) can be set, `scopes` must *also* be set on the
+        # TODO: When custom host (api_endpoint) is set, `scopes` must *also* be set on the
         # credentials object 
         super().__init__(
             host=host,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -88,7 +88,7 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
             credentials=credentials,
             client_info=client_info,
         )
-        self._session = AuthorizedSession(self._credentials, default_host=cls.DEFAULT_HOST)
+        self._session = AuthorizedSession(self._credentials, default_host=self.DEFAULT_HOST)
         {%- if service.has_lro %}
         self._operations_client = None
         {%- endif %}
@@ -114,7 +114,7 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
                     credentials=self._credentials,
                     default_scopes=self.AUTH_SCOPES,
                     scopes=scopes,
-                    default_host=cls.DEFAULT_HOST,
+                    default_host=self.DEFAULT_HOST,
                     options=[
                         ("grpc.max_send_message_length", -1),
                         ("grpc.max_receive_message_length", -1),

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -108,13 +108,14 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         # Sanity check: Only create a new client if we do not already have one.
         if self._operations_client is None:
             from google.api_core import grpc_helpers
+
+            self_signed_jwt_kwargs = cls._get_self_signed_jwt_kwargs(self._host, self._scopes)
+
             self._operations_client = operations_v1.OperationsClient(
                 grpc_helpers.create_channel(
                     self._host,
                     credentials=self._credentials,
-                    default_scopes=self.AUTH_SCOPES,
-                    scopes=scopes,
-                    default_host=self.DEFAULT_HOST,
+                    **self_signed_jwt_kwargs,
                     options=[
                         ("grpc.max_send_message_length", -1),
                         ("grpc.max_receive_message_length", -1),

--- a/gapic/templates/.coveragerc.j2
+++ b/gapic/templates/.coveragerc.j2
@@ -2,7 +2,6 @@
 branch = True
 
 [report]
-fail_under = 100
 show_missing = True
 omit =
     {{ api.naming.module_namespace|join("/") }}/{{ api.naming.module_name }}/__init__.py

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -62,7 +62,7 @@ def mypy(session):
     )
 
 
-@nox.session(python='3.8')
+@nox.session
 def update_lower_bounds(session):
     """Update lower bounds in constraints.txt to match setup.py"""
     session.install('google-cloud-testutils')
@@ -78,7 +78,7 @@ def update_lower_bounds(session):
     )
 
 
-@nox.session(python='3.8')
+@nox.session
 def check_lower_bounds(session):
     """Check lower bounds in setup.py are reflected in constraints file"""
     session.install('google-cloud-testutils')

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -41,7 +41,7 @@ def cover(session):
     test runs (not system test runs), and then erases coverage data.
     """
     session.install("coverage", "pytest-cov")
-    session.run("coverage", "report", "--show-missing", "--fail-under=99")
+    session.run("coverage", "report", "--show-missing", "--fail-under=100")
 
     session.run("coverage", "erase")
 

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -2,9 +2,18 @@
 
 {% block content %}
 import os
+import pathlib
 import shutil
+import subprocess
+import sys
+
 
 import nox  # type: ignore
+
+CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
+
+LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
+PACKAGE_NAME = package_name = subprocess.check_output([sys.executable, "setup.py", "--name"], encoding="utf-8")
 
 
 @nox.session(python=['3.6', '3.7', '3.8', '3.9'])
@@ -38,6 +47,38 @@ def mypy(session):
         {%- else %}
         '{{ api.naming.versioned_module_name }}',
         {%- endif %}
+    )
+
+
+@nox.session(python="3.8")
+def update_lower_bounds(session):
+    """Update lower bounds in constraints.txt to match setup.py"""
+    session.install("google-cloud-testutils")
+    session.install(".")
+
+    session.run(
+        "lower-bound-checker",
+        "update",
+        "--package-name",
+        PACKAGE_NAME,
+        "--constraints-file",
+        str(LOWER_BOUND_CONSTRAINTS_FILE),
+    )
+
+
+@nox.session(python="3.8")
+def check_lower_bounds(session):
+    """Check lower bounds in setup.py are reflected in constraints file"""
+    session.install("google-cloud-testutils")
+    session.install(".")
+
+    session.run(
+        "lower-bound-checker",
+        "check",
+        "--package-name",
+        PACKAGE_NAME,
+        "--constraints-file",
+        str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 
 @nox.session(python='3.6')

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -34,6 +34,18 @@ def unit(session):
     )
 
 
+@nox.session(python='3.7')
+def cover(session):
+    """Run the final coverage report.
+    This outputs the coverage report aggregating coverage from the unit
+    test runs (not system test runs), and then erases coverage data.
+    """
+    session.install("coverage", "pytest-cov")
+    session.run("coverage", "report", "--show-missing", "--fail-under=99")
+
+    session.run("coverage", "erase")
+
+
 @nox.session(python=['3.6', '3.7'])
 def mypy(session):
     """Run the type checker."""
@@ -50,34 +62,34 @@ def mypy(session):
     )
 
 
-@nox.session(python="3.8")
+@nox.session(python='3.8')
 def update_lower_bounds(session):
     """Update lower bounds in constraints.txt to match setup.py"""
-    session.install("google-cloud-testutils")
-    session.install(".")
+    session.install('google-cloud-testutils')
+    session.install('.')
 
     session.run(
-        "lower-bound-checker",
-        "update",
-        "--package-name",
+        'lower-bound-checker',
+        'update',
+        '--package-name',
         PACKAGE_NAME,
-        "--constraints-file",
+        '--constraints-file',
         str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 
 
-@nox.session(python="3.8")
+@nox.session(python='3.8')
 def check_lower_bounds(session):
     """Check lower bounds in setup.py are reflected in constraints file"""
-    session.install("google-cloud-testutils")
-    session.install(".")
+    session.install('google-cloud-testutils')
+    session.install('.')
 
     session.run(
-        "lower-bound-checker",
-        "check",
-        "--package-name",
+        'lower-bound-checker',
+        'check',
+        '--package-name',
         PACKAGE_NAME,
-        "--constraints-file",
+        '--constraints-file',
         str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -13,8 +13,17 @@ import nox  # type: ignore
 CURRENT_DIRECTORY = pathlib.Path(__file__).parent.absolute()
 
 LOWER_BOUND_CONSTRAINTS_FILE = CURRENT_DIRECTORY / "constraints.txt"
-PACKAGE_NAME = package_name = subprocess.check_output([sys.executable, "setup.py", "--name"], encoding="utf-8")
+PACKAGE_NAME = subprocess.check_output([sys.executable, "setup.py", "--name"], encoding="utf-8")
 
+
+nox.sessions = [
+    "unit",
+    "cover",
+    "mypy",
+    "check_lower_bounds"
+    # exclude update_lower_bounds from default
+    "docs",
+]
 
 @nox.session(python=['3.6', '3.7', '3.8', '3.9'])
 def unit(session):

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -31,7 +31,7 @@ setuptools.setup(
         'proto-plus >= 1.4.0',
         'packaging >= 14.3',
     {%- if api.requires_package(('google', 'iam', 'v1')) or opts.add_iam_methods %}
-        'grpc-google-iam-v1',
+        'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',
     {%- endif %}
     ),
     python_requires='>=3.6',

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -29,6 +29,7 @@ setuptools.setup(
         'google-api-core[grpc] >= 1.22.2, < 2.0.0dev',
         'libcst >= 0.2.5',
         'proto-plus >= 1.4.0',
+        'packaging >= 14.3',
     {%- if api.requires_package(('google', 'iam', 'v1')) or opts.add_iam_methods %}
         'grpc-google-iam-v1',
     {%- endif %}

--- a/gapic/templates/tests/__init__.py.j2
+++ b/gapic/templates/tests/__init__.py.j2
@@ -1,0 +1,2 @@
+
+{% extends '_base.py.j2' %}

--- a/gapic/templates/tests/unit/__init__.py.j2
+++ b/gapic/templates/tests/unit/__init__.py.j2
@@ -1,0 +1,2 @@
+
+{% extends '_base.py.j2' %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1505,32 +1505,6 @@ def test_{{ service.name|snake_case }}_base_transport_with_credentials_file_old_
         )
 
 
-@requires_google_auth_gte_1_25_0
-def test_{{ service.name|snake_case }}_base_transport_custom_host():
-    # Test the default credentials are used if credentials and credentials_file are None.
-    with mock.patch.object(auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (credentials.AnonymousCredentials(), None)
-        transport = transports.{{ service.name }}Transport(
-            host="squid.clam.whelk",
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json",
-            # scopes should be set since custom endpoint was passed
-            scopes=(
-            {%- for scope in service.oauth_scopes %}
-            '{{ scope }}',
-            {%- endfor %}
-            ),
-            default_scopes=(
-            {%- for scope in service.oauth_scopes %}
-            '{{ scope }}',
-            {%- endfor %}
-            ),
-            quota_project_id="octopus",
-        )
-
 def test_{{ service.name|snake_case }}_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(auth, 'default', autospec=True) as adc, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
@@ -1588,34 +1562,6 @@ def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
         transport_class(quota_project_id="octopus", scopes=["1", "2"])
         adc.assert_called_once_with(
             scopes=["1", "2"],
-            default_scopes=(
-                {%- for scope in service.oauth_scopes %}
-                '{{ scope }}',
-                {%- endfor %}),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.{{ service.name }}GrpcTransport,
-        transports.{{ service.name }}GrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_gte_1_25_0
-def test_{{ service.name|snake_case }}_transport_auth_adc_custom_host(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(auth, 'default', autospec=True) as adc:
-        adc.return_value = (credentials.AnonymousCredentials(), None)
-        transport_class(host="squid.clam.whelk", quota_project_id="octopus")
-        adc.assert_called_once_with(
-            # scopes should be set since a custom endpoint (host) was set
-            scopes=(
-                {%- for scope in service.oauth_scopes %}
-                '{{ scope }}',
-                {%- endfor %}),
             default_scopes=(
                 {%- for scope in service.oauth_scopes %}
                 '{{ scope }}',

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -25,8 +25,6 @@ from google.oauth2 import service_account
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
 {%- if 'grpc' in opts.transport %}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.async_client_name }}
-from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.grpc import _GOOGLE_AUTH_VERSION
-from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.grpc import _API_CORE_VERSION
 {%- endif %}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import transports
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.base import _GOOGLE_AUTH_VERSION

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -3,6 +3,7 @@
 {% block content %}
 import os
 import mock
+import packaging.version
 
 import grpc
 from grpc.experimental import aio
@@ -24,8 +25,12 @@ from google.oauth2 import service_account
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
 {%- if 'grpc' in opts.transport %}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.async_client_name }}
+from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.grpc import _GOOGLE_AUTH_VERSION
+from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.grpc import _API_CORE_VERSION
 {%- endif %}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import transports
+from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.base import _GOOGLE_AUTH_VERSION
+from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.base import _API_CORE_VERSION
 from google.api_core import client_options
 from google.api_core import exceptions
 from google.api_core import grpc_helpers
@@ -50,6 +55,28 @@ from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 
+
+# TODO(busunkim): Once google-api-core >= 1.26.0 is required:
+# - Delete all the api-core and auth "less than" test cases
+# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
+requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
+    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
+    reason="This test requires google-auth < 1.25.0",
+)
+requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
+    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
+    reason="This test requires google-auth >= 1.25.0",
+)
+
+requires_api_core_lt_1_26_0 = pytest.mark.skipif(
+    packaging.version.parse(_API_CORE_VERSION) >= packaging.version.parse("1.26.0"),
+    reason="This test requires google-api-core < 1.26.0",
+)
+
+requires_api_core_gte_1_26_0 = pytest.mark.skipif(
+    packaging.version.parse(_API_CORE_VERSION) < packaging.version.parse("1.26.0"),
+    reason="This test requires google-api-core >= 1.26.0",
+)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -1439,16 +1466,19 @@ def test_{{ service.name|snake_case }}_base_transport():
     {% endif %}
 
 
+@requires_google_auth_gte_1_25_0
 def test_{{ service.name|snake_case }}_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
-    with mock.patch.object(auth, 'load_credentials_from_file') as load_creds, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
+    with mock.patch.object(auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
         Transport.return_value = None
         load_creds.return_value = (credentials.AnonymousCredentials(), None)
         transport = transports.{{ service.name }}Transport(
             credentials_file="credentials.json",
             quota_project_id="octopus",
         )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
+        load_creds.assert_called_once_with("credentials.json",
+            scopes=None,
+            default_scopes=(
             {%- for scope in service.oauth_scopes %}
             '{{ scope }}',
             {%- endfor %}
@@ -1457,40 +1487,281 @@ def test_{{ service.name|snake_case }}_base_transport_with_credentials_file():
         )
 
 
+@requires_google_auth_lt_1_25_0
+def test_{{ service.name|snake_case }}_base_transport_with_credentials_file_old_google_auth():
+    # Instantiate the base transport with a credentials file
+    with mock.patch.object(auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
+        Transport.return_value = None
+        load_creds.return_value = (credentials.AnonymousCredentials(), None)
+        transport = transports.{{ service.name }}Transport(
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
+        )
+        load_creds.assert_called_once_with("credentials.json",
+            scopes=(
+            {%- for scope in service.oauth_scopes %}
+            '{{ scope }}',
+            {%- endfor %}
+            ),
+            quota_project_id="octopus",
+        )
+
+
+@requires_google_auth_gte_1_25_0
+def test_{{ service.name|snake_case }}_base_transport_custom_host():
+    # Test the default credentials are used if credentials and credentials_file are None.
+    with mock.patch.object(auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
+        Transport.return_value = None
+        load_creds.return_value = (credentials.AnonymousCredentials(), None)
+        transport = transports.{{ service.name }}Transport(
+            host="squid.clam.whelk",
+            credentials_file="credentials.json",
+            quota_project_id="octopus",
+        )
+        load_creds.assert_called_once_with("credentials.json",
+            # scopes should be set since custom endpoint was passed
+            scopes=(
+            {%- for scope in service.oauth_scopes %}
+            '{{ scope }}',
+            {%- endfor %}
+            ),
+            default_scopes=(
+            {%- for scope in service.oauth_scopes %}
+            '{{ scope }}',
+            {%- endfor %}
+            ),
+            quota_project_id="octopus",
+        )
+
 def test_{{ service.name|snake_case }}_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
-    with mock.patch.object(auth, 'default') as adc, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
+    with mock.patch.object(auth, 'default', autospec=True) as adc, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
         Transport.return_value = None
         adc.return_value = (credentials.AnonymousCredentials(), None)
         transport = transports.{{ service.name }}Transport()
         adc.assert_called_once()
 
 
+@requires_google_auth_gte_1_25_0
 def test_{{ service.name|snake_case }}_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(auth, 'default') as adc:
+    with mock.patch.object(auth, 'default', autospec=True) as adc:
         adc.return_value = (credentials.AnonymousCredentials(), None)
         {{ service.client_name }}()
-        adc.assert_called_once_with(scopes=(
-            {%- for scope in service.oauth_scopes %}
-            '{{ scope }}',
-            {%- endfor %}),
+        adc.assert_called_once_with(
+            scopes=None,
+            default_scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
             quota_project_id=None,
         )
 
+
+@requires_google_auth_lt_1_25_0
+def test_{{ service.name|snake_case }}_auth_adc_old_google_auth():
+    # If no credentials are provided, we should use ADC credentials.
+    with mock.patch.object(auth, 'default', autospec=True) as adc:
+        adc.return_value = (credentials.AnonymousCredentials(), None)
+        {{ service.client_name }}()
+        adc.assert_called_once_with(
+            scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
+            quota_project_id=None,
+        )
+
+
 {% if 'grpc' in opts.transport %}
-def test_{{ service.name|snake_case }}_transport_auth_adc():
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.{{ service.name }}GrpcTransport,
+        transports.{{ service.name }}GrpcAsyncIOTransport,
+    ],
+)
+@requires_google_auth_gte_1_25_0
+def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
-    with mock.patch.object(auth, 'default') as adc:
+    with mock.patch.object(auth, 'default', autospec=True) as adc:
         adc.return_value = (credentials.AnonymousCredentials(), None)
-        transports.{{ service.name }}GrpcTransport(host="squid.clam.whelk", quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            {%- for scope in service.oauth_scopes %}
-            '{{ scope }}',
-            {%- endfor %}),
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
             quota_project_id="octopus",
         )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.{{ service.name }}GrpcTransport,
+        transports.{{ service.name }}GrpcAsyncIOTransport,
+    ],
+)
+@requires_google_auth_gte_1_25_0
+def test_{{ service.name|snake_case }}_transport_auth_adc_custom_host(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(auth, 'default', autospec=True) as adc:
+        adc.return_value = (credentials.AnonymousCredentials(), None)
+        transport_class(host="squid.clam.whelk", quota_project_id="octopus")
+        adc.assert_called_once_with(
+            # scopes should be set since a custom endpoint (host) was set
+            scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
+            default_scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
+            quota_project_id="octopus",
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.{{ service.name }}GrpcTransport,
+        transports.{{ service.name }}GrpcAsyncIOTransport,
+    ],
+)
+@requires_google_auth_lt_1_25_0
+def test_{{ service.name|snake_case }}_transport_auth_adc_old_google_auth(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(auth, "default", autospec=True) as adc:
+        adc.return_value = (credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus")
+        adc.assert_called_once_with(
+            scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
+            quota_project_id="octopus",
+        )
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.{{ service.name }}GrpcTransport, grpc_helpers),
+        (transports.{{ service.name }}GrpcAsyncIOTransport, grpc_helpers_async)
+    ],
+)
+@requires_api_core_gte_1_26_0
+def test_{{ service.name|snake_case }}_transport_create_channel(transport_class, grpc_helpers):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(auth, "default", autospec=True) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        transport_class(
+            quota_project_id="octopus",
+            scopes=["1", "2"]
+        )
+
+        {% with host = (service.host|default('localhost', true)) -%}
+        create_channel.assert_called_with(
+            "{{ host }}",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            default_scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
+            scopes=["1", "2"],
+            default_host="{{ host }}",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+        {% endwith %}
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.{{ service.name }}GrpcTransport, grpc_helpers),
+        (transports.{{ service.name }}GrpcAsyncIOTransport, grpc_helpers_async)
+    ],
+)
+@requires_api_core_lt_1_26_0
+def test_{{ service.name|snake_case }}_transport_create_channel_old_api_core(transport_class, grpc_helpers):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(auth, "default", autospec=True) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        transport_class(quota_project_id="octopus")
+
+        {% with host = (service.host|default('localhost', true)) -%}
+        create_channel.assert_called_with(
+            "{{ host }}",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+        {% endwith %}
+
+
+@pytest.mark.parametrize(
+    "transport_class,grpc_helpers",
+    [
+        (transports.{{ service.name }}GrpcTransport, grpc_helpers),
+        (transports.{{ service.name }}GrpcAsyncIOTransport, grpc_helpers_async)
+    ],
+)
+@requires_api_core_lt_1_26_0
+def test_{{ service.name|snake_case }}_transport_create_channel_user_scopes(transport_class, grpc_helpers):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(auth, "default", autospec=True) as adc, mock.patch.object(
+        grpc_helpers, "create_channel", autospec=True
+    ) as create_channel:
+        creds = credentials.AnonymousCredentials()
+        adc.return_value = (creds, None)
+        {% with host = (service.host|default('localhost', true)) -%}
+
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+
+        create_channel.assert_called_with(
+            "{{ host }}",
+            credentials=creds,
+            credentials_file=None,
+            quota_project_id="octopus",
+            scopes=["1", "2"],
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+        {% endwith %}
+
 {% endif %}
 
 {% if 'grpc' in opts.transport %}

--- a/gapic/templates/tests/unit/gapic/__init__.py.j2
+++ b/gapic/templates/tests/unit/gapic/__init__.py.j2
@@ -1,0 +1,2 @@
+
+{% extends '_base.py.j2' %}

--- a/noxfile.py
+++ b/noxfile.py
@@ -213,7 +213,7 @@ def showcase_unit(
         # 1. Run tests at lower bound of dependencies
         session.install("nox")
         session.run("nox", "-s", "update_lower_bounds")
-        session.install(".", "--force-reinstall", "-c", f"constraints.txt")
+        session.install(".", "--force-reinstall", "-c", "constraints.txt")
         # Some code paths require an older version of google-auth.
         # google-auth is a transitive dependency so it isn't in the
         # lower bound constraints file produced above.
@@ -245,7 +245,7 @@ def showcase_unit_add_iam_methods(session):
         # 1. Run tests at lower bound of dependencies
         session.install("nox")
         session.run("nox", "-s", "update_lower_bounds")
-        session.install(".", "--force-reinstall", "-c", f"constraints.txt")
+        session.install(".", "--force-reinstall", "-c", "constraints.txt")
         # Some code paths require an older version of google-auth.
         # google-auth is a transitive dependency so it isn't in the
         # lower bound constraints file produced above.


### PR DESCRIPTION
See [RFC (internal only)](https://docs.google.com/document/d/1SNCVTmW6Rtr__u-_V7nsT9PhSzjj1z0P9fAD3YUgRoc/edit#) and https://aip.dev/auth/4111.

Support the self-signed JWT flow for service accounts by passing `default_scopes` and `default_host` in calls to the auth library and `create_channel`. This depends on features exposed in the following PRs: https://github.com/googleapis/python-api-core/pull/134, https://github.com/googleapis/google-auth-library-python/pull/665.

It may be easier to look at https://github.com/googleapis/python-translate/pull/107/files for a diff on a real library.

This change is written so that the library is (temporarily) compatible with older `google-api-core` and `google-auth` versions. Because of this it not possible to reach 100% coverage on a single unit test run. `pytest` runs twice in two of the `nox` sessions.

Miscellaneous changes:
- sprinkled in `__init__.py` files in subdirs of the `test/` directory, as otherwise pytest-cov seems to fail to collect coverage properly in some instances.
- new dependency on `packaging` for Version comparison https://pypi.org/project/packaging/