### PR TITLE
fix: import warnings when needed

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -8,6 +8,9 @@ import os
 import re
 from typing import Callable, Dict, Optional, {% if service.any_server_streaming %}Iterable, {% endif %}{% if service.any_client_streaming %}Iterator, {% endif %}Sequence, Tuple, Type, Union
 import pkg_resources
+{% if service.any_deprecated %}
+import warnings
+{% endif %}}
 
 from google.api_core import client_options as client_options_lib  # type: ignore
 from google.api_core import exceptions as core_exceptions         # type: ignore
@@ -335,7 +338,9 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% endif %}
         """
         {% if method.is_deprecated %}
-        warnings.warn("{{ method.name|snake_case }} is deprecated", warnings.DeprecationWarning)
+        warnings.warn("{{ service.client_name }}.{{ method.name|snake_case }} is deprecated",
+            warnings.DeprecationWarning)
+
         {% endif %}
         {% if not method.client_streaming %}
         # Create or coerce a protobuf request object.

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -10,7 +10,7 @@ from typing import Callable, Dict, Optional, {% if service.any_server_streaming 
 import pkg_resources
 {% if service.any_deprecated %}
 import warnings
-{% endif %}}
+{% endif %}
 
 from google.api_core import client_options as client_options_lib  # type: ignore
 from google.api_core import exceptions as core_exceptions         # type: ignore

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1207,6 +1207,10 @@ class Service:
     def any_server_streaming(self) -> bool:
         return any(m.server_streaming for m in self.methods.values())
 
+    @utils.cached_property
+    def any_deprecated(self) -> bool:
+        return any(m.is_deprecated for m in self.methods.values())
+
     def with_context(self, *, collisions: FrozenSet[str]) -> 'Service':
         """Return a derivative of this service with the provided context.
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -7,6 +7,9 @@ import functools
 import re
 from typing import Dict, {% if service.any_server_streaming %}AsyncIterable, Awaitable, {% endif %}{% if service.any_client_streaming %}AsyncIterator, {% endif %}Sequence, Tuple, Type, Union
 import pkg_resources
+{% if service.any_deprecated %}
+import warnings
+{% endif %}
 
 import google.api_core.client_options as ClientOptions # type: ignore
 from google.api_core import exceptions as core_exceptions  # type: ignore
@@ -196,6 +199,11 @@ class {{ service.async_client_name }}:
                 {{ method.client_output_async.meta.doc|rst(width=72, indent=16, source_format='rst') }}
         {% endif %}
         """
+        {% if method.is_deprecated %}
+        warnings.warn("{{ service.async_client_name }}.{{ method.name|snake_case }} is deprecated",
+            warnings.DeprecationWarning)
+
+        {% endif %}
         {% if not method.client_streaming %}
         # Create or coerce a protobuf request object.
         {% if method.flattened_fields %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -8,6 +8,9 @@ import os
 import re
 from typing import Callable, Dict, Optional, {% if service.any_server_streaming %}Iterable, {% endif %}{% if service.any_client_streaming %}Iterator, {% endif %}Sequence, Tuple, Type, Union
 import pkg_resources
+{% if service.any_deprecated %}
+import warnings
+{% endif %}
 
 from google.api_core import client_options as client_options_lib  # type: ignore
 from google.api_core import exceptions as core_exceptions         # type: ignore
@@ -360,7 +363,9 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         {% endif %}
         """
         {% if method.is_deprecated %}
-        warnings.warn("{{ method.name|snake_case }} is deprecated", warnings.DeprecationWarning)
+        warnings.warn("{{ service.client_name }}.{{ method.name|snake_case }} is deprecated",
+            warnings.DeprecationWarning)
+
         {% endif %}
         {% if not method.client_streaming %}
         # Create or coerce a protobuf request object.


### PR DESCRIPTION
Fixes #931.

Import `warnings` and append the client name to the deprecation warning.