### PR TITLE
style: update Python client library templates to align with the Python Style Guide

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -1,4 +1,4 @@
-{% extends '_base.py.j2' %}
+{% extends "_base.py.j2" %}
 
 {% block content %}
 
@@ -51,7 +51,8 @@ class {{ service.async_client_name }}:
 
     @classmethod
     def from_service_account_info(cls, info: dict, *args, **kwargs):
-        """Creates an instance of this client using the provided credentials info.
+        """Creates an instance of this client using the provided credentials
+            info.
 
         Args:
             info (dict): The service account private key info.
@@ -66,7 +67,7 @@ class {{ service.async_client_name }}:
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
         """Creates an instance of this client using the provided credentials
-        file.
+            file.
 
         Args:
             filename (str): The path to the service account private key json
@@ -83,7 +84,7 @@ class {{ service.async_client_name }}:
 
     @property
     def transport(self) -> {{ service.name }}Transport:
-        """Return the transport used by the client instance.
+        """Returns the transport used by the client instance.
 
         Returns:
             {{ service.name }}Transport: The transport used by the client instance.
@@ -95,11 +96,11 @@ class {{ service.async_client_name }}:
 
     def __init__(self, *,
             credentials: ga_credentials.Credentials = None,
-            transport: Union[str, {{ service.name }}Transport] = 'grpc_asyncio',
+            transport: Union[str, {{ service.name }}Transport] = "grpc_asyncio",
             client_options: ClientOptions = None,
             client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
             ) -> None:
-        """Instantiate the {{ (service.client_name|snake_case).replace('_', ' ') }}.
+        """Instantiates the {{ (service.client_name|snake_case).replace("_", " ") }}.
 
         Args:
             credentials (Optional[google.auth.credentials.Credentials]): The
@@ -165,7 +166,7 @@ class {{ service.async_client_name }}:
         Args:
             {% if not method.client_streaming %}
             request (:class:`{{ method.input.ident.sphinx }}`):
-                The request object.{{ ' ' }}
+                The request object.{{ " " }}
                 {{- method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             {% for key, field in method.flattened_fields.items() %}
             {{ field.name }} (:class:`{{ field.ident.sphinx }}`):
@@ -176,7 +177,7 @@ class {{ service.async_client_name }}:
             {% endfor %}
             {% else %}
             requests (AsyncIterator[`{{ method.input.ident.sphinx }}`]):
-                The request object AsyncIterator.{{ ' ' }}
+                The request object AsyncIterator.{{ " " }}
                 {{- method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             {% endif %}
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -200,10 +201,10 @@ class {{ service.async_client_name }}:
         {% if method.flattened_fields %}
         # Sanity check: If we got a request object, we should *not* have
         # gotten any keyword arguments that map to the request.
-        has_flattened_params = any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}])
+        has_flattened_params = any([{{ method.flattened_fields.values()|join(", ", attribute="name") }}])
         if request is not None and has_flattened_params:
-            raise ValueError('If the `request` argument is set, then none of '
-                             'the individual field arguments should be set.')
+            raise ValueError("If the `request` argument is set, then none of "
+                             "the individual field arguments should be set.")
 
         {% endif %}
         {% if method.input.ident.package != method.ident.package %} {# request lives in a different package, so there is no proto wrapper #}
@@ -251,7 +252,7 @@ class {{ service.async_client_name }}:
                 {% if method.retry.max_backoff %}maximum={{ method.retry.max_backoff }},{% endif %}
                 {% if method.retry.backoff_multiplier %}multiplier={{ method.retry.backoff_multiplier }},{% endif %}
                 predicate=retries.if_exception_type(
-                    {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
+                    {% for ex in method.retry.retryable_exceptions|sort(attribute="__name__") %}
                     exceptions.{{ ex.__name__ }},
                     {% endfor %}
                 ),
@@ -269,7 +270,7 @@ class {{ service.async_client_name }}:
             gapic_v1.routing_header.to_grpc_metadata((
                 {% for field_header in method.field_headers %}
                 {% if not method.client_streaming %}
-                ('{{ field_header }}', request.{{ field_header }}),
+                ("{{ field_header }}", request.{{ field_header }}),
                 {% endif %}
                 {% endfor %}
             )),
@@ -313,7 +314,7 @@ class {{ service.async_client_name }}:
         # Done; return the response.
         return response
         {% endif %}
-        {{ '\n' }}
+        {{ "\n" }}
     {% endfor %}
 
 
@@ -326,8 +327,10 @@ class {{ service.async_client_name }}:
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> policy_pb2.Policy:
-        r"""Sets the IAM access control policy on the specified
-        function. Replaces any existing policy.
+        r"""Sets the IAM access control policy on the specified function.
+
+        Replaces any existing policy.
+
         Args:
             request (:class:`~.policy_pb2.SetIamPolicyRequest`):
                 The request object. Request message for `SetIamPolicy`
@@ -433,8 +436,10 @@ class {{ service.async_client_name }}:
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> policy_pb2.Policy:
         r"""Gets the IAM access control policy for a function.
