### PR TITLE
fix: also add the async client to __all__

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -43,6 +43,9 @@ __all__ = (
     {% for service in api.services.values()
             if service.meta.address.subpackage == api.subpackage_view -%}
     '{{ service.client_name }}',
+    {% if 'grpc' in opts.transport %}
+    '{{ service.async_client_name }}',
+    {% endif %}
     {% endfor -%}
     {% for proto in api.protos.values()
             if proto.meta.address.subpackage == api.subpackage_view -%}

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -145,7 +145,7 @@ with open({{ attr.input_parameter }}, "rb") as f:
 {% macro render_client_setup(module_name, client_name) %}
 # Create a client
 client = {{ module_name }}.{{ client_name }}()
-{% endmacro %}}
+{% endmacro %}
 
 {% macro render_request_setup(full_request, module_name, request_type) %}
 # Initialize request argument(s)


### PR DESCRIPTION
Follow up to #859

Closes #815 

Also delete a stray } in feature_fragments which was resulting in almost empty files getting generated in clients. https://github.com/googleapis/googleapis-gen/blob/master/google/appengine/v1/google-cloud-appengine-v1-py/examples/feature_fragments