### PR TITLE
fix: Update module alias to resolve naming conflict

### DIFF
--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -115,11 +115,12 @@ class Address:
             return '_'.join(
                 (
                     ''.join(
-                        ''.join(
-                            [partial_name[0] for partial_name in i.split("_")]
-                        )
-                        for i in self.package
-                        if i != self.api_naming.version
+                        [
+                            partial_name[0]
+                            for i in self.package
+                            for partial_name in i.split("_")
+                            if i != self.api_naming.version
+                        ]
                     ),
                     self.module,
                 )

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -115,7 +115,9 @@ class Address:
             return '_'.join(
                 (
                     ''.join(
-                        i[0]
+                        ''.join(
+                            [partial_name[0] for partial_name in i.split("_")]
+                        )
                         for i in self.package
                         if i != self.api_naming.version
                     ),

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -184,6 +184,14 @@ def test_address_name_builtin_keyword():
     )
     assert addr_kword.module_alias == "gp_class"
 
+    addr_kword = metadata.Address(
+        name="Class",
+        module="class",
+        package=("google", "appengine_admin"),
+        api_naming=naming.NewNaming(proto_package="foo.bar.baz.v1"),
+    )
+    assert addr_kword.module_alias == "gaa_class"
+
 
 def test_doc_nothing():
     meta = metadata.Metadata()


### PR DESCRIPTION
In the current design, [the first character](https://github.com/googleapis/gapic-generator-python/blob/master/gapic/schema/metadata.py#L118) of each package is used to create an alias. I'd like to append the first character before underscores in the package name to further reduce conflicts. 

Previously `google.appengine_admin` would have an alias prefix of `ga`. With this change, the alias prefix will be `gaa`.

Fixes: #819