+
         Returns an empty policy if the function exists and does
         not have a policy set.
+
         Args:
             request (:class:`~.iam_policy_pb2.GetIamPolicyRequest`):
                 The request object. Request message for `GetIamPolicy`
@@ -540,8 +545,11 @@ class {{ service.async_client_name }}:
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> iam_policy_pb2.TestIamPermissionsResponse:
         r"""Tests the specified permissions against the IAM access control
-        policy for a function. If the function does not exist, this will
+            policy for a function.
+
+        If the function does not exist, this will
         return an empty set of permissions, not a NOT_FOUND error.
+
         Args:
             request (:class:`~.iam_policy_pb2.TestIamPermissionsRequest`):
                 The request object. Request message for
@@ -586,7 +594,7 @@ class {{ service.async_client_name }}:
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            '{{ api.naming.warehouse_package_name }}',
+            "{{ api.naming.warehouse_package_name }}",
         ).version,
     )
 except pkg_resources.DistributionNotFound:
@@ -594,6 +602,6 @@ except pkg_resources.DistributionNotFound:
 
 
 __all__ = (
-    '{{ service.async_client_name }}',
+    "{{ service.async_client_name }}",
 )
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -252,7 +252,10 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 client_cert_source_func = client_options.client_cert_source
             else:
                 is_mtls = mtls.has_default_client_cert_source()
-                client_cert_source_func = mtls.default_client_cert_source() if is_mtls else None
+                if is_mtls:
+                    client_cert_source_func = mtls.default_client_cert_source()
+                else:
+                    client_cert_source_func = None
 
         # Figure out which api endpoint to use.
         if client_options.api_endpoint is not None:
@@ -264,7 +267,10 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             elif use_mtls_env == "always":
                 api_endpoint = self.DEFAULT_MTLS_ENDPOINT
             elif use_mtls_env == "auto":
-                api_endpoint = self.DEFAULT_MTLS_ENDPOINT if is_mtls else self.DEFAULT_ENDPOINT
+                if is_mtls:
+                    api_endpoint = self.DEFAULT_MTLS_ENDPOINT
+                else:
+                    api_endpoint = self.DEFAULT_ENDPOINT
             else:
                 raise MutualTLSChannelError(
                     "Unsupported GOOGLE_API_USE_MTLS_ENDPOINT value. Accepted "
@@ -560,11 +566,13 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("resource", request.resource),)),
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("resource", request.resource),)),
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request, retry=retry, timeout=timeout, metadata=metadata,)
 
         # Done; return the response.
         return response
@@ -586,8 +594,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             request (:class:`~.iam_policy_pb2.GetIamPolicyRequest`):
                 The request object. Request message for `GetIamPolicy`
                 method.
-            retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
+            retry (google.api_core.retry.Retry): Designation of what errors, if
+                any, should be retried.
             timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
@@ -669,11 +677,13 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("resource", request.resource),)),
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("resource", request.resource),)),
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request, retry=retry, timeout=timeout, metadata=metadata,)
 
         # Done; return the response.
         return response
@@ -696,8 +706,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             request (:class:`~.iam_policy_pb2.TestIamPermissionsRequest`):
                 The request object. Request message for
                 `TestIamPermissions` method.
-            retry (google.api_core.retry.Retry): Designation of what errors, if any,
-                should be retried.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                 if any, should be retried.
             timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
@@ -723,11 +733,13 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         # Certain fields should be provided within the metadata header;
         # add these here.
         metadata = tuple(metadata) + (
-            gapic_v1.routing_header.to_grpc_metadata((("resource", request.resource),)),
+            gapic_v1.routing_header.to_grpc_metadata(
+                (("resource", request.resource),)),
         )
 
         # Send the request.
-        response = rpc(request, retry=retry, timeout=timeout, metadata=metadata,)
+        response = rpc(
+            request, retry=retry, timeout=timeout, metadata=metadata,)
 
         # Done; return the response.
         return response

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -48,18 +48,18 @@ class {{ service.client_name }}Meta(type):
     objects.
     """
     _transport_registry = OrderedDict()  # type: Dict[str, Type[{{ service.name }}Transport]]
