### PR TITLE
chore: deprecate return_immediately flag in Pub/Sub pull()

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -6,6 +6,7 @@ from distutils import util
 import os
 import re
 from typing import Callable, Dict, Optional, {% if service.any_server_streaming %}Iterable, {% endif %}{% if service.any_client_streaming %}Iterator, {% endif %}Sequence, Tuple, Type, Union
+import warnings
 import pkg_resources
 
 from google.api_core import client_options as client_options_lib  # type: ignore
@@ -380,6 +381,14 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             {%- endif %} {# field.map #}
             {%- endfor %} {# key, field in method.flattened_fields.items() #}
             {%- endif %} {# method.client_streaming #}
+
+        {%- if method.name|snake_case == "pull" %}
+        if request.return_immediately:
+            warnings.warn(
+                "The return_immediately flag is deprecated and should be set to False.",
+                category=DeprecationWarning,
+            )
+        {%- endif %}
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -5,6 +5,7 @@ from collections import OrderedDict
 import functools
 import re
 from typing import Dict, {% if service.any_server_streaming %}AsyncIterable, Awaitable, {% endif %}{% if service.any_client_streaming %}AsyncIterator, {% endif %}Sequence, Tuple, Type, Union
+import warnings
 import pkg_resources
 
 import google.api_core.client_options as ClientOptions # type: ignore
@@ -238,6 +239,14 @@ class {{ service.async_client_name }}:
         if {{ field.name }}:
             request.{{ key }}.extend({{ field.name }})
         {%- endfor %}
+        {%- endif %}
+
+        {%- if method.name|snake_case == "pull" %}
+        if request.return_immediately:
+            warnings.warn(
+                "The return_immediately flag is deprecated and should be set to False.",
+                category=DeprecationWarning,
+            )
         {%- endif %}
 
         # Wrap the RPC method; this adds retry and timeout information,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -6,6 +6,7 @@ from distutils import util
 import os
 import re
 from typing import Callable, Dict, Optional, {% if service.any_server_streaming %}Iterable, {% endif %}{% if service.any_client_streaming %}Iterator, {% endif %}Sequence, Tuple, Type, Union
+import warnings
 import pkg_resources
 
 from google.api_core import client_options as client_options_lib  # type: ignore
@@ -396,6 +397,14 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             {%- endif %} {# field.map #}
             {%- endfor %} {# method.flattened_fields.items() #}
             {%- endif %} {# method.client_streaming #}
+
+        {%- if method.name|snake_case == "pull" %}
+        if request.return_immediately:
+            warnings.warn(
+                "The return_immediately flag is deprecated and should be set to False.",
+                category=DeprecationWarning,
+            )
+        {%- endif %}
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -7,6 +7,7 @@ import mock
 import grpc
 from grpc.experimental import aio
 import math
+import warnings
 import pytest
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 
@@ -713,7 +714,10 @@ def test_{{ method.name|snake_case }}_flattened():
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
             type(client.transport.{{ method.name|snake_case }}),
-            '__call__') as call:
+            '__call__') as call
+            {%- if method.name|snake_case == "pull" -%}
+            , warnings.catch_warnings(record=True) as warned
+            {%- endif %}:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
         call.return_value = None
@@ -751,6 +755,14 @@ def test_{{ method.name|snake_case }}_flattened():
         {%- endwith %}
         {%- endfor %}
 
+        {%- if method.name|snake_case == "pull" %}
+        # Setting the deprecated return_immediately flag to True should emit a warning.
+        assert len(warned) == 1
+        assert issubclass(warned[0].category, DeprecationWarning)
+        warning_msg = str(warned[0].message)
+        assert "return_immediately" in warning_msg
+        assert "deprecated" in warning_msg
+        {%- endif %}
 
 
 def test_{{ method.name|snake_case }}_flattened_error():
@@ -778,7 +790,10 @@ async def test_{{ method.name|snake_case }}_flattened_async():
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
             type(client.transport.{{ method.name|snake_case }}),
-            '__call__') as call:
+            '__call__') as call
+            {%- if method.name|snake_case == "pull" -%}
+            , warnings.catch_warnings(record=True) as warned
+            {%- endif %}:
         # Designate an appropriate return value for the call.
         {% if method.void -%}
         call.return_value = None
@@ -835,6 +850,15 @@ async def test_{{ method.name|snake_case }}_flattened_async():
         assert args[0].{{ method.flattened_field_to_key[field.name] }} == {{ field.mock_value }}
         {%- endwith %}
         {%- endfor %}
+
+        {%- if method.name|snake_case == "pull" %}
+        # Setting the deprecated return_immediately flag to True should emit a warning.
+        assert len(warned) == 1
+        assert issubclass(warned[0].category, DeprecationWarning)
+        warning_msg = str(warned[0].message)
+        assert "return_immediately" in warning_msg
+        assert "deprecated" in warning_msg
+        {%- endif %}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes googleapis/google-cloud-python#16454.

As per ticket description and internal discussion, the said flag should emit a `DeprecationWarning` if set to `True`.

~~Might run out of time today to update the tests, though.~~ Done.