### PR TITLE
fix: fix syntax for DeprecationWarning

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -339,7 +339,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         """
         {% if method.is_deprecated %}
         warnings.warn("{{ service.client_name }}.{{ method.name|snake_case }} is deprecated",
-            warnings.DeprecationWarning)
+            DeprecationWarning)
 
         {% endif %}
         {% if not method.client_streaming %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -201,7 +201,7 @@ class {{ service.async_client_name }}:
         """
         {% if method.is_deprecated %}
         warnings.warn("{{ service.async_client_name }}.{{ method.name|snake_case }} is deprecated",
-            warnings.DeprecationWarning)
+            DeprecationWarning)
 
         {% endif %}
         {% if not method.client_streaming %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -364,7 +364,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
         """
         {% if method.is_deprecated %}
         warnings.warn("{{ service.client_name }}.{{ method.name|snake_case }} is deprecated",
-            warnings.DeprecationWarning)
+            DeprecationWarning)
 
         {% endif %}
         {% if not method.client_streaming %}


### PR DESCRIPTION
I've verified that the generated code is valid with bigquery datatransfer:

```
(env) busunkim@busunkim:~/github/googleapis$ protoc google/cloud/bigquery/datatransfer/v1/*.proto --proto_path=../api-common-protos/ --proto_path=. --python_gapic_out=dest
(env) busunkim@busunkim:~/github/googleapis$ cd dest
(env) busunkim@busunkim:~/github/googleapis/dest$ nox -s unit-3.6
nox > Running session unit-3.6
nox > Creating virtual environment (virtualenv) using python3.6 in .nox/unit-3-6
nox > pip install coverage pytest pytest-cov asyncmock pytest-asyncio
nox > pip install -e .
nox > py.test --quiet --cov=google/cloud/bigquery/datatransfer_v1/ --cov-config=.coveragerc --cov-report=term --cov-report=html tests/unit/
....................................................................................................................................................................................................s..s..ss................. [ 94%]
............                                                                                                                                                                                                                  [100%]
========================================================================================================= warnings summary ==========================================================================================================
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_from_dict
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_empty_call
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_field_headers
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_flattened
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_flattened_error
  /usr/local/google/home/busunkim/github/googleapis/dest/google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/client.py:1028: DeprecationWarning: DataTransferServiceClient.schedule_transfer_runs is deprecated
    DeprecationWarning)

tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_async
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_async_from_dict
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_field_headers_async
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_flattened_async
tests/unit/gapic/datatransfer_v1/test_data_transfer_service.py::test_schedule_transfer_runs_flattened_error_async
  /usr/local/google/home/busunkim/github/googleapis/dest/google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/async_client.py:823: DeprecationWarning: DataTransferServiceAsyncClient.schedule_transfer_runs is deprecated
    DeprecationWarning)

-- Docs: https://docs.pytest.org/en/stable/warnings.html

----------- coverage: platform linux, python 3.6.9-final-0 -----------
Name                                                                                              Stmts   Miss Branch BrPart  Cover   Missing
---------------------------------------------------------------------------------------------------------------------------------------------
google/cloud/bigquery/datatransfer_v1/__init__.py                                                    33      0      0      0   100%
google/cloud/bigquery/datatransfer_v1/services/__init__.py                                            0      0      0      0   100%
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/__init__.py                      3      0      0      0   100%
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/async_client.py                219      0     60      0   100%
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/client.py                      332      0    122      0   100%
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/pagers.py                      159      0     40      0   100%
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/transports/__init__.py           9      0      0      0   100%
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/transports/base.py              91      4     12      1    95%   45-47, 144
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/transports/grpc.py             116      0     42      0   100%
google/cloud/bigquery/datatransfer_v1/services/data_transfer_service/transports/grpc_asyncio.py     119      0     42      0   100%
google/cloud/bigquery/datatransfer_v1/types/__init__.py                                               3      0      0      0   100%
google/cloud/bigquery/datatransfer_v1/types/datatransfer.py                                         145      0      0      0   100%
google/cloud/bigquery/datatransfer_v1/types/transfer.py                                              66      0      0      0   100%
---------------------------------------------------------------------------------------------------------------------------------------------
TOTAL                                                                                              1295      4    318      1    99%
Coverage HTML written to dir htmlcov

229 passed, 4 skipped, 11 warnings in 3.58s
nox > Session unit-3.6 was successful.
```