-    {% if 'grpc' in opts.transport %}
-    _transport_registry['grpc'] = {{ service.grpc_transport_name }}
-    _transport_registry['grpc_asyncio'] = {{ service.grpc_asyncio_transport_name }}
+    {% if "grpc" in opts.transport %}
+    _transport_registry["grpc"] = {{ service.grpc_transport_name }}
+    _transport_registry["grpc_asyncio"] = {{ service.grpc_asyncio_transport_name }}
     {% endif %}
-    {% if 'rest' in opts.transport %}
-    _transport_registry['rest'] = {{ service.name }}RestTransport
+    {% if "rest" in opts.transport %}
+    _transport_registry["rest"] = {{ service.name }}RestTransport
     {% endif %}
 
     def get_transport_class(cls,
             label: str = None,
         ) -> Type[{{ service.name }}Transport]:
-        """Return an appropriate transport class.
+        """Returns an appropriate transport class.
 
         Args:
             label: The name of the desired transport. If none is
@@ -82,7 +82,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
     @staticmethod
     def _get_default_mtls_endpoint(api_endpoint):
-        """Convert api endpoint to mTLS endpoint.
+        """Converts api endpoint to mTLS endpoint.
+
         Convert "*.sandbox.googleapis.com" and "*.googleapis.com" to
         "*.mtls.sandbox.googleapis.com" and "*.mtls.googleapis.com" respectively.
         Args:
@@ -109,7 +110,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
         return api_endpoint.replace(".googleapis.com", ".mtls.googleapis.com")
 
