### PR TITLE
feat: Add `x-goog-api-client` header to rest clients

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -33,6 +33,12 @@ try:
         gapic_version=pkg_resources.get_distribution(
             '{{ api.naming.warehouse_package_name }}',
         ).version,
+        {% if 'grpc' not in opts.transport %}
+        grpc_version=None,
+        {% endif %}
+        {% if 'rest' in opts.transport %}
+        rest_version=pkg_resources.get_distribution("requests").version,
+        {% endif %}
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -6,6 +6,9 @@ import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import packaging.version
 import pkg_resources
+{% if 'rest' in opts.transport %}
+from requests import __version__ as requests_version
+{% endif %}
 
 import google.auth  # type: ignore
 import google.api_core  # type: ignore
@@ -37,7 +40,7 @@ try:
         grpc_version=None,
         {% endif %}
         {% if 'rest' in opts.transport %}
-        rest_version=pkg_resources.get_distribution("requests").version,
+        rest_version=requests_version,
         {% endif %}
     )
 except pkg_resources.DistributionNotFound:

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -207,8 +207,11 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
         url += '?{}'.format('&'.join(query_params)).replace(' ', '+')
 
         # Send the request
+        headers = dict(metadata)
+        headers['Content-Type'] = 'application/json'
         response = self._session.{{ method.http_opt['verb'] }}(
             url,
+            headers=headers,
             {% if 'body' in method.http_opt %}
             data=body,
             {% endif %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -27,7 +27,7 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.26.0, < 2.0.0dev',
+        'google-api-core[grpc] >= 1.27.0, < 2.0.0dev',
         'libcst >= 0.2.5',
         'proto-plus >= 1.15.0',
         'packaging >= 14.3',

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -27,7 +27,7 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.22.2, < 2.0.0dev',
+        'google-api-core[grpc] >= 1.27.0, < 2.0.0dev',
         'libcst >= 0.2.5',
         'proto-plus >= 1.15.0',
         'packaging >= 14.3',


### PR DESCRIPTION
Also add `Content-Type: application/json` header.

This PR depends on https://github.com/googleapis/python-api-core/pull/189, and assumes that google-api-core version 1.27.0 has been already released (which was not the case on the moment of creation of this PR).