### PR TITLE
fix: s/grpcAsync/grpc-async for gapic metadata

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -415,7 +415,7 @@ class API:
             transports = []
             if "grpc" in options.transport:
                 transports.append(("grpc", service.client_name))
-                transports.append(("grpcAsync", service.async_client_name))
+                transports.append(("grpc-async", service.async_client_name))
 
             if "rest" in options.transport:
                 transports.append(("rest", service.client_name))

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -1363,7 +1363,7 @@ def test_gapic_metadata():
                             "GiantPacific": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["giant_pacific"]),
                         },
                     ),
-                    "grpcAsync": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
+                    "grpc-async": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
                         library_client="OctopusAsyncClient",
                         rpcs={
                             "BlueSpot": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["blue_spot"]),
@@ -1382,7 +1382,7 @@ def test_gapic_metadata():
                             "Ramshorn": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["ramshorn"]),
                         },
                     ),
-                    "grpcAsync": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
+                    "grpc-async": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
                         library_client="SquidAsyncClient",
                         rpcs={
                             "Giant": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["giant"]),
@@ -1457,7 +1457,7 @@ def test_gapic_metadata():
                             "GiantPacific": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["giant_pacific"]),
                         },
                     ),
-                    "grpcAsync": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
+                    "grpc-async": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
                         library_client="OctopusAsyncClient",
                         rpcs={
                             "BlueSpot": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["blue_spot"]),
@@ -1483,7 +1483,7 @@ def test_gapic_metadata():
                             "Ramshorn": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["ramshorn"]),
                         },
                     ),
-                    "grpcAsync": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
+                    "grpc-async": gapic_metadata_pb2.GapicMetadata.ServiceAsClient(
                         library_client="SquidAsyncClient",
                         rpcs={
                             "Giant": gapic_metadata_pb2.GapicMetadata.MethodList(methods=["giant"]),


### PR DESCRIPTION
As discussed in the design doc, the agreed upon naming convention for
the the asynchronous variants in gapic metadata use kebab-case instead
of Pascal case.