### PR TITLE
Update Ads templates to support Python 3.6 as a minimum

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
@@ -6,8 +6,8 @@ import importlib
 import sys
 
 
-if sys.version_info < (3, 7):
-    raise ImportError('This module requires Python 3.7 or later.')
+if sys.version_info < (3, 6):
+    raise ImportError('This module requires Python 3.6 or later.')
 
 
 _lazy_type_to_package_map = {
@@ -108,3 +108,9 @@ __all__ = (
 )
 {% endif %} {# lazy import #}
 {% endblock %}
+
+
+if not sys.version_info >= (3, 7):
+    from pep562 import Pep562
+
+    Pep562(__name__)

--- a/gapic/ads-templates/%namespace/%name/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/__init__.py.j2
@@ -6,8 +6,8 @@ import importlib
 import sys
 
 
-if sys.version_info < (3, 7):
-    raise ImportError('This module requires Python 3.7 or later.')
+if sys.version_info < (3, 6):
+    raise ImportError('This module requires Python 3.6 or later.')
 
 
 _lazy_type_to_package_map = {
@@ -106,3 +106,9 @@ __all__ = (
 )
 {% endif %} {# lazy import #}
 {% endblock %}
+
+
+if not sys.version_info >= (3, 7):
+    from pep562 import Pep562
+
+    Pep562(__name__)


### PR DESCRIPTION
Includes a backport to `pep562` module to support module-level __getattr__ methods where used.