### PR TITLE
fix: fix wrong scopes for self signed jwt

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -111,7 +111,7 @@ class {{ service.name }}Transport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
+        self._scopes = scopes
 
         # If no credentials are provided, then determine the appropriate
         # defaults.

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1667,11 +1667,7 @@ def test_{{ service.name|snake_case }}_grpc_transport_client_cert_source_for_mtl
             "squid.clam.whelk:443",
             credentials=cred,
             credentials_file=None,
-            scopes=(
-                {% for scope in service.oauth_scopes %}
-                '{{ scope }}',
-                {% endfor %}
-            ),
+            scopes=None,
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
             options=[
@@ -1784,11 +1780,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                 "mtls.squid.clam.whelk:443",
                 credentials=cred,
                 credentials_file=None,
-                scopes=(
-                    {% for scope in service.oauth_scopes %}
-                    '{{ scope }}',
-                    {% endfor %}
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[
@@ -1829,11 +1821,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
                 "mtls.squid.clam.whelk:443",
                 credentials=mock_cred,
                 credentials_file=None,
-                scopes=(
-                    {% for scope in service.oauth_scopes %}
-                    '{{ scope }}',
-                    {% endfor %}
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -101,7 +101,7 @@ class AssetServiceTransport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
+        self._scopes = scopes
 
         # If no credentials are provided, then determine the appropriate
         # defaults.

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -3711,9 +3711,7 @@ def test_asset_service_grpc_transport_client_cert_source_for_mtls(
             "squid.clam.whelk:443",
             credentials=cred,
             credentials_file=None,
-            scopes=(
-                'https://www.googleapis.com/auth/cloud-platform',
-            ),
+            scopes=None,
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
             options=[
@@ -3810,9 +3808,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
                 "mtls.squid.clam.whelk:443",
                 credentials=cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[
@@ -3853,9 +3849,7 @@ def test_asset_service_transport_channel_mtls_with_adc(
                 "mtls.squid.clam.whelk:443",
                 credentials=mock_cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
@@ -98,7 +98,7 @@ class IAMCredentialsTransport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
+        self._scopes = scopes
 
         # If no credentials are provided, then determine the appropriate
         # defaults.

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -1640,9 +1640,7 @@ def test_iam_credentials_grpc_transport_client_cert_source_for_mtls(
             "squid.clam.whelk:443",
             credentials=cred,
             credentials_file=None,
-            scopes=(
-                'https://www.googleapis.com/auth/cloud-platform',
-            ),
+            scopes=None,
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
             options=[
@@ -1739,9 +1737,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
                 "mtls.squid.clam.whelk:443",
                 credentials=cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[
@@ -1782,9 +1778,7 @@ def test_iam_credentials_transport_channel_mtls_with_adc(
                 "mtls.squid.clam.whelk:443",
                 credentials=mock_cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -102,7 +102,7 @@ class ConfigServiceV2Transport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
+        self._scopes = scopes
 
         # If no credentials are provided, then determine the appropriate
         # defaults.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -103,7 +103,7 @@ class LoggingServiceV2Transport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
+        self._scopes = scopes
 
         # If no credentials are provided, then determine the appropriate
         # defaults.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -103,7 +103,7 @@ class MetricsServiceV2Transport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
+        self._scopes = scopes
 
         # If no credentials are provided, then determine the appropriate
         # defaults.

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -6077,12 +6077,7 @@ def test_config_service_v2_grpc_transport_client_cert_source_for_mtls(
             "squid.clam.whelk:443",
             credentials=cred,
             credentials_file=None,
-            scopes=(
-                'https://www.googleapis.com/auth/cloud-platform',
-                'https://www.googleapis.com/auth/cloud-platform.read-only',
-                'https://www.googleapis.com/auth/logging.admin',
-                'https://www.googleapis.com/auth/logging.read',
-            ),
+            scopes=None,
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
             options=[
@@ -6179,12 +6174,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                 "mtls.squid.clam.whelk:443",
                 credentials=cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[
@@ -6225,12 +6215,7 @@ def test_config_service_v2_transport_channel_mtls_with_adc(
                 "mtls.squid.clam.whelk:443",
                 credentials=mock_cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -2204,13 +2204,7 @@ def test_logging_service_v2_grpc_transport_client_cert_source_for_mtls(
             "squid.clam.whelk:443",
             credentials=cred,
             credentials_file=None,
-            scopes=(
-                'https://www.googleapis.com/auth/cloud-platform',
-                'https://www.googleapis.com/auth/cloud-platform.read-only',
-                'https://www.googleapis.com/auth/logging.admin',
-                'https://www.googleapis.com/auth/logging.read',
-                'https://www.googleapis.com/auth/logging.write',
-            ),
+            scopes=None,
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
             options=[
@@ -2307,13 +2301,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                 "mtls.squid.clam.whelk:443",
                 credentials=cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                    'https://www.googleapis.com/auth/logging.write',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[
@@ -2354,13 +2342,7 @@ def test_logging_service_v2_transport_channel_mtls_with_adc(
                 "mtls.squid.clam.whelk:443",
                 credentials=mock_cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                    'https://www.googleapis.com/auth/logging.write',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2069,13 +2069,7 @@ def test_metrics_service_v2_grpc_transport_client_cert_source_for_mtls(
             "squid.clam.whelk:443",
             credentials=cred,
             credentials_file=None,
-            scopes=(
-                'https://www.googleapis.com/auth/cloud-platform',
-                'https://www.googleapis.com/auth/cloud-platform.read-only',
-                'https://www.googleapis.com/auth/logging.admin',
-                'https://www.googleapis.com/auth/logging.read',
-                'https://www.googleapis.com/auth/logging.write',
-            ),
+            scopes=None,
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
             options=[
@@ -2172,13 +2166,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                 "mtls.squid.clam.whelk:443",
                 credentials=cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                    'https://www.googleapis.com/auth/logging.write',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[
@@ -2219,13 +2207,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_adc(
                 "mtls.squid.clam.whelk:443",
                 credentials=mock_cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                    'https://www.googleapis.com/auth/logging.write',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -100,7 +100,7 @@ class CloudRedisTransport(abc.ABC):
         scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
 
         # Save the scopes.
-        self._scopes = scopes or self.AUTH_SCOPES
+        self._scopes = scopes
 
         # If no credentials are provided, then determine the appropriate
         # defaults.

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -3020,9 +3020,7 @@ def test_cloud_redis_grpc_transport_client_cert_source_for_mtls(
             "squid.clam.whelk:443",
             credentials=cred,
             credentials_file=None,
-            scopes=(
-                'https://www.googleapis.com/auth/cloud-platform',
-            ),
+            scopes=None,
             ssl_credentials=mock_ssl_channel_creds,
             quota_project_id=None,
             options=[
@@ -3119,9 +3117,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                 "mtls.squid.clam.whelk:443",
                 credentials=cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[
@@ -3162,9 +3158,7 @@ def test_cloud_redis_transport_channel_mtls_with_adc(
                 "mtls.squid.clam.whelk:443",
                 credentials=mock_cred,
                 credentials_file=None,
-                scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                ),
+                scopes=None,
                 ssl_credentials=mock_ssl_cred,
                 quota_project_id=None,
                 options=[


### PR DESCRIPTION
Fixes: #929 

When auth library creates self signed jwt, it looks for `scopes`, `audience` and `default_scopes` **in order**, and uses the first one available.

In the transport base class, we are using `self.AUTH_SCOPES` as `scopes` if `scopes` are not provided. This is not right. 
https://github.com/googleapis/gapic-generator-python/blob/ceb64d961d885df67e3cfb7ca2889b8b2eb28386/gapic/templates/%25namespace/%25name_%25version/%25sub/services/%25service/transports/base.py.j2#L114

This is not right since `self.AUTH_SCOPES` should be only used as `default_scopes`. `self.AUTH_SCOPES` may contain only a generic `"https://www.googleapis.com/auth/cloud-platform"` scope, for instance for all the failed APIs listed in this issue. If it is used as `scopes` in self signed jwt, the samples may fail with invalid scopes. For the success APIs, the `AUTH_SCOPES` of kms contains an additional `https://www.googleapis.com/auth/cloudkms` scope so it has no problem; the other two API are mysterious to me since they are using the same generic scope in `AUTH_SCOPES` as the failed APIs. 

The fix is simple. We just need to change `self._scopes = scopes or self.AUTH_SCOPES` to `self._scopes = scopes` in the transport base class. Note that `self.AUTH_SCOPES` is already passed to grpc channel as `default_scopes`.
https://github.com/googleapis/gapic-generator-python/blob/ceb64d961d885df67e3cfb7ca2889b8b2eb28386/gapic/templates/%25namespace/%25name_%25version/%25sub/services/%25service/transports/grpc.py.j2#L208-L217

I tested the PR for all the failed APIs, now all the samples passed (I didn't update the unit test, so kokoro would fail in these PRs):
https://github.com/googleapis/python-speech/pull/189
https://github.com/googleapis/python-asset/pull/215
https://github.com/googleapis/python-videointelligence/pull/171
https://github.com/googleapis/python-analytics-data/pull/95

I also tested the secret_manager and automl APIs, their samples still pass with this fix.
https://github.com/googleapis/python-secret-manager/pull/141
https://github.com/googleapis/python-automl/pull/179