### PR TITLE
fix: samplegen always produces sample dicts with "response"

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -35,7 +35,7 @@ config_setting(
 py_runtime(
     name = "pyenv3_runtime",
     interpreter = ":pyenv3wrapper.sh",
-    python_version="PY3",
+    python_version = "PY3",
 )
 
 py_runtime_pair(
@@ -52,7 +52,10 @@ toolchain(
 py_binary(
     name = "gapic_plugin",
     srcs = glob(["gapic/**/*.py"]),
-    data = [":pandoc_binary"] + glob(["gapic/**/*.j2", "gapic/**/.*.j2"]),
+    data = [":pandoc_binary"] + glob([
+        "gapic/**/*.j2",
+        "gapic/**/.*.j2",
+    ]),
     main = "gapic/cli/generate_with_pandoc.py",
     python_version = "PY3",
     visibility = ["//visibility:public"],

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -39,7 +39,13 @@ Execute unit tests by running one of the sessions prefixed with `unit-`.
     bazel test //tests/integration:asset
     ```
 
--   Update goldens files. This overwrites the golden files in
+-   Run integration tests for all APIs.
+
+    ```sh
+    bazel test //tests/integration:all
+    ```
+
+-   Update all goldens files. This overwrites the golden files in
     `tests/integration/goldens/`.
 
     ```sh

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -33,15 +33,19 @@ Execute unit tests by running one of the sessions prefixed with `unit-`.
 
 -   Run a single integration test for one API. This generates Python source code
     with the microgenerator and compares them to the golden files in
-    `test/integration/goldens/asset`.
+    `tests/integration/goldens/asset`.
 
     ```sh
-    bazel test //test/integration:asset
+    bazel test //tests/integration:asset
     ```
 
 -   Update goldens files. This overwrites the golden files in
-    `test/integration/goldens/asset`.
+    `tests/integration/goldens/`.
 
     ```sh
-    bazel run //test/integration:asset_update
+    bazel run //tests/integration:asset_update
+    bazel run //tests/integration:credentials_update
+    bazel run //tests/integration:logging_update
+    bazel run //tests/integration:redis_update
     ```
+

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -301,8 +301,6 @@ class Validator:
         # Add reasonable defaults depending on the type of the sample
         if not rpc.void:
             sample.setdefault("response", [{"print": ["%s", "$resp"]}])
-        else:
-            sample["response"] = []
 
     @utils.cached_property
     def flattenable_fields(self) -> FrozenSet[str]:

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -301,6 +301,8 @@ class Validator:
         # Add reasonable defaults depending on the type of the sample
         if not rpc.void:
             sample.setdefault("response", [{"print": ["%s", "$resp"]}])
+        else:
+            sample["response"] = []
 
     @utils.cached_property
     def flattenable_fields(self) -> FrozenSet[str]:

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -1000,7 +1000,9 @@ def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> str
     sample["request"] = v.validate_and_transform_request(
         calling_form, sample["request"]
     )
-    v.validate_response(sample["response"])
+
+    if "response" in sample:
+        v.validate_response(sample["response"])
 
     return sample_template.render(
         sample=sample,

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -301,6 +301,8 @@ class Validator:
         # Add reasonable defaults depending on the type of the sample
         if not rpc.void:
             sample.setdefault("response", [{"print": ["%s", "$resp"]}])
+        else:
+            sample.setdefault("response", [])
 
     @utils.cached_property
     def flattenable_fields(self) -> FrozenSet[str]:
@@ -1001,8 +1003,7 @@ def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> str
         calling_form, sample["request"]
     )
 
-    if "response" in sample:
-        v.validate_response(sample["response"])
+    v.validate_response(sample["response"])
 
     return sample_template.render(
         sample=sample,

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -220,10 +220,12 @@ client.{{ sample.rpc|snake_case }}({{ render_request_params_unary(sample.request
 {% if calling_form == calling_form_enum.Request %}
 response = {{ method_invocation_text|trim }}
 
+{% if response_statements %}
 # Handle response
 {% for statement in response_statements %}
 {{ dispatch_statement(statement)|trim }}
 {% endfor %}
+{% endif %}
 {% elif calling_form == calling_form_enum.RequestPagedAll %}
 page_result = {{ method_invocation_text|trim }}
 for response in page_result:

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -59,7 +59,7 @@ def cover(session):
 @nox.session(python=['3.6', '3.7'])
 def mypy(session):
     """Run the type checker."""
-    session.install('mypy')
+    session.install('mypy', 'types-pkg_resources')
     session.install('.')
     session.run(
         'mypy',

--- a/noxfile.py
+++ b/noxfile.py
@@ -273,7 +273,7 @@ def showcase_mypy(
     """Perform typecheck analysis on the generated Showcase library."""
 
     # Install pytest and gapic-generator-python
-    session.install("mypy")
+    session.install("mypy", "types-pkg-resources")
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
         session.chdir(lib)

--- a/noxfile.py
+++ b/noxfile.py
@@ -340,6 +340,11 @@ def docs(session):
 def mypy(session):
     """Perform typecheck analysis."""
 
-    session.install("mypy")
+    session.install(
+        "mypy",
+        "types-protobuf",
+        "types-PyYAML",
+        "types-dataclasses"
+    )
     session.install(".")
     session.run("mypy", "gapic")

--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -3,15 +3,10 @@ load(
     "py_gapic_library",
 )
 load(
-    "@gapic_generator_python//rules_python_gapic:py_gapic_pkg.bzl",
-    "py_gapic_assembly_pkg",
-)
-load(
     "@gapic_generator_python//rules_python_gapic/test:integration_test.bzl",
     "golden_update",
     "integration_test",
 )
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -51,6 +46,9 @@ py_gapic_library(
     name = "asset_py_gapic",
     srcs = ["@com_google_googleapis//google/cloud/asset/v1:asset_proto"],
     grpc_service_config = "cloudasset_grpc_service_config.json",
+    opt_args = [
+        "autogen-snippets",
+    ],
 )
 
 # Credentials.
@@ -58,6 +56,9 @@ py_gapic_library(
     name = "credentials_py_gapic",
     srcs = ["@com_google_googleapis//google/iam/credentials/v1:credentials_proto"],
     grpc_service_config = "iamcredentials_grpc_service_config.json",
+    opt_args = [
+        "autogen-snippets",
+    ],
 )
 
 # Logging.
@@ -68,6 +69,7 @@ py_gapic_library(
     opt_args = [
         "python-gapic-namespace=google.cloud",
         "python-gapic-name=logging",
+        "autogen-snippets",
     ],
 )
 
@@ -75,4 +77,7 @@ py_gapic_library(
     name = "redis_py_gapic",
     srcs = ["@com_google_googleapis//google/cloud/redis/v1:redis_proto"],
     grpc_service_config = "redis_grpc_service_config.json",
+    opt_args = [
+        "autogen-snippets",
+    ],
 )

--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -3,10 +3,15 @@ load(
     "py_gapic_library",
 )
 load(
+    "@gapic_generator_python//rules_python_gapic:py_gapic_pkg.bzl",
+    "py_gapic_assembly_pkg",
+)
+load(
     "@gapic_generator_python//rules_python_gapic/test:integration_test.bzl",
     "golden_update",
     "integration_test",
 )
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 package(default_visibility = ["//visibility:public"])
 

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -70,7 +70,7 @@ def cover(session):
 @nox.session(python=['3.6', '3.7'])
 def mypy(session):
     """Run the type checker."""
-    session.install('mypy')
+    session.install('mypy', 'types-pkg_resources')
     session.install('.')
     session.run(
         'mypy',

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_analyze_iam_policy_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_analyze_iam_policy_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for AnalyzeIamPolicy
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_AnalyzeIamPolicy_grpc]
+from google.cloud import asset_v1
+
+
+def sample_analyze_iam_policy():
+    """Snippet for analyze_iam_policy"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.AnalyzeIamPolicyRequest(
+    )
+
+    # Make the request
+    response = client.analyze_iam_policy(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_AnalyzeIamPolicy_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_analyze_iam_policy_longrunning_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_analyze_iam_policy_longrunning_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for AnalyzeIamPolicyLongrunning
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_AnalyzeIamPolicyLongrunning_grpc]
+from google.cloud import asset_v1
+
+
+def sample_analyze_iam_policy_longrunning():
+    """Snippet for analyze_iam_policy_longrunning"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.AnalyzeIamPolicyLongrunningRequest(
+    )
+
+    # Make the request
+    operation = client.analyze_iam_policy_longrunning(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_AnalyzeIamPolicyLongrunning_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for BatchGetAssetsHistory
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_BatchGetAssetsHistory_grpc]
+from google.cloud import asset_v1
+
+
+def sample_batch_get_assets_history():
+    """Snippet for batch_get_assets_history"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.BatchGetAssetsHistoryRequest(
+    )
+
+    # Make the request
+    response = client.batch_get_assets_history(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_BatchGetAssetsHistory_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_create_feed_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_create_feed_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateFeed
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_CreateFeed_grpc]
+from google.cloud import asset_v1
+
+
+def sample_create_feed():
+    """Snippet for create_feed"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.CreateFeedRequest(
+    )
+
+    # Make the request
+    response = client.create_feed(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_CreateFeed_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteFeed
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_DeleteFeed_grpc]
+from google.cloud import asset_v1
+
+
+def sample_delete_feed():
+    """Snippet for delete_feed"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.DeleteFeedRequest(
+    )
+
+    # Make the request
+    response = client.delete_feed(request=request)
+
+    # Handle response
+
+# [END cloudasset_generated_asset_v1_AssetService_DeleteFeed_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_grpc.py
@@ -40,6 +40,5 @@ def sample_delete_feed():
     # Make the request
     response = client.delete_feed(request=request)
 
-    # Handle response
 
 # [END cloudasset_generated_asset_v1_AssetService_DeleteFeed_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ExportAssets
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_ExportAssets_grpc]
+from google.cloud import asset_v1
+
+
+def sample_export_assets():
+    """Snippet for export_assets"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.ExportAssetsRequest(
+    )
+
+    # Make the request
+    operation = client.export_assets(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_ExportAssets_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_get_feed_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_get_feed_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetFeed
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_GetFeed_grpc]
+from google.cloud import asset_v1
+
+
+def sample_get_feed():
+    """Snippet for get_feed"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.GetFeedRequest(
+    )
+
+    # Make the request
+    response = client.get_feed(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_GetFeed_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_feeds_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_feeds_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListFeeds
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_ListFeeds_grpc]
+from google.cloud import asset_v1
+
+
+def sample_list_feeds():
+    """Snippet for list_feeds"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.ListFeedsRequest(
+    )
+
+    # Make the request
+    response = client.list_feeds(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_ListFeeds_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_search_all_iam_policies_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_search_all_iam_policies_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for SearchAllIamPolicies
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_SearchAllIamPolicies_grpc]
+from google.cloud import asset_v1
+
+
+def sample_search_all_iam_policies():
+    """Snippet for search_all_iam_policies"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.SearchAllIamPoliciesRequest(
+    )
+
+    # Make the request
+    page_result = client.search_all_iam_policies(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_SearchAllIamPolicies_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_search_all_resources_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_search_all_resources_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for SearchAllResources
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_SearchAllResources_grpc]
+from google.cloud import asset_v1
+
+
+def sample_search_all_resources():
+    """Snippet for search_all_resources"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.SearchAllResourcesRequest(
+    )
+
+    # Make the request
+    page_result = client.search_all_resources(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_SearchAllResources_grpc]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_update_feed_grpc.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_update_feed_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateFeed
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-asset
+
+
+# [START cloudasset_generated_asset_v1_AssetService_UpdateFeed_grpc]
+from google.cloud import asset_v1
+
+
+def sample_update_feed():
+    """Snippet for update_feed"""
+
+    # Create a client
+    client = asset_v1.AssetServiceClient()
+
+    # Initialize request argument(s)
+    request = asset_v1.UpdateFeedRequest(
+    )
+
+    # Make the request
+    response = client.update_feed(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END cloudasset_generated_asset_v1_AssetService_UpdateFeed_grpc]

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -70,7 +70,7 @@ def cover(session):
 @nox.session(python=['3.6', '3.7'])
 def mypy(session):
     """Run the type checker."""
-    session.install('mypy')
+    session.install('mypy', 'types-pkg_resources')
     session.install('.')
     session.run(
         'mypy',

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_access_token_grpc.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_access_token_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GenerateAccessToken
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-iam-credentials
+
+
+# [START iamcredentials_generated_credentials_v1_IAMCredentials_GenerateAccessToken_grpc]
+from google.iam import credentials_v1
+
+
+def sample_generate_access_token():
+    """Snippet for generate_access_token"""
+
+    # Create a client
+    client = credentials_v1.IAMCredentialsClient()
+
+    # Initialize request argument(s)
+    request = credentials_v1.GenerateAccessTokenRequest(
+    )
+
+    # Make the request
+    response = client.generate_access_token(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END iamcredentials_generated_credentials_v1_IAMCredentials_GenerateAccessToken_grpc]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_id_token_grpc.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_id_token_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GenerateIdToken
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-iam-credentials
+
+
+# [START iamcredentials_generated_credentials_v1_IAMCredentials_GenerateIdToken_grpc]
+from google.iam import credentials_v1
+
+
+def sample_generate_id_token():
+    """Snippet for generate_id_token"""
+
+    # Create a client
+    client = credentials_v1.IAMCredentialsClient()
+
+    # Initialize request argument(s)
+    request = credentials_v1.GenerateIdTokenRequest(
+    )
+
+    # Make the request
+    response = client.generate_id_token(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END iamcredentials_generated_credentials_v1_IAMCredentials_GenerateIdToken_grpc]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_blob_grpc.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_blob_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for SignBlob
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-iam-credentials
+
+
+# [START iamcredentials_generated_credentials_v1_IAMCredentials_SignBlob_grpc]
+from google.iam import credentials_v1
+
+
+def sample_sign_blob():
+    """Snippet for sign_blob"""
+
+    # Create a client
+    client = credentials_v1.IAMCredentialsClient()
+
+    # Initialize request argument(s)
+    request = credentials_v1.SignBlobRequest(
+    )
+
+    # Make the request
+    response = client.sign_blob(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END iamcredentials_generated_credentials_v1_IAMCredentials_SignBlob_grpc]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_jwt_grpc.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_jwt_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for SignJwt
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-iam-credentials
+
+
+# [START iamcredentials_generated_credentials_v1_IAMCredentials_SignJwt_grpc]
+from google.iam import credentials_v1
+
+
+def sample_sign_jwt():
+    """Snippet for sign_jwt"""
+
+    # Create a client
+    client = credentials_v1.IAMCredentialsClient()
+
+    # Initialize request argument(s)
+    request = credentials_v1.SignJwtRequest(
+    )
+
+    # Make the request
+    response = client.sign_jwt(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END iamcredentials_generated_credentials_v1_IAMCredentials_SignJwt_grpc]

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -70,7 +70,7 @@ def cover(session):
 @nox.session(python=['3.6', '3.7'])
 def mypy(session):
     """Run the type checker."""
-    session.install('mypy')
+    session.install('mypy', 'types-pkg_resources')
     session.install('.')
     session.run(
         'mypy',

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_bucket_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_bucket_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateBucket
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_CreateBucket_grpc]
+from google.cloud import logging_v2
+
+
+def sample_create_bucket():
+    """Snippet for create_bucket"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateBucketRequest(
+    )
+
+    # Make the request
+    response = client.create_bucket(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_CreateBucket_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_exclusion_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_exclusion_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_CreateExclusion_grpc]
+from google.cloud import logging_v2
+
+
+def sample_create_exclusion():
+    """Snippet for create_exclusion"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateExclusionRequest(
+    )
+
+    # Make the request
+    response = client.create_exclusion(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_CreateExclusion_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_sink_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_sink_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_CreateSink_grpc]
+from google.cloud import logging_v2
+
+
+def sample_create_sink():
+    """Snippet for create_sink"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateSinkRequest(
+    )
+
+    # Make the request
+    response = client.create_sink(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_CreateSink_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_view_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_view_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_CreateView_grpc]
+from google.cloud import logging_v2
+
+
+def sample_create_view():
+    """Snippet for create_view"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateViewRequest(
+    )
+
+    # Make the request
+    response = client.create_view(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_CreateView_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteBucket
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_DeleteBucket_grpc]
+from google.cloud import logging_v2
+
+
+def sample_delete_bucket():
+    """Snippet for delete_bucket"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteBucketRequest(
+    )
+
+    # Make the request
+    response = client.delete_bucket(request=request)
+
+    # Handle response
+
+# [END logging_generated_logging_v2_ConfigServiceV2_DeleteBucket_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_grpc.py
@@ -40,6 +40,5 @@ def sample_delete_bucket():
     # Make the request
     response = client.delete_bucket(request=request)
 
-    # Handle response
 
 # [END logging_generated_logging_v2_ConfigServiceV2_DeleteBucket_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_grpc.py
@@ -40,6 +40,5 @@ def sample_delete_exclusion():
     # Make the request
     response = client.delete_exclusion(request=request)
 
-    # Handle response
 
 # [END logging_generated_logging_v2_ConfigServiceV2_DeleteExclusion_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_DeleteExclusion_grpc]
+from google.cloud import logging_v2
+
+
+def sample_delete_exclusion():
+    """Snippet for delete_exclusion"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteExclusionRequest(
+    )
+
+    # Make the request
+    response = client.delete_exclusion(request=request)
+
+    # Handle response
+
+# [END logging_generated_logging_v2_ConfigServiceV2_DeleteExclusion_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_DeleteSink_grpc]
+from google.cloud import logging_v2
+
+
+def sample_delete_sink():
+    """Snippet for delete_sink"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteSinkRequest(
+    )
+
+    # Make the request
+    response = client.delete_sink(request=request)
+
+    # Handle response
+
+# [END logging_generated_logging_v2_ConfigServiceV2_DeleteSink_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_grpc.py
@@ -40,6 +40,5 @@ def sample_delete_sink():
     # Make the request
     response = client.delete_sink(request=request)
 
-    # Handle response
 
 # [END logging_generated_logging_v2_ConfigServiceV2_DeleteSink_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_grpc.py
@@ -40,6 +40,5 @@ def sample_delete_view():
     # Make the request
     response = client.delete_view(request=request)
 
-    # Handle response
 
 # [END logging_generated_logging_v2_ConfigServiceV2_DeleteView_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_DeleteView_grpc]
+from google.cloud import logging_v2
+
+
+def sample_delete_view():
+    """Snippet for delete_view"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteViewRequest(
+    )
+
+    # Make the request
+    response = client.delete_view(request=request)
+
+    # Handle response
+
+# [END logging_generated_logging_v2_ConfigServiceV2_DeleteView_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_bucket_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_bucket_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetBucket
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_GetBucket_grpc]
+from google.cloud import logging_v2
+
+
+def sample_get_bucket():
+    """Snippet for get_bucket"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetBucketRequest(
+    )
+
+    # Make the request
+    response = client.get_bucket(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_GetBucket_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_cmek_settings_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_cmek_settings_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetCmekSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_GetCmekSettings_grpc]
+from google.cloud import logging_v2
+
+
+def sample_get_cmek_settings():
+    """Snippet for get_cmek_settings"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetCmekSettingsRequest(
+    )
+
+    # Make the request
+    response = client.get_cmek_settings(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_GetCmekSettings_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_exclusion_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_exclusion_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_GetExclusion_grpc]
+from google.cloud import logging_v2
+
+
+def sample_get_exclusion():
+    """Snippet for get_exclusion"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetExclusionRequest(
+    )
+
+    # Make the request
+    response = client.get_exclusion(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_GetExclusion_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_sink_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_sink_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_GetSink_grpc]
+from google.cloud import logging_v2
+
+
+def sample_get_sink():
+    """Snippet for get_sink"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetSinkRequest(
+    )
+
+    # Make the request
+    response = client.get_sink(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_GetSink_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_view_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_view_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_GetView_grpc]
+from google.cloud import logging_v2
+
+
+def sample_get_view():
+    """Snippet for get_view"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetViewRequest(
+    )
+
+    # Make the request
+    response = client.get_view(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_GetView_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_buckets_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_buckets_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListBuckets
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_ListBuckets_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_buckets():
+    """Snippet for list_buckets"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListBucketsRequest(
+    )
+
+    # Make the request
+    page_result = client.list_buckets(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_ListBuckets_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_exclusions_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_exclusions_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListExclusions
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_ListExclusions_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_exclusions():
+    """Snippet for list_exclusions"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListExclusionsRequest(
+    )
+
+    # Make the request
+    page_result = client.list_exclusions(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_ListExclusions_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_sinks_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_sinks_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListSinks
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_ListSinks_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_sinks():
+    """Snippet for list_sinks"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListSinksRequest(
+    )
+
+    # Make the request
+    page_result = client.list_sinks(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_ListSinks_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_views_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_views_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListViews
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_ListViews_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_views():
+    """Snippet for list_views"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListViewsRequest(
+    )
+
+    # Make the request
+    page_result = client.list_views(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_ListViews_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_grpc.py
@@ -40,6 +40,5 @@ def sample_undelete_bucket():
     # Make the request
     response = client.undelete_bucket(request=request)
 
-    # Handle response
 
 # [END logging_generated_logging_v2_ConfigServiceV2_UndeleteBucket_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UndeleteBucket
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_UndeleteBucket_grpc]
+from google.cloud import logging_v2
+
+
+def sample_undelete_bucket():
+    """Snippet for undelete_bucket"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UndeleteBucketRequest(
+    )
+
+    # Make the request
+    response = client.undelete_bucket(request=request)
+
+    # Handle response
+
+# [END logging_generated_logging_v2_ConfigServiceV2_UndeleteBucket_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_bucket_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_bucket_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateBucket
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_UpdateBucket_grpc]
+from google.cloud import logging_v2
+
+
+def sample_update_bucket():
+    """Snippet for update_bucket"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateBucketRequest(
+    )
+
+    # Make the request
+    response = client.update_bucket(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_UpdateBucket_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_cmek_settings_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_cmek_settings_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateCmekSettings
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_UpdateCmekSettings_grpc]
+from google.cloud import logging_v2
+
+
+def sample_update_cmek_settings():
+    """Snippet for update_cmek_settings"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateCmekSettingsRequest(
+    )
+
+    # Make the request
+    response = client.update_cmek_settings(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_UpdateCmekSettings_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_exclusion_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_exclusion_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateExclusion
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_UpdateExclusion_grpc]
+from google.cloud import logging_v2
+
+
+def sample_update_exclusion():
+    """Snippet for update_exclusion"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateExclusionRequest(
+    )
+
+    # Make the request
+    response = client.update_exclusion(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_UpdateExclusion_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_sink_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_sink_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateSink
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_UpdateSink_grpc]
+from google.cloud import logging_v2
+
+
+def sample_update_sink():
+    """Snippet for update_sink"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateSinkRequest(
+    )
+
+    # Make the request
+    response = client.update_sink(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_UpdateSink_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_view_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_view_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateView
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_ConfigServiceV2_UpdateView_grpc]
+from google.cloud import logging_v2
+
+
+def sample_update_view():
+    """Snippet for update_view"""
+
+    # Create a client
+    client = logging_v2.ConfigServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateViewRequest(
+    )
+
+    # Make the request
+    response = client.update_view(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_ConfigServiceV2_UpdateView_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteLog
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_LoggingServiceV2_DeleteLog_grpc]
+from google.cloud import logging_v2
+
+
+def sample_delete_log():
+    """Snippet for delete_log"""
+
+    # Create a client
+    client = logging_v2.LoggingServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteLogRequest(
+    )
+
+    # Make the request
+    response = client.delete_log(request=request)
+
+    # Handle response
+
+# [END logging_generated_logging_v2_LoggingServiceV2_DeleteLog_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_grpc.py
@@ -40,6 +40,5 @@ def sample_delete_log():
     # Make the request
     response = client.delete_log(request=request)
 
