### PR TITLE
feat: Raise GoogleAPICallError on REST response errors

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -10,8 +10,9 @@ from typing import Callable, Dict, Optional, Sequence, Tuple
 from google.api_core import operations_v1
 {% endif %}
 from google.api_core import gapic_v1       # type: ignore
-from google.auth import credentials as ga_credentials  # type: ignore
-from google.auth.transport.grpc import SslCredentials  # type: ignore
+from google.api_core import exceptions as core_exceptions  # type: ignore
+from google.auth import credentials as ga_credentials      # type: ignore
+from google.auth.transport.grpc import SslCredentials      # type: ignore
 
 import grpc  # type: ignore
 
@@ -215,11 +216,10 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
             {% endif %}
         )
 
-        # Raise descriptive ResponseError if the status code is >= 400
-        try:
-          response.raise_for_status()
-        except requests.exceptions.HTTPError as http_error:
-          raise ResponseError(http_error) from None
+        # In case of error, raise the appropriate core_exceptions.GoogleAPICallError exception
+        # subclass.
+        if response.status_code >= 400:
+            raise core_exceptions.from_http_response(response)
         {% if not method.void %}
 
         # Return the response
@@ -231,18 +231,6 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
     {% endif %}
     {% endfor %}
 
-class ResponseError(Exception):
-    """Exception raised for failing REST responses, reporting the response body.
-
-       Attributes:
-           http_error: The underlying requests.exceptions.HTTPError being wrapped
-    """
-
-    def __init__(self, http_error):
-        self.http_error = http_error
-    
-    def __str__(self):
-        return f'{self.http_error}\n{self.http_error.response.text}'
 
 __all__ = (
     '{{ service.name }}RestTransport',

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -2,7 +2,6 @@
 
 {% block content %}
 
-import requests
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -2,6 +2,7 @@
 
 {% block content %}
 
+import requests
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple
 
@@ -214,8 +215,11 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
             {% endif %}
         )
 
-        # Raise requests.exceptions.HTTPError if the status code is >= 400
-        response.raise_for_status()
+        # Raise descriptive ResponseError if the status code is >= 400
+        try:
+          response.raise_for_status()
+        except requests.exceptions.HTTPError as http_error:
+          raise ResponseError(http_error) from None
         {% if not method.void %}
 
         # Return the response
@@ -227,6 +231,18 @@ class {{ service.name }}RestTransport({{ service.name }}Transport):
     {% endif %}
     {% endfor %}
 
+class ResponseError(Exception):
+    """Exception raised for failing REST responses, reporting the response body.
+
+       Attributes:
+           http_error: The underlying requests.exceptions.HTTPError being wrapped
+    """
+
+    def __init__(self, http_error):
+        self.http_error = http_error
+    
+    def __str__(self):
+        return f'{self.http_error}\n{self.http_error.response.text}'
 
 __all__ = (
     '{{ service.name }}RestTransport',


### PR DESCRIPTION
While testing against Showcase, I found that server errors resulted in a large exception stack dump that did not include the body of the erroring response. This PR shortens the stack dump and prints out the request body.

Fixes #769 