### PR TITLE
chore: use trim_blocks and lstrip_blocks for jinja templates

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/__init__.py.j2
@@ -2,28 +2,29 @@
 
 {% block content %}
 
+
 {#  Define __all__.
     This requires the full set of imported names, so we iterate over
     them again.
 -#}
 __all__ = (
-    {%- filter sort_lines %}
-    {%- for subpackage in api.subpackages.keys() %}
+    {% filter sort_lines %}
+    {% for subpackage in api.subpackages.keys() %}
     '{{ subpackage }}',
-    {%- endfor %}
-    {%- for service in api.services.values()
+    {% endfor %}
+    {% for service in api.services.values()
             if service.meta.address.subpackage == api.subpackage_view %}
     '{{ service.client_name }}',
-    {%- endfor %}
-    {%- for proto in api.protos.values()
+    {% endfor %}
+    {% for proto in api.protos.values()
             if proto.meta.address.subpackage == api.subpackage_view %}
-    {%- for message in proto.messages.values() %}
+    {% for message in proto.messages.values() %}
     '{{ message.name }}',
-    {%- endfor %}
-    {%- for enum in proto.enums.values() %}
+    {% endfor %}
+    {% for enum in proto.enums.values() %}
     '{{ enum.name }}',
-    {%- endfor %}
-    {%- endfor %}
-    {%- endfilter %}
+    {% endfor %}
+    {% endfor %}
+    {% endfilter %}
 )
 {% endblock %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/__init__.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 from .client import {{ service.client_name }}
 
 __all__ = (

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 from collections import OrderedDict
 from distutils import util
 import os
@@ -18,12 +19,12 @@ from google.auth.transport.grpc import SslCredentials             # type: ignore
 from google.auth.exceptions import MutualTLSChannelError          # type: ignore
 from google.oauth2 import service_account                         # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
-{% for ref_type in method.flat_ref_types -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
+{% for ref_type in method.flat_ref_types %}
 {{ ref_type.ident.python_import }}
-{% endfor -%}
-{% endfor -%}
+{% endfor %}
+{% endfor %}
 {% endfilter %}
 from .transports.base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc import {{ service.name }}GrpcTransport
@@ -144,7 +145,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         return self._transport
 
 
-    {% for message in service.resource_messages|sort(attribute="resource_type") -%}
+    {% for message in service.resource_messages|sort(attribute="resource_type") %}
     @staticmethod
     def {{ message.resource_type|snake_case }}_path({% for arg in message.resource_path_args %}{{ arg }}: str,{% endfor %}) -> str:
         """Return a fully-qualified {{ message.resource_type|snake_case }} string."""
@@ -157,7 +158,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         m = re.match(r"{{ message.path_regex_str }}", path)
         return m.groupdict() if m else {}
     {% endfor %}
-    {% for resource_msg in service.common_resources.values()|sort(attribute="type_name") -%}
+    {% for resource_msg in service.common_resources.values()|sort(attribute="type_name") %}
     @staticmethod
     def common_{{ resource_msg.message_type.resource_type|snake_case }}_path({% for arg in resource_msg.message_type.resource_path_args %}{{ arg }}: str, {%endfor %}) -> str:
         """Return a fully-qualified {{ resource_msg.message_type.resource_type|snake_case }} string."""
@@ -277,81 +278,81 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
               )
 
 
-    {% for method in service.methods.values() -%}
+    {% for method in service.methods.values() %}
     def {{ method.name|snake_case }}(self,
-            {%- if not method.client_streaming %}
+            {% if not method.client_streaming %}
             request: {{ method.input.ident }} = None,
             *,
-            {% for field in method.flattened_fields.values() -%}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}: {{ field.ident }} = None,
-            {% endfor -%}
-            {%- else %}
+            {% endfor %}
+            {% else %}
             requests: Iterator[{{ method.input.ident }}] = None,
             *,
-            {% endif -%}
+            {% endif %}
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            {%- if not method.server_streaming %}
+            {% if not method.server_streaming %}
             ) -> {{ method.client_output.ident }}:
-            {%- else %}
+            {% else %}
             ) -> Iterable[{{ method.client_output.ident }}]:
-            {%- endif %}
+            {% endif %}
         r"""{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
-            {%- if not method.client_streaming %}
+            {% if not method.client_streaming %}
             request (:class:`{{ method.input.ident.sphinx }}`):
-                The request object.{{ ' ' -}}
+                The request object.{{ ' ' }}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
-            {% for key, field in method.flattened_fields.items() -%}
+            {% for key, field in method.flattened_fields.items() %}
             {{ field.name }} (:class:`{{ field.ident.sphinx }}`):
                 {{ field.meta.doc|rst(width=72, indent=16) }}
                 This corresponds to the ``{{ key }}`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-            {% endfor -%}
-            {%- else %}
+            {% endfor %}
+            {% else %}
             requests (Iterator[`{{ method.input.ident.sphinx }}`]):
-                The request object iterator.{{ ' ' -}}
+                The request object iterator.{{ ' ' }}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
-            {%- endif %}
+            {% endif %}
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
-        {%- if not method.void %}
+        {% if not method.void %}
 
         Returns:
-            {%- if not method.server_streaming %}
+            {% if not method.server_streaming %}
             {{ method.client_output.ident.sphinx }}:
-            {%- else %}
+            {% else %}
             Iterable[{{ method.client_output.ident.sphinx }}]:
-            {%- endif %}
+            {% endif %}
                 {{ method.client_output.meta.doc|rst(width=72, indent=16, source_format='rst') }}
-        {%- endif %}
+        {% endif %}
         """
-        {%- if not method.client_streaming %}
+        {% if not method.client_streaming %}
         # Create or coerce a protobuf request object.
-        {% if method.flattened_fields -%}
+        {% if method.flattened_fields %}
         # Sanity check: If we got a request object, we should *not* have
         # gotten any keyword arguments that map to the request.
         if request is not None and any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}]):
             raise ValueError('If the `request` argument is set, then none of '
                              'the individual field arguments should be set.')
 
