### PR TITLE
fix: add a separate DEFAULT_CLIENT_INFO for rest clients

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -6,9 +6,6 @@ import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 import packaging.version
 import pkg_resources
-{% if 'rest' in opts.transport %}
-from requests import __version__ as requests_version
-{% endif %}
 
 import google.auth  # type: ignore
 import google.api_core  # type: ignore
@@ -37,12 +34,6 @@ try:
         gapic_version=pkg_resources.get_distribution(
             '{{ api.naming.warehouse_package_name }}',
         ).version,
-        {% if 'grpc' not in opts.transport %}
-        grpc_version=None,
-        {% endif %}
-        {% if 'rest' in opts.transport %}
-        rest_version=requests_version,
-        {% endif %}
     )
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -4,6 +4,7 @@
 
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple
+from requests import __version__ as requests_version
 
 {% if service.has_lro %}
 from google.api_core import operations_v1
@@ -30,8 +31,14 @@ from google.iam.v1 import policy_pb2  # type: ignore
 {% endif %}
 {% endfilter %}
 
-from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
+from .base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
+
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
+    gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
+    grpc_version=None,
+    rest_version=requests_version,
+)
 
 class {{ service.name }}RestTransport({{ service.name }}Transport):
     """REST backend transport for {{ service.name }}.


### PR DESCRIPTION
Previously, DEFAULT_CLIENT_INFO would be used for rest transports. However, if you generated both rest and grpc transports, rest version information would appear in both transport's client_infos. Now, we create our own DEFAULT_CLIENT_INFO for rest clients and copy the common information from the base DEFAULT_CLIENT_INFO.