### PR TITLE
fix: disable self signed jwt if cred is provided

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -305,7 +305,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
                 {% if "grpc" in opts.transport %}
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -139,6 +139,19 @@ def test_{{ service.client_name|snake_case }}_service_account_always_use_jwt(tra
     {{ service.async_client_name }},
     {% endif %}
 ])
+def test_{{ service.client_name|snake_case }}_service_account_not_use_jwt_if_credentials_provided(client_class):
+    with mock.patch.object(service_account.Credentials, 'with_always_use_jwt_access', create=True) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = client_class(credentials=creds)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize("client_class", [
+    {{ service.client_name }},
+    {% if 'grpc' in opts.transport %}
+    {{ service.async_client_name }},
+    {% endif %}
+])
 def test_{{ service.client_name|snake_case }}_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -344,7 +344,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -125,6 +125,17 @@ def test_asset_service_client_service_account_always_use_jwt(transport_class, tr
     AssetServiceClient,
     AssetServiceAsyncClient,
 ])
+def test_asset_service_client_service_account_not_use_jwt_if_credentials_provided(client_class):
+    with mock.patch.object(service_account.Credentials, 'with_always_use_jwt_access', create=True) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = client_class(credentials=creds)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize("client_class", [
+    AssetServiceClient,
+    AssetServiceAsyncClient,
+])
 def test_asset_service_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -340,7 +340,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -117,6 +117,17 @@ def test_iam_credentials_client_service_account_always_use_jwt(transport_class, 
     IAMCredentialsClient,
     IAMCredentialsAsyncClient,
 ])
+def test_iam_credentials_client_service_account_not_use_jwt_if_credentials_provided(client_class):
+    with mock.patch.object(service_account.Credentials, 'with_always_use_jwt_access', create=True) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = client_class(credentials=creds)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize("client_class", [
+    IAMCredentialsClient,
+    IAMCredentialsAsyncClient,
+])
 def test_iam_credentials_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -375,7 +375,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -331,7 +331,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -332,7 +332,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -118,6 +118,17 @@ def test_config_service_v2_client_service_account_always_use_jwt(transport_class
     ConfigServiceV2Client,
     ConfigServiceV2AsyncClient,
 ])
+def test_config_service_v2_client_service_account_not_use_jwt_if_credentials_provided(client_class):
+    with mock.patch.object(service_account.Credentials, 'with_always_use_jwt_access', create=True) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = client_class(credentials=creds)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize("client_class", [
+    ConfigServiceV2Client,
+    ConfigServiceV2AsyncClient,
+])
 def test_config_service_v2_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -124,6 +124,17 @@ def test_logging_service_v2_client_service_account_always_use_jwt(transport_clas
     LoggingServiceV2Client,
     LoggingServiceV2AsyncClient,
 ])
+def test_logging_service_v2_client_service_account_not_use_jwt_if_credentials_provided(client_class):
+    with mock.patch.object(service_account.Credentials, 'with_always_use_jwt_access', create=True) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = client_class(credentials=creds)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize("client_class", [
+    LoggingServiceV2Client,
+    LoggingServiceV2AsyncClient,
+])
 def test_logging_service_v2_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -122,6 +122,17 @@ def test_metrics_service_v2_client_service_account_always_use_jwt(transport_clas
     MetricsServiceV2Client,
     MetricsServiceV2AsyncClient,
 ])
+def test_metrics_service_v2_client_service_account_not_use_jwt_if_credentials_provided(client_class):
+    with mock.patch.object(service_account.Credentials, 'with_always_use_jwt_access', create=True) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = client_class(credentials=creds)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize("client_class", [
+    MetricsServiceV2Client,
+    MetricsServiceV2AsyncClient,
+])
 def test_metrics_service_v2_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -355,7 +355,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                always_use_jwt_access=(
+                always_use_jwt_access= not credentials and (
                     Transport == type(self).get_transport_class("grpc")
                     or Transport == type(self).get_transport_class("grpc_asyncio")
                 ),

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -122,6 +122,17 @@ def test_cloud_redis_client_service_account_always_use_jwt(transport_class, tran
     CloudRedisClient,
     CloudRedisAsyncClient,
 ])
+def test_cloud_redis_client_service_account_not_use_jwt_if_credentials_provided(client_class):
+    with mock.patch.object(service_account.Credentials, 'with_always_use_jwt_access', create=True) as use_jwt:
+        creds = service_account.Credentials(None, None, None)
+        transport = client_class(credentials=creds)
+        use_jwt.assert_not_called()
+
+
+@pytest.mark.parametrize("client_class", [
+    CloudRedisClient,
+    CloudRedisAsyncClient,
+])
 def test_cloud_redis_client_from_service_account_file(client_class):
     creds = ga_credentials.AnonymousCredentials()
     with mock.patch.object(service_account.Credentials, 'from_service_account_file') as factory:


### PR DESCRIPTION
Self signed jwt doesn't work for non-prod endpoint, so this PR allows users to pass credentials to disable self signed jwt.

see https://github.com/googleapis/python-aiplatform/issues/553#issuecomment-887124490, b/197117709