-    DEFAULT_ENDPOINT = {% if service.host %}'{{ service.host }}'{% else %}None{% endif %}
+    DEFAULT_ENDPOINT = {% if service.host %}"{{ service.host }}"{% else %}None{% endif %}
 
     DEFAULT_MTLS_ENDPOINT = _get_default_mtls_endpoint.__func__(  # type: ignore
         DEFAULT_ENDPOINT
@@ -117,7 +118,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
     @classmethod
     def from_service_account_info(cls, info: dict, *args, **kwargs):
-        """Creates an instance of this client using the provided credentials info.
+        """Creates an instance of this client using the provided credentials
+            info.
 
         Args:
             info (dict): The service account private key info.
@@ -134,7 +136,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     @classmethod
     def from_service_account_file(cls, filename: str, *args, **kwargs):
         """Creates an instance of this client using the provided credentials
-        file.
+            file.
 
         Args:
             filename (str): The path to the service account private key json
@@ -147,17 +149,18 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         """
         credentials = service_account.Credentials.from_service_account_file(
             filename)
-        kwargs['credentials'] = credentials
+        kwargs["credentials"] = credentials
         return cls(*args, **kwargs)
 
     from_service_account_json = from_service_account_file
 
     @property
     def transport(self) -> {{ service.name }}Transport:
-        """Return the transport used by the client instance.
+        """Returns the transport used by the client instance.
 
         Returns:
-            {{ service.name }}Transport: The transport used by the client instance.
+            {{ service.name }}Transport: The transport used by the client
+                instance.
         """
         return self._transport
 
@@ -165,13 +168,13 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     {% for message in service.resource_messages|sort(attribute="resource_type") %}
     @staticmethod
     def {{ message.resource_type|snake_case }}_path({% for arg in message.resource_path_args %}{{ arg }}: str,{% endfor %}) -> str:
-        """Return a fully-qualified {{ message.resource_type|snake_case }} string."""
+        """Returns a fully-qualified {{ message.resource_type|snake_case }} string."""
         return "{{ message.resource_path }}".format({% for arg in message.resource_path_args %}{{ arg }}={{ arg }}, {% endfor %})
 
 
     @staticmethod
     def parse_{{ message.resource_type|snake_case }}_path(path: str) -> Dict[str,str]:
-        """Parse a {{ message.resource_type|snake_case }} path into its component segments."""
+        """Parses a {{ message.resource_type|snake_case }} path into its component segments."""
         m = re.match(r"{{ message.path_regex_str }}", path)
         return m.groupdict() if m else {}
 
@@ -179,7 +182,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     {% for resource_msg in service.common_resources.values()|sort(attribute="type_name") %}
     @staticmethod
     def common_{{ resource_msg.message_type.resource_type|snake_case }}_path({% for arg in resource_msg.message_type.resource_path_args %}{{ arg }}: str, {%endfor %}) -> str:
-        """Return a fully-qualified {{ resource_msg.message_type.resource_type|snake_case }} string."""
+        """Returns a fully-qualified {{ resource_msg.message_type.resource_type|snake_case }} string."""
         return "{{ resource_msg.message_type.resource_path }}".format({% for arg in resource_msg.message_type.resource_path_args %}{{ arg }}={{ arg }}, {% endfor %})
 
     @staticmethod
@@ -196,7 +199,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             client_options: Optional[client_options_lib.ClientOptions] = None,
             client_info: gapic_v1.client_info.ClientInfo = DEFAULT_CLIENT_INFO,
             ) -> None:
-        """Instantiate the {{ (service.client_name|snake_case).replace('_', ' ') }}.
+        """Instantiates the {{ (service.client_name|snake_case).replace('_', ' ') }}.
 
         Args:
             credentials (Optional[google.auth.credentials.Credentials]): The
@@ -264,7 +267,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 api_endpoint = self.DEFAULT_MTLS_ENDPOINT if is_mtls else self.DEFAULT_ENDPOINT
             else:
                 raise MutualTLSChannelError(
-                    "Unsupported GOOGLE_API_USE_MTLS_ENDPOINT value. Accepted values: never, auto, always"
+                    "Unsupported GOOGLE_API_USE_MTLS_ENDPOINT value. Accepted "
+                    "values: never, auto, always"
                 )
 
         # Save or instantiate the transport.
@@ -273,12 +277,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         if isinstance(transport, {{ service.name }}Transport):
             # transport is a {{ service.name }}Transport instance.
             if credentials or client_options.credentials_file:
-                raise ValueError('When providing a transport instance, '
-                                 'provide its credentials directly.')
+                raise ValueError("When providing a transport instance, "
+                                 "provide its credentials directly.")
             if client_options.scopes:
                 raise ValueError(
-                    "When providing a transport instance, "
-                    "provide its scopes directly."
+                    "When providing a transport instance, provide its scopes "
+                    "directly."
                 )
             self._transport = transport
         else:
@@ -319,7 +323,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         Args:
             {% if not method.client_streaming %}
             request ({{ method.input.ident.sphinx }}):
-                The request object.{{ ' ' }}
+                The request object.{{ " " }}
                 {{- method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             {% for key, field in method.flattened_fields.items() %}
             {{ field.name }} ({{ field.ident.sphinx }}):
@@ -330,7 +334,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             {% endfor %}
             {% else %}
             requests (Iterator[{{ method.input.ident.sphinx }}]):
-                The request object iterator.{{ ' ' }}
+                The request object iterator.{{ " " }}
                 {{- method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             {% endif %}
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -346,7 +350,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             {% else %}
             Iterable[{{ method.client_output.ident.sphinx }}]:
             {% endif %}
-                {{ method.client_output.meta.doc|rst(width=72, indent=16, source_format='rst') }}
+                {{ method.client_output.meta.doc|rst(width=72, indent=16, source_format="rst") }}
         {% endif %}
         """
         {% if not method.client_streaming %}
@@ -354,7 +358,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% if method.flattened_fields %}
         # Sanity check: If we got a request object, we should *not* have
         # gotten any keyword arguments that map to the request.
