### PR TITLE
fix: consistently use _pb2 identifier

### DIFF
--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -84,16 +84,16 @@ class Address(BaseAddress):
         if self.module:
             module_name = self.module
 
+            # If collisions are registered and conflict with our module,
+            # use the module alias instead.
+            if self.module_alias:
+                module_name = self.module_alias
+
             # This module is from a different proto package
             # Most commonly happens for a common proto
             # https://pypi.org/project/googleapis-common-protos/
             if not self.proto_package.startswith(self.api_naming.proto_package):
                 module_name = f'{self.module}_pb2'
-
-            # If collisions are registered and conflict with our module,
-            # use the module alias instead.
-            if self.module_alias:
-                module_name = self.module_alias
 
             # Return the dot-separated Python identifier.
             return '.'.join((module_name,) + self.parent + (self.name,))

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -56,7 +56,7 @@ def test_address_str_different_proto_package_with_collision():
         name='Status',
         api_naming=naming.NewNaming(proto_package='foo.bar.baz.v1')
     ).with_context(collisions=frozenset({'status'}))
-     # the module alias should be ignored for _pb2 types
+    # the module alias should be ignored for _pb2 types
     assert str(addr) == 'status_pb2.Status'
 
 

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -49,6 +49,17 @@ def test_address_str_different_proto_package():
     assert str(addr) == 'options_pb2.GetPolicyOptions'
 
 
+def test_address_str_different_proto_package_with_collision():
+    addr = metadata.Address(
+        package=('google', 'rpc'),
+        module='status',
+        name='Status',
+        api_naming=naming.NewNaming(proto_package='foo.bar.baz.v1')
+    ).with_context(collisions=frozenset({'status'}))
+     # the module alias should be ignored for _pb2 types
+    assert str(addr) == 'status_pb2.Status'
+
+
 def test_address_proto():
     addr = metadata.Address(package=('foo', 'bar'), module='baz', name='Bacon')
     assert addr.proto == 'foo.bar.Bacon'


### PR DESCRIPTION
Small change to fix bug noticed in https://github.com/googleapis/python-dialogflow/pull/288.

The import was `from google.rpc import status_pb2` but code expected `gr_status`