### PR TITLE
fix: fix datetime comparison unit tests

### DIFF
--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -444,9 +444,9 @@ def test_{{ method.name|snake_case }}_flattened():
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
         {% for key, field in method.flattened_fields.items() %}{% if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' %}
+        {% if field.ident|string() == 'timestamp_pb2.Timestamp' %}
         assert TimestampRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' %}
+        {% elif field.ident|string() == 'duration_pb2.Duration' %}
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
         {% else %}
         assert args[0].{{ key }} == {{ field.mock_value }}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -760,9 +760,9 @@ def test_{{ method.name|snake_case }}_flattened():
         assert len(call.mock_calls) == 1
         _, args, _ = call.mock_calls[0]
         {% for key, field in method.flattened_fields.items() %}{% if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' %}
+        {% if field.ident|string() == 'timestamp_pb2.Timestamp' %}
         assert TimestampRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' %}
+        {% elif field.ident|string() == 'duration_pb2.Duration' %}
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
         {% else %}
         assert args[0].{{ key }} == {{ field.mock_value }}
@@ -845,9 +845,9 @@ async def test_{{ method.name|snake_case }}_flattened_async():
         assert len(call.mock_calls)
         _, args, _ = call.mock_calls[0]
         {% for key, field in method.flattened_fields.items() %}{% if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' %}
+        {% if field.ident|string() == 'timestamp_pb2.Timestamp' %}
         assert TimestampRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' %}
+        {% elif field.ident|string() == 'duration_pb2.Duration' %}
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
         {% else %}
         assert args[0].{{ key }} == {{ field.mock_value }}
@@ -1194,9 +1194,9 @@ def test_{{ method.name|snake_case }}_rest_flattened():
         body = http_params.get('data')
         {% for key, field in method.flattened_fields.items() %}
         {% if not field.oneof or field.proto3_optional %}
-        {% if field.ident|string() == 'timestamp.Timestamp' %}
+        {% if field.ident|string() == 'timestamp_pb2.Timestamp' %}
         assert TimestampRule().to_proto(http_call[0].{{ key }}) == {{ field.mock_value }}
-        {% elif field.ident|string() == 'duration.Duration' %}
+        {% elif field.ident|string() == 'duration_pb2.Duration' %}
         assert DurationRule().to_proto(http_call[0].{{ key }}) == {{ field.mock_value }}
         {% else %}
         assert {% if field.field_pb is msg_field_pb %}{{ field.ident }}.to_json({{ field.name }}, including_default_value_fields=False, use_integers_for_enums=False)


### PR DESCRIPTION
Fixes #897 

The string ident changed to have an `_pb2` in #851. If there's a more robust way to do this comparison please let me know.