### PR TITLE
feat: update templates to permit enum aliases

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/types/_enum.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/types/_enum.py.j2
@@ -1,5 +1,8 @@
 class {{ enum.name }}({{ p }}.Enum):
     r"""{{ enum.meta.doc|rst(indent=4) }}"""
+    {% if enum.enum_pb.HasField("options") -%}
+     _pb_options = {{ enum.options_dict }}
+    {% endif -%}
     {% for enum_value in enum.values -%}
     {{ enum_value.name }} = {{ enum_value.number }}
     {% endfor -%}

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -19,7 +19,7 @@ setuptools.setup(
         'google-api-core >= 1.22.2, < 2.0.0dev',
         'googleapis-common-protos >= 1.5.8',
         'grpcio >= 1.10.0',
-        'proto-plus >= 1.4.0',
+        'proto-plus >= 1.15.0',
     {%- if api.requires_package(('google', 'iam', 'v1')) %}
         'grpc-google-iam-v1',
     {%- endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/types/_enum.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/_enum.py.j2
@@ -1,5 +1,8 @@
 class {{ enum.name }}({{ p }}.Enum):
     r"""{{ enum.meta.doc|rst(indent=4) }}"""
+    {% if enum.enum_pb.HasField("options") -%}
+     _pb_options = {{ enum.options_dict }}
+    {% endif -%}
     {% for enum_value in enum.values -%}
     {{ enum_value.name }} = {{ enum_value.number }}
     {% endfor -%}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -28,7 +28,7 @@ setuptools.setup(
     install_requires=(
         'google-api-core[grpc] >= 1.22.2, < 2.0.0dev',
         'libcst >= 0.2.5',
-        'proto-plus >= 1.4.0',
+        'proto-plus >= 1.15.0',
     {%- if api.requires_package(('google', 'iam', 'v1')) or opts.add_iam_methods %}
         'grpc-google-iam-v1',
     {%- endif %}

--- a/test_utils/test_utils.py
+++ b/test_utils/test_utils.py
@@ -290,6 +290,7 @@ def make_enum(
     module: str = 'baz',
     values: typing.Tuple[str, int] = (),
     meta: metadata.Metadata = None,
+    options: desc.EnumOptions = None,
 ) -> wrappers.EnumType:
     enum_value_pbs = [
         desc.EnumValueDescriptorProto(name=i[0], number=i[1])
@@ -298,6 +299,7 @@ def make_enum(
     enum_pb = desc.EnumDescriptorProto(
         name=name,
         value=enum_value_pbs,
+        options=options,
     )
     return wrappers.EnumType(
         enum_pb=enum_pb,

--- a/tests/unit/schema/wrappers/test_enums.py
+++ b/tests/unit/schema/wrappers/test_enums.py
@@ -37,6 +37,18 @@ def test_enum_value_properties():
 
 
 def test_enum_ident():
-    message = make_enum('Baz', package='foo.v1', module='bar')
-    assert str(message.ident) == 'bar.Baz'
-    assert message.ident.sphinx == 'foo.v1.bar.Baz'
+    enum = make_enum('Baz', package='foo.v1', module='bar')
+    assert str(enum.ident) == 'bar.Baz'
+    assert enum.ident.sphinx == 'foo.v1.bar.Baz'
+
+
+def test_enum_options_dict():
+    cephalopod = make_enum("Cephalopod", package="animalia.v1",
+                     module="mollusca", options={"allow_alias": True})
+    assert isinstance(cephalopod.enum_pb.options, descriptor_pb2.EnumOptions)
+    assert cephalopod.options_dict == {"allow_alias": True}
+
+    bivalve = make_enum("Bivalve", package="animalia.v1",
+                     module="mollusca")
+    assert isinstance(bivalve.enum_pb.options, descriptor_pb2.EnumOptions)
+    assert bivalve.options_dict == {}


### PR DESCRIPTION
Certain APIs like RecommendationEngine use multiple enum variant
monikers to reference the same value. Achieving this in protos
requires explicit support from proto-plus and the generated surface.

Hand testing indicates compliance.