### PR TITLE
fix: use mock from unittest if available

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -3,7 +3,10 @@
 {% block content %}
 
 import os
-import mock
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 import packaging.version
 
 import grpc


### PR DESCRIPTION
Try to import `mock` from the `unittest` builtin package if possible, otherwise fall back to importing the `mock` package.