### PR TITLE
chore: prevent normalization of semver versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with io.open(os.path.join(PACKAGE_ROOT, "README.rst")) as file_obj:
 
 setup(
     name="gapic-generator",
-    version=version,
+    version=setuptools.sic(version),
     license="Apache 2.0",
     author="Dov Shlachter",
     author_email="dovs@google.com",


### PR DESCRIPTION
When there is a patch version added to semver versioning, setuptools.setup(version) will normalize the versioning from `-patch` to `.patch` which is not correct SEMVER versioning. The added feature with setuptools.sic(version) will prevent this from happening.