-        {% endif -%} {# method.flattened_fields #}
-        {% if method.input.ident.package != method.ident.package -%} {# request lives in a different package, so there is no proto wrapper #}
+        {% endif %} {# method.flattened_fields #}
+        {% if method.input.ident.package != method.ident.package %} {# request lives in a different package, so there is no proto wrapper #}
         # The request isn't a proto-plus wrapped type.
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
             request = {{ method.input.ident }}(**request)
-        {% if method.flattened_fields -%}{# Cross-package req and flattened fields #}
+        {% if method.flattened_fields %}{# Cross-package req and flattened fields #}
         elif not request:
             request = {{ method.input.ident }}({% if method.input.ident.package != method.ident.package %}{% for f in method.flattened_fields.values() %}{{ f.name }}={{ f.name }}, {% endfor %}{% endif %})
-        {% endif -%}{# Cross-package req and flattened fields #}
-        {%- else %}  {# Request is in _our_ package #}
+        {% endif %}{# Cross-package req and flattened fields #}
+        {% else %}  {# Request is in _our_ package #}
         # Minor optimization to avoid making a copy if the user passes
         # in a {{ method.input.ident }}.
         # There's no risk of modifying the input as we've already verified
@@ -360,57 +361,57 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             request = {{ method.input.ident }}(request)
         {% endif %} {# different request package #}
         {#- Vanilla python protobuf wrapper types cannot _set_ repeated fields #}
-            {% if method.flattened_fields and method.input.ident.package == method.ident.package -%}
+            {% if method.flattened_fields and method.input.ident.package == method.ident.package %}
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-            {% endif -%}
-            {%- for key, field in method.flattened_fields.items() if not field.repeated or method.input.ident.package == method.ident.package %}
+            {% endif %}
+            {% for key, field in method.flattened_fields.items() if not field.repeated or method.input.ident.package == method.ident.package %}
             if {{ field.name }} is not None:
                 request.{{ key }} = {{ field.name }}
-            {%- endfor %}
+            {% endfor %}
             {# Map-y fields can be _updated_, however #}
-            {%- for key, field in method.flattened_fields.items() if field.repeated and method.input.ident.package != method.ident.package %}
-            {%- if field.map %} {# map implies repeated, but repeated does NOT imply map#}
+            {% for key, field in method.flattened_fields.items() if field.repeated and method.input.ident.package != method.ident.package %}
+            {% if field.map %} {# map implies repeated, but repeated does NOT imply map#}
             if {{ field.name }}:
                 request.{{ key }}.update({{ field.name }})
-            {%- else %}
+            {% else %}
             {# And list-y fields can be _extended_ -#}
             if {{ field.name }}:
                 request.{{ key }}.extend({{ field.name }})
-            {%- endif %} {# field.map #}
-            {%- endfor %} {# key, field in method.flattened_fields.items() #}
-            {%- endif %} {# method.client_streaming #}
+            {% endif %} {# field.map #}
+            {% endfor %} {# key, field in method.flattened_fields.items() #}
+            {% endif %} {# method.client_streaming #}
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
         rpc = self._transport._wrapped_methods[self._transport.{{ method.name|snake_case}}]
-        {%- if method.field_headers %}
+        {% if method.field_headers %}
 
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
-                {%- for field_header in method.field_headers %}
-                {%- if not method.client_streaming %}
+                {% for field_header in method.field_headers %}
+                {% if not method.client_streaming %}
                 ('{{ field_header }}', request.{{ field_header }}),
-                {%- endif %}
-                {%- endfor %}
+                {% endif %}
+                {% endfor %}
             )),
         )
-        {%- endif %} {# method.field_headers #}
+        {% endif %} {# method.field_headers #}
 
         # Send the request.
         {% if not method.void %}response = {% endif %}rpc(
-            {%- if not method.client_streaming %}
+            {% if not method.client_streaming %}
             request,
-            {%- else %}
+            {% else %}
             requests,
-            {%- endif %} {# method.client_streaming #}
+            {% endif %} {# method.client_streaming #}
             retry=retry,
             timeout=timeout,
             metadata=metadata,
         )
-        {%- if method.lro %}
+        {% if method.lro %}
 
         # Wrap the response in an operation future.
         response = {{ method.client_output.ident.module_alias or method.client_output.ident.module }}.from_gapic(
@@ -419,7 +420,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             {{ method.lro.response_type.ident }},
             metadata_type={{ method.lro.metadata_type.ident }},
         )
-        {%- elif method.paged_result_field %}
+        {% elif method.paged_result_field %}
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -429,12 +430,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             response=response,
             metadata=metadata,
         )
-        {%- endif %} {# method.lro #}
-        {%- if not method.void %}
+        {% endif %} {# method.lro #}
+        {% if not method.void %}
 
         # Done; return the response.
         return response
-        {%- endif %} {# method.void #}
+        {% endif %} {# method.void #}
         {{ '\n' }}
     {% endfor %}
 

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -94,6 +94,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         return api_endpoint.replace(".googleapis.com", ".mtls.googleapis.com")
 
     DEFAULT_ENDPOINT = {% if service.host %}'{{ service.host }}'{% else %}None{% endif %}
+
     DEFAULT_MTLS_ENDPOINT = _get_default_mtls_endpoint.__func__(  # type: ignore
         DEFAULT_ENDPOINT
     )
@@ -401,7 +402,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% endif %} {# method.field_headers #}
 
         # Send the request.
-        {% if not method.void %}response = {% endif %}rpc(
+        {%+ if not method.void %}response = {% endif %}rpc(
             {% if not method.client_streaming %}
             request,
             {% else %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
@@ -13,7 +13,9 @@ from typing import Any, Callable, Iterable, Sequence, Tuple
 {% for method in service.methods.values() | selectattr('paged_result_field') %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% if not method.paged_result_field.is_primitive %}{{ method.paged_result_field.message.ident.python_import }}{% endif %}
+{% if not method.paged_result_field.is_primitive %}
+{{ method.paged_result_field.message.ident.python_import }}
+{% endif %}
 {% endfor %}
 {% endfilter %}
 {% endif %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
@@ -1,20 +1,21 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-{% for method in service.methods.values() | selectattr('paged_result_field') -%}
-{% if loop.first -%}
+
+{% for method in service.methods.values() | selectattr('paged_result_field') %}
+{% if loop.first %}
 {# This lives within the loop in order to ensure that this template
    is empty if there are no paged methods.
  -#}
 from typing import Any, Callable, Iterable, Sequence, Tuple
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() | selectattr('paged_result_field') -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() | selectattr('paged_result_field') %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
 {% if not method.paged_result_field.is_primitive %}{{ method.paged_result_field.message.ident.python_import }}{% endif %}
 {% endfor %}
-{% endfilter -%}
+{% endfilter %}
 {% endif %}
 
 class {{ method.name }}Pager:

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/__init__.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 from collections import OrderedDict
 from typing import Dict, Type
 

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import abc
 import typing
 import pkg_resources
@@ -8,16 +9,16 @@ import pkg_resources
 from google import auth
 from google.api_core import gapic_v1    # type: ignore
 from google.api_core import retry as retries  # type: ignore
-{%- if service.has_lro %}
+{% if service.has_lro %}
 from google.api_core import operations_v1  # type: ignore
-{%- endif %}
+{% endif %}
 from google.auth import credentials  # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% endfor -%}
+{% endfor %}
 {% endfilter %}
 
 try:
@@ -34,9 +35,9 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
     """Abstract transport class for {{ service.name }}."""
 
     AUTH_SCOPES = (
-        {%- for scope in service.oauth_scopes %}
+        {% for scope in service.oauth_scopes %}
         '{{ scope }}',
-        {%- endfor %}
+        {% endfor %}
     )
 
     def __init__(
@@ -49,7 +50,7 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
-                {{- ' ' }}The hostname to connect to.
+                {{ ' ' }}The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -80,22 +81,22 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
     def _prep_wrapped_messages(self, client_info):
         # Precomputed wrapped methods
         self._wrapped_methods = {
-            {% for method in service.methods.values() -%}
+            {% for method in service.methods.values() %}
             self.{{ method.name|snake_case }}: gapic_v1.method.wrap_method(
                 self.{{ method.name|snake_case }},
-                {%- if method.retry %}
+                {% if method.retry %}
                 default_retry=retries.Retry(
                     {% if method.retry.initial_backoff %}initial={{ method.retry.initial_backoff }},{% endif %}
                     {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
                     {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                     predicate=retries.if_exception_type(
-                        {%- for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
+                        {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
                         exceptions.{{ ex.__name__ }},
-                        {%- endfor %}
+                        {% endfor %}
                     ),
                     deadline={{ method.timeout }},
                 ),
-                {%- endif %}
+                {% endif %}
                 default_timeout={{ method.timeout }},
                 client_info=client_info,
             ),
@@ -103,21 +104,21 @@ class {{ service.name }}Transport(metaclass=abc.ABCMeta):
         }
 
 
-    {%- if service.has_lro %}
+    {% if service.has_lro %}
 
     @property
     def operations_client(self) -> operations_v1.OperationsClient:
         """Return the client designed to process long-running operations."""
         raise NotImplementedError
-    {%- endif %}
-    {%- for method in service.methods.values() %}
+    {% endif %}
+    {% for method in service.methods.values() %}
 
     @property
     def {{ method.name|snake_case }}(self) -> typing.Callable[
             [{{ method.input.ident }}],
             {{ method.output.ident }}]:
         raise NotImplementedError
-    {%- endfor %}
+    {% endfor %}
 
 
 __all__ = (

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/grpc.py.j2
@@ -1,13 +1,14 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple
 
 from google.api_core import grpc_helpers   # type: ignore
-{%- if service.has_lro %}
+{% if service.has_lro %}
 from google.api_core import operations_v1  # type: ignore
-{%- endif %}
+{% endif %}
 from google.api_core import gapic_v1       # type: ignore
 from google import auth                    # type: ignore
 from google.auth import credentials        # type: ignore
@@ -15,11 +16,11 @@ from google.auth.transport.grpc import SslCredentials  # type: ignore
 
 import grpc  # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% endfor -%}
+{% endfor %}
 {% endfilter %}
 from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
 
@@ -52,7 +53,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
-                {{- ' ' }}The hostname to connect to.
+                {{ ' ' }}The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -192,7 +193,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
-    {%- if service.has_lro %}
+    {% if service.has_lro %}
 
     @property
     def operations_client(self) -> operations_v1.OperationsClient:
@@ -209,17 +210,17 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
         # Return the client from cache.
         return self.__dict__['operations_client']
-    {%- endif %}
-    {%- for method in service.methods.values() %}
+    {% endif %}
+    {% for method in service.methods.values() %}
 
     @property
     def {{ method.name|snake_case }}(self) -> Callable[
             [{{ method.input.ident }}],
             {{ method.output.ident }}]:
-        r"""Return a callable for the {{- ' ' -}}
+        r"""Return a callable for the {{ ' ' }}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=40, indent=8) }}
-        {{- ' ' -}} method over gRPC.
+        {{ ' ' }} method over gRPC.
 
         {{ method.meta.doc|rst(width=72, indent=8) }}
 
@@ -240,10 +241,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 response_deserializer={{ method.output.ident }}.{% if method.output.ident.python_import.module.endswith('_pb2') %}FromString{% else %}deserialize{% endif %},
             )
         return self._stubs['{{ method.name|snake_case }}']
-    {%- endfor %}
+    {% endfor %}
 
 
 __all__ = (
     '{{ service.name }}GrpcTransport',
 )
-{%- endblock -%}
+{% endblock %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/types/%proto.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/types/%proto.py.j2
@@ -1,40 +1,41 @@
 {% extends "_base.py.j2" %}
 
-{% block content -%}
+{% block content %}
+
 {% with p = proto.disambiguate('proto') %}
-{% if proto.messages|length or proto.all_enums|length -%}
+{% if proto.messages|length or proto.all_enums|length %}
 import proto{% if p != 'proto' %} as {{ p }}{% endif %}  # type: ignore
 {% endif %}
 
-{% filter sort_lines -%}
-{% for import_ in proto.python_modules -%}
+{% filter sort_lines %}
+{% for import_ in proto.python_modules %}
 {{ import_ }}
-{% endfor -%}
+{% endfor %}
 {% endfilter %}
 
 
 __protobuf__ = {{ p }}.module(
     package='{{ '.'.join(proto.meta.address.package) }}',
-    {% if api.naming.proto_package != '.'.join(proto.meta.address.package) -%}
+    {% if api.naming.proto_package != '.'.join(proto.meta.address.package) %}
     marshal='{{ api.naming.proto_package }}',
-    {% endif -%}
+    {% endif %}
     manifest={
-    {%- for enum in proto.enums.values() %}
+    {% for enum in proto.enums.values() %}
         '{{ enum.name }}',
-    {%- endfor %}
-    {%- for message in proto.messages.values() %}
+    {% endfor %}
+    {% for message in proto.messages.values() %}
         '{{ message.name }}',
-    {%- endfor %}
+    {% endfor %}
     },
 )
 
 
-{% for enum in proto.enums.values() -%}
+{% for enum in proto.enums.values() %}
     {% include '%namespace/%name/%version/%sub/types/_enum.py.j2' with context %}
 {% endfor %}
 
-{% for message in proto.messages.values() -%}
-    {% include '%namespace/%name/%version/%sub/types/_message.py.j2' with context %} 
+{% for message in proto.messages.values() %}
+    {% include '%namespace/%name/%version/%sub/types/_message.py.j2' with context %}
 {% endfor %}
 {% endwith %}
 

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/types/_enum.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/types/_enum.py.j2
@@ -1,9 +1,9 @@
 class {{ enum.name }}({{ p }}.Enum):
     r"""{{ enum.meta.doc|rst(indent=4) }}"""
-    {% if enum.enum_pb.HasField("options") -%}
+    {% if enum.enum_pb.HasField("options") %}
      _pb_options = {{ enum.options_dict }}
-    {% endif -%}
-    {% for enum_value in enum.values -%}
+    {% endif %}
+    {% for enum_value in enum.values %}
     {{ enum_value.name }} = {{ enum_value.number }}
-    {% endfor -%}
+    {% endfor %}
 {{ '\n\n' }}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
@@ -2,27 +2,27 @@ class {{ message.name }}({{ p }}.Message):
     r"""{{ message.meta.doc|rst(indent=4) }}{% if message.fields|length %}
 
     Attributes:
-    {%- for field in message.fields.values() %}
+    {% for field in message.fields.values() %}
         {{ field.name }} ({{ field.ident.sphinx }}):
             {{ field.meta.doc|rst(indent=12, nl=False) }}
-    {%- endfor %}
-    {% endif -%}
+    {% endfor %}
+    {% endif %}
     """
     {# Iterate over nested enums. -#}
-    {% for enum in message.nested_enums.values() -%}
+    {% for enum in message.nested_enums.values() %}
         {% filter indent %}
-            {%- include '%namespace/%name/%version/%sub/types/_enum.py.j2' %}
+            {% include '%namespace/%name/%version/%sub/types/_enum.py.j2' %}
         {% endfilter %}
-    {% endfor -%}
+    {% endfor %}
 
     {# Iterate over nested messages. -#}
-    {% for submessage in message.nested_messages.values() -%}
-        {% if not submessage.map -%}
+    {% for submessage in message.nested_messages.values() %}
+        {% if not submessage.map %}
         {% with message = submessage %}{% filter indent %}
-            {%- include '%namespace/%name/%version/%sub/types/_message.py.j2' %}
+            {% include '%namespace/%name/%version/%sub/types/_message.py.j2' %}
         {% endfilter %}{% endwith %}
         {% endif %}
-    {% endfor -%}
+    {% endfor %}
 
     {% if "next_page_token" in message.fields.values()|map(attribute='name') %}
     @property
@@ -31,21 +31,31 @@ class {{ message.name }}({{ p }}.Message):
     {% endif %}
 
     {# Iterate over fields. -#}
-    {% for field in message.fields.values() -%}
-    {% if field.map -%}
-    {% with key_field = field.message.fields['key'], value_field = field.message.fields['value'] -%}
+    {% for field in message.fields.values() %}
+    {% if field.map %}
+    {% with key_field = field.message.fields['key'], value_field = field.message.fields['value'] %}
     {{ field.name }} = {{ p }}.MapField(
-        {{- p }}.{{ key_field.proto_type }}, {{ p }}.{{ value_field.proto_type }}, number={{ field.number }}
-    {%- if value_field.enum or value_field.message %},
+        {{ p }}.{{ key_field.proto_type }},
+        {{ p }}.{{ value_field.proto_type }},
+        number={{ field.number }}
+    {% if value_field.enum or value_field.message %},
         {{ value_field.proto_type.lower() }}={{ value_field.type.ident.rel(message.ident) }},
-    {% endif %})
-    {% endwith -%}
-    {% else -%}
+    {% endif %}
+    )
+    {% endwith %}
+    {% else %}
     {{ field.name }} = {{ p }}.{% if field.repeated %}Repeated{% endif %}Field(
-        {{- p }}.{{ field.proto_type }}, number={{ field.number }}{% if field.proto3_optional %}, optional=True{% elif field.oneof %}, oneof='{{ field.oneof }}'{% endif %}
-    {%- if field.enum or field.message %},
+        {{ p }}.{{ field.proto_type }},
+        number={{ field.number }},
+        {% if field.proto3_optional %}
+        optional=True,
+        {% elif field.oneof %}
+        oneof='{{ field.oneof }}',
+        {% endif %}
+    {% if field.enum or field.message %},
         {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
-    {% endif %})
-    {% endif -%}
-    {% endfor -%}
+    {% endif %}
+    )
+    {% endif %}
+    {% endfor %}
 {{ '\n\n' }}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
@@ -10,7 +10,7 @@ class {{ message.name }}({{ p }}.Message):
     """
     {# Iterate over nested enums. -#}
     {% for enum in message.nested_enums.values() %}
-        {% filter indent %}
+        {% filter indent(first=True) %}
             {% include '%namespace/%name/%version/%sub/types/_enum.py.j2' %}
         {% endfilter %}
     {% endfor %}
@@ -18,7 +18,7 @@ class {{ message.name }}({{ p }}.Message):
     {# Iterate over nested messages. -#}
     {% for submessage in message.nested_messages.values() %}
         {% if not submessage.map %}
-        {% with message = submessage %}{% filter indent %}
+        {% with message = submessage %}{% filter indent(first=True) %}
             {% include '%namespace/%name/%version/%sub/types/_message.py.j2' %}
         {% endfilter %}{% endwith %}
         {% endif %}
@@ -37,8 +37,8 @@ class {{ message.name }}({{ p }}.Message):
     {{ field.name }} = {{ p }}.MapField(
         {{ p }}.{{ key_field.proto_type }},
         {{ p }}.{{ value_field.proto_type }},
-        number={{ field.number }}
-    {% if value_field.enum or value_field.message %},
+        number={{ field.number }},
+    {% if value_field.enum or value_field.message %}
         {{ value_field.proto_type.lower() }}={{ value_field.type.ident.rel(message.ident) }},
     {% endif %}
     )
@@ -52,9 +52,9 @@ class {{ message.name }}({{ p }}.Message):
         {% elif field.oneof %}
         oneof='{{ field.oneof }}',
         {% endif %}
-    {% if field.enum or field.message %},
+        {% if field.enum or field.message %}
         {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
-    {% endif %}
+        {% endif %}
     )
     {% endif %}
     {% endfor %}

--- a/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 {% block content %}
-{% if opts.lazy_import -%} {# lazy import #}
+
+{% if opts.lazy_import %} {# lazy import #}
 import importlib
 import sys
 
@@ -11,22 +12,22 @@ if sys.version_info < (3, 7):
 
 _lazy_type_to_package_map = {
     # Message types
-{%- for _, message in api.top_level_messages|dictsort %}
+{% for _, message in api.top_level_messages|dictsort %}
     '{{ message.name }}': '{{ message.ident.package|join('.') }}.types.{{ message.ident.module }}',
-{%- endfor %}
+{% endfor %}
 
     # Enum types
-{%- for _, enum in api.top_level_enums|dictsort %}
+{% for _, enum in api.top_level_enums|dictsort %}
     '{{ enum.name }}': '{{ enum.ident.package|join('.') }}.types.{{enum.ident.module }}',
-{%- endfor %}
+{% endfor %}
 
     {# TODO(yon-mg): add rest transport service once I know what this is #}
     # Client classes and transports
-{%- for _, service in api.services|dictsort %}
+{% for _, service in api.services|dictsort %}
     '{{ service.client_name }}': '{{ service.meta.address.package|join('.') }}.services.{{ service.meta.address.module }}',
     '{{ service.transport_name }}': '{{ service.meta.address.package|join('.') }}.services.{{ service.meta.address.module }}.transports',
     '{{ service.grpc_transport_name }}': '{{ service.meta.address.package|join('.') }}.services.{{ service.meta.address.module }}.transports',
-{%- endfor %}
+{% endfor %}
 }
 
 
@@ -47,20 +48,20 @@ def __getattr__(name):  # Requires Python >= 3.7
 
 def __dir__():
     return globals().get('__all__') or __getattr__('__all__')
-{% else -%}                {# do not use lazy import #}
+{% else %}                {# do not use lazy import #}
 {#  Import subpackages. -#}
-{% filter sort_lines -%}
-{% for subpackage in api.subpackages.keys() -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
+{% filter sort_lines %}
+{% for subpackage in api.subpackages.keys() %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
     {{ api.naming.versioned_module_name }} import {{ subpackage }}
-{% endfor -%}
+{% endfor %}
 
 {#  Import services for this package. -#}
 {% for service in api.services.values()|sort(attribute='name')
-        if service.meta.address.subpackage == api.subpackage_view -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
+        if service.meta.address.subpackage == api.subpackage_view %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
     {{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.client_name }}
-{% endfor -%}
+{% endfor %}
 
 {#  Import messages and enums from each proto.
     It is safe to import all of the messages into the same namespace here,
@@ -73,41 +74,41 @@ from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.'
     a proto package.
   -#}
 {% for proto in api.protos.values()|sort(attribute='module_name')
-        if proto.meta.address.subpackage == api.subpackage_view -%}
-  {% for message in proto.messages.values()|sort(attribute='name') -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
+        if proto.meta.address.subpackage == api.subpackage_view %}
+  {% for message in proto.messages.values()|sort(attribute='name') %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
     {{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
-{% endfor -%}
-{% for enum in proto.enums.values()|sort(attribute='name') -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
+{% endfor %}
+{% for enum in proto.enums.values()|sort(attribute='name') %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
     {{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ enum.name }}
-{% endfor %}{% endfor -%}
+{% endfor %}{% endfor %}
 {% endfilter %}
 {#  Define __all__.
     This requires the full set of imported names, so we iterate over
     them again.
 -#}
 __all__ = (
-{%- filter indent %}
-{% filter sort_lines -%}
-{% for subpackage in api.subpackages.keys() -%}
+{% filter indent %}
+{% filter sort_lines %}
+{% for subpackage in api.subpackages.keys() %}
 '{{ subpackage }}',
-{% endfor -%}
+{% endfor %}
 {% for service in api.services.values()|sort(attribute='name')
-   if service.meta.address.subpackage == api.subpackage_view -%}
+   if service.meta.address.subpackage == api.subpackage_view %}
 '{{ service.client_name }}',
-{% endfor -%}
+{% endfor %}
 {% for proto in api.protos.values()|sort(attribute='module_name')
-   if proto.meta.address.subpackage == api.subpackage_view -%}
-{% for message in proto.messages.values()|sort(attribute='name') -%}
+   if proto.meta.address.subpackage == api.subpackage_view %}
+{% for message in proto.messages.values()|sort(attribute='name') %}
 '{{ message.name }}',
-{% endfor -%}
+{% endfor %}
 {% for enum in proto.enums.values()|sort(attribute='name')
-   if proto.meta.address.subpackage == api.subpackage_view -%}
+   if proto.meta.address.subpackage == api.subpackage_view %}
 '{{ enum.name }}',
-{% endfor -%}{% endfor -%}
-{% endfilter -%}
-{% endfilter -%}
+{% endfor %}{% endfor %}
+{% endfilter %}
+{% endfilter %}
 )
-{% endif -%} {# lazy import #}
+{% endif %} {# lazy import #}
 {% endblock %}

--- a/gapic/ads-templates/%namespace/%name/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/__init__.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 {% block content %}
-{% if opts.lazy_import -%} {# lazy import #}
+
+{% if opts.lazy_import %} {# lazy import #}
 import importlib
 import sys
 
@@ -11,22 +12,20 @@ if sys.version_info < (3, 7):
 
 _lazy_type_to_package_map = {
     # Message types
-{%- for _, message in api.top_level_messages|dictsort %}
+{% for _, message in api.top_level_messages|dictsort %}
     '{{ message.name }}': '{{ message.ident.package|join('.') }}.types.{{ message.ident.module }}',
-{%- endfor %}
-
+{% endfor %}
     # Enum types
-{%- for _, enum in api.top_level_enums|dictsort %}
+{% for _, enum in api.top_level_enums|dictsort %}
     '{{ enum.name }}': '{{ enum.ident.package|join('.') }}.types.{{enum.ident.module }}',
-{%- endfor %}
-
+{% endfor %}
     {# TODO(yon-mg): add rest transport service once I know what this is #}
     # Client classes and transports
-{%- for _, service in api.services|dictsort %}
+{% for _, service in api.services|dictsort %}
     '{{ service.client_name }}': '{{ service.meta.address.package|join('.') }}.services.{{ service.meta.address.module }}',
     '{{ service.transport_name }}': '{{ service.meta.address.package|join('.') }}.services.{{ service.meta.address.module }}.transports',
     '{{ service.grpc_transport_name }}': '{{ service.meta.address.package|join('.') }}.services.{{ service.meta.address.module }}.transports',
-{%- endfor %}
+{% endfor %}
 }
 
 
@@ -47,67 +46,67 @@ def __getattr__(name):  # Requires Python >= 3.7
 
 def __dir__():
     return globals().get('__all__') or __getattr__('__all__')
-{% else -%}                {# do not use lazy import #}
+{% else %}                {# do not use lazy import #}
 {#  Import subpackages. -#}
-{% filter sort_lines -%}
-{% for subpackage in api.subpackages.keys() -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }} import {{ subpackage }}
-{% endfor -%}
+{% filter sort_lines %}
+{% for subpackage in api.subpackages.keys() %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }} import {{ subpackage }}
+{% endfor %}
 
 {#  Import services for this package. -#}
 {% for service in api.services.values()|sort(attribute='name')
-        if service.meta.address.subpackage == api.subpackage_view -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.client_name }}
-{% endfor -%}
+        if service.meta.address.subpackage == api.subpackage_view %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.client_name }}
+{% endfor %}
 
 {#  Import messages and enums from each proto.
     It is safe to import all of the messages into the same namespace here,
     because protocol buffers itself enforces selector uniqueness within
     a proto package.
--#}
+#}
 {#  Import messages from each proto.
     It is safe to import all of the messages into the same namespace here,
     because protocol buffers itself enforces selector uniqueness within
     a proto package.
-  -#}
+#}
 {% for proto in api.protos.values()|sort(attribute='module_name')
-        if proto.meta.address.subpackage == api.subpackage_view -%}
-  {% for message in proto.messages.values()|sort(attribute='name') -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
-{% endfor -%}
-{% for enum in proto.enums.values()|sort(attribute='name') -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ enum.name }}
-{% endfor %}{% endfor -%}
+        if proto.meta.address.subpackage == api.subpackage_view %}
+  {% for message in proto.messages.values()|sort(attribute='name') %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
+{% endfor %}
+{% for enum in proto.enums.values()|sort(attribute='name') %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ enum.name }}
+{% endfor %}{% endfor %}
 {% endfilter %}
 {#  Define __all__.
     This requires the full set of imported names, so we iterate over
     them again.
--#}
+#}
 __all__ = (
-{%- filter indent %}
-{% filter sort_lines -%}
-{% for subpackage, _ in api.subpackages|dictsort -%}
+{% filter indent %}
+{% filter sort_lines %}
+{% for subpackage, _ in api.subpackages|dictsort %}
 '{{ subpackage }}',
-{% endfor -%}
+{% endfor %}
 {% for service in api.services.values()|sort(attribute='name')
-   if service.meta.address.subpackage == api.subpackage_view -%}
+   if service.meta.address.subpackage == api.subpackage_view %}
 '{{ service.client_name }}',
-{% endfor -%}
+{% endfor %}
 {% for proto in api.protos.values()|sort(attribute='module_name')
-   if proto.meta.address.subpackage == api.subpackage_view -%}
-{% for message in proto.messages.values()|sort(attribute='name') -%}
+   if proto.meta.address.subpackage == api.subpackage_view %}
+{% for message in proto.messages.values()|sort(attribute='name') %}
 '{{ message.name }}',
-{% endfor -%}
+{% endfor %}
 {% for enum in proto.enums.values()|sort(attribute='name')
-   if proto.meta.address.subpackage == api.subpackage_view -%}
+   if proto.meta.address.subpackage == api.subpackage_view %}
 '{{ enum.name }}',
-{% endfor -%}{% endfor -%}
-{% endfilter -%}
-{% endfilter -%}
+{% endfor %}{% endfor %}
+{% endfilter %}
+{% endfilter %}
 )
-{% endif -%} {# lazy import #}
+{% endif %} {# lazy import #}
 {% endblock %}

--- a/gapic/ads-templates/_base.py.j2
+++ b/gapic/ads-templates/_base.py.j2
@@ -2,5 +2,5 @@
 {% block license %}
 {% include "_license.j2" %}
 {% endblock %}
-{%- block content %}
+{% block content %}
 {% endblock %}

--- a/gapic/ads-templates/docs/%name_%version/services.rst.j2
+++ b/gapic/ads-templates/docs/%name_%version/services.rst.j2
@@ -1,7 +1,7 @@
 Services for {{ api.naming.long_name }} {{ api.naming.version }} API
 {{ '=' * (18 + api.naming.long_name|length + api.naming.version|length) }}
 
-{% for service in api.services.values()|sort(attribute='name') -%}
+{% for service in api.services.values()|sort(attribute='name') %}
 .. automodule:: {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}
     :members:
     :inherited-members:

--- a/gapic/ads-templates/docs/conf.py.j2
+++ b/gapic/ads-templates/docs/conf.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 #
 # {{ api.naming.warehouse_package_name }} documentation build configuration file
 #

--- a/gapic/ads-templates/examples/feature_fragments.j2
+++ b/gapic/ads-templates/examples/feature_fragments.j2
@@ -52,7 +52,7 @@ There is a little, but not enough for it to be important because
       {% do input_parameters.append(request.single.input_parameter) %}
     {% endif %}
   {% endfor %}
-{{ input_parameters|join(", ") -}}
+{{ input_parameters|join(", ") }}
 {% endwith %}
 {% endmacro %}
 
@@ -89,7 +89,7 @@ for {{ statement.variable }} in {{ statement.collection|coerce_response_name }}:
 {% endmacro %}
 
 {% macro render_map_loop(statement) %}
- {# At least one of key and value exist; validated in python #}
+{# At least one of key and value exist; validated in python #}
 {% if "key" not in statement %}
 for {{ statement.value }} in {{ statement.map|coerce_response_name }}.values():
 {% elif "value" not in statement %}
@@ -111,21 +111,21 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 
 {% macro dispatch_statement(statement, indentation=0) %}
 {# Each statement is a dict with a single key/value pair #}
-{% if "print" in statement -%}
+{% if "print" in statement %}
 {{ render_print(statement["print"])|indent(width=indentation, first=True) }}
-{% elif "define" in statement -%}
+{% elif "define" in statement %}
 {{ render_define(statement["define"])|indent(width=indentation, first=True) }}
-{% elif "comment" in statement -%}
+{% elif "comment" in statement %}
 {{ render_comment(statement["comment"])|indent(width=indentation, first=True) }}
-{% elif "loop" in statement -%}
-  {% with loop = statement["loop"] -%}
-    {% if "collection" in loop -%}
+{% elif "loop" in statement %}
+  {% with loop = statement["loop"] %}
+    {% if "collection" in loop %}
 {{ render_collection_loop(loop)|indent(width=indentation, first=True) }}
-    {% else -%}
+    {% else %}
 {{ render_map_loop(loop)|indent(width=indentation, first=True) }}
-    {% endif -%}
-  {% endwith -%}
-{% elif "write_file" in statement -%}
+    {% endif %}
+  {% endwith %}
+{% elif "write_file" in statement %}
 {{ render_write_file(statement["write_file"])|indent(indentation, first=True) }}
 {% endif %}
 {% endmacro %}
@@ -135,9 +135,9 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 {# to be the correct enum from the right module, if necessary. #}
 {# Python is also responsible for verifying that each input parameter is unique,#}
 {# no parameter is a reserved keyword #}
-  {% if attr.input_parameter %}
+{% if attr.input_parameter %}
 # {{ attr.input_parameter }} = {{ attr.value }}
-  {% if attr.value_is_file %}
+{% if attr.value_is_file %}
 with open({{ attr.input_parameter }}, "rb") as f:
     {{ base_name }}["{{ attr.field }}"] = f.read()
     {% else %}
@@ -150,67 +150,66 @@ with open({{ attr.input_parameter }}, "rb") as f:
 
 {% macro render_request_setup(full_request) %}
 {% for parameter_block in full_request.request_list if parameter_block.body %}
-{% if parameter_block.pattern -%}
+{% if parameter_block.pattern %}
 {# This is a resource-name patterned lookup parameter #}
-{% with formals = [] -%} 
-{% for attr in parameter_block.body -%} 
-{% do formals.append("%s=%s"|format(attr.field, attr.input_parameter or attr.value)) -%} 
-{% endfor -%} 
+{% with formals = [] %}
+{% for attr in parameter_block.body %}
+{% do formals.append("%s=%s"|format(attr.field, attr.input_parameter or attr.value)) %}
+{% endfor %}
 {{ parameter_block.base }} = "{{parameter_block.pattern }}".format({{ formals|join(", ") }})
-{% endwith -%}  
-{% else -%} {# End resource name construction #}
+{% endwith %}
+{% else %}{# End resource name construction #}
 {{ parameter_block.base }} = {}
 {% for attr in parameter_block.body %}
 {{ render_request_attr(parameter_block.base, attr) }}
 {% endfor %}
-{% endif -%}
+{% endif %}
 {% endfor %}
-{% if not full_request.flattenable -%}
+{% if not full_request.flattenable %}
 request = {
 {% for parameter in full_request.request_list %}
     '{{ parameter.base  }}': {{ parameter.base if parameter.body else parameter.single }},
-{% endfor -%}
-}
-{% endif -%}
+{% endfor %}}
+{% endif %}
 {% endmacro %}
 
 {% macro render_request_params(request) %}
-  {# Provide the top level parameters last and as keyword params #}
-  {% with params = [] -%}
-    {% for r in request if r.body -%}
-      {% do params.append(r.base) -%}
-    {% endfor -%}
-    {% for r in request if r.single -%}
-      {% do params.append("%s=%s"|format(r.base, r.single.value)) -%}
-    {% endfor -%}
-{{ params|join(", ") -}}
-  {% endwith -%}
+{# Provide the top level parameters last and as keyword params #}
+  {% with params = [] %}
+    {% for r in request if r.body %}
+      {% do params.append(r.base) %}
+    {% endfor %}
+    {% for r in request if r.single %}
+      {% do params.append("%s=%s"|format(r.base, r.single.value)) %}
+    {% endfor %}
+{{ params|join(", ") }}
+  {% endwith %}
 {% endmacro %}
 
 {% macro render_request_params_unary(request) %}
-  {# Provide the top level parameters last and as keyword params #}
-  {% if request.flattenable -%}
-  {% with params = [] -%}
-    {% for r in request.request_list -%}
-      {% do params.append("%s=%s"|format(r.base, r.single.value if r.single else r.base)) -%}
-    {% endfor -%}
-{{ params|join(", ") -}}
-  {% endwith -%}
-  {% else -%}
+{# Provide the top level parameters last and as keyword params #}
+  {% if request.flattenable %}
+  {% with params = [] %}
+    {% for r in request.request_list %}
+      {% do params.append("%s=%s"|format(r.base, r.single.value if r.single else r.base)) %}
+    {% endfor %}
+{{ params|join(", ") }}
+  {% endwith %}
+  {% else %}
 request=request
-  {% endif -%}
+  {% endif %}
 {% endmacro %}
 
 
 {% macro render_method_call(sample, calling_form, calling_form_enum) %}
-  {# Note: this doesn't deal with enums or unions #}
+{# Note: this doesn't deal with enums or unions #}
 {% if calling_form in [calling_form_enum.RequestStreamingBidi,
-                       calling_form_enum.RequestStreamingClient] -%}
-client.{{ sample.rpc|snake_case }}([{{ render_request_params(sample.request.request_list)|trim -}}])
-{% else -%} {# TODO: deal with flattening #}
+                       calling_form_enum.RequestStreamingClient] %}
+client.{{ sample.rpc|snake_case }}([{{ render_request_params(sample.request.request_list)|trim }}])
+{% else %}{# TODO: deal with flattening #}
 {# TODO: set up client streaming once some questions are answered #}
-client.{{ sample.rpc|snake_case }}({{ render_request_params_unary(sample.request)|trim -}})
-{% endif -%}
+client.{{ sample.rpc|snake_case }}({{ render_request_params_unary(sample.request)|trim }})
+{% endif %}
 {% endmacro %}
 
 {# Setting up the method invocation is the responsibility of the caller: #}
@@ -262,15 +261,15 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-{% with arg_list = [] -%}
-{% for request in full_request.request_list if request.body -%}
+{% with arg_list = [] %}
+{% for request in full_request.request_list if request.body %}
 {% for attr in request.body if attr.input_parameter %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
                         default={{ attr.value }})
-{% do arg_list.append("args." + attr.input_parameter) -%}
-{% endfor -%}
-{% endfor -%}
+{% do arg_list.append("args." + attr.input_parameter) %}
+{% endfor %}
+{% endfor %}
 {% for request in full_request.request_list if request.single and request.single.input_parameter %}
     parser.add_argument("--{{ request.single.input_parameter }}",
                         type=str,

--- a/gapic/ads-templates/examples/sample.py.j2
+++ b/gapic/ads-templates/examples/sample.py.j2
@@ -16,6 +16,7 @@
 {% extends "_base.py.j2" %}
 
 {% block content %}
+
 {# Input parameters: sample #}
 {#                   callingForm #}
 {% import "examples/feature_fragments.j2" as frags %}
@@ -29,7 +30,7 @@
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
 
 {# also need calling form #}
-def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input_params(sample.request)|trim -}}):
+def sample_{{ frags.render_method_name(sample.rpc)|trim }}({{ frags.print_input_params(sample.request)|trim }}):
     """{{ sample.description }}"""
 
     client = {{ service.client_name }}(
@@ -37,12 +38,12 @@ def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input
         transport="grpc",
     )
 
-    {{ frags.render_request_setup(sample.request)|indent }} 
-{% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %} 
-    {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response, )|indent -}} 
-{% endwith %} 
+    {{ frags.render_request_setup(sample.request) }}
+{% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %}
+    {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response, )|indent }}
+{% endwith %}
 
 # [END {{ sample.id }}]
 
-{{ frags.render_main_block(sample.rpc, sample.request) }} 
-{%- endblock %}
+{{ frags.render_main_block(sample.rpc, sample.request) }}
+{% endblock %}

--- a/gapic/ads-templates/noxfile.py.j2
+++ b/gapic/ads-templates/noxfile.py.j2
@@ -1,6 +1,7 @@
 {% extends "_base.py.j2" %}
 
 {% block content %}
+
 import os
 
 import nox  # type: ignore
@@ -31,10 +32,10 @@ def mypy(session):
     session.install('.')
     session.run(
         'mypy',
-        {%- if api.naming.module_namespace %}
+        {% if api.naming.module_namespace %}
         '{{ api.naming.module_namespace[0] }}',
-        {%- else %}
+        {% else %}
         '{{ api.naming.versioned_module_name }}',
-        {%- endif %}
+        {% endif %}
     )
 {% endblock %}

--- a/gapic/ads-templates/scripts/fixup_%name_%version_keywords.py.j2
+++ b/gapic/ads-templates/scripts/fixup_%name_%version_keywords.py.j2
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 {% extends '_base.py.j2' %}
 {% block content %}
+
 import argparse
 import os
 import libcst as cst
@@ -25,14 +26,14 @@ def partition(
 
 class {{ api.naming.module_name }}CallTransformer(cst.CSTTransformer):
     CTRL_PARAMS: Tuple[str] = ('retry', 'timeout', 'metadata')
-    {% with all_methods = [] -%}
-    {% for service in api.services.values() %}{% for method in service.methods.values() -%}
-    {% do all_methods.append(method) -%}
-    {% endfor %}{% endfor -%}
+    {% with all_methods = [] %}
+    {% for service in api.services.values() %}{% for method in service.methods.values() %}
+    {% do all_methods.append(method) %}
+    {% endfor %}{% endfor %}
     METHOD_TO_PARAMS: Dict[str, Tuple[str]] = {
-    {% for method in all_methods|sort(attribute='name')|unique(attribute='name') -%}
+    {% for method in all_methods|sort(attribute='name')|unique(attribute='name') %}
           '{{ method.name|snake_case }}': ({% for field in method.legacy_flattened_fields.values() %}'{{ field.name }}', {% endfor %}),
-    {% endfor -%}
+    {% endfor %}
     }
     {% endwith %}
 

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -1,18 +1,19 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import setuptools  # type: ignore
 
 
 setuptools.setup(
     name='{{ api.naming.warehouse_package_name }}',
     version='0.0.1',
-    {% if api.naming.namespace -%}
+    {% if api.naming.namespace %}
     packages=setuptools.PEP420PackageFinder.find(),
     namespace_packages={{ api.naming.namespace_packages }},
-    {% else -%}
+    {% else %}
     packages=setuptools.find_packages(),
-    {% endif -%}
+    {% endif %}
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
@@ -20,9 +21,9 @@ setuptools.setup(
         'googleapis-common-protos >= 1.5.8',
         'grpcio >= 1.10.0',
         'proto-plus >= 1.15.0',
-    {%- if api.requires_package(('google', 'iam', 'v1')) %}
+    {% if api.requires_package(('google', 'iam', 'v1')) %}
         'grpc-google-iam-v1',
-    {%- endif %}
+    {% endif %}
     ),
     python_requires='>=3.7',{# Lazy import requires module-level getattr #}
     setup_requires=[

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1,6 +1,7 @@
 {% extends "_base.py.j2" %}
 
 {% block content %}
+
 import os
 from unittest import mock
 
@@ -10,7 +11,7 @@ import pytest
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 
 {# Import the service itself as well as every proto module that it imports. -#}
-{% filter sort_lines -%}
+{% filter sort_lines %}
 from google import auth
 from google.auth import credentials
 from google.auth.exceptions import MutualTLSChannelError
@@ -19,19 +20,19 @@ from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + ser
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import transports
 from google.api_core import client_options
 from google.api_core import grpc_helpers
-{% if service.has_lro -%}
+{% if service.has_lro %}
 from google.api_core import future
 from google.api_core import operations_v1
 from google.longrunning import operations_pb2
-{% endif -%}
+{% endif %}
 from google.api_core import gapic_v1
-{% for method in service.methods.values() -%}
+{% for method in service.methods.values() %}
 {% for ref_type in method.ref_types
    if not ((ref_type.ident.python_import.package == ('google', 'api_core') and ref_type.ident.python_import.module == 'operation')
-           or ref_type.ident.python_import.package == ('google', 'protobuf') and ref_type.ident.python_import.module == 'empty_pb2') -%}
+           or ref_type.ident.python_import.package == ('google', 'protobuf') and ref_type.ident.python_import.module == 'empty_pb2') %}
 {{ ref_type.ident.python_import }}
-{% endfor -%}
-{% endfor -%}
+{% endfor %}
+{% endfor %}
 {% endfilter %}
 
 
@@ -246,7 +247,7 @@ def test_{{ service.client_name|snake_case }}_client_options_from_dict():
         )
 
 
-{% for method in service.methods.values() -%}
+{% for method in service.methods.values() %}
 def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ method.input.ident }}):
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
@@ -265,25 +266,25 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/spam')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}(
-            {%- for field in method.output.fields.values() | rejectattr('message')%}{% if not field.oneof or field.proto3_optional %}
+            {% for field in method.output.fields.values() | rejectattr('message')%}{% if not field.oneof or field.proto3_optional %}
             {{ field.name }}={{ field.mock_value }},
-            {% endif %}{%- endfor %}
+            {% endif %}{% endfor %}
             {#- This is a hack to only pick one field  #}
-            {%- for oneof_fields in method.output.oneof_fields().values() %}
+            {% for oneof_fields in method.output.oneof_fields().values() %}
             {% with field = oneof_fields[0] %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endwith %}
-            {%- endfor %}
+            {% endwith %}
+            {% endfor %}
         )
-        {% endif -%}
+        {% endif %}
         {% if method.client_streaming %}
         response = client.{{ method.name|snake_case }}(iter(requests))
         {% else %}
@@ -300,28 +301,28 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
         {% endif %}
 
     # Establish that the response is the type that we expect.
-    {% if method.void -%}
+    {% if method.void %}
     assert response is None
-    {% elif method.lro -%}
+    {% elif method.lro %}
     assert isinstance(response, future.Future)
-    {% elif method.server_streaming -%}
+    {% elif method.server_streaming %}
     for message in response:
         assert isinstance(message, {{ method.output.ident }})
-    {% else -%}
+    {% else %}
     {% if "next_page_token" in method.output.fields.values()|map(attribute='name') and not method.paged_result_field %}
     {# Cheeser assertion to force code coverage for bad paginated methods #}
     assert response.raw_page is response
     {% endif %}
     assert isinstance(response, {{ method.client_output.ident }})
-    {% for field in method.output.fields.values() | rejectattr('message') -%}{% if not field.oneof or field.proto3_optional %}
-    {% if field.field_pb.type in [1, 2] -%} {# Use approx eq for floats -#}
+    {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
+    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 -%} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
-    {% else -%}
+    {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
-    {% endif -%}
-    {% endif -%} {# end oneof/optional #}
+    {% endif %}
+    {% endif %} {# end oneof/optional #}
     {% endfor %}
     {% endif %}
 
@@ -340,21 +341,21 @@ def test_{{ method.name|snake_case }}_field_headers():
     # a field header. Set these to a non-empty value.
     request = {{ method.input.ident }}()
 
-    {%- for field_header in method.field_headers %}
+    {% for field_header in method.field_headers %}
     request.{{ field_header }} = '{{ field_header }}/value'
-    {%- endfor %}
+    {% endfor %}
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
         client.{{ method.name|snake_case }}(request)
@@ -368,10 +369,10 @@ def test_{{ method.name|snake_case }}_field_headers():
     _, _, kw = call.mock_calls[0]
     assert (
         'x-goog-request-params',
-        '{% for field_header in method.field_headers -%}
+        '{% for field_header in method.field_headers %}
         {{ field_header }}={{ field_header }}/value
-        {%- if not loop.last %}&{% endif -%}
-        {%- endfor %}',
+        {% if not loop.last %}&{% endif %}
+        {% endfor %}',
     ) in kw['metadata']
 {% endif %}
 
@@ -385,19 +386,19 @@ def test_{{ method.name|snake_case }}_from_dict():
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
         response = client.{{ method.name|snake_case }}(request={
-            {%- for field in method.input.fields.values() %}
+            {% for field in method.input.fields.values() %}
             '{{ field.name }}': {{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
             }
         )
         call.assert_called()
@@ -415,41 +416,41 @@ def test_{{ method.name|snake_case }}_flattened():
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.{{ method.name|snake_case }}(
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-        {% for key, field in method.flattened_fields.items() -%}{%- if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' -%}
+        {% for key, field in method.flattened_fields.items() %}{% if not field.oneof or field.proto3_optional %}
+        {% if field.ident|string() == 'timestamp.Timestamp' %}
         assert TimestampRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' -%}
+        {% elif field.ident|string() == 'duration.Duration' %}
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% else -%}
+        {% else %}
         assert args[0].{{ key }} == {{ field.mock_value }}
         {% endif %}
         {% endif %}{% endfor %}
-        {%- for oneofs in method.flattened_oneof_fields().values() %}
-        {%- with field = oneofs[-1]  %}
+        {% for oneofs in method.flattened_oneof_fields().values() %}
+        {% with field = oneofs[-1]  %}
         assert args[0].{{ method.flattened_field_to_key[field.name] }} == {{ field.mock_value }}
-        {%- endwith %}
-        {%- endfor %}
+        {% endwith %}
+        {% endfor %}
 
 
 def test_{{ method.name|snake_case }}_flattened_error():
@@ -462,9 +463,9 @@ def test_{{ method.name|snake_case }}_flattened_error():
     with pytest.raises(ValueError):
         client.{{ method.name|snake_case }}(
             {{ method.input.ident }}(),
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
 {% endif %}
 
@@ -509,17 +510,17 @@ def test_{{ method.name|snake_case }}_pager():
         )
 
         metadata = ()
-        {% if method.field_headers -%}
+        {% if method.field_headers %}
         metadata = tuple(metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
-                {%- for field_header in method.field_headers %}
-                {%- if not method.client_streaming %}
+                {% for field_header in method.field_headers %}
+                {% if not method.client_streaming %}
                 ('{{ field_header }}', ''),
-                {%- endif %}
-                {%- endfor %}
+                {% endif %}
+                {% endfor %}
             )),
         )
-        {% endif -%}
+        {% endif %}
         pager = client.{{ method.name|snake_case }}(request={})
 
         assert pager._metadata == metadata
@@ -575,7 +576,7 @@ def test_{{ method.name|snake_case }}_raw_page_lro():
     assert response.raw_page is response
 {% endif %} {#- method.paged_result_field #}
 
-{% endfor -%} {#- method in methods #}
+{% endfor %} {#- method in methods #}
 
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
@@ -639,15 +640,15 @@ def test_{{ service.name|snake_case }}_base_transport():
     # Every method on the transport should just blindly
     # raise NotImplementedError.
     methods = (
-        {% for method in service.methods.values() -%}
+        {% for method in service.methods.values() %}
         '{{ method.name|snake_case }}',
-        {% endfor -%}
+        {% endfor %}
     )
     for method in methods:
         with pytest.raises(NotImplementedError):
             getattr(transport, method)(request=object())
 
-    {% if service.has_lro -%}
+    {% if service.has_lro %}
     # Additionally, the LRO client (a property) should
     # also raise NotImplementedError
     with pytest.raises(NotImplementedError):
@@ -670,9 +671,9 @@ def test_{{ service.name|snake_case }}_auth_adc():
         adc.return_value = (credentials.AnonymousCredentials(), None)
         {{ service.client_name }}()
         adc.assert_called_once_with(scopes=(
-            {%- for scope in service.oauth_scopes %}
+            {% for scope in service.oauth_scopes %}
             '{{ scope }}',
-            {%- endfor %}
+            {% endfor %}
         ))
 
 
@@ -683,14 +684,14 @@ def test_{{ service.name|snake_case }}_transport_auth_adc():
         adc.return_value = (credentials.AnonymousCredentials(), None)
         transports.{{ service.name }}GrpcTransport(host="squid.clam.whelk")
         adc.assert_called_once_with(scopes=(
-            {%- for scope in service.oauth_scopes %}
+            {% for scope in service.oauth_scopes %}
             '{{ scope }}',
-            {%- endfor %}
+            {% endfor %}
         ))
 
 
 def test_{{ service.name|snake_case }}_host_no_port():
-    {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
+    {% with host = (service.host|default('localhost', true)).split(':')[0] %}
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}'),
@@ -700,7 +701,7 @@ def test_{{ service.name|snake_case }}_host_no_port():
 
 
 def test_{{ service.name|snake_case }}_host_with_port():
-    {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
+    {% with host = (service.host|default('localhost', true)).split(':')[0] %}
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}:8000'),
@@ -753,9 +754,9 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                 credentials=cred,
                 credentials_file=None,
                 scopes=(
-                    {%- for scope in service.oauth_scopes %}
+                    {% for scope in service.oauth_scopes %}
                     '{{ scope }}',
-                    {%- endfor %}
+                    {% endfor %}
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
@@ -796,9 +797,9 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
                 credentials=mock_cred,
                 credentials_file=None,
                 scopes=(
-                    {%- for scope in service.oauth_scopes %}
+                    {% for scope in service.oauth_scopes %}
                     '{{ scope }}',
-                    {%- endfor %}
+                    {% endfor %}
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
@@ -810,7 +811,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
             assert transport.grpc_channel == mock_grpc_channel
 
 
-{% if service.has_lro -%}
+{% if service.has_lro %}
 def test_{{ service.name|snake_case }}_grpc_lro_client():
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
@@ -827,12 +828,12 @@ def test_{{ service.name|snake_case }}_grpc_lro_client():
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
 
-{% endif -%}
+{% endif %}
 
-{% with molluscs = cycler("squid", "clam", "whelk", "octopus", "oyster", "nudibranch", "cuttlefish", "mussel", "winkle", "nautilus", "scallop", "abalone") -%}
-{% for message in service.resource_messages|sort(attribute="resource_type") -%}
+{% with molluscs = cycler("squid", "clam", "whelk", "octopus", "oyster", "nudibranch", "cuttlefish", "mussel", "winkle", "nautilus", "scallop", "abalone") %}
+{% for message in service.resource_messages|sort(attribute="resource_type") %}
 def test_{{ message.resource_type|snake_case }}_path():
-    {% for arg in message.resource_path_args -%}
+    {% for arg in message.resource_path_args %}
     {{ arg }} = "{{ molluscs.next() }}"
     {% endfor %}
     expected = "{{ message.resource_path }}".format({% for arg in message.resource_path_args %}{{ arg }}={{ arg }}, {% endfor %})
@@ -842,7 +843,7 @@ def test_{{ message.resource_type|snake_case }}_path():
 
 def test_parse_{{ message.resource_type|snake_case }}_path():
     expected = {
-    {% for arg in message.resource_path_args -%}
+    {% for arg in message.resource_path_args %}
         "{{ arg }}": "{{ molluscs.next() }}",
     {% endfor %}
     }
@@ -852,10 +853,10 @@ def test_parse_{{ message.resource_type|snake_case }}_path():
     actual = {{ service.client_name }}.parse_{{ message.resource_type|snake_case }}_path(path)
     assert expected == actual
 
-{% endfor -%}
-{% for resource_msg in service.common_resources.values()|sort(attribute="type_name") -%}
+{% endfor %}
+{% for resource_msg in service.common_resources.values()|sort(attribute="type_name") %}
 def test_common_{{ resource_msg.message_type.resource_type|snake_case }}_path():
-    {% for arg in resource_msg.message_type.resource_path_args -%}
+    {% for arg in resource_msg.message_type.resource_path_args %}
     {{ arg }} = "{{ molluscs.next() }}"
     {% endfor %}
     expected = "{{ resource_msg.message_type.resource_path }}".format({% for arg in resource_msg.message_type.resource_path_args %}{{ arg }}={{ arg }}, {% endfor %})
@@ -865,7 +866,7 @@ def test_common_{{ resource_msg.message_type.resource_type|snake_case }}_path():
 
 def test_parse_common_{{ resource_msg.message_type.resource_type|snake_case }}_path():
     expected = {
-    {% for arg in resource_msg.message_type.resource_path_args -%}
+    {% for arg in resource_msg.message_type.resource_path_args %}
         "{{ arg }}": "{{ molluscs.next() }}",
     {% endfor %}
     }
@@ -875,8 +876,8 @@ def test_parse_common_{{ resource_msg.message_type.resource_type|snake_case }}_p
     actual = {{ service.client_name }}.parse_common_{{ resource_msg.message_type.resource_type|snake_case }}_path(path)
     assert expected == actual
 
-{% endfor -%} {# common resources#}
-{% endwith -%} {# cycler #}
+{% endfor %} {# common resources#}
+{% endwith %} {# cycler #}
 
 def test_client_withDEFAULT_CLIENT_INFO():
     client_info = gapic_v1.client_info.ClientInfo()

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -70,7 +70,9 @@ def test_{{ service.client_name|snake_case }}_from_service_account_info():
         client = {{ service.client_name }}.from_service_account_info(info)
         assert client.transport._credentials == creds
 
-        {% if service.host %}assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
+        {% if service.host %}
+        assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'
+        {% endif %}
 
 
 def test_{{ service.client_name|snake_case }}_from_service_account_file():
@@ -83,7 +85,9 @@ def test_{{ service.client_name|snake_case }}_from_service_account_file():
         client = {{ service.client_name }}.from_service_account_json("dummy/file/path.json")
         assert client.transport._credentials == creds
 
-        {% if service.host %}assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
+        {% if service.host %}
+        assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'
+        {% endif %}
 
 
 def test_{{ service.client_name|snake_case }}_get_transport_class():
@@ -274,10 +278,11 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
         call.return_value = iter([{{ method.output.ident }}()])
         {% else %}
         call.return_value = {{ method.output.ident }}(
-            {% for field in method.output.fields.values() | rejectattr('message')%}{% if not field.oneof or field.proto3_optional %}
+            {% for field in method.output.fields.values() | rejectattr('message')%}
+            {% if not field.oneof or field.proto3_optional %}
             {{ field.name }}={{ field.mock_value }},
             {% endif %}{% endfor %}
-            {#- This is a hack to only pick one field  #}
+            {# This is a hack to only pick one field  #}
             {% for oneof_fields in method.output.oneof_fields().values() %}
             {% with field = oneof_fields[0] %}
             {{ field.name }}={{ field.mock_value }},
@@ -314,15 +319,16 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
     assert response.raw_page is response
     {% endif %}
     assert isinstance(response, {{ method.client_output.ident }})
-    {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
-    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
+    {% for field in method.output.fields.values() | rejectattr('message') %}
+    {% if not field.oneof or field.proto3_optional %}
+    {% if field.field_pb.type in [1, 2] %}{# Use approx eq for floats #}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %}{# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
     {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
     {% endif %}
-    {% endif %} {# end oneof/optional #}
+    {% endif %}{# end oneof/optional #}
     {% endfor %}
     {% endif %}
 
@@ -369,10 +375,10 @@ def test_{{ method.name|snake_case }}_field_headers():
     _, _, kw = call.mock_calls[0]
     assert (
         'x-goog-request-params',
-        '{% for field_header in method.field_headers %}
+        '{% for field_header in method.field_headers -%}
         {{ field_header }}={{ field_header }}/value
-        {% if not loop.last %}&{% endif %}
-        {% endfor %}',
+        {%- if not loop.last %}&{% endif %}
+        {%- endfor -%}',
     ) in kw['metadata']
 {% endif %}
 

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/test_module_import.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/test_module_import.py.j2
@@ -1,8 +1,9 @@
 {% extends "_base.py.j2" %}
 {% block content %}
-{% if opts.lazy_import -%} {# lazy import #}
+
+{% if opts.lazy_import %} {# lazy import #}
 import pytest
-  
+
 
 def test_module_level_imports():
     expected_names = []
@@ -11,23 +12,23 @@ def test_module_level_imports():
     {% for message in api.top_level_messages.values() %}
     from {{ api.naming.module_namespace|join('.') }}.{{ api.naming.module_name }} import {{ message.name }}
     expected_names.append({{ message.name }}.__name__)
-    {%- endfor %}
+    {% endfor %}
 
     {% if api.top_level_enums %}# Enum types{% endif %}
-    {%- for enum in api.top_level_enums.values() %}
+    {% for enum in api.top_level_enums.values() %}
     from {{ api.naming.module_namespace|join('.') }}.{{ api.naming.module_name }} import {{ enum.name }}
     expected_names.append({{ enum.name }}.__name__)
-    {%- endfor %}
+    {% endfor %}
 
     # Client and transport classes
-    {%- for service in api.services.values() %}
+    {% for service in api.services.values() %}
     from {{ api.naming.module_namespace|join('.')}}.{{ api.naming.module_name }} import {{ service.client_name }}
     expected_names.append({{ service.client_name}}.__name__)
     from {{ api.naming.module_namespace|join('.')}}.{{ api.naming.module_name }} import {{ service.transport_name }}
     expected_names.append({{ service.transport_name }}.__name__)
     from {{ api.naming.module_namespace|join('.')}}.{{ api.naming.module_name }} import {{ service.grpc_transport_name }}
     expected_names.append({{ service.grpc_transport_name }}.__name__)
-    {%- endfor %}
+    {% endfor %}
 
     expected_names.sort()
     from {{ api.naming.module_namespace|join('.') }} import {{ api.naming.module_name }}
@@ -47,23 +48,23 @@ def test_versionsed_module_level_imports():
     {% for message in api.top_level_messages.values() %}
     from {{ api.naming.module_namespace|join('.') }}.{{ api.naming.versioned_module_name }} import {{ message.name }}
     expected_names.append({{ message.name }}.__name__)
-    {%- endfor %}
+    {% endfor %}
 
     {% if api.top_level_enums %}# Enum types{% endif %}
-    {%- for enum in api.top_level_enums.values() %}
+    {% for enum in api.top_level_enums.values() %}
     from {{ api.naming.module_namespace|join('.') }}.{{ api.naming.versioned_module_name }} import {{ enum.name }}
     expected_names.append({{ enum.name }}.__name__)
-    {%- endfor %}
+    {% endfor %}
 
     # Client and transport classes
-    {%- for service in api.services.values() %}
+    {% for service in api.services.values() %}
     from {{ api.naming.module_namespace|join('.')}}.{{ api.naming.versioned_module_name }} import {{ service.client_name }}
     expected_names.append({{ service.client_name}}.__name__)
     from {{ api.naming.module_namespace|join('.')}}.{{ api.naming.versioned_module_name }} import {{ service.transport_name }}
     expected_names.append({{ service.transport_name }}.__name__)
     from {{ api.naming.module_namespace|join('.')}}.{{ api.naming.versioned_module_name }} import {{ service.grpc_transport_name }}
     expected_names.append({{ service.grpc_transport_name }}.__name__)
-    {%- endfor %}
+    {% endfor %}
 
     expected_names.sort()
     from {{ api.naming.module_namespace|join('.') }}.{{ api.naming.module_name }} import {{ api.naming.version }}
@@ -73,7 +74,7 @@ def test_versionsed_module_level_imports():
     # Verify the logic for handling non-existant names
     with pytest.raises(ImportError):
         from {{ api.naming.module_namespace|join('.' )}}.{{ api.naming.versioned_module_name }} import GiantSquid
-    
-    
-{% endif -%} {# lazy import #}
+
+
+{% endif %} {# lazy import #}
 {% endblock %}

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -49,6 +49,8 @@ class Generator:
             loader=jinja2.FileSystemLoader(searchpath=opts.templates),
             undefined=jinja2.StrictUndefined,
             extensions=["jinja2.ext.do"],
+            trim_blocks=True,
+            lstrip_blocks=True,
         )
 
         # Add filters which templates require.

--- a/gapic/templates/%namespace/%name/__init__.py.j2
+++ b/gapic/templates/%namespace/%name/__init__.py.j2
@@ -1,71 +1,73 @@
 {% extends '_base.py.j2' %}
 {% block content %}
-{#  Import subpackages. -#}
-{% filter sort_lines -%}
-{% for subpackage in api.subpackages.keys() -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }} import {{ subpackage }}
-{% endfor -%}
 
-{#  Import services for this package. -#}
+{#  Import subpackages. -#}
+{% filter sort_lines %}
+{% for subpackage in api.subpackages.keys() %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }} import {{ subpackage }}
+{% endfor %}
+
+{#  Import services for this package. #}
 {% for service in api.services.values()|sort(attribute='name')
-        if service.meta.address.subpackage == api.subpackage_view -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.client_name }}
-{%- if 'grpc' in opts.transport %}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.async_client import {{ service.async_client_name }}
-{%- endif %}
-{% endfor -%}
+        if service.meta.address.subpackage == api.subpackage_view %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.client import {{ service.client_name }}
+{% if 'grpc' in opts.transport %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }}.services.{{ service.name|snake_case }}.async_client import {{ service.async_client_name }}
+{% endif %}
+{% endfor %}
 
 {#  Import messages and enums from each proto.
     It is safe to import all of the messages into the same namespace here,
     because protocol buffers itself enforces selector uniqueness within
     a proto package.
--#}
+#}
 {#  Import messages from each proto.
     It is safe to import all of the messages into the same namespace here,
     because protocol buffers itself enforces selector uniqueness within
     a proto package.
-  -#}
+  #}
 {% for proto in api.protos.values()|sort(attribute='module_name')
-        if proto.meta.address.subpackage == api.subpackage_view -%}
-  {% for message in proto.messages.values()|sort(attribute='name') -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
-{% endfor -%}
-{% for enum in proto.enums.values()|sort(attribute='name') -%}
-from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif -%}
-    {{ api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ enum.name }}
-{% endfor %}{% endfor -%}
+        if proto.meta.address.subpackage == api.subpackage_view %}
+  {% for message in proto.messages.values()|sort(attribute='name') %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ message.name }}
+{% endfor %}
+{% for enum in proto.enums.values()|sort(attribute='name') %}
+from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.') }}.{% endif %}
+    {{- api.naming.versioned_module_name }}.types.{{ proto.module_name }} import {{ enum.name }}
+{% endfor %}{% endfor %}
 {% endfilter %}
 {#  Define __all__.
     This requires the full set of imported names, so we iterate over
     them again.
--#}
+#}
+
 __all__ = (
 {%- filter indent %}
-{% filter sort_lines -%}
-{% for subpackage, _ in api.subpackages|dictsort -%}
+{% filter sort_lines %}
+{% for subpackage, _ in api.subpackages|dictsort %}
 '{{ subpackage }}',
-{% endfor -%}
+{% endfor %}
 {% for service in api.services.values()|sort(attribute='name')
-   if service.meta.address.subpackage == api.subpackage_view -%}
+   if service.meta.address.subpackage == api.subpackage_view %}
 '{{ service.client_name }}',
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
 '{{ service.async_client_name }}',
-    {%- endif %}
-{% endfor -%}
+    {% endif %}
+{% endfor %}
 {% for proto in api.protos.values()|sort(attribute='module_name')
-   if proto.meta.address.subpackage == api.subpackage_view -%}
-{% for message in proto.messages.values()|sort(attribute='name') -%}
+   if proto.meta.address.subpackage == api.subpackage_view %}
+{% for message in proto.messages.values()|sort(attribute='name') %}
 '{{ message.name }}',
-{% endfor -%}
+{% endfor %}
 {% for enum in proto.enums.values()|sort(attribute='name')
-   if proto.meta.address.subpackage == api.subpackage_view -%}
+   if proto.meta.address.subpackage == api.subpackage_view %}
 '{{ enum.name }}',
-{% endfor -%}{% endfor -%}
-{% endfilter -%}
-{% endfilter -%}
+{% endfor %}{% endfor %}
+{% endfilter %}
+{% endfilter %}
 )
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -1,34 +1,35 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 {#  Import subpackages. -#}
-{% for subpackage, _ in api.subpackages|dictsort -%}
+{% for subpackage, _ in api.subpackages|dictsort %}
 from . import {{ subpackage }}
-{% endfor -%}
+{% endfor %}
 
 {#  Import services for this package. -#}
-{% filter sort_lines -%}
+{% filter sort_lines %}
 {% for service in api.services.values()|sort(attribute='name')
-        if service.meta.address.subpackage == api.subpackage_view -%}
+        if service.meta.address.subpackage == api.subpackage_view %}
 from .services.{{ service.name|snake_case }} import {{ service.client_name }}
-{% endfor -%}
-{% endfilter -%}
+{% endfor %}
+{% endfilter %}
 
 {#  Import messages and enums from each proto.
     It is safe to import all of the messages into the same namespace here,
     because protocol buffers itself enforces selector uniqueness within
     a proto package.
 -#}
-{% filter sort_lines -%}
+{% filter sort_lines %}
 {% for proto in api.protos.values()
-        if proto.meta.address.subpackage == api.subpackage_view -%}
-{% for message in proto.messages.values() -%}
+        if proto.meta.address.subpackage == api.subpackage_view %}
+{% for message in proto.messages.values() %}
 from .types.{{ proto.module_name }} import {{ message.name }}
-{% endfor -%}
-{% for enum in proto.enums.values() -%}
+{% endfor %}
+{% for enum in proto.enums.values() %}
 from .types.{{ proto.module_name }} import {{ enum.name }}
-{% endfor -%}
-{% endfor -%}
+{% endfor %}
+{% endfor %}
 {% endfilter %}
 
 {#  Define __all__.
@@ -36,23 +37,23 @@ from .types.{{ proto.module_name }} import {{ enum.name }}
     them again.
 -#}
 __all__ = (
-    {%- filter sort_lines %}
-    {%- for subpackage in api.subpackages.keys() %}
+    {% filter sort_lines %}
+    {% for subpackage in api.subpackages.keys() %}
     '{{ subpackage }}',
-    {%- endfor %}
-    {%- for service in api.services.values()
+    {% endfor %}
+    {% for service in api.services.values()
             if service.meta.address.subpackage == api.subpackage_view %}
     '{{ service.client_name }}',
-    {%- endfor %}
-    {%- for proto in api.protos.values()
+    {% endfor %}
+    {% for proto in api.protos.values()
             if proto.meta.address.subpackage == api.subpackage_view %}
-    {%- for message in proto.messages.values() %}
+    {% for message in proto.messages.values() %}
     '{{ message.name }}',
-    {%- endfor %}
-    {%- for enum in proto.enums.values() %}
+    {% endfor %}
+    {% for enum in proto.enums.values() %}
     '{{ enum.name }}',
-    {%- endfor %}
-    {%- endfor %}
-    {%- endfilter %}
+    {% endfor %}
+    {% endfor %}
+    {% endfilter %}
 )
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/__init__.py.j2
@@ -1,15 +1,16 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 from .client import {{ service.client_name }}
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 from .async_client import {{ service.async_client_name }}
-{%- endif %}
+{% endif %}
 
 __all__ = (
     '{{ service.client_name }}',
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     '{{ service.async_client_name }}',
-    {%- endif %}
+    {% endif %}
 )
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -141,7 +141,7 @@ class {{ service.async_client_name }}:
         )
 
     {% for method in service.methods.values() %}
-    {% if not method.server_streaming %}async {% endif %}def {{ method.name|snake_case }}(self,
+    {%+ if not method.server_streaming %}async {% endif %}def {{ method.name|snake_case }}(self,
             {% if not method.client_streaming %}
             request: {{ method.input.ident }} = None,
             *,
@@ -219,7 +219,7 @@ class {{ service.async_client_name }}:
         request = {{ method.input.ident }}(request)
         {% endif %} {# different request package #}
 
-        {#- Vanilla python protobuf wrapper types cannot _set_ repeated fields #}
+        {# Vanilla python protobuf wrapper types cannot _set_ repeated fields #}
         {% if method.flattened_fields and method.input.ident.package == method.ident.package %}
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
@@ -234,7 +234,7 @@ class {{ service.async_client_name }}:
         if {{ field.name }}:
             request.{{ key }}.update({{ field.name }})
         {% endfor %}
-        {# And list-y fields can be _extended_ -#}
+        {# And list-y fields can be _extended_ #}
         {% for key, field in method.flattened_fields.items() if field.repeated and not field.map and method.input.ident.package == method.ident.package %}
         if {{ field.name }}:
             request.{{ key }}.extend({{ field.name }})
@@ -277,8 +277,7 @@ class {{ service.async_client_name }}:
         {% endif %}
 
         # Send the request.
-        {% if not method.void %}
-        response = {% endif %}
+        {%+ if not method.void %}response = {% endif %}
         {% if not method.server_streaming %}await {% endif %}rpc(
             {% if not method.client_streaming %}
             request,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 from collections import OrderedDict
 import functools
 import re
@@ -14,12 +15,12 @@ from google.api_core import retry as retries           # type: ignore
 from google.auth import credentials                    # type: ignore
 from google.oauth2 import service_account              # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
-{% for ref_type in method.flat_ref_types -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
+{% for ref_type in method.flat_ref_types %}
 {{ ref_type.ident.python_import }}
-{% endfor -%}
-{% endfor -%}
+{% endfor %}
+{% endfor %}
 {% if opts.add_iam_methods %}
 from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
 from google.iam.v1 import policy_pb2 as policy  # type: ignore
@@ -39,7 +40,7 @@ class {{ service.async_client_name }}:
     DEFAULT_ENDPOINT = {{ service.client_name }}.DEFAULT_ENDPOINT
     DEFAULT_MTLS_ENDPOINT = {{ service.client_name }}.DEFAULT_MTLS_ENDPOINT
 
-    {% for message in service.resource_messages|sort(attribute="resource_type") -%}
+    {% for message in service.resource_messages|sort(attribute="resource_type") %}
     {{ message.resource_type|snake_case }}_path = staticmethod({{ service.client_name }}.{{ message.resource_type|snake_case }}_path)
     parse_{{ message.resource_type|snake_case}}_path = staticmethod({{ service.client_name }}.parse_{{ message.resource_type|snake_case }}_path)
     {% endfor %}
@@ -139,64 +140,64 @@ class {{ service.async_client_name }}:
 
         )
 
-    {% for method in service.methods.values() -%}
-    {% if not method.server_streaming %}async {% endif -%}def {{ method.name|snake_case }}(self,
-            {%- if not method.client_streaming %}
+    {% for method in service.methods.values() %}
+    {% if not method.server_streaming %}async {% endif %}def {{ method.name|snake_case }}(self,
+            {% if not method.client_streaming %}
             request: {{ method.input.ident }} = None,
             *,
-            {% for field in method.flattened_fields.values() -%}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}: {{ field.ident }} = None,
-            {% endfor -%}
-            {%- else %}
+            {% endfor %}
+            {% else %}
             requests: AsyncIterator[{{ method.input.ident }}] = None,
             *,
-            {% endif -%}
+            {% endif %}
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            {%- if not method.server_streaming %}
+            {% if not method.server_streaming %}
             ) -> {{ method.client_output_async.ident }}:
-            {%- else %}
+            {% else %}
             ) -> Awaitable[AsyncIterable[{{ method.client_output_async.ident }}]]:
-            {%- endif %}
+            {% endif %}
         r"""{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
-            {%- if not method.client_streaming %}
+            {% if not method.client_streaming %}
             request (:class:`{{ method.input.ident.sphinx }}`):
-                The request object.{{ ' ' -}}
+                The request object.{{ ' ' }}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
-            {% for key, field in method.flattened_fields.items() -%}
+            {% for key, field in method.flattened_fields.items() %}
             {{ field.name }} (:class:`{{ field.ident.sphinx }}`):
                 {{ field.meta.doc|rst(width=72, indent=16) }}
                 This corresponds to the ``{{ key }}`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-            {% endfor -%}
-            {%- else %}
+            {% endfor %}
+            {% else %}
             requests (AsyncIterator[`{{ method.input.ident.sphinx }}`]):
-                The request object AsyncIterator.{{ ' ' -}}
+                The request object AsyncIterator.{{ ' ' }}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
-            {%- endif %}
+            {% endif %}
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
-        {%- if not method.void %}
+        {% if not method.void %}
 
         Returns:
-            {%- if not method.server_streaming %}
+            {% if not method.server_streaming %}
             {{ method.client_output_async.ident.sphinx }}:
-            {%- else %}
+            {% else %}
             AsyncIterable[{{ method.client_output_async.ident.sphinx }}]:
-            {%- endif %}
+            {% endif %}
                 {{ method.client_output_async.meta.doc|rst(width=72, indent=16, source_format='rst') }}
-        {%- endif %}
+        {% endif %}
         """
-        {%- if not method.client_streaming %}
+        {% if not method.client_streaming %}
         # Create or coerce a protobuf request object.
-        {% if method.flattened_fields -%}
+        {% if method.flattened_fields %}
         # Sanity check: If we got a request object, we should *not* have
         # gotten any keyword arguments that map to the request.
         has_flattened_params = any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}])
@@ -204,90 +205,91 @@ class {{ service.async_client_name }}:
             raise ValueError('If the `request` argument is set, then none of '
                              'the individual field arguments should be set.')
 
-        {% endif -%}
-        {% if method.input.ident.package != method.ident.package -%} {# request lives in a different package, so there is no proto wrapper #}
+        {% endif %}
+        {% if method.input.ident.package != method.ident.package %} {# request lives in a different package, so there is no proto wrapper #}
         # The request isn't a proto-plus wrapped type,
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
             request = {{ method.input.ident }}(**request)
-        {% if method.flattened_fields -%}{# Cross-package req and flattened fields #}
+        {% if method.flattened_fields %}{# Cross-package req and flattened fields #}
         elif not request:
             request = {{ method.input.ident }}({% if method.input.ident.package != method.ident.package %}{% for f in method.flattened_fields.values() %}{{ f.name }}={{ f.name }}, {% endfor %}{% endif %})
-        {% endif -%}{# Cross-package req and flattened fields #}
-        {%- else %}
+        {% endif %}{# Cross-package req and flattened fields #}
+        {% else %}
         request = {{ method.input.ident }}(request)
         {% endif %} {# different request package #}
 
         {#- Vanilla python protobuf wrapper types cannot _set_ repeated fields #}
-        {% if method.flattened_fields and method.input.ident.package == method.ident.package -%}
+        {% if method.flattened_fields and method.input.ident.package == method.ident.package %}
         # If we have keyword arguments corresponding to fields on the
         # request, apply these.
-        {% endif -%}
-        {%- for key, field in method.flattened_fields.items() if not field.repeated and method.input.ident.package == method.ident.package %}
+        {% endif %}
+        {% for key, field in method.flattened_fields.items() if not field.repeated and method.input.ident.package == method.ident.package %}
         if {{ field.name }} is not None:
             request.{{ key }} = {{ field.name }}
-        {%- endfor %}
+        {% endfor %}
         {# Map-y fields can be _updated_, however #}
-        {%- for key, field in method.flattened_fields.items() if field.map and method.input.ident.package == method.ident.package %}
+        {% for key, field in method.flattened_fields.items() if field.map and method.input.ident.package == method.ident.package %}
 
         if {{ field.name }}:
             request.{{ key }}.update({{ field.name }})
-        {%- endfor %}
+        {% endfor %}
         {# And list-y fields can be _extended_ -#}
-        {%- for key, field in method.flattened_fields.items() if field.repeated and not field.map and method.input.ident.package == method.ident.package %}
+        {% for key, field in method.flattened_fields.items() if field.repeated and not field.map and method.input.ident.package == method.ident.package %}
         if {{ field.name }}:
             request.{{ key }}.extend({{ field.name }})
-        {%- endfor %}
-        {%- endif %}
+        {% endfor %}
+        {% endif %}
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
         rpc = gapic_v1.method_async.wrap_method(
             self._client._transport.{{ method.name|snake_case }},
-            {%- if method.retry %}
+            {% if method.retry %}
             default_retry=retries.Retry(
                 {% if method.retry.initial_backoff %}initial={{ method.retry.initial_backoff }},{% endif %}
                 {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
                 {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                 predicate=retries.if_exception_type(
-                    {%- for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
+                    {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
                     exceptions.{{ ex.__name__ }},
-                    {%- endfor %}
+                    {% endfor %}
                 ),
                 deadline={{ method.timeout }},
             ),
-            {%- endif %}
+            {% endif %}
             default_timeout={{ method.timeout }},
             client_info=DEFAULT_CLIENT_INFO,
         )
-        {%- if method.field_headers %}
+        {% if method.field_headers %}
 
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
-                {%- for field_header in method.field_headers %}
-                {%- if not method.client_streaming %}
+                {% for field_header in method.field_headers %}
+                {% if not method.client_streaming %}
                 ('{{ field_header }}', request.{{ field_header }}),
-                {%- endif %}
-                {%- endfor %}
+                {% endif %}
+                {% endfor %}
             )),
         )
-        {%- endif %}
+        {% endif %}
 
         # Send the request.
-        {% if not method.void %}response = {% endif %}
-        {%- if not method.server_streaming %}await {% endif %}rpc(
-            {%- if not method.client_streaming %}
+        {% if not method.void %}
+        response = {% endif %}
+        {% if not method.server_streaming %}await {% endif %}rpc(
+            {% if not method.client_streaming %}
             request,
-            {%- else %}
+            {% else %}
             requests,
-            {%- endif %}
+            {% endif %}
             retry=retry,
             timeout=timeout,
             metadata=metadata,
         )
-        {%- if method.lro %}
+        {% if method.lro %}
 
         # Wrap the response in an operation future.
         response = {{ method.client_output_async.ident.module_alias or method.client_output_async.ident.module }}.from_gapic(
@@ -296,7 +298,7 @@ class {{ service.async_client_name }}:
             {{ method.lro.response_type.ident }},
             metadata_type={{ method.lro.metadata_type.ident }},
         )
-        {%- elif method.paged_result_field %}
+        {% elif method.paged_result_field %}
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -306,12 +308,12 @@ class {{ service.async_client_name }}:
             response=response,
             metadata=metadata,
         )
-        {%- endif %}
-        {%- if not method.void %}
+        {% endif %}
+        {% if not method.void %}
 
         # Done; return the response.
         return response
-        {%- endif %}
+        {% endif %}
         {{ '\n' }}
     {% endfor %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -392,7 +392,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             if {{ field.name }}:
                 request.{{ key }}.update({{ field.name }})
             {% else %}
-            {# And list-y fields can be _extended_ -#}
+            {# And list-y fields can be _extended_ #}
             if {{ field.name }}:
                 request.{{ key }}.extend({{ field.name }})
             {% endif %} {# field.map #}
@@ -418,8 +418,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% endif %}
 
         # Send the request.
-        {% if not method.void %}
-        response = {% endif %}rpc(
+        {%+ if not method.void %}response = {% endif %}rpc(
             {% if not method.client_streaming %}
             request,
             {% else %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 from collections import OrderedDict
 from distutils import util
 import os
@@ -18,25 +19,25 @@ from google.auth.transport.grpc import SslCredentials             # type: ignore
 from google.auth.exceptions import MutualTLSChannelError          # type: ignore
 from google.oauth2 import service_account                         # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
-{% for ref_type in method.flat_ref_types -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
+{% for ref_type in method.flat_ref_types %}
 {{ ref_type.ident.python_import }}
-{% endfor -%}
-{% endfor -%}
+{% endfor %}
+{% endfor %}
 {% if opts.add_iam_methods %}
 from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
 from google.iam.v1 import policy_pb2 as policy  # type: ignore
 {% endif %}
 {% endfilter %}
 from .transports.base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 from .transports.grpc import {{ service.grpc_transport_name }}
 from .transports.grpc_asyncio import {{ service.grpc_asyncio_transport_name }}
-{%- endif %}
-{%- if 'rest' in opts.transport %}
+{% endif %}
+{% if 'rest' in opts.transport %}
 from .transports.rest import {{ service.name }}RestTransport
-{%- endif %}
+{% endif %}
 
 
 class {{ service.client_name }}Meta(type):
@@ -47,13 +48,13 @@ class {{ service.client_name }}Meta(type):
     objects.
     """
     _transport_registry = OrderedDict()  # type: Dict[str, Type[{{ service.name }}Transport]]
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     _transport_registry['grpc'] = {{ service.grpc_transport_name }}
     _transport_registry['grpc_asyncio'] = {{ service.grpc_asyncio_transport_name }}
-    {%- endif %}
-    {%- if 'rest' in opts.transport %}
+    {% endif %}
+    {% if 'rest' in opts.transport %}
     _transport_registry['rest'] = {{ service.name }}RestTransport
-    {%- endif %}
+    {% endif %}
 
     def get_transport_class(cls,
             label: str = None,
@@ -109,6 +110,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         return api_endpoint.replace(".googleapis.com", ".mtls.googleapis.com")
 
     DEFAULT_ENDPOINT = {% if service.host %}'{{ service.host }}'{% else %}None{% endif %}
+
     DEFAULT_MTLS_ENDPOINT = _get_default_mtls_endpoint.__func__(  # type: ignore
         DEFAULT_ENDPOINT
     )
@@ -160,7 +162,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         return self._transport
 
 
-    {% for message in service.resource_messages|sort(attribute="resource_type") -%}
+    {% for message in service.resource_messages|sort(attribute="resource_type") %}
     @staticmethod
     def {{ message.resource_type|snake_case }}_path({% for arg in message.resource_path_args %}{{ arg }}: str,{% endfor %}) -> str:
         """Return a fully-qualified {{ message.resource_type|snake_case }} string."""
@@ -173,8 +175,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         m = re.match(r"{{ message.path_regex_str }}", path)
         return m.groupdict() if m else {}
 
-    {% endfor %} {# resources #}
-    {% for resource_msg in service.common_resources.values()|sort(attribute="type_name") -%}
+    {% endfor %}{# resources #}
+    {% for resource_msg in service.common_resources.values()|sort(attribute="type_name") %}
     @staticmethod
     def common_{{ resource_msg.message_type.resource_type|snake_case }}_path({% for arg in resource_msg.message_type.resource_path_args %}{{ arg }}: str, {%endfor %}) -> str:
         """Return a fully-qualified {{ resource_msg.message_type.resource_type|snake_case }} string."""
@@ -186,7 +188,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         m = re.match(r"{{ resource_msg.message_type.path_regex_str }}", path)
         return m.groupdict() if m else {}
 
-    {% endfor %} {# common resources #}
+    {% endfor %}{# common resources #}
 
     def __init__(self, *,
             credentials: Optional[credentials.Credentials] = None,
@@ -292,64 +294,64 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             )
 
 
-    {% for method in service.methods.values() -%}
+    {% for method in service.methods.values() %}
     def {{ method.name|snake_case }}(self,
-            {%- if not method.client_streaming %}
+            {% if not method.client_streaming %}
             request: {{ method.input.ident }} = None,
             *,
-            {% for field in method.flattened_fields.values() -%}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}: {{ field.ident }} = None,
-            {% endfor -%}
-            {%- else %}
+            {% endfor %}
+            {% else %}
             requests: Iterator[{{ method.input.ident }}] = None,
             *,
-            {% endif -%}
+            {% endif %}
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = (),
-            {%- if not method.server_streaming %}
+            {% if not method.server_streaming %}
             ) -> {{ method.client_output.ident }}:
-            {%- else %}
+            {% else %}
             ) -> Iterable[{{ method.client_output.ident }}]:
-            {%- endif %}
+            {% endif %}
         r"""{{ method.meta.doc|rst(width=72, indent=8) }}
 
         Args:
-            {%- if not method.client_streaming %}
+            {% if not method.client_streaming %}
             request ({{ method.input.ident.sphinx }}):
-                The request object.{{ ' ' -}}
+                The request object.{{ ' ' }}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
-            {% for key, field in method.flattened_fields.items() -%}
+            {% for key, field in method.flattened_fields.items() %}
             {{ field.name }} ({{ field.ident.sphinx }}):
                 {{ field.meta.doc|rst(width=72, indent=16) }}
                 This corresponds to the ``{{ key }}`` field
                 on the ``request`` instance; if ``request`` is provided, this
                 should not be set.
-            {% endfor -%}
-            {%- else %}
+            {% endfor %}
+            {% else %}
             requests (Iterator[{{ method.input.ident.sphinx }}]):
-                The request object iterator.{{ ' ' -}}
+                The request object iterator.{{ ' ' }}
                 {{ method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
-            {%- endif %}
+            {% endif %}
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
             timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
-        {%- if not method.void %}
+        {% if not method.void %}
 
         Returns:
-            {%- if not method.server_streaming %}
+            {% if not method.server_streaming %}
             {{ method.client_output.ident.sphinx }}:
-            {%- else %}
+            {% else %}
             Iterable[{{ method.client_output.ident.sphinx }}]:
-            {%- endif %}
+            {% endif %}
                 {{ method.client_output.meta.doc|rst(width=72, indent=16, source_format='rst') }}
-        {%- endif %}
+        {% endif %}
         """
-        {%- if not method.client_streaming %}
+        {% if not method.client_streaming %}
         # Create or coerce a protobuf request object.
-        {% if method.flattened_fields -%}
+        {% if method.flattened_fields %}
         # Sanity check: If we got a request object, we should *not* have
         # gotten any keyword arguments that map to the request.
         has_flattened_params = any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}])
@@ -357,8 +359,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             raise ValueError('If the `request` argument is set, then none of '
                              'the individual field arguments should be set.')
 
-        {% endif -%}
-        {% if method.input.ident.package != method.ident.package -%} {# request lives in a different package, so there is no proto wrapper #}
+        {% endif %}
+        {% if method.input.ident.package != method.ident.package %} {# request lives in a different package, so there is no proto wrapper #}
         if isinstance(request, dict):
             # The request isn't a proto-plus wrapped type,
             # so it must be constructed via keyword expansion.
@@ -366,7 +368,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         elif not request:
             # Null request, just make one.
             request = {{ method.input.ident }}()
-        {%- else %}
+        {% else %}
         # Minor optimization to avoid making a copy if the user passes
         # in a {{ method.input.ident }}.
         # There's no risk of modifying the input as we've already verified
@@ -376,57 +378,58 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% endif %} {# different request package #}
 
             {#- Vanilla python protobuf wrapper types cannot _set_ repeated fields #}
-            {% if method.flattened_fields and method.input.ident.package == method.ident.package -%}
+            {% if method.flattened_fields and method.input.ident.package == method.ident.package %}
             # If we have keyword arguments corresponding to fields on the
             # request, apply these.
-            {% endif -%}
-            {%- for key, field in method.flattened_fields.items() if not field.repeated or method.input.ident.package == method.ident.package %}
+            {% endif %}
+            {% for key, field in method.flattened_fields.items() if not field.repeated or method.input.ident.package == method.ident.package %}
             if {{ field.name }} is not None:
                 request.{{ key }} = {{ field.name }}
-            {%- endfor %}
+            {% endfor %}
             {# Map-y fields can be _updated_, however #}
-            {%- for key, field in method.flattened_fields.items() if field.repeated and method.input.ident.package != method.ident.package %}
-            {%- if field.map %} {# map implies repeated, but repeated does NOT imply map#}
+            {% for key, field in method.flattened_fields.items() if field.repeated and method.input.ident.package != method.ident.package %}
+            {% if field.map %} {# map implies repeated, but repeated does NOT imply map#}
             if {{ field.name }}:
                 request.{{ key }}.update({{ field.name }})
-            {%- else %}
+            {% else %}
             {# And list-y fields can be _extended_ -#}
             if {{ field.name }}:
                 request.{{ key }}.extend({{ field.name }})
-            {%- endif %} {# field.map #}
-            {%- endfor %} {# method.flattened_fields.items() #}
-            {%- endif %} {# method.client_streaming #}
+            {% endif %} {# field.map #}
+            {% endfor %} {# method.flattened_fields.items() #}
+            {% endif %} {# method.client_streaming #}
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
         rpc = self._transport._wrapped_methods[self._transport.{{ method.name|snake_case}}]
-        {%- if method.field_headers %}
+        {% if method.field_headers %}
 
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
-                {%- for field_header in method.field_headers %}
-                {%- if not method.client_streaming %}
+                {% for field_header in method.field_headers %}
+                {% if not method.client_streaming %}
                 ('{{ field_header }}', request.{{ field_header }}),
-                {%- endif %}
-                {%- endfor %}
+                {% endif %}
+                {% endfor %}
             )),
         )
-        {%- endif %}
+        {% endif %}
 
         # Send the request.
-        {% if not method.void %}response = {% endif %}rpc(
-            {%- if not method.client_streaming %}
+        {% if not method.void %}
+        response = {% endif %}rpc(
+            {% if not method.client_streaming %}
             request,
-            {%- else %}
+            {% else %}
             requests,
-            {%- endif %}
+            {% endif %}
             retry=retry,
             timeout=timeout,
             metadata=metadata,
         )
-        {%- if method.lro %}
+        {% if method.lro %}
 
         # Wrap the response in an operation future.
         response = {{ method.client_output.ident.module_alias or method.client_output.ident.module }}.from_gapic(
@@ -435,7 +438,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             {{ method.lro.response_type.ident }},
             metadata_type={{ method.lro.metadata_type.ident }},
         )
-        {%- elif method.paged_result_field %}
+        {% elif method.paged_result_field %}
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -445,12 +448,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             response=response,
             metadata=metadata,
         )
-        {%- endif %}
-        {%- if not method.void %}
+        {% endif %}
+        {% if not method.void %}
 
         # Done; return the response.
         return response
-        {%- endif %}
+        {% endif %}
         {{ '\n' }}
     {% endfor %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
@@ -1,20 +1,21 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-{% for method in service.methods.values() | selectattr('paged_result_field') -%}
-{% if loop.first -%}
+
+{% for method in service.methods.values() | selectattr('paged_result_field') %}
+{% if loop.first %}
 {# This lives within the loop in order to ensure that this template
    is empty if there are no paged methods.
  -#}
 from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Sequence, Tuple, Optional
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() | selectattr('paged_result_field') -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() | selectattr('paged_result_field') %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
 {% if not method.paged_result_field.is_primitive %}{{ method.paged_result_field.message.ident.python_import }}{% endif %}
 {% endfor %}
-{% endfilter -%}
+{% endfilter %}
 {% endif %}
 
 class {{ method.name }}Pager:

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
@@ -6,17 +6,20 @@
 {% if loop.first %}
 {# This lives within the loop in order to ensure that this template
    is empty if there are no paged methods.
- -#}
+ #}
 from typing import Any, AsyncIterable, Awaitable, Callable, Iterable, Sequence, Tuple, Optional
 
 {% filter sort_lines %}
 {% for method in service.methods.values() | selectattr('paged_result_field') %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% if not method.paged_result_field.is_primitive %}{{ method.paged_result_field.message.ident.python_import }}{% endif %}
+{% if not method.paged_result_field.is_primitive %}
+{{ method.paged_result_field.message.ident.python_import }}
+{% endif %}
 {% endfor %}
 {% endfilter %}
 {% endif %}
+
 
 class {{ method.name }}Pager:
     """A pager for iterating through ``{{ method.name|snake_case }}`` requests.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/__init__.py.j2
@@ -1,38 +1,39 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 from collections import OrderedDict
 from typing import Dict, Type
 
 from .base import {{ service.name }}Transport
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 from .grpc import {{ service.name }}GrpcTransport
 from .grpc_asyncio import {{ service.name }}GrpcAsyncIOTransport
-{%- endif %}
-{%- if 'rest' in opts.transport %}
+{% endif %}
+{% if 'rest' in opts.transport %}
 from .rest import {{ service.name }}RestTransport
-{%- endif %}
+{% endif %}
 
 
 
 # Compile a registry of transports.
 _transport_registry = OrderedDict()  # type: Dict[str, Type[{{ service.name }}Transport]]
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 _transport_registry['grpc'] = {{ service.name }}GrpcTransport
 _transport_registry['grpc_asyncio'] = {{ service.name }}GrpcAsyncIOTransport
-{%- endif %}
-{%- if 'rest' in opts.transport %}
+{% endif %}
+{% if 'rest' in opts.transport %}
 _transport_registry['rest'] = {{ service.name }}RestTransport
-{%- endif %}
+{% endif %}
 
 __all__ = (
     '{{ service.name }}Transport',
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     '{{ service.name }}GrpcTransport',
     '{{ service.name }}GrpcAsyncIOTransport',
-    {%- endif %}
-    {%- if 'rest' in opts.transport %}
+    {% endif %}
+    {% if 'rest' in opts.transport %}
     '{{ service.name }}RestTransport',
-    {%- endif %}
+    {% endif %}
 )
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import packaging.version
@@ -11,16 +12,16 @@ import google.api_core  # type: ignore
 from google.api_core import exceptions  # type: ignore
 from google.api_core import gapic_v1    # type: ignore
 from google.api_core import retry as retries  # type: ignore
-{%- if service.has_lro %}
+{% if service.has_lro %}
 from google.api_core import operations_v1  # type: ignore
-{%- endif %}
+{% endif %}
 from google.auth import credentials  # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% endfor -%}
+{% endfor %}
 {% if opts.add_iam_methods %}
 from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
 from google.iam.v1 import policy_pb2 as policy  # type: ignore
@@ -52,9 +53,9 @@ class {{ service.name }}Transport(abc.ABC):
     """Abstract transport class for {{ service.name }}."""
 
     AUTH_SCOPES = (
-        {%- for scope in service.oauth_scopes %}
+        {% for scope in service.oauth_scopes %}
         '{{ scope }}',
-        {%- endfor %}
+        {% endfor %}
     )
 
     DEFAULT_HOST: str = {% if service.host %}'{{ service.host }}'{% else %}{{ '' }}{% endif %}
@@ -73,7 +74,7 @@ class {{ service.name }}Transport(abc.ABC):
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
-                {{- ' ' }}The hostname to connect to.
+                {{ ' ' }}The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -165,22 +166,22 @@ class {{ service.name }}Transport(abc.ABC):
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
         self._wrapped_methods = {
-            {% for method in service.methods.values() -%}
+            {% for method in service.methods.values() %}
             self.{{ method.name|snake_case }}: gapic_v1.method.wrap_method(
                 self.{{ method.name|snake_case }},
-                {%- if method.retry %}
+                {% if method.retry %}
                 default_retry=retries.Retry(
                     {% if method.retry.initial_backoff %}initial={{ method.retry.initial_backoff }},{% endif %}
                     {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
                     {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                     predicate=retries.if_exception_type(
-                        {%- for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
+                        {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
                         exceptions.{{ ex.__name__ }},
-                        {%- endfor %}
+                        {% endfor %}
                     ),
                     deadline={{ method.timeout }},
                 ),
-                {%- endif %}
+                {% endif %}
                 default_timeout={{ method.timeout }},
                 client_info=client_info,
             ),
@@ -188,14 +189,14 @@ class {{ service.name }}Transport(abc.ABC):
         }
 
 
-    {%- if service.has_lro %}
+    {% if service.has_lro %}
 
     @property
     def operations_client(self) -> operations_v1.OperationsClient:
         """Return the client designed to process long-running operations."""
         raise NotImplementedError()
-    {%- endif %}
-    {%- for method in service.methods.values() %}
+    {% endif %}
+    {% for method in service.methods.values() %}
 
     @property
     def {{ method.name|snake_case }}(self) -> Callable[
@@ -205,7 +206,7 @@ class {{ service.name }}Transport(abc.ABC):
                 Awaitable[{{ method.output.ident }}]
             ]]:
         raise NotImplementedError()
-    {%- endfor %}
+    {% endfor %}
 
 
     {% if opts.add_iam_methods %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -1,13 +1,14 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import grpc_helpers   # type: ignore
-{%- if service.has_lro %}
+{% if service.has_lro %}
 from google.api_core import operations_v1  # type: ignore
-{%- endif %}
+{% endif %}
 from google.api_core import gapic_v1       # type: ignore
 from google import auth                    # type: ignore
 from google.auth import credentials        # type: ignore
@@ -15,11 +16,11 @@ from google.auth.transport.grpc import SslCredentials  # type: ignore
 
 import grpc  # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% endfor -%}
+{% endfor %}
 {% if opts.add_iam_methods %}
 from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
 from google.iam.v1 import policy_pb2 as policy  # type: ignore
@@ -59,7 +60,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
-                {{- ' ' }}The hostname to connect to.
+                {{ ' ' }}The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -104,9 +105,9 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         self._grpc_channel = None
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
-        {%- if service.has_lro %}
+        {% if service.has_lro %}
         self._operations_client = None
-        {%- endif %}
+        {% endif %}
 
         if api_mtls_endpoint:
             warnings.warn("api_mtls_endpoint is deprecated", DeprecationWarning)
@@ -219,7 +220,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
-    {%- if service.has_lro %}
+    {% if service.has_lro %}
 
     @property
     def operations_client(self) -> operations_v1.OperationsClient:
@@ -236,17 +237,17 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 
         # Return the client from cache.
         return self._operations_client
-    {%- endif %}
-    {%- for method in service.methods.values() %}
+    {% endif %}
+    {% for method in service.methods.values() %}
 
     @property
     def {{ method.name|snake_case }}(self) -> Callable[
             [{{ method.input.ident }}],
             {{ method.output.ident }}]:
-        r"""Return a callable for the {{- ' ' -}}
+        r"""Return a callable for the {{ ' ' }}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=40, indent=8) }}
-        {{- ' ' -}} method over gRPC.
+        {{ ' ' }} method over gRPC.
 
         {{ method.meta.doc|rst(width=72, indent=8) }}
 
@@ -267,7 +268,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                 response_deserializer={{ method.output.ident }}.{% if method.output.ident.python_import.module.endswith('_pb2') %}FromString{% else %}deserialize{% endif %},
             )
         return self._stubs['{{ method.name|snake_case }}']
-    {%- endfor %}
+    {% endfor %}
 
     {% if opts.add_iam_methods %}
     @property
@@ -353,4 +354,4 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
 __all__ = (
     '{{ service.name }}GrpcTransport',
 )
-{%- endblock -%}
+{% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -1,14 +1,15 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
-{%- if service.has_lro %}
+{% if service.has_lro %}
 from google.api_core import operations_v1              # type: ignore
-{%- endif %}
+{% endif %}
 from google import auth                                # type: ignore
 from google.auth import credentials                    # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
@@ -17,11 +18,11 @@ import packaging.version
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore
 
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% endfor -%}
+{% endfor %}
 {% if opts.add_iam_methods %}
 from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
 from google.iam.v1 import policy_pb2 as policy  # type: ignore
@@ -105,7 +106,7 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
-                {{- ' ' }}The hostname to connect to.
+                {{ ' ' }}The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -151,9 +152,9 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         self._grpc_channel = None
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
-        {%- if service.has_lro %}
+        {% if service.has_lro %}
         self._operations_client = None
-        {%- endif %}
+        {% endif %}
 
         if api_mtls_endpoint:
             warnings.warn("api_mtls_endpoint is deprecated", DeprecationWarning)
@@ -223,7 +224,7 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         """
         # Return the channel from cache.
         return self._grpc_channel
-    {%- if service.has_lro %}
+    {% if service.has_lro %}
 
     @property
     def operations_client(self) -> operations_v1.OperationsAsyncClient:
@@ -240,17 +241,17 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
 
         # Return the client from cache.
         return self._operations_client
-    {%- endif %}
-    {%- for method in service.methods.values() %}
+    {% endif %}
+    {% for method in service.methods.values() %}
 
     @property
     def {{ method.name|snake_case }}(self) -> Callable[
             [{{ method.input.ident }}],
             Awaitable[{{ method.output.ident }}]]:
-        r"""Return a callable for the {{- ' ' -}}
+        r"""Return a callable for the {{ ' ' }}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=40, indent=8) }}
-        {{- ' ' -}} method over gRPC.
+        {{ ' ' }} method over gRPC.
 
         {{ method.meta.doc|rst(width=72, indent=8) }}
 
@@ -271,7 +272,7 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
                 response_deserializer={{ method.output.ident }}.{% if method.output.ident.python_import.module.endswith('_pb2') %}FromString{% else %}deserialize{% endif %},
             )
         return self._stubs['{{ method.name|snake_case }}']
-    {%- endfor %}
+    {% endfor %}
 
     {% if opts.add_iam_methods %}
     @property
@@ -358,4 +359,4 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
 __all__ = (
     '{{ service.name }}GrpcAsyncIOTransport',
 )
-{%- endblock -%}
+{% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -1,12 +1,13 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple
 
 {% if service.has_lro %}
 from google.api_core import operations_v1
-{%- endif %}
+{% endif %}
 from google.api_core import gapic_v1       # type: ignore
 from google import auth                    # type: ignore
 from google.auth import credentials        # type: ignore
@@ -17,11 +18,11 @@ import grpc  # type: ignore
 from google.auth.transport.requests import AuthorizedSession
 
 {# TODO(yon-mg): re-add python_import/ python_modules from removed diff/current grpc template code #}
-{% filter sort_lines -%}
-{% for method in service.methods.values() -%}
+{% filter sort_lines %}
+{% for method in service.methods.values() %}
 {{ method.input.ident.python_import }}
 {{ method.output.ident.python_import }}
-{% endfor -%}
+{% endfor %}
 {% if opts.add_iam_methods %}
 from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
 from google.iam.v1 import policy_pb2 as policy  # type: ignore
@@ -56,7 +57,7 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):
-                {{- ' ' }}The hostname to connect to.
+                {{ ' ' }}The hostname to connect to.
             credentials (Optional[google.auth.credentials.Credentials]): The
                 authorization credentials to attach to requests. These
                 credentials identify the application to the service; if none
@@ -82,7 +83,7 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         # Run the base constructor
         # TODO(yon-mg): resolve other ctor params i.e. scopes, quota, etc.
         # TODO: When custom host (api_endpoint) is set, `scopes` must *also* be set on the
-        # credentials object 
+        # credentials object
         super().__init__(
             host=host,
             credentials=credentials,
@@ -91,12 +92,12 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         self._session = AuthorizedSession(self._credentials, default_host=self.DEFAULT_HOST)
         {%- if service.has_lro %}
         self._operations_client = None
-        {%- endif %}
+        {% endif %}
         if client_cert_source_for_mtls:
             self._session.configure_mtls_channel(client_cert_source_for_mtls)
         self._prep_wrapped_messages(client_info)
 
-    {%- if service.has_lro %}
+    {% if service.has_lro %}
 
     @property
     def operations_client(self) -> operations_v1.OperationsClient:
@@ -125,18 +126,18 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
 
         # Return the client from cache.
         return self._operations_client
-    {%- endif %}
-    {%- for method in service.methods.values() %}
-    {%- if method.http_opt %}
+    {% endif %}
+    {% for method in service.methods.values() %}
+    {% if method.http_opt %}
 
     def {{ method.name|snake_case }}(self,
             request: {{ method.input.ident }}, *,
             metadata: Sequence[Tuple[str, str]] = (),
             ) -> {{ method.output.ident }}:
-        r"""Call the {{- ' ' -}}
+        r"""Call the {{ ' ' }}
         {{ (method.name|snake_case).replace('_',' ')|wrap(
                 width=70, offset=45, indent=8) }}
-        {{- ' ' -}} method over HTTP.
+        {{ ' ' }} method over HTTP.
 
         Args:
             request (~.{{ method.input.ident }}):
@@ -144,12 +145,12 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
                 {{ method.input.meta.doc|rst(width=72, indent=16) }}
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
-        {%- if not method.void %}
+        {% if not method.void %}
 
         Returns:
             ~.{{ method.output.ident }}:
                 {{ method.output.meta.doc|rst(width=72, indent=16) }}
-        {%- endif %}
+        {% endif %}
         """
 
         {# TODO(yon-mg): refactor when implementing grpc transcoding
@@ -158,30 +159,30 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
                          - make sure dotted nested fields preserved
                          - format url and send the request
         #}
-        {%- if 'body' in method.http_opt %}
+        {% if 'body' in method.http_opt %}
         # Jsonify the request body
-        {%- if method.http_opt['body'] != '*' %}
+        {% if method.http_opt['body'] != '*' %}
         body = {{ method.input.fields[method.http_opt['body']].type.ident }}.to_json(
             request.{{ method.http_opt['body'] }},
             including_default_value_fields=False,
             use_integers_for_enums=False
         )
-        {%- else %}
+        {% else %}
         body = {{ method.input.ident }}.to_json(
             request,
             use_integers_for_enums=False
         )
-        {%- endif %}
-        {%- endif %}
+        {% endif %}
+        {% endif %}
 
         {# TODO(yon-mg): Write helper method for handling grpc transcoding url #}
         # TODO(yon-mg): need to handle grpc transcoding and parse url correctly
         #               current impl assumes basic case of grpc transcoding
         url = 'https://{host}{{ method.http_opt['url'] }}'.format(
             host=self._host,
-            {%- for field in method.path_params %}
+            {% for field in method.path_params %}
             {{ field }}=request.{{ method.input.get_field(field).name }},
-            {%- endfor %}
+            {% endfor %}
         )
 
         {# TODO(yon-mg): move all query param logic out of wrappers into here to handle
@@ -190,9 +191,9 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         # TODO(yon-mg): handle nested fields corerctly rather than using only top level fields
         #               not required for GCE
         query_params = {
-            {%- for field in method.query_params | sort%}
+            {% for field in method.query_params | sort%}
             '{{ field|camel_case }}': request.{{ field }},
-            {%- endfor %}
+            {% endfor %}
         }
         # TODO(yon-mg): further discussion needed whether 'python truthiness' is appropriate here
         #               discards default values
@@ -203,23 +204,23 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         # Send the request
         {% if not method.void %}response = {% endif %}self._session.{{ method.http_opt['verb'] }}(
             url
-            {%- if 'body' in method.http_opt %},
+            {% if 'body' in method.http_opt %},
             data=body,
-            {%- endif %}
+            {% endif %}
         )
 
         # Raise requests.exceptions.HTTPError if the status code is >= 400
         response.raise_for_status()
-        {%- if not method.void %}
+        {% if not method.void %}
 
         # Return the response
         return {{ method.output.ident }}.from_json(
             response.content,
             ignore_unknown_fields=True
         )
-        {%- endif %}
-    {%- endif %}
-    {%- endfor %}
+        {% endif %}
+    {% endif %}
+    {% endfor %}
 
 
 __all__ = (

--- a/gapic/templates/%namespace/%name_%version/%sub/types/%proto.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/%proto.py.j2
@@ -1,39 +1,40 @@
 {% extends "_base.py.j2" %}
 
-{% block content -%}
+{% block content %}
+
 {% with p = proto.disambiguate('proto') %}
-{% if proto.messages|length or proto.all_enums|length -%}
+{% if proto.messages|length or proto.all_enums|length %}
 import proto{% if p != 'proto' %} as {{ p }}{% endif %}  # type: ignore
 {% endif %}
 
-{% filter sort_lines -%}
-{% for import_ in proto.python_modules -%}
+{% filter sort_lines %}
+{% for import_ in proto.python_modules %}
 {{ import_ }}
-{% endfor -%}
+{% endfor %}
 {% endfilter %}
 
 
 __protobuf__ = {{ p }}.module(
     package='{{ '.'.join(proto.meta.address.package) }}',
-    {% if api.naming.proto_package != '.'.join(proto.meta.address.package) -%}
+    {% if api.naming.proto_package != '.'.join(proto.meta.address.package) %}
     marshal='{{ api.naming.proto_package }}',
-    {% endif -%}
+    {% endif %}
     manifest={
-    {%- for enum in proto.enums.values() %}
+    {% for enum in proto.enums.values() %}
         '{{ enum.name }}',
-    {%- endfor %}
-    {%- for message in proto.messages.values() %}
+    {% endfor %}
+    {% for message in proto.messages.values() %}
         '{{ message.name }}',
-    {%- endfor %}
+    {% endfor %}
     },
 )
 
 
-{% for enum in proto.enums.values() -%}
+{% for enum in proto.enums.values() %}
     {% include '%namespace/%name_%version/%sub/types/_enum.py.j2' with context %}
 {% endfor %}
 
-{% for message in proto.messages.values() -%}
+{% for message in proto.messages.values() %}
     {% include "%namespace/%name_%version/%sub/types/_message.py.j2" with context %}
 {% endfor %}
 {% endwith %}

--- a/gapic/templates/%namespace/%name_%version/%sub/types/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/__init__.py.j2
@@ -10,7 +10,8 @@ from .{{proto.module_name }} import (
   {% for _, enum in proto.enums|dictsort %}
     {{ enum.name }},
   {% endfor %}
-){% endfor %}
+)
+{% endfor %}
 
 __all__ = (
   {% for _, proto in api.protos|dictsort if proto.file_to_generate %}

--- a/gapic/templates/%namespace/%name_%version/%sub/types/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/__init__.py.j2
@@ -1,22 +1,25 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
-{%- for _, proto in api.protos|dictsort if proto.file_to_generate and proto.messages %}
+
+{% for _, proto in api.protos|dictsort if proto.file_to_generate and proto.messages %}
 from .{{proto.module_name }} import (
-  {%- for _, message in proto.messages|dictsort %}
-    {{message.name }}, {% endfor %}
-  {%- for _, enum in proto.enums|dictsort %}
-    {{ enum.name }}, {% endfor %}
+  {% for _, message in proto.messages|dictsort %}
+    {{message.name }},
+  {% endfor %}
+  {% for _, enum in proto.enums|dictsort %}
+    {{ enum.name }},
+  {% endfor %}
 ){% endfor %}
 
 __all__ = (
-  {%- for _, proto in api.protos|dictsort if proto.file_to_generate %}
-  {%- for _, message in proto.messages|dictsort %}
+  {% for _, proto in api.protos|dictsort if proto.file_to_generate %}
+  {% for _, message in proto.messages|dictsort %}
     '{{ message.name }}',
-  {%- endfor -%}
-  {%- for _, enum in proto.enums|dictsort %}
+  {% endfor %}
+  {% for _, enum in proto.enums|dictsort %}
     '{{ enum.name }}',
-  {%- endfor -%}
-  {%- endfor %}
+  {% endfor %}
+  {% endfor %}
 )
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/types/_enum.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/_enum.py.j2
@@ -1,9 +1,9 @@
 class {{ enum.name }}({{ p }}.Enum):
     r"""{{ enum.meta.doc|rst(indent=4) }}"""
-    {% if enum.enum_pb.HasField("options") -%}
+    {% if enum.enum_pb.HasField("options") %}
      _pb_options = {{ enum.options_dict }}
-    {% endif -%}
-    {% for enum_value in enum.values -%}
+    {% endif %}
+    {% for enum_value in enum.values %}
     {{ enum_value.name }} = {{ enum_value.number }}
-    {% endfor -%}
+    {% endfor %}
 {{ '\n\n' }}

--- a/gapic/templates/%namespace/%name_%version/%sub/types/_message.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/_message.py.j2
@@ -2,27 +2,27 @@ class {{ message.name }}({{ p }}.Message):
     r"""{{ message.meta.doc|rst(indent=4) }}{% if message.fields|length %}
 
     Attributes:
-    {%- for field in message.fields.values() %}
+    {% for field in message.fields.values() %}
         {{ field.name }} ({{ field.ident.sphinx }}):
             {{ field.meta.doc|rst(indent=12, nl=False) }}
-    {%- endfor %}
-    {% endif -%}
+    {% endfor %}
+    {% endif %}
     """
     {# Iterate over nested enums. -#}
-    {% for enum in message.nested_enums.values() -%}
-        {% filter indent %}
-            {%- include '%namespace/%name_%version/%sub/types/_enum.py.j2' %}
+    {% for enum in message.nested_enums.values() %}
+        {% filter indent(first=True) %}
+            {% include '%namespace/%name_%version/%sub/types/_enum.py.j2' %}
         {% endfilter %}
-    {% endfor -%}
+    {% endfor %}
 
     {# Iterate over nested messages. -#}
-    {% for submessage in message.nested_messages.values() -%}
-        {% if not submessage.map -%}
-        {% with message = submessage %}{% filter indent %}
-            {%- include '%namespace/%name_%version/%sub/types/_message.py.j2' %}
+    {% for submessage in message.nested_messages.values() %}
+        {% if not submessage.map %}
+        {% with message = submessage %}{% filter indent(first=True) %}
+            {% include '%namespace/%name_%version/%sub/types/_message.py.j2' %}
         {% endfilter %}{% endwith %}
         {% endif %}
-    {% endfor -%}
+    {% endfor %}
 
     {% if "next_page_token" in message.fields.values()|map(attribute='name') %}
     @property
@@ -31,21 +31,31 @@ class {{ message.name }}({{ p }}.Message):
     {% endif %}
 
     {# Iterate over fields. -#}
-    {% for field in message.fields.values() -%}
-    {% if field.map -%}
-    {% with key_field = field.message.fields['key'], value_field = field.message.fields['value'] -%}
+    {% for field in message.fields.values() %}
+    {% if field.map %}
+    {% with key_field = field.message.fields['key'], value_field = field.message.fields['value'] %}
     {{ field.name }} = {{ p }}.MapField(
-        {{- p }}.{{ key_field.proto_type }}, {{ p }}.{{ value_field.proto_type }}, number={{ field.number }}
-    {%- if value_field.enum or value_field.message %},
+        {{ p }}.{{ key_field.proto_type }},
+        {{ p }}.{{ value_field.proto_type }},
+        number={{ field.number }}
+    {% if value_field.enum or value_field.message %}
         {{ value_field.proto_type.lower() }}={{ value_field.type.ident.rel(message.ident) }},
-    {% endif %})                {# enum or message#}
-    {% endwith -%}
-    {% else -%}                 {# field.map #}
+    {% endif %}{# enum or message#}
+    )
+    {% endwith %}
+    {% else %}{# field.map #}
     {{ field.name }} = {{ p }}.{% if field.repeated %}Repeated{% endif %}Field(
-        {{- p }}.{{ field.proto_type }}, number={{ field.number }}{% if field.proto3_optional %}, optional=True{% elif field.oneof %}, oneof='{{ field.oneof }}'{% endif %}
-    {%- if field.enum or field.message %},
+        {{ p }}.{{ field.proto_type }},
+        number={{ field.number }},
+    {% if field.proto3_optional %}
+        optional=True,
+    {% elif field.oneof %}
+        oneof='{{ field.oneof }}',
+    {% endif %}
+    {% if field.enum or field.message %}
         {{ field.proto_type.lower() }}={{ field.type.ident.rel(message.ident) }},
-    {% endif %})                {# enum or message #}
-    {% endif -%}                {# field.map #}
-    {% endfor -%} {# for field in message.fields.values#}
+    {% endif %}{# enum or message #}
+    )
+    {% endif %}{# field.map #}
+    {% endfor %}{# for field in message.fields.values#}
 {{ '\n\n' }}

--- a/gapic/templates/docs/conf.py.j2
+++ b/gapic/templates/docs/conf.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 #
 # {{ api.naming.warehouse_package_name }} documentation build configuration file
 #

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -52,7 +52,7 @@ There is a little, but not enough for it to be important because
       {% do input_parameters.append(request.single.input_parameter) %}
     {% endif %}
   {% endfor %}
-{{ input_parameters|join(", ") -}}
+{{ input_parameters|join(", ") }}
 {% endwith %}
 {% endmacro %}
 
@@ -111,21 +111,21 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 
 {% macro dispatch_statement(statement, indentation=0) %}
 {# Each statement is a dict with a single key/value pair #}
-{% if "print" in statement -%}
+{% if "print" in statement %}
 {{ render_print(statement["print"])|indent(width=indentation, first=True) }}
-{% elif "define" in statement -%}
+{% elif "define" in statement %}
 {{ render_define(statement["define"])|indent(width=indentation, first=True) }}
-{% elif "comment" in statement -%}
+{% elif "comment" in statement %}
 {{ render_comment(statement["comment"])|indent(width=indentation, first=True) }}
-{% elif "loop" in statement -%}
-  {% with loop = statement["loop"] -%}
-    {% if "collection" in loop -%}
+{% elif "loop" in statement %}
+  {% with loop = statement["loop"] %}
+    {% if "collection" in loop %}
 {{ render_collection_loop(loop)|indent(width=indentation, first=True) }}
-    {% else -%}
+    {% else %}
 {{ render_map_loop(loop)|indent(width=indentation, first=True) }}
-    {% endif -%}
-  {% endwith -%}
-{% elif "write_file" in statement -%}
+    {% endif %}
+  {% endwith %}
+{% elif "write_file" in statement %}
 {{ render_write_file(statement["write_file"])|indent(indentation, first=True) }}
 {% endif %}
 {% endmacro %}
@@ -150,67 +150,66 @@ with open({{ attr.input_parameter }}, "rb") as f:
 
 {% macro render_request_setup(full_request) %}
 {% for parameter_block in full_request.request_list if parameter_block.body %}
-{% if parameter_block.pattern -%}
+{% if parameter_block.pattern %}
 {# This is a resource-name patterned lookup parameter #}
-{% with formals = [] -%} 
-{% for attr in parameter_block.body -%} 
-{% do formals.append("%s=%s"|format(attr.field, attr.input_parameter or attr.value)) -%} 
-{% endfor -%} 
+{% with formals = [] %}
+{% for attr in parameter_block.body %}
+{% do formals.append("%s=%s"|format(attr.field, attr.input_parameter or attr.value)) %}
+{% endfor %}
 {{ parameter_block.base }} = "{{parameter_block.pattern }}".format({{ formals|join(", ") }})
-{% endwith -%}  
-{% else -%} {# End resource name construction #}
+{% endwith %}
+{% else %}{# End resource name construction #}
 {{ parameter_block.base }} = {}
 {% for attr in parameter_block.body %}
 {{ render_request_attr(parameter_block.base, attr) }}
 {% endfor %}
-{% endif -%}
+{% endif %}
 {% endfor %}
-{% if not full_request.flattenable -%}
+{% if not full_request.flattenable %}
 request = {
 {% for parameter in full_request.request_list %}
     '{{ parameter.base  }}': {{ parameter.base if parameter.body else parameter.single }},
-{% endfor -%}
-}
-{% endif -%}
+{% endfor %}}
+{% endif %}
 {% endmacro %}
 
 {% macro render_request_params(request) %}
-  {# Provide the top level parameters last and as keyword params #}
-  {% with params = [] -%}
-    {% for r in request if r.body -%}
-      {% do params.append(r.base) -%}
-    {% endfor -%}
-    {% for r in request if r.single -%}
-      {% do params.append("%s=%s"|format(r.base, r.single.value)) -%}
-    {% endfor -%}
-{{ params|join(", ") -}}
-  {% endwith -%}
+{# Provide the top level parameters last and as keyword params #}
+  {% with params = [] %}
+    {% for r in request if r.body %}
+      {% do params.append(r.base) %}
+    {% endfor %}
+    {% for r in request if r.single %}
+      {% do params.append("%s=%s"|format(r.base, r.single.value)) %}
+    {% endfor %}
+{{ params|join(", ") }}
+  {% endwith %}
 {% endmacro %}
 
 {% macro render_request_params_unary(request) %}
-  {# Provide the top level parameters last and as keyword params #}
-  {% if request.flattenable -%}
-  {% with params = [] -%}
-    {% for r in request.request_list -%}
-      {% do params.append("%s=%s"|format(r.base, r.single.value if r.single else r.base)) -%}
-    {% endfor -%}
-{{ params|join(", ") -}}
-  {% endwith -%}
-  {% else -%}
+{# Provide the top level parameters last and as keyword params #}
+  {% if request.flattenable %}
+  {% with params = [] %}
+    {% for r in request.request_list %}
+      {% do params.append("%s=%s"|format(r.base, r.single.value if r.single else r.base)) %}
+    {% endfor %}
+{{ params|join(", ") }}
+  {% endwith %}
+  {% else %}
 request=request
-  {% endif -%}
+  {% endif %}
 {% endmacro %}
 
 
 {% macro render_method_call(sample, calling_form, calling_form_enum) %}
-  {# Note: this doesn't deal with enums or unions #}
+{# Note: this doesn't deal with enums or unions #}
 {% if calling_form in [calling_form_enum.RequestStreamingBidi,
-                       calling_form_enum.RequestStreamingClient] -%}
-client.{{ sample.rpc|snake_case }}([{{ render_request_params(sample.request.request_list)|trim -}}])
-{% else -%} {# TODO: deal with flattening #}
+                       calling_form_enum.RequestStreamingClient] %}
+client.{{ sample.rpc|snake_case }}([{{ render_request_params(sample.request.request_list)|trim }}])
+{% else %}{# TODO: deal with flattening #}
 {# TODO: set up client streaming once some questions are answered #}
-client.{{ sample.rpc|snake_case }}({{ render_request_params_unary(sample.request)|trim -}})
-{% endif -%}
+client.{{ sample.rpc|snake_case }}({{ render_request_params_unary(sample.request)|trim }})
+{% endif %}
 {% endmacro %}
 
 {# Setting up the method invocation is the responsibility of the caller: #}
@@ -262,15 +261,15 @@ def main():
     import argparse
 
     parser = argparse.ArgumentParser()
-{% with arg_list = [] -%}
-{% for request in full_request.request_list if request.body -%}
+{% with arg_list = [] %}
+{% for request in full_request.request_list if request.body %}
 {% for attr in request.body if attr.input_parameter %}
     parser.add_argument("--{{ attr.input_parameter }}",
                         type=str,
                         default={{ attr.value }})
-{% do arg_list.append("args." + attr.input_parameter) -%}
-{% endfor -%}
-{% endfor -%}
+{% do arg_list.append("args." + attr.input_parameter) %}
+{% endfor %}
+{% endfor %}
 {% for request in full_request.request_list if request.single and request.single.input_parameter %}
     parser.add_argument("--{{ request.single.input_parameter }}",
                         type=str,

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -26,7 +26,6 @@ There is a little, but not enough for it to be important because
 {# response handling macros #}
 
 {% macro sample_header(sample, calling_form) %}
-
 # DO NOT EDIT! This is a generated sample ("{{ calling_form }}",  "{{ sample.id }}")
 #
 # To install the latest published package dependency, execute the following:
@@ -52,7 +51,7 @@ There is a little, but not enough for it to be important because
       {% do input_parameters.append(request.single.input_parameter) %}
     {% endif %}
   {% endfor %}
-{{ input_parameters|join(", ") }}
+{{ input_parameters|join(", ") -}}
 {% endwith %}
 {% endmacro %}
 
@@ -135,17 +134,17 @@ with open({{ print_string_formatting(statement["filename"])|trim }}, "wb") as f:
 {# to be the correct enum from the right module, if necessary. #}
 {# Python is also responsible for verifying that each input parameter is unique,#}
 {# no parameter is a reserved keyword #}
-  {% if attr.input_parameter %}
+{% if attr.input_parameter %}
 # {{ attr.input_parameter }} = {{ attr.value }}
-  {% if attr.value_is_file %}
+{% if attr.value_is_file %}
 with open({{ attr.input_parameter }}, "rb") as f:
     {{ base_name }}["{{ attr.field }}"] = f.read()
-    {% else %}
+{% else %}
 {{ base_name }}["{{ attr.field }}"] = {{ attr.input_parameter }}
-    {% endif %}
-  {% else %}
+{% endif %}
+{% else %}
 {{ base_name }}["{{ attr.field }}"] = {{ attr.value }}
-  {% endif %}
+{% endif %}
 {% endmacro %}
 
 {% macro render_request_setup(full_request) %}
@@ -182,7 +181,7 @@ request = {
     {% for r in request if r.single %}
       {% do params.append("%s=%s"|format(r.base, r.single.value)) %}
     {% endfor %}
-{{ params|join(", ") }}
+{{ params|join(", ") -}}
   {% endwith %}
 {% endmacro %}
 

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -16,6 +16,7 @@
 {% extends "_base.py.j2" %}
 
 {% block content %}
+
 {# Input parameters: sample #}
 {#                   callingForm #}
 {% import "examples/feature_fragments.j2" as frags %}
@@ -29,7 +30,7 @@
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
 
 {# also need calling form #}
-def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input_params(sample.request)|trim -}}):
+def sample_{{ frags.render_method_name(sample.rpc)|trim }}({{ frags.print_input_params(sample.request)|trim }}):
     """{{ sample.description }}"""
 
     client = {{ service.client_name }}(
@@ -37,12 +38,12 @@ def sample_{{ frags.render_method_name(sample.rpc)|trim -}}({{ frags.print_input
         transport="grpc",
     )
 
-    {{ frags.render_request_setup(sample.request)|indent }} 
-{% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %} 
-    {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response, )|indent -}} 
-{% endwith %} 
+    {{ frags.render_request_setup(sample.request)|indent }}
+{% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum) %}
+    {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.response, )|indent }}
+{% endwith %}
 
 # [END {{ sample.id }}]
 
-{{ frags.render_main_block(sample.rpc, sample.request) }} 
-{%- endblock %}
+{{ frags.render_main_block(sample.rpc, sample.request) }}
+{% endblock %}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -45,5 +45,5 @@ def sample_{{ frags.render_method_name(sample.rpc)|trim }}({{ frags.print_input_
 
 # [END {{ sample.id }}]
 
-{{ frags.render_main_block(sample.rpc, sample.request) }}
+{{ frags.render_main_block(sample.rpc, sample.request) -}}
 {% endblock %}

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -1,6 +1,7 @@
 {% extends "_base.py.j2" %}
 
 {% block content %}
+
 import os
 import pathlib
 import shutil

--- a/gapic/templates/scripts/fixup_%name_%version_keywords.py.j2
+++ b/gapic/templates/scripts/fixup_%name_%version_keywords.py.j2
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3
 {% extends '_base.py.j2' %}
 {% block content %}
+
 import argparse
 import os
 import libcst as cst
@@ -25,14 +26,14 @@ def partition(
 
 class {{ api.naming.module_name }}CallTransformer(cst.CSTTransformer):
     CTRL_PARAMS: Tuple[str] = ('retry', 'timeout', 'metadata')
-    {% with all_methods = [] -%}
-    {% for service in api.services.values() %}{% for method in service.methods.values() -%}
-    {% do all_methods.append(method) -%}
-    {% endfor %}{% endfor -%}
+    {% with all_methods = [] %}
+    {% for service in api.services.values() %}{% for method in service.methods.values() %}
+    {% do all_methods.append(method) %}
+    {% endfor %}{% endfor %}
     METHOD_TO_PARAMS: Dict[str, Tuple[str]] = {
-    {% for method in all_methods|sort(attribute='name')|unique(attribute='name') -%}
+    {% for method in all_methods|sort(attribute='name')|unique(attribute='name') %}
           '{{ method.name|snake_case }}': ({% for field in method.legacy_flattened_fields.values() %}'{{ field.name }}', {% endfor %}),
-    {% endfor -%}
+    {% endfor %}
     {% if opts.add_iam_methods %}
     'get_iam_policy': ('resource', 'options', ),
     'set_iam_policy': ('resource', 'policy', ),

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -1,6 +1,7 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+
 import io
 import os
 import setuptools  # type: ignore
@@ -17,12 +18,12 @@ setuptools.setup(
     name='{{ api.naming.warehouse_package_name }}',
     version=version,
     long_description=readme,
-    {% if api.naming.namespace -%}
+    {% if api.naming.namespace %}
     packages=setuptools.PEP420PackageFinder.find(),
     namespace_packages={{ api.naming.namespace_packages }},
-    {% else -%}
+    {% else %}
     packages=setuptools.PEP420PackageFinder.find(),
-    {% endif -%}
+    {% endif %}
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -17,7 +17,7 @@ from requests import Response
 from requests.sessions import Session
 {% endif %}
 
-{# Import the service itself as well as every proto module that it imports. -#}
+{# Import the service itself as well as every proto module that it imports. #}
 {% filter sort_lines %}
 from google import auth
 from google.auth import credentials
@@ -118,7 +118,9 @@ def test_{{ service.client_name|snake_case }}_from_service_account_info(client_c
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        {% if service.host %}assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
+        {% if service.host %}
+        assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'
+        {% endif %}
 
 
 @pytest.mark.parametrize("client_class", [
@@ -139,7 +141,9 @@ def test_{{ service.client_name|snake_case }}_from_service_account_file(client_c
         assert client.transport._credentials == creds
         assert isinstance(client, client_class)
 
-        {% if service.host %}assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'{% endif %}
+        {% if service.host %}
+        assert client.transport._host == '{{ service.host }}{% if ":" not in service.host %}:443{% endif %}'
+        {% endif %}
 
 
 def test_{{ service.client_name|snake_case }}_get_transport_class():
@@ -440,10 +444,11 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
         call.return_value = iter([{{ method.output.ident }}()])
         {% else %}
         call.return_value = {{ method.output.ident }}(
-          {% for field in method.output.fields.values() | rejectattr('message')%}{% if not field.oneof or field.proto3_optional %}
+          {% for field in method.output.fields.values() | rejectattr('message')%}
+          {% if not field.oneof or field.proto3_optional %}
             {{ field.name }}={{ field.mock_value }},
             {% endif %}{% endfor %}
-            {#- This is a hack to only pick one field  #}
+            {# This is a hack to only pick one field  #}
             {% for oneof_fields in method.output.oneof_fields().values() %}
             {% with field = oneof_fields[0] %}
             {{ field.name }}={{ field.mock_value }},
@@ -480,15 +485,16 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
     assert response.raw_page is response
     {% endif %}
     assert isinstance(response, {{ method.client_output.ident }})
-    {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
-    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
+    {% for field in method.output.fields.values() | rejectattr('message') %}
+    {% if not field.oneof or field.proto3_optional %}
+    {% if field.field_pb.type in [1, 2] %}{# Use approx eq for floats #}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %}{# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
     {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
     {% endif %}
-    {% endif %} {# end oneof/optional #}
+    {% endif %}{# end oneof/optional #}
     {% endfor %}
     {% endif %}
 
@@ -558,7 +564,7 @@ async def test_{{ method.name|snake_case }}_async(transport: str = 'grpc_asyncio
                 grpc_helpers_async.FakeUnaryUnaryCall
             {%- else -%}
                 grpc_helpers_async.FakeStreamUnaryCall
-            {% endif %}({{ method.output.ident }}(
+            {%- endif -%}({{ method.output.ident }}(
             {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
             {{ field.name }}={{ field.mock_value }},
             {% endif %}
@@ -592,15 +598,16 @@ async def test_{{ method.name|snake_case }}_async(transport: str = 'grpc_asyncio
     assert isinstance(message, {{ method.output.ident }})
     {% else %}
     assert isinstance(response, {{ method.client_output_async.ident }})
-    {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
-    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
+    {% for field in method.output.fields.values() | rejectattr('message') %}
+    {% if not field.oneof or field.proto3_optional %}
+    {% if field.field_pb.type in [1, 2] %}{# Use approx eq for floats #}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %}{# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
     {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
     {% endif %}
-    {% endif %} {# oneof/optional #}
+    {% endif %}{# oneof/optional #}
     {% endfor %}
     {% endif %}
 
@@ -648,10 +655,10 @@ def test_{{ method.name|snake_case }}_field_headers():
     _, _, kw = call.mock_calls[0]
     assert (
         'x-goog-request-params',
-        '{% for field_header in method.field_headers %}
+        '{% for field_header in method.field_headers -%}
         {{ field_header }}={{ field_header }}/value
-        {% if not loop.last %}&{% endif %}
-        {% endfor %}',
+        {%- if not loop.last %}&{% endif %}
+        {%- endfor -%}',
     ) in kw['metadata']
 
 
@@ -694,10 +701,10 @@ async def test_{{ method.name|snake_case }}_field_headers_async():
     _, _, kw = call.mock_calls[0]
     assert (
         'x-goog-request-params',
-        '{% for field_header in method.field_headers %}
+        '{% for field_header in method.field_headers -%}
         {{ field_header }}={{ field_header }}/value
-        {% if not loop.last %}&{% endif %}
-        {% endfor %}',
+        {%- if not loop.last %}&{% endif %}
+        {%- endfor -%}',
     ) in kw['metadata']
 {% endif %}
 
@@ -833,7 +840,7 @@ async def test_{{ method.name|snake_case }}_flattened_async():
                 grpc_helpers_async.FakeUnaryUnaryCall
             {%- else -%}
                 grpc_helpers_async.FakeStreamUnaryCall
-            {% endif %}({{ method.output.ident }}())
+            {%- endif -%}({{ method.output.ident }}())
         {% endif %}
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
@@ -1077,9 +1084,9 @@ async def test_{{ method.name|snake_case }}_async_pages():
 def test_{{ method.name|snake_case }}_raw_page_lro():
     response = {{ method.lro.response_type.ident }}()
     assert response.raw_page is response
-{% endif %} {#- method.paged_result_field #}
+{% endif %} {# method.paged_result_field #}
 
-{% endfor %} {#- method in methods for grpc #}
+{% endfor %} {# method in methods for grpc #}
 
 {% for method in service.methods.values() if 'rest' in opts.transport %}
 def test_{{ method.name|snake_case }}_rest(transport: str = 'rest', request_type={{ method.input.ident }}):
@@ -1135,9 +1142,9 @@ def test_{{ method.name|snake_case }}_rest(transport: str = 'rest', request_type
     {% else %}
     assert isinstance(response, {{ method.client_output.ident }})
     {% for field in method.output.fields.values() %}
-    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
+    {% if field.field_pb.type in [1, 2] %}{# Use approx eq for floats #}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %}{# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
     {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
@@ -1339,8 +1346,8 @@ def test_{{ method.name|snake_case }}_pager():
             assert page_.raw_page.next_page_token == token
 
 
-{% endif %} {# paged methods #}
-{% endfor %} {#- method in methods for rest #}
+{% endif %}{# paged methods #}
+{% endfor %}{# method in methods for rest #}
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.{{ service.name }}{{ opts.transport[0].capitalize() }}Transport(

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1,6 +1,7 @@
 {% extends "_base.py.j2" %}
 
 {% block content %}
+
 import os
 import mock
 import packaging.version
@@ -11,21 +12,21 @@ import math
 import pytest
 from proto.marshal.rules.dates import DurationRule, TimestampRule
 
-{%- if 'rest' in opts.transport %}
+{% if 'rest' in opts.transport %}
 from requests import Response
 from requests.sessions import Session
-{%- endif %}
+{% endif %}
 
 {# Import the service itself as well as every proto module that it imports. -#}
-{% filter sort_lines -%}
+{% filter sort_lines %}
 from google import auth
 from google.auth import credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.oauth2 import service_account
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.client_name }}
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.async_client_name }}
-{%- endif %}
+{% endif %}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import transports
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.base import _GOOGLE_AUTH_VERSION
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.base import _API_CORE_VERSION
@@ -33,19 +34,19 @@ from google.api_core import client_options
 from google.api_core import exceptions
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
-{% if service.has_lro -%}
+{% if service.has_lro %}
 from google.api_core import future
 from google.api_core import operations_v1
 from google.longrunning import operations_pb2
-{% endif -%}
+{% endif %}
 from google.api_core import gapic_v1
-{% for method in service.methods.values() -%}
+{% for method in service.methods.values() %}
 {% for ref_type in method.ref_types
    if not ((ref_type.ident.python_import.package == ('google', 'api_core') and ref_type.ident.python_import.module == 'operation')
-           or ref_type.ident.python_import.package == ('google', 'protobuf') and ref_type.ident.python_import.module == 'empty_pb2') -%}
+           or ref_type.ident.python_import.package == ('google', 'protobuf') and ref_type.ident.python_import.module == 'empty_pb2') %}
 {{ ref_type.ident.python_import }}
-{% endfor -%}
-{% endfor -%}
+{% endfor %}
+{% endfor %}
 {% if opts.add_iam_methods %}
 from google.iam.v1 import iam_policy_pb2 as iam_policy  # type: ignore
 from google.iam.v1 import options_pb2 as options  # type: ignore
@@ -104,9 +105,9 @@ def test__get_default_mtls_endpoint():
 
 @pytest.mark.parametrize("client_class", [
     {{ service.client_name }},
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     {{ service.async_client_name }},
-    {%- endif %}
+    {% endif %}
 ])
 def test_{{ service.client_name|snake_case }}_from_service_account_info(client_class):
     creds = credentials.AnonymousCredentials()
@@ -122,9 +123,9 @@ def test_{{ service.client_name|snake_case }}_from_service_account_info(client_c
 
 @pytest.mark.parametrize("client_class", [
     {{ service.client_name }},
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     {{ service.async_client_name }},
-    {%- endif %}
+    {% endif %}
 ])
 def test_{{ service.client_name|snake_case }}_from_service_account_file(client_class):
     creds = credentials.AnonymousCredentials()
@@ -144,9 +145,9 @@ def test_{{ service.client_name|snake_case }}_from_service_account_file(client_c
 def test_{{ service.client_name|snake_case }}_get_transport_class():
     transport = {{ service.client_name }}.get_transport_class()
     available_transports = [
-        {%- for transport_name in opts.transport %}
+        {% for transport_name in opts.transport %}
         transports.{{ service.name }}{{ transport_name.capitalize() }}Transport,
-        {%- endfor %}
+        {% endfor %}
     ]
     assert transport in available_transports
 
@@ -155,17 +156,17 @@ def test_{{ service.client_name|snake_case }}_get_transport_class():
 
 
 @pytest.mark.parametrize("client_class,transport_class,transport_name", [
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     ({{ service.client_name }}, transports.{{ service.grpc_transport_name }}, "grpc"),
     ({{ service.async_client_name }}, transports.{{ service.grpc_asyncio_transport_name }}, "grpc_asyncio"),
-    {%- elif 'rest' in opts.transport %}
+    {% elif 'rest' in opts.transport %}
     ({{ service.client_name }}, transports.{{ service.rest_transport_name }}, "rest"),
-    {%- endif %}
+    {% endif %}
 ])
 @mock.patch.object({{ service.client_name }}, "DEFAULT_ENDPOINT", modify_default_endpoint({{ service.client_name }}))
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 @mock.patch.object({{ service.async_client_name }}, "DEFAULT_ENDPOINT", modify_default_endpoint({{ service.async_client_name }}))
-{%- endif %}
+{% endif %}
 def test_{{ service.client_name|snake_case }}_client_options(client_class, transport_class, transport_name):
     # Check that if channel is provided we won't create a new one.
     with mock.patch.object({{ service.client_name }}, 'get_transport_class') as gtc:
@@ -262,12 +263,12 @@ def test_{{ service.client_name|snake_case }}_client_options(client_class, trans
     {% elif 'rest' in opts.transport %}
     ({{ service.client_name }}, transports.{{ service.rest_transport_name }}, "rest", "true"),
     ({{ service.client_name }}, transports.{{ service.rest_transport_name }}, "rest", "false"),
-    {%- endif %}
+    {% endif %}
 ])
 @mock.patch.object({{ service.client_name }}, "DEFAULT_ENDPOINT", modify_default_endpoint({{ service.client_name }}))
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 @mock.patch.object({{ service.async_client_name }}, "DEFAULT_ENDPOINT", modify_default_endpoint({{ service.async_client_name }}))
-{%- endif %}
+{% endif %}
 @mock.patch.dict(os.environ, {"GOOGLE_API_USE_MTLS_ENDPOINT": "auto"})
 def test_{{ service.client_name|snake_case }}_mtls_env_auto(client_class, transport_class, transport_name, use_client_cert_env):
     # This tests the endpoint autoswitch behavior. Endpoint is autoswitched to the default
@@ -341,12 +342,12 @@ def test_{{ service.client_name|snake_case }}_mtls_env_auto(client_class, transp
 
 
 @pytest.mark.parametrize("client_class,transport_class,transport_name", [
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     ({{ service.client_name }}, transports.{{ service.grpc_transport_name }}, "grpc"),
     ({{ service.async_client_name }}, transports.{{ service.grpc_asyncio_transport_name }}, "grpc_asyncio"),
-    {%- elif 'rest' in opts.transport %}
+    {% elif 'rest' in opts.transport %}
     ({{ service.client_name }}, transports.{{ service.rest_transport_name }}, "rest"),
-    {%- endif %}
+    {% endif %}
 ])
 def test_{{ service.client_name|snake_case }}_client_options_scopes(client_class, transport_class, transport_name):
     # Check the case scopes are provided.
@@ -367,12 +368,12 @@ def test_{{ service.client_name|snake_case }}_client_options_scopes(client_class
         )
 
 @pytest.mark.parametrize("client_class,transport_class,transport_name", [
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     ({{ service.client_name }}, transports.{{ service.grpc_transport_name }}, "grpc"),
     ({{ service.async_client_name }}, transports.{{ service.grpc_asyncio_transport_name }}, "grpc_asyncio"),
-    {%- elif 'rest' in opts.transport %}
+    {% elif 'rest' in opts.transport %}
     ({{ service.client_name }}, transports.{{ service.rest_transport_name }}, "rest"),
-    {%- endif %}
+    {% endif %}
 ])
 def test_{{ service.client_name|snake_case }}_client_options_credentials_file(client_class, transport_class, transport_name):
     # Check the case credentials file is provided.
@@ -391,7 +392,7 @@ def test_{{ service.client_name|snake_case }}_client_options_credentials_file(cl
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
         )
-{%- if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport %}
 
 
 def test_{{ service.client_name|snake_case }}_client_options_from_dict():
@@ -409,10 +410,10 @@ def test_{{ service.client_name|snake_case }}_client_options_from_dict():
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
         )
-{%- endif %}
+{% endif %}
 
 
-{% for method in service.methods.values() if 'grpc' in opts.transport -%}
+{% for method in service.methods.values() if 'grpc' in opts.transport %}
 def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ method.input.ident }}):
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
@@ -431,25 +432,25 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/spam')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}(
-          {%- for field in method.output.fields.values() | rejectattr('message')%}{% if not field.oneof or field.proto3_optional %}
+          {% for field in method.output.fields.values() | rejectattr('message')%}{% if not field.oneof or field.proto3_optional %}
             {{ field.name }}={{ field.mock_value }},
-            {% endif %}{%- endfor %}
+            {% endif %}{% endfor %}
             {#- This is a hack to only pick one field  #}
-            {%- for oneof_fields in method.output.oneof_fields().values() %}
+            {% for oneof_fields in method.output.oneof_fields().values() %}
             {% with field = oneof_fields[0] %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endwith %}
-            {%- endfor %}
+            {% endwith %}
+            {% endfor %}
         )
-        {% endif -%}
+        {% endif %}
         {% if method.client_streaming %}
         response = client.{{ method.name|snake_case }}(iter(requests))
         {% else %}
@@ -466,28 +467,28 @@ def test_{{ method.name|snake_case }}(transport: str = 'grpc', request_type={{ m
         {% endif %}
 
     # Establish that the response is the type that we expect.
-    {% if method.void -%}
+    {% if method.void %}
     assert response is None
-    {% elif method.lro -%}
+    {% elif method.lro %}
     assert isinstance(response, future.Future)
-    {% elif method.server_streaming -%}
+    {% elif method.server_streaming %}
     for message in response:
         assert isinstance(message, {{ method.output.ident }})
-    {% else -%}
+    {% else %}
     {% if "next_page_token" in method.output.fields.values()|map(attribute='name') and not method.paged_result_field %}
     {# Cheeser assertion to force code coverage for bad paginated methods #}
     assert response.raw_page is response
     {% endif %}
     assert isinstance(response, {{ method.client_output.ident }})
-    {% for field in method.output.fields.values() | rejectattr('message') -%}{% if not field.oneof or field.proto3_optional %}
-    {% if field.field_pb.type in [1, 2] -%} {# Use approx eq for floats -#}
+    {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
+    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 -%} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
-    {% else -%}
+    {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
-    {% endif -%}
-    {% endif -%} {# end oneof/optional #}
+    {% endif %}
+    {% endif %} {# end oneof/optional #}
     {% endfor %}
     {% endif %}
 
@@ -496,7 +497,7 @@ def test_{{ method.name|snake_case }}_from_dict():
     test_{{ method.name|snake_case }}(request_type=dict)
 
 
-{% if not method.client_streaming -%}
+{% if not method.client_streaming %}
 def test_{{ method.name|snake_case }}_empty_call():
     # This test is a coverage failsafe to make sure that totally empty calls,
     # i.e. request == None and no flattened fields passed, work.
@@ -517,7 +518,7 @@ def test_{{ method.name|snake_case }}_empty_call():
         {% else %}
         assert args[0] == {{ method.input.ident }}()
         {% endif %}
-{% endif -%}
+{% endif %}
 
 
 @pytest.mark.asyncio
@@ -539,31 +540,31 @@ async def test_{{ method.name|snake_case }}_async(transport: str = 'grpc_asyncio
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        {% elif not method.client_streaming and method.server_streaming -%}
+        {% elif not method.client_streaming and method.server_streaming %}
         call.return_value = mock.Mock(aio.UnaryStreamCall, autospec=True)
         call.return_value.read = mock.AsyncMock(side_effect=[{{ method.output.ident }}()])
-        {% elif method.client_streaming and method.server_streaming -%}
+        {% elif method.client_streaming and method.server_streaming %}
         call.return_value = mock.Mock(aio.StreamStreamCall, autospec=True)
         call.return_value.read = mock.AsyncMock(side_effect=[{{ method.output.ident }}()])
-        {% else -%}
-        call.return_value ={{' '}}
+        {% else %}
+        call.return_value ={{ '' }}
             {%- if not method.client_streaming and not method.server_streaming -%}
                 grpc_helpers_async.FakeUnaryUnaryCall
             {%- else -%}
                 grpc_helpers_async.FakeStreamUnaryCall
-            {%- endif -%}({{ method.output.ident }}(
-            {%- for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
+            {% endif %}({{ method.output.ident }}(
+            {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endif %}
-            {%- endfor %}
+            {% endif %}
+            {% endfor %}
         ))
-        {% endif -%}
+        {% endif %}
         {% if method.client_streaming and method.server_streaming %}
         response = await client.{{ method.name|snake_case }}(iter(requests))
         {% elif method.client_streaming and not method.server_streaming %}
@@ -582,24 +583,24 @@ async def test_{{ method.name|snake_case }}_async(transport: str = 'grpc_asyncio
         {% endif %}
 
     # Establish that the response is the type that we expect.
-    {% if method.void -%}
+    {% if method.void %}
     assert response is None
-    {% elif method.lro -%}
+    {% elif method.lro %}
     assert isinstance(response, future.Future)
-    {% elif method.server_streaming -%}
+    {% elif method.server_streaming %}
     message = await response.read()
     assert isinstance(message, {{ method.output.ident }})
-    {% else -%}
+    {% else %}
     assert isinstance(response, {{ method.client_output_async.ident }})
-    {% for field in method.output.fields.values() | rejectattr('message') -%}{% if not field.oneof or field.proto3_optional %}
-    {% if field.field_pb.type in [1, 2] -%} {# Use approx eq for floats -#}
+    {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
+    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 -%} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
-    {% else -%}
+    {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
-    {% endif -%}
-    {% endif -%} {# oneof/optional #}
+    {% endif %}
+    {% endif %} {# oneof/optional #}
     {% endfor %}
     {% endif %}
 
@@ -619,21 +620,21 @@ def test_{{ method.name|snake_case }}_field_headers():
     # a field header. Set these to a non-empty value.
     request = {{ method.input.ident }}()
 
-    {%- for field_header in method.field_headers %}
+    {% for field_header in method.field_headers %}
     request.{{ field_header }} = '{{ field_header }}/value'
-    {%- endfor %}
+    {% endfor %}
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
         client.{{ method.name|snake_case }}(request)
@@ -647,10 +648,10 @@ def test_{{ method.name|snake_case }}_field_headers():
     _, _, kw = call.mock_calls[0]
     assert (
         'x-goog-request-params',
-        '{% for field_header in method.field_headers -%}
+        '{% for field_header in method.field_headers %}
         {{ field_header }}={{ field_header }}/value
-        {%- if not loop.last %}&{% endif -%}
-        {%- endfor %}',
+        {% if not loop.last %}&{% endif %}
+        {% endfor %}',
     ) in kw['metadata']
 
 
@@ -664,22 +665,22 @@ async def test_{{ method.name|snake_case }}_field_headers_async():
     # a field header. Set these to a non-empty value.
     request = {{ method.input.ident }}()
 
-    {%- for field_header in method.field_headers %}
+    {% for field_header in method.field_headers %}
     request.{{ field_header }} = '{{ field_header }}/value'
-    {%- endfor %}
+    {% endfor %}
 
     # Mock the actual call within the gRPC stub, and fake the request.
     with mock.patch.object(
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(operations_pb2.Operation(name='operations/op'))
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = mock.Mock(aio.UnaryStreamCall, autospec=True)
         call.return_value.read = mock.AsyncMock(side_effect=[{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall({{ method.output.ident }}())
         {% endif %}
         await client.{{ method.name|snake_case }}(request)
@@ -693,10 +694,10 @@ async def test_{{ method.name|snake_case }}_field_headers_async():
     _, _, kw = call.mock_calls[0]
     assert (
         'x-goog-request-params',
-        '{% for field_header in method.field_headers -%}
+        '{% for field_header in method.field_headers %}
         {{ field_header }}={{ field_header }}/value
-        {%- if not loop.last %}&{% endif -%}
-        {%- endfor %}',
+        {% if not loop.last %}&{% endif %}
+        {% endfor %}',
     ) in kw['metadata']
 {% endif %}
 
@@ -710,19 +711,19 @@ def test_{{ method.name|snake_case }}_from_dict_foreign():
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
         response = client.{{ method.name|snake_case }}(request={
-            {%- for field in method.input.fields.values() %}
+            {% for field in method.input.fields.values() %}
             '{{ field.name }}': {{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
             }
         )
         call.assert_called()
@@ -740,41 +741,41 @@ def test_{{ method.name|snake_case }}_flattened():
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         client.{{ method.name|snake_case }}(
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
-        {% for key, field in method.flattened_fields.items() -%}{%- if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' -%}
+        {% for key, field in method.flattened_fields.items() %}{% if not field.oneof or field.proto3_optional %}
+        {% if field.ident|string() == 'timestamp.Timestamp' %}
         assert TimestampRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' -%}
+        {% elif field.ident|string() == 'duration.Duration' %}
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% else -%}
+        {% else %}
         assert args[0].{{ key }} == {{ field.mock_value }}
         {% endif %}
         {% endif %}{% endfor %}
-        {%- for oneofs in method.flattened_oneof_fields().values() %}
-        {%- with field = oneofs[-1]  %}
+        {% for oneofs in method.flattened_oneof_fields().values() %}
+        {% with field = oneofs[-1]  %}
         assert args[0].{{ method.flattened_field_to_key[field.name] }} == {{ field.mock_value }}
-        {%- endwith %}
-        {%- endfor %}
+        {% endwith %}
+        {% endfor %}
 
 
 
@@ -788,9 +789,9 @@ def test_{{ method.name|snake_case }}_flattened_error():
     with pytest.raises(ValueError):
         client.{{ method.name|snake_case }}(
             {{ method.input.ident }}(),
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
 
 
@@ -805,61 +806,61 @@ async def test_{{ method.name|snake_case }}_flattened_async():
             type(client.transport.{{ method.name|snake_case }}),
             '__call__') as call:
         # Designate an appropriate return value for the call.
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = operations_pb2.Operation(name='operations/op')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         call.return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
 
 
-        {% if method.void -%}
+        {% if method.void %}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        {% elif method.lro -%}
+        {% elif method.lro %}
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        {% elif not method.client_streaming and method.server_streaming -%}
+        {% elif not method.client_streaming and method.server_streaming %}
         call.return_value = mock.Mock(aio.UnaryStreamCall, autospec=True)
-        {% elif method.client_streaming and method.server_streaming -%}
+        {% elif method.client_streaming and method.server_streaming %}
         call.return_value = mock.Mock(aio.StreamStreamCall, autospec=True)
-        {% else -%}
-        call.return_value ={{' '}}
+        {% else %}
+        call.return_value = {{ '' }}
             {%- if not method.client_streaming and not method.server_streaming -%}
                 grpc_helpers_async.FakeUnaryUnaryCall
             {%- else -%}
                 grpc_helpers_async.FakeStreamUnaryCall
-            {%- endif -%}({{ method.output.ident }}())
-        {% endif -%}
+            {% endif %}({{ method.output.ident }}())
+        {% endif %}
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
         response = await client.{{ method.name|snake_case }}(
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
 
         # Establish that the underlying call was made with the expected
         # request object values.
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
-        {% for key, field in method.flattened_fields.items() -%}{%- if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' -%}
+        {% for key, field in method.flattened_fields.items() %}{% if not field.oneof or field.proto3_optional %}
+        {% if field.ident|string() == 'timestamp.Timestamp' %}
         assert TimestampRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' -%}
+        {% elif field.ident|string() == 'duration.Duration' %}
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% else -%}
+        {% else %}
         assert args[0].{{ key }} == {{ field.mock_value }}
         {% endif %}
         {% endif %}{% endfor %}
-        {%- for oneofs in method.flattened_oneof_fields().values() %}
-        {%- with field = oneofs[-1]  %}
+        {% for oneofs in method.flattened_oneof_fields().values() %}
+        {% with field = oneofs[-1]  %}
         assert args[0].{{ method.flattened_field_to_key[field.name] }} == {{ field.mock_value }}
-        {%- endwith %}
-        {%- endfor %}
+        {% endwith %}
+        {% endfor %}
 
 
 @pytest.mark.asyncio
@@ -873,9 +874,9 @@ async def test_{{ method.name|snake_case }}_flattened_error_async():
     with pytest.raises(ValueError):
         await client.{{ method.name|snake_case }}(
             {{ method.input.ident }}(),
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
 {% endif %}
 
@@ -920,17 +921,17 @@ def test_{{ method.name|snake_case }}_pager():
         )
 
         metadata = ()
-        {% if method.field_headers -%}
+        {% if method.field_headers %}
         metadata = tuple(metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
-                {%- for field_header in method.field_headers %}
-                {%- if not method.client_streaming %}
+                {% for field_header in method.field_headers %}
+                {% if not method.client_streaming %}
                 ('{{ field_header }}', ''),
-                {%- endif %}
-                {%- endfor %}
+                {% endif %}
+                {% endfor %}
             )),
         )
-        {% endif -%}
+        {% endif %}
         pager = client.{{ method.name|snake_case }}(request={})
 
         assert pager._metadata == metadata
@@ -1078,9 +1079,9 @@ def test_{{ method.name|snake_case }}_raw_page_lro():
     assert response.raw_page is response
 {% endif %} {#- method.paged_result_field #}
 
-{% endfor -%} {#- method in methods for grpc #}
+{% endfor %} {#- method in methods for grpc #}
 
-{% for method in service.methods.values() if 'rest' in opts.transport -%}
+{% for method in service.methods.values() if 'rest' in opts.transport %}
 def test_{{ method.name|snake_case }}_rest(transport: str = 'rest', request_type={{ method.input.ident }}):
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
@@ -1097,19 +1098,19 @@ def test_{{ method.name|snake_case }}_rest(transport: str = 'rest', request_type
     # Mock the http request call within the method and fake a response.
     with mock.patch.object(Session, 'request') as req:
         # Designate an appropriate value for the returned response.
-        {% if method.void -%}
+        {% if method.void %}
         return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         return_value = operations_pb2.Operation(name='operations/spam')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         return_value = {{ method.output.ident }}(
-            {%- for field in method.output.fields.values() %}
+            {% for field in method.output.fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
-        {% endif -%}
+        {% endif %}
 
         # Wrap the value into a proper Response obj
         json_return_value = {{ method.output.ident }}.to_json(return_value)
@@ -1129,18 +1130,18 @@ def test_{{ method.name|snake_case }}_rest(transport: str = 'rest', request_type
     {% endif %}
 
     # Establish that the response is the type that we expect.
-    {% if method.void -%}
+    {% if method.void %}
     assert response is None
     {% else %}
     assert isinstance(response, {{ method.client_output.ident }})
-    {% for field in method.output.fields.values() -%}
-    {% if field.field_pb.type in [1, 2] -%} {# Use approx eq for floats -#}
+    {% for field in method.output.fields.values() %}
+    {% if field.field_pb.type in [1, 2] %} {# Use approx eq for floats -#}
     assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
-    {% elif field.field_pb.type == 8 -%} {# Use 'is' for bools #}
+    {% elif field.field_pb.type == 8 %} {# Use 'is' for bools #}
     assert response.{{ field.name }} is {{ field.mock_value }}
-    {% else -%}
+    {% else %}
     assert response.{{ field.name }} == {{ field.mock_value }}
-    {% endif -%}
+    {% endif %}
     {% endfor %}
     {% endif %}
 
@@ -1157,13 +1158,13 @@ def test_{{ method.name|snake_case }}_rest_flattened():
     # Mock the http request call within the method and fake a response.
     with mock.patch.object(Session, 'request') as req:
         # Designate an appropriate value for the returned response.
-        {% if method.void -%}
+        {% if method.void %}
         return_value = None
-        {% elif method.lro -%}
+        {% elif method.lro %}
         return_value = operations_pb2.Operation(name='operations/spam')
-        {% elif method.server_streaming -%}
+        {% elif method.server_streaming %}
         return_value = iter([{{ method.output.ident }}()])
-        {% else -%}
+        {% else %}
         return_value = {{ method.output.ident }}()
         {% endif %}
 
@@ -1176,13 +1177,13 @@ def test_{{ method.name|snake_case }}_rest_flattened():
 
         # Call the method with a truthy value for each flattened field,
         # using the keyword arguments to the method.
-        {%- for field in method.flattened_fields.values() if field.field_pb is msg_field_pb %}
+        {% for field in method.flattened_fields.values() if field.field_pb is msg_field_pb %}
         {{ field.name }} = {{ field.mock_value }}
         {% endfor %}
         client.{{ method.name|snake_case }}(
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {% if field.field_pb is msg_field_pb %}{{ field.name }}={{ field.name }},{% else %}{{ field.name }}={{ field.mock_value }},{% endif %}
-            {%- endfor %}
+            {% endfor %}
         )
 
         # Establish that the underlying call was made with the expected
@@ -1190,16 +1191,16 @@ def test_{{ method.name|snake_case }}_rest_flattened():
         assert len(req.mock_calls) == 1
         _, http_call, http_params = req.mock_calls[0]
         body = http_params.get('data')
-        {% for key, field in method.flattened_fields.items() -%}{%- if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' -%}
+        {% for key, field in method.flattened_fields.items() %}{% if not field.oneof or field.proto3_optional %}
+        {% if field.ident|string() == 'timestamp.Timestamp' %}
         assert TimestampRule().to_proto(http_call[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' -%}
+        {% elif field.ident|string() == 'duration.Duration' %}
         assert DurationRule().to_proto(http_call[0].{{ key }}) == {{ field.mock_value }}
-        {% else -%}
+        {% else %}
         assert {% if field.field_pb is msg_field_pb %}{{ field.ident }}.to_json({{ field.name }}, including_default_value_fields=False, use_integers_for_enums=False)
-               {%- elif field.field_pb is str_field_pb %}{{ field.mock_value }}
-               {%- else %}str({{ field.mock_value }})
-               {%- endif %} in http_call[1] + str(body)
+               {% elif field.field_pb is str_field_pb %}{{ field.mock_value }}
+               {% else %}str({{ field.mock_value }})
+               {% endif %} in http_call[1] + str(body)
         {% endif %}
         {% endif %}{% endfor %}
 
@@ -1214,9 +1215,9 @@ def test_{{ method.name|snake_case }}_rest_flattened_error():
     with pytest.raises(ValueError):
         client.{{ method.name|snake_case }}(
             {{ method.input.ident }}(),
-            {%- for field in method.flattened_fields.values() %}
+            {% for field in method.flattened_fields.values() %}
             {{ field.name }}={{ field.mock_value }},
-            {%- endfor %}
+            {% endfor %}
         )
 
 
@@ -1296,17 +1297,17 @@ def test_{{ method.name|snake_case }}_pager():
         req.side_effect = return_values
 
         metadata = ()
-        {% if method.field_headers -%}
+        {% if method.field_headers %}
         metadata = tuple(metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
-                {%- for field_header in method.field_headers %}
-                {%- if not method.client_streaming %}
+                {% for field_header in method.field_headers %}
+                {% if not method.client_streaming %}
                 ('{{ field_header }}', ''),
-                {%- endif %}
-                {%- endfor %}
+                {% endif %}
+                {% endfor %}
             )),
         )
-        {% endif -%}
+        {% endif %}
         pager = client.{{ method.name|snake_case }}(request={})
 
         assert pager._metadata == metadata
@@ -1339,7 +1340,7 @@ def test_{{ method.name|snake_case }}_pager():
 
 
 {% endif %} {# paged methods #}
-{% endfor -%} {#- method in methods for rest #}
+{% endfor %} {#- method in methods for rest #}
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.{{ service.name }}{{ opts.transport[0].capitalize() }}Transport(
@@ -1397,12 +1398,12 @@ def test_transport_get_channel():
 {% endif %}
 
 @pytest.mark.parametrize("transport_class", [
-    {%- if 'grpc' in opts.transport %}
+    {% if 'grpc' in opts.transport %}
     transports.{{ service.grpc_transport_name }},
     transports.{{ service.grpc_asyncio_transport_name }},
-    {%- elif 'rest' in opts.transport %}
+    {% elif 'rest' in opts.transport %}
     transports.{{ service.rest_transport_name }},
-    {%- endif %}
+    {% endif %}
 ])
 def test_transport_adc(transport_class):
     # Test default credentials are used if not provided.
@@ -1443,20 +1444,20 @@ def test_{{ service.name|snake_case }}_base_transport():
     # Every method on the transport should just blindly
     # raise NotImplementedError.
     methods = (
-        {% for method in service.methods.values() -%}
+        {% for method in service.methods.values() %}
         '{{ method.name|snake_case }}',
-        {% endfor -%}
-        {%- if opts.add_iam_methods -%}
+        {% endfor %}
+        {% if opts.add_iam_methods %}
         'set_iam_policy',
         'get_iam_policy',
         'test_iam_permissions',
-        {% endif -%}
+        {% endif %}
     )
     for method in methods:
         with pytest.raises(NotImplementedError):
             getattr(transport, method)(request=object())
 
-    {% if service.has_lro -%}
+    {% if service.has_lro %}
     # Additionally, the LRO client (a property) should
     # also raise NotImplementedError
     with pytest.raises(NotImplementedError):
@@ -1495,11 +1496,16 @@ def test_{{ service.name|snake_case }}_base_transport_with_credentials_file_old_
             credentials_file="credentials.json",
             quota_project_id="octopus",
         )
+<<<<<<< HEAD
         load_creds.assert_called_once_with("credentials.json",
             scopes=(
             {%- for scope in service.oauth_scopes %}
+=======
+        load_creds.assert_called_once_with("credentials.json", scopes=(
+            {% for scope in service.oauth_scopes %}
+>>>>>>> ab9188c (fix: use trim_blocks and lstrip_blocks for jinja templates)
             '{{ scope }}',
-            {%- endfor %}
+            {% endfor %}
             ),
             quota_project_id="octopus",
         )
@@ -1523,9 +1529,10 @@ def test_{{ service.name|snake_case }}_auth_adc():
         adc.assert_called_once_with(
             scopes=None,
             default_scopes=(
-                {%- for scope in service.oauth_scopes %}
-                '{{ scope }}',
-                {%- endfor %}),
+            {% for scope in service.oauth_scopes %}
+            '{{ scope }}',
+            {% endfor %}),
+
             quota_project_id=None,
         )
 
@@ -1584,11 +1591,10 @@ def test_{{ service.name|snake_case }}_transport_auth_adc_old_google_auth(transp
     with mock.patch.object(auth, "default", autospec=True) as adc:
         adc.return_value = (credentials.AnonymousCredentials(), None)
         transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(
-            scopes=(
-                {%- for scope in service.oauth_scopes %}
-                '{{ scope }}',
-                {%- endfor %}),
+        adc.assert_called_once_with(scopes=(
+            {% for scope in service.oauth_scopes %}
+            '{{ scope }}',
+            {% endfor %}),
             quota_project_id="octopus",
         )
 
@@ -1728,9 +1734,9 @@ def test_{{ service.name|snake_case }}_grpc_transport_client_cert_source_for_mtl
             credentials=cred,
             credentials_file=None,
             scopes=(
-                {%- for scope in service.oauth_scopes %}
+                {% for scope in service.oauth_scopes %}
                 '{{ scope }}',
-                {%- endfor %}
+                {% endfor %}
             ),
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
@@ -1767,7 +1773,7 @@ def test_{{ service.name|snake_case }}_http_transport_client_cert_source_for_mtl
 {% endif %}
 
 def test_{{ service.name|snake_case }}_host_no_port():
-    {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
+    {% with host = (service.host|default('localhost', true)).split(':')[0] %}
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}'),
@@ -1777,7 +1783,7 @@ def test_{{ service.name|snake_case }}_host_no_port():
 
 
 def test_{{ service.name|snake_case }}_host_with_port():
-    {% with host = (service.host|default('localhost', true)).split(':')[0] -%}
+    {% with host = (service.host|default('localhost', true)).split(':')[0] %}
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
         client_options=client_options.ClientOptions(api_endpoint='{{ host }}:8000'),
@@ -1845,9 +1851,9 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                 credentials=cred,
                 credentials_file=None,
                 scopes=(
-                    {%- for scope in service.oauth_scopes %}
+                    {% for scope in service.oauth_scopes %}
                     '{{ scope }}',
-                    {%- endfor %}
+                    {% endfor %}
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
@@ -1890,9 +1896,9 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
                 credentials=mock_cred,
                 credentials_file=None,
                 scopes=(
-                    {%- for scope in service.oauth_scopes %}
+                    {% for scope in service.oauth_scopes %}
                     '{{ scope }}',
-                    {%- endfor %}
+                    {% endfor %}
                 ),
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
@@ -1904,7 +1910,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
             assert transport.grpc_channel == mock_grpc_channel
 
 
-{% if service.has_lro -%}
+{% if service.has_lro %}
 def test_{{ service.name|snake_case }}_grpc_lro_client():
     client = {{ service.client_name }}(
         credentials=credentials.AnonymousCredentials(),
@@ -1938,13 +1944,13 @@ def test_{{ service.name|snake_case }}_grpc_lro_async_client():
     # Ensure that subsequent calls to the property send the exact same object.
     assert transport.operations_client is transport.operations_client
 
-{% endif -%}
+{% endif %}
 {% endif %} {# if grpc in opts #}
 
-{% with molluscs = cycler("squid", "clam", "whelk", "octopus", "oyster", "nudibranch", "cuttlefish", "mussel", "winkle", "nautilus", "scallop", "abalone") -%}
-{% for message in service.resource_messages|sort(attribute="resource_type") -%}
+{% with molluscs = cycler("squid", "clam", "whelk", "octopus", "oyster", "nudibranch", "cuttlefish", "mussel", "winkle", "nautilus", "scallop", "abalone") %}
+{% for message in service.resource_messages|sort(attribute="resource_type") %}
 def test_{{ message.resource_type|snake_case }}_path():
-    {% for arg in message.resource_path_args -%}
+    {% for arg in message.resource_path_args %}
     {{ arg }} = "{{ molluscs.next() }}"
     {% endfor %}
     expected = "{{ message.resource_path }}".format({% for arg in message.resource_path_args %}{{ arg }}={{ arg }}, {% endfor %})
@@ -1954,7 +1960,7 @@ def test_{{ message.resource_type|snake_case }}_path():
 
 def test_parse_{{ message.resource_type|snake_case }}_path():
     expected = {
-    {% for arg in message.resource_path_args -%}
+    {% for arg in message.resource_path_args %}
         "{{ arg }}": "{{ molluscs.next() }}",
     {% endfor %}
     }
@@ -1964,10 +1970,10 @@ def test_parse_{{ message.resource_type|snake_case }}_path():
     actual = {{ service.client_name }}.parse_{{ message.resource_type|snake_case }}_path(path)
     assert expected == actual
 
-{% endfor -%}
-{% for resource_msg in service.common_resources.values()|sort(attribute="type_name") -%}
+{% endfor %}
+{% for resource_msg in service.common_resources.values()|sort(attribute="type_name") %}
 def test_common_{{ resource_msg.message_type.resource_type|snake_case }}_path():
-    {% for arg in resource_msg.message_type.resource_path_args -%}
+    {% for arg in resource_msg.message_type.resource_path_args %}
     {{ arg }} = "{{ molluscs.next() }}"
     {% endfor %}
     expected = "{{ resource_msg.message_type.resource_path }}".format({% for arg in resource_msg.message_type.resource_path_args %}{{ arg }}={{ arg }}, {% endfor %})
@@ -1977,7 +1983,7 @@ def test_common_{{ resource_msg.message_type.resource_type|snake_case }}_path():
 
 def test_parse_common_{{ resource_msg.message_type.resource_type|snake_case }}_path():
     expected = {
-    {% for arg in resource_msg.message_type.resource_path_args -%}
+    {% for arg in resource_msg.message_type.resource_path_args %}
         "{{ arg }}": "{{ molluscs.next() }}",
     {% endfor %}
     }
@@ -1987,8 +1993,8 @@ def test_parse_common_{{ resource_msg.message_type.resource_type|snake_case }}_p
     actual = {{ service.client_name }}.parse_common_{{ resource_msg.message_type.resource_type|snake_case }}_path(path)
     assert expected == actual
 
-{% endfor -%} {# common resources#}
-{% endwith -%} {# cycler #}
+{% endfor %} {# common resources#}
+{% endwith %} {# cycler #}
 
 
 def test_client_withDEFAULT_CLIENT_INFO():

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1621,7 +1621,7 @@ def test_{{ service.name|snake_case }}_transport_create_channel(transport_class,
             scopes=["1", "2"]
         )
 
-        {% with host = (service.host|default('localhost', true)) -%}
+        {% with host = (service.host|default('localhost', true)) %}
         create_channel.assert_called_with(
             "{{ host }}",
             credentials=creds,
@@ -1660,7 +1660,7 @@ def test_{{ service.name|snake_case }}_transport_create_channel_old_api_core(tra
         adc.return_value = (creds, None)
         transport_class(quota_project_id="octopus")
 
-        {% with host = (service.host|default('localhost', true)) -%}
+        {% with host = (service.host|default('localhost', true)) %}
         create_channel.assert_called_with(
             "{{ host }}",
             credentials=creds,
@@ -1695,7 +1695,7 @@ def test_{{ service.name|snake_case }}_transport_create_channel_user_scopes(tran
     ) as create_channel:
         creds = credentials.AnonymousCredentials()
         adc.return_value = (creds, None)
-        {% with host = (service.host|default('localhost', true)) -%}
+        {% with host = (service.host|default('localhost', true)) %}
 
         transport_class(quota_project_id="octopus", scopes=["1", "2"])
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1503,14 +1503,8 @@ def test_{{ service.name|snake_case }}_base_transport_with_credentials_file_old_
             credentials_file="credentials.json",
             quota_project_id="octopus",
         )
-<<<<<<< HEAD
-        load_creds.assert_called_once_with("credentials.json",
-            scopes=(
-            {%- for scope in service.oauth_scopes %}
-=======
         load_creds.assert_called_once_with("credentials.json", scopes=(
             {% for scope in service.oauth_scopes %}
->>>>>>> ab9188c (fix: use trim_blocks and lstrip_blocks for jinja templates)
             '{{ scope }}',
             {% endfor %}
             ),

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -153,11 +153,10 @@ def sample_classify(video, location):
     # location = "New Zealand"
     classify_target["location_annotation"] = location
 
- 
- 
+
     response = client.classify(classify_target=classify_target)
     print("Mollusc is a \\"{}\\"".format(response.taxonomy))
- 
+
 
 # [END %s]
 
@@ -293,11 +292,10 @@ def sample_classify(video, location):
     request = {
         'classify_target': classify_target,
     }
- 
- 
+
     response = client.classify(request=request)
     print("Mollusc is a \\"{}\\"".format(response.taxonomy))
- 
+
 
 # [END %s]
 


### PR DESCRIPTION
Enable `trim_blocks` and `lstrip_blocks` in the Jinja environment to make it easier to manage whitespace and newlines. This PR may result in slight changes to the formatting of generated code.

https://jinja.palletsprojects.com/en/2.11.x/api/#jinja2.Environment
https://jinja.palletsprojects.com/en/2.11.x/templates/#whitespace-control