-        has_flattened_params = any([{{ method.flattened_fields.values()|join(', ', attribute='name') }}])
+        has_flattened_params = any([{{ method.flattened_fields.values()|join(", ", attribute="name") }}])
         if request is not None and has_flattened_params:
             raise ValueError('If the `request` argument is set, then none of '
                              'the individual field arguments should be set.')
@@ -410,7 +414,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             gapic_v1.routing_header.to_grpc_metadata((
                 {% for field_header in method.field_headers %}
                 {% if not method.client_streaming %}
-                ('{{ field_header }}', request.{{ field_header }}),
+                ("{{ field_header }}", request.{{ field_header }}),
                 {% endif %}
                 {% endfor %}
             )),
@@ -453,7 +457,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         # Done; return the response.
         return response
         {% endif %}
-        {{ '\n' }}
+        {{ "\n" }}
     {% endfor %}
 
     {% if opts.add_iam_methods %}
@@ -465,8 +469,10 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> policy_pb2.Policy:
-        r"""Sets the IAM access control policy on the specified
-        function. Replaces any existing policy.
+        r"""Sets the IAM access control policy on the specified function.
+        
+        Replaces any existing policy.
+        
         Args:
             request (:class:`~.iam_policy_pb2.SetIamPolicyRequest`):
                 The request object. Request message for `SetIamPolicy`
@@ -572,8 +578,10 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> policy_pb2.Policy:
         r"""Gets the IAM access control policy for a function.
-        Returns an empty policy if the function exists and does
-        not have a policy set.
+
+        Returns an empty policy if the function exists and does not have a
+        policy set.
+
         Args:
             request (:class:`~.iam_policy_pb2.GetIamPolicyRequest`):
                 The request object. Request message for `GetIamPolicy`
@@ -678,9 +686,12 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         timeout: float = None,
         metadata: Sequence[Tuple[str, str]] = (),
     ) -> iam_policy_pb2.TestIamPermissionsResponse:
-        r"""Tests the specified permissions against the IAM access control
-        policy for a function. If the function does not exist, this will
-        return an empty set of permissions, not a NOT_FOUND error.
+        r"""Tests the specified IAM permissions against the IAM access control
+            policy for a function.
+
+        If the function does not exist, this will return an empty set
+        of permissions, not a NOT_FOUND error.
+
         Args:
             request (:class:`~.iam_policy_pb2.TestIamPermissionsRequest`):
                 The request object. Request message for
@@ -726,7 +737,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
         gapic_version=pkg_resources.get_distribution(
-            '{{ api.naming.warehouse_package_name }}',
+            "{{ api.naming.warehouse_package_name }}",
         ).version,
     )
 except pkg_resources.DistributionNotFound:
@@ -734,6 +745,6 @@ except pkg_resources.DistributionNotFound:
 
 
 __all__ = (
-    '{{ service.client_name }}',
+    "{{ service.client_name }}",
 )
 {% endblock %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
@@ -114,7 +114,7 @@ class {{ method.name }}AsyncPager:
             response: {{ method.output.ident }},
             *,
             metadata: Sequence[Tuple[str, str]] = ()):
-        """Instantiate the pager.
+        """Instantiates the pager.
 
         Args:
             method (Callable): The method that was originally called, and


### PR DESCRIPTION
The template conflicts with the [Python Style Guide](https://google.github.io/styleguide/pyguide.html) in a couple of areas:
- ["Be consistent with your choice of string quote character within a file. Pick ' or " and stick with it. It is okay to use the other quote character on a string to avoid the need to \\ escape within the string."](https://google.github.io/styleguide/pyguide.html#310-strings)
- Lambda functions: ["Okay to use them for one-liners. If the code inside the lambda function is longer than 60-80 chars, it’s probably better to define it as a regular nested function."](https://google.github.io/styleguide/pyguide.html#2104-decision)
- ["Maximum line length is 80 characters."](https://google.github.io/styleguide/pyguide.html#32-line-length)
- [Function docstrings](https://google.github.io/styleguide/pyguide.html#383-functions-and-methods) including descriptive-style phrasing and newlines.

This will improve the style of the auto-generated Python client library; however, the changes are not exhaustive because the code is still auto-generated. It does not change any functionality.