-    # Handle response
 
 # [END logging_generated_logging_v2_LoggingServiceV2_DeleteLog_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_log_entries_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_log_entries_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListLogEntries
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_LoggingServiceV2_ListLogEntries_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_log_entries():
+    """Snippet for list_log_entries"""
+
+    # Create a client
+    client = logging_v2.LoggingServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListLogEntriesRequest(
+    )
+
+    # Make the request
+    page_result = client.list_log_entries(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_LoggingServiceV2_ListLogEntries_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_logs_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_logs_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListLogs
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_LoggingServiceV2_ListLogs_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_logs():
+    """Snippet for list_logs"""
+
+    # Create a client
+    client = logging_v2.LoggingServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListLogsRequest(
+    )
+
+    # Make the request
+    page_result = client.list_logs(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_LoggingServiceV2_ListLogs_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_monitored_resource_descriptors_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_monitored_resource_descriptors_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListMonitoredResourceDescriptors
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_LoggingServiceV2_ListMonitoredResourceDescriptors_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_monitored_resource_descriptors():
+    """Snippet for list_monitored_resource_descriptors"""
+
+    # Create a client
+    client = logging_v2.LoggingServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListMonitoredResourceDescriptorsRequest(
+    )
+
+    # Make the request
+    page_result = client.list_monitored_resource_descriptors(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_LoggingServiceV2_ListMonitoredResourceDescriptors_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_tail_log_entries_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_tail_log_entries_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for TailLogEntries
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_LoggingServiceV2_TailLogEntries_grpc]
+from google.cloud import logging_v2
+
+
+def sample_tail_log_entries():
+    """Snippet for tail_log_entries"""
+
+    # Create a client
+    client = logging_v2.LoggingServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.TailLogEntriesRequest(
+    )
+
+    # Make the request
+    stream = client.tail_log_entries([])
+    for response in stream:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_LoggingServiceV2_TailLogEntries_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_write_log_entries_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_write_log_entries_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for WriteLogEntries
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_LoggingServiceV2_WriteLogEntries_grpc]
+from google.cloud import logging_v2
+
+
+def sample_write_log_entries():
+    """Snippet for write_log_entries"""
+
+    # Create a client
+    client = logging_v2.LoggingServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.WriteLogEntriesRequest(
+    )
+
+    # Make the request
+    response = client.write_log_entries(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_LoggingServiceV2_WriteLogEntries_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_create_log_metric_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_create_log_metric_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_MetricsServiceV2_CreateLogMetric_grpc]
+from google.cloud import logging_v2
+
+
+def sample_create_log_metric():
+    """Snippet for create_log_metric"""
+
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.CreateLogMetricRequest(
+    )
+
+    # Make the request
+    response = client.create_log_metric(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_MetricsServiceV2_CreateLogMetric_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_grpc.py
@@ -40,6 +40,5 @@ def sample_delete_log_metric():
     # Make the request
     response = client.delete_log_metric(request=request)
 
-    # Handle response
 
 # [END logging_generated_logging_v2_MetricsServiceV2_DeleteLogMetric_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_MetricsServiceV2_DeleteLogMetric_grpc]
+from google.cloud import logging_v2
+
+
+def sample_delete_log_metric():
+    """Snippet for delete_log_metric"""
+
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.DeleteLogMetricRequest(
+    )
+
+    # Make the request
+    response = client.delete_log_metric(request=request)
+
+    # Handle response
+
+# [END logging_generated_logging_v2_MetricsServiceV2_DeleteLogMetric_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_get_log_metric_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_get_log_metric_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_MetricsServiceV2_GetLogMetric_grpc]
+from google.cloud import logging_v2
+
+
+def sample_get_log_metric():
+    """Snippet for get_log_metric"""
+
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.GetLogMetricRequest(
+    )
+
+    # Make the request
+    response = client.get_log_metric(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_MetricsServiceV2_GetLogMetric_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_list_log_metrics_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_list_log_metrics_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListLogMetrics
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_MetricsServiceV2_ListLogMetrics_grpc]
+from google.cloud import logging_v2
+
+
+def sample_list_log_metrics():
+    """Snippet for list_log_metrics"""
+
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.ListLogMetricsRequest(
+    )
+
+    # Make the request
+    page_result = client.list_log_metrics(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END logging_generated_logging_v2_MetricsServiceV2_ListLogMetrics_grpc]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_update_log_metric_grpc.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_update_log_metric_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateLogMetric
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-logging
+
+
+# [START logging_generated_logging_v2_MetricsServiceV2_UpdateLogMetric_grpc]
+from google.cloud import logging_v2
+
+
+def sample_update_log_metric():
+    """Snippet for update_log_metric"""
+
+    # Create a client
+    client = logging_v2.MetricsServiceV2Client()
+
+    # Initialize request argument(s)
+    request = logging_v2.UpdateLogMetricRequest(
+    )
+
+    # Make the request
+    response = client.update_log_metric(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END logging_generated_logging_v2_MetricsServiceV2_UpdateLogMetric_grpc]

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -70,7 +70,7 @@ def cover(session):
 @nox.session(python=['3.6', '3.7'])
 def mypy(session):
     """Run the type checker."""
-    session.install('mypy')
+    session.install('mypy', 'types-pkg_resources')
     session.install('.')
     session.run(
         'mypy',

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_create_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_create_instance_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for CreateInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_CreateInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_create_instance():
+    """Snippet for create_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.CreateInstanceRequest(
+    )
+
+    # Make the request
+    operation = client.create_instance(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_CreateInstance_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_delete_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_delete_instance_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for DeleteInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_DeleteInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_delete_instance():
+    """Snippet for delete_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.DeleteInstanceRequest(
+    )
+
+    # Make the request
+    operation = client.delete_instance(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_DeleteInstance_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_export_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_export_instance_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ExportInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_ExportInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_export_instance():
+    """Snippet for export_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.ExportInstanceRequest(
+    )
+
+    # Make the request
+    operation = client.export_instance(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_ExportInstance_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_failover_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_failover_instance_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for FailoverInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_FailoverInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_failover_instance():
+    """Snippet for failover_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.FailoverInstanceRequest(
+    )
+
+    # Make the request
+    operation = client.failover_instance(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_FailoverInstance_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_get_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_get_instance_grpc.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for GetInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_GetInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_get_instance():
+    """Snippet for get_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.GetInstanceRequest(
+    )
+
+    # Make the request
+    response = client.get_instance(request=request)
+
+    # Handle response
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_GetInstance_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_import_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_import_instance_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ImportInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_ImportInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_import_instance():
+    """Snippet for import_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.ImportInstanceRequest(
+    )
+
+    # Make the request
+    operation = client.import_instance(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_ImportInstance_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_list_instances_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_list_instances_grpc.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for ListInstances
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_ListInstances_grpc]
+from google.cloud import redis_v1
+
+
+def sample_list_instances():
+    """Snippet for list_instances"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.ListInstancesRequest(
+    )
+
+    # Make the request
+    page_result = client.list_instances(request=request)
+    for response in page_result:
+        print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_ListInstances_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_update_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_update_instance_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpdateInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_UpdateInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_update_instance():
+    """Snippet for update_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.UpdateInstanceRequest(
+    )
+
+    # Make the request
+    operation = client.update_instance(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_UpdateInstance_grpc]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_upgrade_instance_grpc.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_upgrade_instance_grpc.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for UpgradeInstance
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install google-cloud-redis
+
+
+# [START redis_generated_redis_v1_CloudRedis_UpgradeInstance_grpc]
+from google.cloud import redis_v1
+
+
+def sample_upgrade_instance():
+    """Snippet for upgrade_instance"""
+
+    # Create a client
+    client = redis_v1.CloudRedisClient()
+
+    # Initialize request argument(s)
+    request = redis_v1.UpgradeInstanceRequest(
+    )
+
+    # Make the request
+    operation = client.upgrade_instance(request=request)
+
+    print("Waiting for operation to complete...")
+
+    response = operation.result()
+    print("{}".format(response))
+
+# [END redis_generated_redis_v1_CloudRedis_UpgradeInstance_grpc]

--- a/tests/unit/samplegen/golden_snippets/sample_basic_void_method.py
+++ b/tests/unit/samplegen/golden_snippets/sample_basic_void_method.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Generated code. DO NOT EDIT!
+#
+# Snippet for Classify
+# NOTE: This snippet has been automatically generated for illustrative purposes only.
+# It may require modifications to work in your environment.
+
+# To install the latest published package dependency, execute the following:
+#   python3 -m pip install molluscs-v1-molluscclient
+
+
+# [START mollusc_classify_sync]
+from molluscs.v1 import molluscclient
+
+
+def sample_classify(video, location):
+    """Determine the full taxonomy of input mollusc"""
+
+    # Create a client
+    client = molluscclient.MolluscServiceClient()
+
+    # Initialize request argument(s)
+    classify_target = {}
+    # video = "path/to/mollusc/video.mkv"
+    with open(video, "rb") as f:
+        classify_target["video"] = f.read()
+
+    # location = "New Zealand"
+    classify_target["location_annotation"] = location
+
+    request = molluscclient.molluscs.v1.ClassifyRequest(
+        classify_target=classify_target,
+    )
+
+    # Make the request
+    response = client.classify(request=request)
+
+
+# [END mollusc_classify_sync]

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -191,6 +191,71 @@ def test_generate_sample_basic_unflattenable():
     assert sample_str == golden_snippet("sample_basic_unflattenable.py")
 
 
+def test_generate_sample_void_method():
+    input_type = DummyMessage(
+        type="REQUEST TYPE",
+        fields={
+            "classify_target": DummyField(
+                message=DummyMessage(
+                    type="CLASSIFY TYPE",
+                    fields={
+                        "video": DummyField(
+                            message=DummyMessage(type="VIDEO TYPE"),
+                        ),
+                        "location_annotation": DummyField(
+                            message=DummyMessage(type="LOCATION TYPE"),
+                        )
+                    },
+                )
+            )
+        },
+        ident=DummyIdent(name="molluscs.v1.ClassifyRequest")
+    )
+
+    api_naming = naming.NewNaming(
+        name="MolluscClient", namespace=("molluscs", "v1"))
+    service = wrappers.Service(
+        service_pb=namedtuple('service_pb', ['name'])('MolluscService'),
+        methods={
+            "Classify": DummyMethod(
+                void=True,
+                input=input_type,
+                output=message_factory("$resp.taxonomy"),
+                flattened_fields={
+                    "classify_target": DummyField(name="classify_target")
+                }
+            )
+        },
+        visible_resources={},
+    )
+
+    schema = DummyApiSchema(
+        services={"animalia.mollusca.v1.Mollusc": service},
+        naming=api_naming,
+    )
+
+    sample = {"service": "animalia.mollusca.v1.Mollusc",
+              "rpc": "Classify",
+              "id": "mollusc_classify_sync",
+              "description": "Determine the full taxonomy of input mollusc",
+              "request": [
+                  {"field": "classify_target.video",
+                   "value": "path/to/mollusc/video.mkv",
+                   "input_parameter": "video",
+                   "value_is_file": True},
+                  {"field": "classify_target.location_annotation",
+                   "value": "New Zealand",
+                   "input_parameter": "location"}
+              ]}
+
+    sample_str = samplegen.generate_sample(
+        sample,
+        schema,
+        env.get_template('examples/sample.py.j2')
+    )
+
+    assert sample_str == golden_snippet("sample_basic_void_method.py")
+
 def test_generate_sample_service_not_found():
     schema = DummyApiSchema({}, DummyNaming("pkg_name"))
     sample = {"service": "Mollusc"}

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -256,6 +256,7 @@ def test_generate_sample_void_method():
 
     assert sample_str == golden_snippet("sample_basic_void_method.py")
 
+
 def test_generate_sample_service_not_found():
     schema = DummyApiSchema({}, DummyNaming("pkg_name"))
     sample = {"service": "Mollusc"}

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -117,7 +117,6 @@ def test_preprocess_sample():
 
 
 def test_preprocess_sample_void_method():
-    # Verify no response is added for a void method
     sample = {"service": "Mollusc", "rpc": "Classify"}
     api_schema = DummyApiSchema(
         services={"Mollusc": DummyService(
@@ -131,7 +130,7 @@ def test_preprocess_sample_void_method():
 
     samplegen.Validator.preprocess_sample(sample, api_schema, rpc)
 
-    assert "response" not in sample
+    assert sample["response"] == []
 
 
 def test_define_input_param():


### PR DESCRIPTION
- fix samplegen logic to always set a `sample[response]`
- enable `autogen-snippets` for the golden integration tests that are run through Bazel
- install some extra stub packages for mypy that are needed with the new release
