### PR TITLE
fix: Check for default value presence for non-optional fields in REST

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -196,7 +196,7 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
             query_params['{{ field|camel_case }}'] = request.{{ field }}
         {% else %}
         if request.{{ field }}:
-          query_params['{{ field|camel_case }}'] = request.{{ field }}
+            query_params['{{ field|camel_case }}'] = request.{{ field }}
         {% endif %}
         {% endfor %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -195,14 +195,15 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         if {{ method.input.ident }}.{{ field }} in request:
             query_params['{{ field|camel_case }}'] = request.{{ field }}
         {% else %}
-        query_params['{{ field|camel_case }}'] = request.{{ field }}
+        if request.{{ field }}:
+          query_params['{{ field|camel_case }}'] = request.{{ field }}
         {% endif %}
         {% endfor %}
 
         # TODO(yon-mg): further discussion needed whether 'python truthiness' is appropriate here
         #               discards default values
         # TODO(yon-mg): add test for proper url encoded strings
-        query_params = ['{k}={v}'.format(k=k, v=v) for k, v in query_params.items() if v]
+        query_params = ['{k}={v}'.format(k=k, v=v) for k, v in query_params.items()]
         url += '?{}'.format('&'.join(query_params)).replace(' ', '+')
 
         # Send the request


### PR DESCRIPTION
Otherwise on practical cases we may get 400 errors because of empty body of the non-optional query params.