### PR TITLE
fix: add 'dict' type annotation to 'request'

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -306,7 +306,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
         Args:
             {% if not method.client_streaming %}
-             request (Union[{{ method.input.ident.sphinx }}, dict]):
+            request (Union[{{ method.input.ident.sphinx }}, dict]):
                 The request object.{{ ' ' }}
                 {{- method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             {% for key, field in method.flattened_fields.items() %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -285,7 +285,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     {% for method in service.methods.values() %}
     def {{ method.name|snake_case }}(self,
             {% if not method.client_streaming %}
-            request: {{ method.input.ident }} = None,
+            request: Union[{{ method.input.ident }}, dict] = None,
             *,
             {% for field in method.flattened_fields.values() %}
             {{ field.name }}: {{ field.ident }} = None,
@@ -306,7 +306,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
         Args:
             {% if not method.client_streaming %}
-            request (:class:`{{ method.input.ident.sphinx }}`):
+             request (Union[{{ method.input.ident.sphinx }}, dict]):
                 The request object.{{ ' ' }}
                 {{- method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             {% for key, field in method.flattened_fields.items() %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -316,7 +316,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     {% for method in service.methods.values() %}
     def {{ method.name|snake_case }}(self,
             {% if not method.client_streaming %}
-            request: {{ method.input.ident }} = None,
+            request: Union[{{ method.input.ident }}, dict] = None,
             *,
             {% for field in method.flattened_fields.values() %}
             {{ field.name }}: {{ field.ident }} = None,
@@ -337,7 +337,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
 
         Args:
             {% if not method.client_streaming %}
-            request ({{ method.input.ident.sphinx }}):
+            request (Union[{{ method.input.ident.sphinx }}, dict]):
                 The request object.{{ " " }}
                 {{- method.input.meta.doc|wrap(width=72, offset=36, indent=16) }}
             {% for key, field in method.flattened_fields.items() %}

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -351,7 +351,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             )
 
     def export_assets(self,
-            request: asset_service.ExportAssetsRequest = None,
+            request: Union[asset_service.ExportAssetsRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -372,7 +372,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         the export operation usually finishes within 5 minutes.
 
         Args:
-            request (google.cloud.asset_v1.types.ExportAssetsRequest):
+            request (Union[google.cloud.asset_v1.types.ExportAssetsRequest, dict]):
                 The request object. Export asset request.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -431,7 +431,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def list_assets(self,
-            request: asset_service.ListAssetsRequest = None,
+            request: Union[asset_service.ListAssetsRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -442,7 +442,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         paged results in response.
 
         Args:
-            request (google.cloud.asset_v1.types.ListAssetsRequest):
+            request (Union[google.cloud.asset_v1.types.ListAssetsRequest, dict]):
                 The request object. ListAssets request.
             parent (str):
                 Required. Name of the organization or project the assets
@@ -520,7 +520,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def batch_get_assets_history(self,
-            request: asset_service.BatchGetAssetsHistoryRequest = None,
+            request: Union[asset_service.BatchGetAssetsHistoryRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -535,7 +535,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         INVALID_ARGUMENT error.
 
         Args:
-            request (google.cloud.asset_v1.types.BatchGetAssetsHistoryRequest):
+            request (Union[google.cloud.asset_v1.types.BatchGetAssetsHistoryRequest, dict]):
                 The request object. Batch get assets history request.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -579,7 +579,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def create_feed(self,
-            request: asset_service.CreateFeedRequest = None,
+            request: Union[asset_service.CreateFeedRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -591,7 +591,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         updates.
 
         Args:
-            request (google.cloud.asset_v1.types.CreateFeedRequest):
+            request (Union[google.cloud.asset_v1.types.CreateFeedRequest, dict]):
                 The request object. Create asset feed request.
             parent (str):
                 Required. The name of the
@@ -667,7 +667,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def get_feed(self,
-            request: asset_service.GetFeedRequest = None,
+            request: Union[asset_service.GetFeedRequest, dict] = None,
             *,
             name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -677,7 +677,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         r"""Gets details about an asset feed.
 
         Args:
-            request (google.cloud.asset_v1.types.GetFeedRequest):
+            request (Union[google.cloud.asset_v1.types.GetFeedRequest, dict]):
                 The request object. Get asset feed request.
             name (str):
                 Required. The name of the Feed and it must be in the
@@ -748,7 +748,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def list_feeds(self,
-            request: asset_service.ListFeedsRequest = None,
+            request: Union[asset_service.ListFeedsRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -759,7 +759,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         project/folder/organization.
 
         Args:
-            request (google.cloud.asset_v1.types.ListFeedsRequest):
+            request (Union[google.cloud.asset_v1.types.ListFeedsRequest, dict]):
                 The request object. List asset feeds request.
             parent (str):
                 Required. The parent
@@ -825,7 +825,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def update_feed(self,
-            request: asset_service.UpdateFeedRequest = None,
+            request: Union[asset_service.UpdateFeedRequest, dict] = None,
             *,
             feed: asset_service.Feed = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -835,7 +835,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         r"""Updates an asset feed configuration.
 
         Args:
-            request (google.cloud.asset_v1.types.UpdateFeedRequest):
+            request (Union[google.cloud.asset_v1.types.UpdateFeedRequest, dict]):
                 The request object. Update asset feed request.
             feed (google.cloud.asset_v1.types.Feed):
                 Required. The new values of feed details. It must match
@@ -907,7 +907,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def delete_feed(self,
-            request: asset_service.DeleteFeedRequest = None,
+            request: Union[asset_service.DeleteFeedRequest, dict] = None,
             *,
             name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -917,7 +917,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         r"""Deletes an asset feed.
 
         Args:
-            request (google.cloud.asset_v1.types.DeleteFeedRequest):
+            request (Union[google.cloud.asset_v1.types.DeleteFeedRequest, dict]):
                 The request object.
             name (str):
                 Required. The name of the feed and it must be in the
@@ -974,7 +974,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         )
 
     def search_all_resources(self,
-            request: asset_service.SearchAllResourcesRequest = None,
+            request: Union[asset_service.SearchAllResourcesRequest, dict] = None,
             *,
             scope: str = None,
             query: str = None,
@@ -989,7 +989,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         desired scope, otherwise the request will be rejected.
 
         Args:
-            request (google.cloud.asset_v1.types.SearchAllResourcesRequest):
+            request (Union[google.cloud.asset_v1.types.SearchAllResourcesRequest, dict]):
                 The request object. Search all resources request.
             scope (str):
                 Required. A scope can be a project, a folder, or an
@@ -1154,7 +1154,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def search_all_iam_policies(self,
-            request: asset_service.SearchAllIamPoliciesRequest = None,
+            request: Union[asset_service.SearchAllIamPoliciesRequest, dict] = None,
             *,
             scope: str = None,
             query: str = None,
@@ -1168,7 +1168,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         desired scope, otherwise the request will be rejected.
 
         Args:
-            request (google.cloud.asset_v1.types.SearchAllIamPoliciesRequest):
+            request (Union[google.cloud.asset_v1.types.SearchAllIamPoliciesRequest, dict]):
                 The request object. Search all IAM policies request.
             scope (str):
                 Required. A scope can be a project, a folder, or an
@@ -1313,7 +1313,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def analyze_iam_policy(self,
-            request: asset_service.AnalyzeIamPolicyRequest = None,
+            request: Union[asset_service.AnalyzeIamPolicyRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -1323,7 +1323,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         what accesses on which resources.
 
         Args:
-            request (google.cloud.asset_v1.types.AnalyzeIamPolicyRequest):
+            request (Union[google.cloud.asset_v1.types.AnalyzeIamPolicyRequest, dict]):
                 The request object. A request message for
                 [AssetService.AnalyzeIamPolicy][google.cloud.asset.v1.AssetService.AnalyzeIamPolicy].
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -1370,7 +1370,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         return response
 
     def analyze_iam_policy_longrunning(self,
-            request: asset_service.AnalyzeIamPolicyLongrunningRequest = None,
+            request: Union[asset_service.AnalyzeIamPolicyLongrunningRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -1390,7 +1390,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
         to help callers to map responses to requests.
 
         Args:
-            request (google.cloud.asset_v1.types.AnalyzeIamPolicyLongrunningRequest):
+            request (Union[google.cloud.asset_v1.types.AnalyzeIamPolicyLongrunningRequest, dict]):
                 The request object. A request message for
                 [AssetService.AnalyzeIamPolicyLongrunning][google.cloud.asset.v1.AssetService.AnalyzeIamPolicyLongrunning].
             retry (google.api_core.retry.Retry): Designation of what errors, if any,

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -347,7 +347,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             )
 
     def generate_access_token(self,
-            request: common.GenerateAccessTokenRequest = None,
+            request: Union[common.GenerateAccessTokenRequest, dict] = None,
             *,
             name: str = None,
             delegates: Sequence[str] = None,
@@ -361,7 +361,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         account.
 
         Args:
-            request (google.iam.credentials_v1.types.GenerateAccessTokenRequest):
+            request (Union[google.iam.credentials_v1.types.GenerateAccessTokenRequest, dict]):
                 The request object.
             name (str):
                 Required. The resource name of the service account for
@@ -473,7 +473,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         return response
 
     def generate_id_token(self,
-            request: common.GenerateIdTokenRequest = None,
+            request: Union[common.GenerateIdTokenRequest, dict] = None,
             *,
             name: str = None,
             delegates: Sequence[str] = None,
@@ -487,7 +487,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         account.
 
         Args:
-            request (google.iam.credentials_v1.types.GenerateIdTokenRequest):
+            request (Union[google.iam.credentials_v1.types.GenerateIdTokenRequest, dict]):
                 The request object.
             name (str):
                 Required. The resource name of the service account for
@@ -593,7 +593,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         return response
 
     def sign_blob(self,
-            request: common.SignBlobRequest = None,
+            request: Union[common.SignBlobRequest, dict] = None,
             *,
             name: str = None,
             delegates: Sequence[str] = None,
@@ -606,7 +606,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         private key.
 
         Args:
-            request (google.iam.credentials_v1.types.SignBlobRequest):
+            request (Union[google.iam.credentials_v1.types.SignBlobRequest, dict]):
                 The request object.
             name (str):
                 Required. The resource name of the service account for
@@ -699,7 +699,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         return response
 
     def sign_jwt(self,
-            request: common.SignJwtRequest = None,
+            request: Union[common.SignJwtRequest, dict] = None,
             *,
             name: str = None,
             delegates: Sequence[str] = None,
@@ -712,7 +712,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
         private key.
 
         Args:
-            request (google.iam.credentials_v1.types.SignJwtRequest):
+            request (Union[google.iam.credentials_v1.types.SignJwtRequest, dict]):
                 The request object.
             name (str):
                 Required. The resource name of the service account for

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -382,7 +382,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             )
 
     def list_buckets(self,
-            request: logging_config.ListBucketsRequest = None,
+            request: Union[logging_config.ListBucketsRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -392,7 +392,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Lists buckets.
 
         Args:
-            request (google.cloud.logging_v2.types.ListBucketsRequest):
+            request (Union[google.cloud.logging_v2.types.ListBucketsRequest, dict]):
                 The request object. The parameters to `ListBuckets`.
             parent (str):
                 Required. The parent resource whose buckets are to be
@@ -478,7 +478,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def get_bucket(self,
-            request: logging_config.GetBucketRequest = None,
+            request: Union[logging_config.GetBucketRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -487,7 +487,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Gets a bucket.
 
         Args:
-            request (google.cloud.logging_v2.types.GetBucketRequest):
+            request (Union[google.cloud.logging_v2.types.GetBucketRequest, dict]):
                 The request object. The parameters to `GetBucket`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -531,7 +531,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def create_bucket(self,
-            request: logging_config.CreateBucketRequest = None,
+            request: Union[logging_config.CreateBucketRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -542,7 +542,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         cannot be changed.
 
         Args:
-            request (google.cloud.logging_v2.types.CreateBucketRequest):
+            request (Union[google.cloud.logging_v2.types.CreateBucketRequest, dict]):
                 The request object. The parameters to `CreateBucket`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -586,7 +586,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def update_bucket(self,
-            request: logging_config.UpdateBucketRequest = None,
+            request: Union[logging_config.UpdateBucketRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -605,7 +605,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         A buckets region may not be modified after it is created.
 
         Args:
-            request (google.cloud.logging_v2.types.UpdateBucketRequest):
+            request (Union[google.cloud.logging_v2.types.UpdateBucketRequest, dict]):
                 The request object. The parameters to `UpdateBucket`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -649,7 +649,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def delete_bucket(self,
-            request: logging_config.DeleteBucketRequest = None,
+            request: Union[logging_config.DeleteBucketRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -660,7 +660,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         the bucket will be permanently deleted.
 
         Args:
-            request (google.cloud.logging_v2.types.DeleteBucketRequest):
+            request (Union[google.cloud.logging_v2.types.DeleteBucketRequest, dict]):
                 The request object. The parameters to `DeleteBucket`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -697,7 +697,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         )
 
     def undelete_bucket(self,
-            request: logging_config.UndeleteBucketRequest = None,
+            request: Union[logging_config.UndeleteBucketRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -707,7 +707,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         may be undeleted within the grace period of 7 days.
 
         Args:
-            request (google.cloud.logging_v2.types.UndeleteBucketRequest):
+            request (Union[google.cloud.logging_v2.types.UndeleteBucketRequest, dict]):
                 The request object. The parameters to `UndeleteBucket`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -744,7 +744,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         )
 
     def list_views(self,
-            request: logging_config.ListViewsRequest = None,
+            request: Union[logging_config.ListViewsRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -754,7 +754,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Lists views on a bucket.
 
         Args:
-            request (google.cloud.logging_v2.types.ListViewsRequest):
+            request (Union[google.cloud.logging_v2.types.ListViewsRequest, dict]):
                 The request object. The parameters to `ListViews`.
             parent (str):
                 Required. The bucket whose views are to be listed:
@@ -832,7 +832,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def get_view(self,
-            request: logging_config.GetViewRequest = None,
+            request: Union[logging_config.GetViewRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -841,7 +841,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Gets a view.
 
         Args:
-            request (google.cloud.logging_v2.types.GetViewRequest):
+            request (Union[google.cloud.logging_v2.types.GetViewRequest, dict]):
                 The request object. The parameters to `GetView`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -887,7 +887,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def create_view(self,
-            request: logging_config.CreateViewRequest = None,
+            request: Union[logging_config.CreateViewRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -897,7 +897,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         contain a maximum of 50 views.
 
         Args:
-            request (google.cloud.logging_v2.types.CreateViewRequest):
+            request (Union[google.cloud.logging_v2.types.CreateViewRequest, dict]):
                 The request object. The parameters to `CreateView`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -943,7 +943,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def update_view(self,
-            request: logging_config.UpdateViewRequest = None,
+            request: Union[logging_config.UpdateViewRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -953,7 +953,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         existing view with values from the new view: ``filter``.
 
         Args:
-            request (google.cloud.logging_v2.types.UpdateViewRequest):
+            request (Union[google.cloud.logging_v2.types.UpdateViewRequest, dict]):
                 The request object. The parameters to `UpdateView`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -999,7 +999,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def delete_view(self,
-            request: logging_config.DeleteViewRequest = None,
+            request: Union[logging_config.DeleteViewRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -1008,7 +1008,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Deletes a view from a bucket.
 
         Args:
-            request (google.cloud.logging_v2.types.DeleteViewRequest):
+            request (Union[google.cloud.logging_v2.types.DeleteViewRequest, dict]):
                 The request object. The parameters to `DeleteView`.
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
                 should be retried.
@@ -1045,7 +1045,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         )
 
     def list_sinks(self,
-            request: logging_config.ListSinksRequest = None,
+            request: Union[logging_config.ListSinksRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1055,7 +1055,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Lists sinks.
 
         Args:
-            request (google.cloud.logging_v2.types.ListSinksRequest):
+            request (Union[google.cloud.logging_v2.types.ListSinksRequest, dict]):
                 The request object. The parameters to `ListSinks`.
             parent (str):
                 Required. The parent resource whose sinks are to be
@@ -1137,7 +1137,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def get_sink(self,
-            request: logging_config.GetSinkRequest = None,
+            request: Union[logging_config.GetSinkRequest, dict] = None,
             *,
             sink_name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1147,7 +1147,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Gets a sink.
 
         Args:
-            request (google.cloud.logging_v2.types.GetSinkRequest):
+            request (Union[google.cloud.logging_v2.types.GetSinkRequest, dict]):
                 The request object. The parameters to `GetSink`.
             sink_name (str):
                 Required. The resource name of the sink:
@@ -1226,7 +1226,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def create_sink(self,
-            request: logging_config.CreateSinkRequest = None,
+            request: Union[logging_config.CreateSinkRequest, dict] = None,
             *,
             parent: str = None,
             sink: logging_config.LogSink = None,
@@ -1241,7 +1241,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         entries only from the resource owning the sink.
 
         Args:
-            request (google.cloud.logging_v2.types.CreateSinkRequest):
+            request (Union[google.cloud.logging_v2.types.CreateSinkRequest, dict]):
                 The request object. The parameters to `CreateSink`.
             parent (str):
                 Required. The resource in which to create the sink:
@@ -1330,7 +1330,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def update_sink(self,
-            request: logging_config.UpdateSinkRequest = None,
+            request: Union[logging_config.UpdateSinkRequest, dict] = None,
             *,
             sink_name: str = None,
             sink: logging_config.LogSink = None,
@@ -1347,7 +1347,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         the ``unique_writer_identity`` field.
 
         Args:
-            request (google.cloud.logging_v2.types.UpdateSinkRequest):
+            request (Union[google.cloud.logging_v2.types.UpdateSinkRequest, dict]):
                 The request object. The parameters to `UpdateSink`.
             sink_name (str):
                 Required. The full resource name of the sink to update,
@@ -1458,7 +1458,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def delete_sink(self,
-            request: logging_config.DeleteSinkRequest = None,
+            request: Union[logging_config.DeleteSinkRequest, dict] = None,
             *,
             sink_name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1469,7 +1469,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         then that service account is also deleted.
 
         Args:
-            request (google.cloud.logging_v2.types.DeleteSinkRequest):
+            request (Union[google.cloud.logging_v2.types.DeleteSinkRequest, dict]):
                 The request object. The parameters to `DeleteSink`.
             sink_name (str):
                 Required. The full resource name of the sink to delete,
@@ -1533,7 +1533,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         )
 
     def list_exclusions(self,
-            request: logging_config.ListExclusionsRequest = None,
+            request: Union[logging_config.ListExclusionsRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1543,7 +1543,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Lists all the exclusions in a parent resource.
 
         Args:
-            request (google.cloud.logging_v2.types.ListExclusionsRequest):
+            request (Union[google.cloud.logging_v2.types.ListExclusionsRequest, dict]):
                 The request object. The parameters to `ListExclusions`.
             parent (str):
                 Required. The parent resource whose exclusions are to be
@@ -1625,7 +1625,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def get_exclusion(self,
-            request: logging_config.GetExclusionRequest = None,
+            request: Union[logging_config.GetExclusionRequest, dict] = None,
             *,
             name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1635,7 +1635,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Gets the description of an exclusion.
 
         Args:
-            request (google.cloud.logging_v2.types.GetExclusionRequest):
+            request (Union[google.cloud.logging_v2.types.GetExclusionRequest, dict]):
                 The request object. The parameters to `GetExclusion`.
             name (str):
                 Required. The resource name of an existing exclusion:
@@ -1717,7 +1717,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def create_exclusion(self,
-            request: logging_config.CreateExclusionRequest = None,
+            request: Union[logging_config.CreateExclusionRequest, dict] = None,
             *,
             parent: str = None,
             exclusion: logging_config.LogExclusion = None,
@@ -1731,7 +1731,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         resource.
 
         Args:
-            request (google.cloud.logging_v2.types.CreateExclusionRequest):
+            request (Union[google.cloud.logging_v2.types.CreateExclusionRequest, dict]):
                 The request object. The parameters to `CreateExclusion`.
             parent (str):
                 Required. The parent resource in which to create the
@@ -1824,7 +1824,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def update_exclusion(self,
-            request: logging_config.UpdateExclusionRequest = None,
+            request: Union[logging_config.UpdateExclusionRequest, dict] = None,
             *,
             name: str = None,
             exclusion: logging_config.LogExclusion = None,
@@ -1837,7 +1837,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         exclusion.
 
         Args:
-            request (google.cloud.logging_v2.types.UpdateExclusionRequest):
+            request (Union[google.cloud.logging_v2.types.UpdateExclusionRequest, dict]):
                 The request object. The parameters to `UpdateExclusion`.
             name (str):
                 Required. The resource name of the exclusion to update:
@@ -1945,7 +1945,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def delete_exclusion(self,
-            request: logging_config.DeleteExclusionRequest = None,
+            request: Union[logging_config.DeleteExclusionRequest, dict] = None,
             *,
             name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1955,7 +1955,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         r"""Deletes an exclusion.
 
         Args:
-            request (google.cloud.logging_v2.types.DeleteExclusionRequest):
+            request (Union[google.cloud.logging_v2.types.DeleteExclusionRequest, dict]):
                 The request object. The parameters to `DeleteExclusion`.
             name (str):
                 Required. The resource name of an existing exclusion to
@@ -2020,7 +2020,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         )
 
     def get_cmek_settings(self,
-            request: logging_config.GetCmekSettingsRequest = None,
+            request: Union[logging_config.GetCmekSettingsRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -2037,7 +2037,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         for more information.
 
         Args:
-            request (google.cloud.logging_v2.types.GetCmekSettingsRequest):
+            request (Union[google.cloud.logging_v2.types.GetCmekSettingsRequest, dict]):
                 The request object. The parameters to
                 [GetCmekSettings][google.logging.v2.ConfigServiceV2.GetCmekSettings].
                 See [Enabling CMEK for Logs
@@ -2097,7 +2097,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         return response
 
     def update_cmek_settings(self,
-            request: logging_config.UpdateCmekSettingsRequest = None,
+            request: Union[logging_config.UpdateCmekSettingsRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -2120,7 +2120,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
         for more information.
 
         Args:
-            request (google.cloud.logging_v2.types.UpdateCmekSettingsRequest):
+            request (Union[google.cloud.logging_v2.types.UpdateCmekSettingsRequest, dict]):
                 The request object. The parameters to
                 [UpdateCmekSettings][google.logging.v2.ConfigServiceV2.UpdateCmekSettings].
                 See [Enabling CMEK for Logs

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -338,7 +338,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             )
 
     def delete_log(self,
-            request: logging.DeleteLogRequest = None,
+            request: Union[logging.DeleteLogRequest, dict] = None,
             *,
             log_name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -352,7 +352,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         with a timestamp before the operation will be deleted.
 
         Args:
-            request (google.cloud.logging_v2.types.DeleteLogRequest):
+            request (Union[google.cloud.logging_v2.types.DeleteLogRequest, dict]):
                 The request object. The parameters to DeleteLog.
             log_name (str):
                 Required. The resource name of the log to delete:
@@ -419,7 +419,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         )
 
     def write_log_entries(self,
-            request: logging.WriteLogEntriesRequest = None,
+            request: Union[logging.WriteLogEntriesRequest, dict] = None,
             *,
             log_name: str = None,
             resource: monitored_resource_pb2.MonitoredResource = None,
@@ -438,7 +438,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         organizations, billing accounts or folders)
 
         Args:
-            request (google.cloud.logging_v2.types.WriteLogEntriesRequest):
+            request (Union[google.cloud.logging_v2.types.WriteLogEntriesRequest, dict]):
                 The request object. The parameters to WriteLogEntries.
             log_name (str):
                 Optional. A default log resource name that is assigned
@@ -579,7 +579,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         return response
 
     def list_log_entries(self,
-            request: logging.ListLogEntriesRequest = None,
+            request: Union[logging.ListLogEntriesRequest, dict] = None,
             *,
             resource_names: Sequence[str] = None,
             filter: str = None,
@@ -594,7 +594,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         Logs <https://cloud.google.com/logging/docs/export>`__.
 
         Args:
-            request (google.cloud.logging_v2.types.ListLogEntriesRequest):
+            request (Union[google.cloud.logging_v2.types.ListLogEntriesRequest, dict]):
                 The request object. The parameters to `ListLogEntries`.
             resource_names (Sequence[str]):
                 Required. Names of one or more parent resources from
@@ -708,7 +708,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         return response
 
     def list_monitored_resource_descriptors(self,
-            request: logging.ListMonitoredResourceDescriptorsRequest = None,
+            request: Union[logging.ListMonitoredResourceDescriptorsRequest, dict] = None,
             *,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -718,7 +718,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         used by Logging.
 
         Args:
-            request (google.cloud.logging_v2.types.ListMonitoredResourceDescriptorsRequest):
+            request (Union[google.cloud.logging_v2.types.ListMonitoredResourceDescriptorsRequest, dict]):
                 The request object. The parameters to
                 ListMonitoredResourceDescriptors
             retry (google.api_core.retry.Retry): Designation of what errors, if any,
@@ -769,7 +769,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         return response
 
     def list_logs(self,
-            request: logging.ListLogsRequest = None,
+            request: Union[logging.ListLogsRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -781,7 +781,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
         listed.
 
         Args:
-            request (google.cloud.logging_v2.types.ListLogsRequest):
+            request (Union[google.cloud.logging_v2.types.ListLogsRequest, dict]):
                 The request object. The parameters to ListLogs.
             parent (str):
                 Required. The resource name that owns the logs:

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -339,7 +339,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             )
 
     def list_log_metrics(self,
-            request: logging_metrics.ListLogMetricsRequest = None,
+            request: Union[logging_metrics.ListLogMetricsRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -349,7 +349,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         r"""Lists logs-based metrics.
 
         Args:
-            request (google.cloud.logging_v2.types.ListLogMetricsRequest):
+            request (Union[google.cloud.logging_v2.types.ListLogMetricsRequest, dict]):
                 The request object. The parameters to ListLogMetrics.
             parent (str):
                 Required. The name of the project containing the
@@ -428,7 +428,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         return response
 
     def get_log_metric(self,
-            request: logging_metrics.GetLogMetricRequest = None,
+            request: Union[logging_metrics.GetLogMetricRequest, dict] = None,
             *,
             metric_name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -438,7 +438,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         r"""Gets a logs-based metric.
 
         Args:
-            request (google.cloud.logging_v2.types.GetLogMetricRequest):
+            request (Union[google.cloud.logging_v2.types.GetLogMetricRequest, dict]):
                 The request object. The parameters to GetLogMetric.
             metric_name (str):
                 Required. The resource name of the desired metric:
@@ -514,7 +514,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         return response
 
     def create_log_metric(self,
-            request: logging_metrics.CreateLogMetricRequest = None,
+            request: Union[logging_metrics.CreateLogMetricRequest, dict] = None,
             *,
             parent: str = None,
             metric: logging_metrics.LogMetric = None,
@@ -525,7 +525,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         r"""Creates a logs-based metric.
 
         Args:
-            request (google.cloud.logging_v2.types.CreateLogMetricRequest):
+            request (Union[google.cloud.logging_v2.types.CreateLogMetricRequest, dict]):
                 The request object. The parameters to CreateLogMetric.
             parent (str):
                 Required. The resource name of the project in which to
@@ -614,7 +614,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         return response
 
     def update_log_metric(self,
-            request: logging_metrics.UpdateLogMetricRequest = None,
+            request: Union[logging_metrics.UpdateLogMetricRequest, dict] = None,
             *,
             metric_name: str = None,
             metric: logging_metrics.LogMetric = None,
@@ -625,7 +625,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         r"""Creates or updates a logs-based metric.
 
         Args:
-            request (google.cloud.logging_v2.types.UpdateLogMetricRequest):
+            request (Union[google.cloud.logging_v2.types.UpdateLogMetricRequest, dict]):
                 The request object. The parameters to UpdateLogMetric.
             metric_name (str):
                 Required. The resource name of the metric to update:
@@ -713,7 +713,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         return response
 
     def delete_log_metric(self,
-            request: logging_metrics.DeleteLogMetricRequest = None,
+            request: Union[logging_metrics.DeleteLogMetricRequest, dict] = None,
             *,
             metric_name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -723,7 +723,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
         r"""Deletes a logs-based metric.
 
         Args:
-            request (google.cloud.logging_v2.types.DeleteLogMetricRequest):
+            request (Union[google.cloud.logging_v2.types.DeleteLogMetricRequest, dict]):
                 The request object. The parameters to DeleteLogMetric.
             metric_name (str):
                 Required. The resource name of the metric to delete:

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -362,7 +362,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             )
 
     def list_instances(self,
-            request: cloud_redis.ListInstancesRequest = None,
+            request: Union[cloud_redis.ListInstancesRequest, dict] = None,
             *,
             parent: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -381,7 +381,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         are aggregated.
 
         Args:
-            request (google.cloud.redis_v1.types.ListInstancesRequest):
+            request (Union[google.cloud.redis_v1.types.ListInstancesRequest, dict]):
                 The request object. Request for
                 [ListInstances][google.cloud.redis.v1.CloudRedis.ListInstances].
             parent (str):
@@ -460,7 +460,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def get_instance(self,
-            request: cloud_redis.GetInstanceRequest = None,
+            request: Union[cloud_redis.GetInstanceRequest, dict] = None,
             *,
             name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -470,7 +470,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         r"""Gets the details of a specific Redis instance.
 
         Args:
-            request (google.cloud.redis_v1.types.GetInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.GetInstanceRequest, dict]):
                 The request object. Request for
                 [GetInstance][google.cloud.redis.v1.CloudRedis.GetInstance].
             name (str):
@@ -534,7 +534,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def create_instance(self,
-            request: cloud_redis.CreateInstanceRequest = None,
+            request: Union[cloud_redis.CreateInstanceRequest, dict] = None,
             *,
             parent: str = None,
             instance_id: str = None,
@@ -559,7 +559,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         hours, so there is no need to call DeleteOperation.
 
         Args:
-            request (google.cloud.redis_v1.types.CreateInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.CreateInstanceRequest, dict]):
                 The request object. Request for
                 [CreateInstance][google.cloud.redis.v1.CloudRedis.CreateInstance].
             parent (str):
@@ -660,7 +660,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def update_instance(self,
-            request: cloud_redis.UpdateInstanceRequest = None,
+            request: Union[cloud_redis.UpdateInstanceRequest, dict] = None,
             *,
             update_mask: field_mask_pb2.FieldMask = None,
             instance: cloud_redis.Instance = None,
@@ -676,7 +676,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         there is no need to call DeleteOperation.
 
         Args:
-            request (google.cloud.redis_v1.types.UpdateInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.UpdateInstanceRequest, dict]):
                 The request object. Request for
                 [UpdateInstance][google.cloud.redis.v1.CloudRedis.UpdateInstance].
             update_mask (google.protobuf.field_mask_pb2.FieldMask):
@@ -768,7 +768,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def upgrade_instance(self,
-            request: cloud_redis.UpgradeInstanceRequest = None,
+            request: Union[cloud_redis.UpgradeInstanceRequest, dict] = None,
             *,
             name: str = None,
             redis_version: str = None,
@@ -780,7 +780,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         specified in the request.
 
         Args:
-            request (google.cloud.redis_v1.types.UpgradeInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.UpgradeInstanceRequest, dict]):
                 The request object. Request for
                 [UpgradeInstance][google.cloud.redis.v1.CloudRedis.UpgradeInstance].
             name (str):
@@ -866,7 +866,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def import_instance(self,
-            request: cloud_redis.ImportInstanceRequest = None,
+            request: Union[cloud_redis.ImportInstanceRequest, dict] = None,
             *,
             name: str = None,
             input_config: cloud_redis.InputConfig = None,
@@ -885,7 +885,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         few hours, so there is no need to call DeleteOperation.
 
         Args:
-            request (google.cloud.redis_v1.types.ImportInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.ImportInstanceRequest, dict]):
                 The request object. Request for
                 [Import][google.cloud.redis.v1.CloudRedis.ImportInstance].
             name (str):
@@ -971,7 +971,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def export_instance(self,
-            request: cloud_redis.ExportInstanceRequest = None,
+            request: Union[cloud_redis.ExportInstanceRequest, dict] = None,
             *,
             name: str = None,
             output_config: cloud_redis.OutputConfig = None,
@@ -986,7 +986,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         few hours, so there is no need to call DeleteOperation.
 
         Args:
-            request (google.cloud.redis_v1.types.ExportInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.ExportInstanceRequest, dict]):
                 The request object. Request for
                 [Export][google.cloud.redis.v1.CloudRedis.ExportInstance].
             name (str):
@@ -1072,7 +1072,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def failover_instance(self,
-            request: cloud_redis.FailoverInstanceRequest = None,
+            request: Union[cloud_redis.FailoverInstanceRequest, dict] = None,
             *,
             name: str = None,
             data_protection_mode: cloud_redis.FailoverInstanceRequest.DataProtectionMode = None,
@@ -1085,7 +1085,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         Memorystore for Redis instance.
 
         Args:
-            request (google.cloud.redis_v1.types.FailoverInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.FailoverInstanceRequest, dict]):
                 The request object. Request for
                 [Failover][google.cloud.redis.v1.CloudRedis.FailoverInstance].
             name (str):
@@ -1172,7 +1172,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         return response
 
     def delete_instance(self,
-            request: cloud_redis.DeleteInstanceRequest = None,
+            request: Union[cloud_redis.DeleteInstanceRequest, dict] = None,
             *,
             name: str = None,
             retry: retries.Retry = gapic_v1.method.DEFAULT,
@@ -1183,7 +1183,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
         serving and data is deleted.
 
         Args:
-            request (google.cloud.redis_v1.types.DeleteInstanceRequest):
+            request (Union[google.cloud.redis_v1.types.DeleteInstanceRequest, dict]):
                 The request object. Request for
                 [DeleteInstance][google.cloud.redis.v1.CloudRedis.DeleteInstance].
             name (str):


### PR DESCRIPTION
The generated libraries have always accepted both a generated type or an equivalent dict. This PR updates the type hints/docstrings to include dict. 

It looks like [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict) could be useful too, but we won't be able to use it until 3.8 is the lowest supported python version.