### PR TITLE
fix: re-create gRPC channel on 'socket operation on non-socket' error

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -148,6 +148,12 @@ class {{ service.name }}Transport(abc.ABC):
 
         return scopes_kwargs
 
+    def _refresh_transport(self, exc: Exception) -> None:
+        """If the exception indicates the connection has been lost,
+        this function attempts to re-establish it.
+        Intended to be passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        pass
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
@@ -166,6 +172,7 @@ class {{ service.name }}Transport(abc.ABC):
                         {% endfor %}
                     ),
                     deadline={{ method.timeout }},
+                    on_error=self._refresh_transport,
                 ),
                 {% endif %}
                 default_timeout={{ method.timeout }},

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -151,9 +151,10 @@ class {{ service.name }}Transport(abc.ABC):
     def _refresh_transport(self, exc: Exception) -> None:
         """If the exception indicates the connection has been lost,
         this function attempts to re-establish it.
-        Intended to be passed to ``on_error`` on ``google.api_core.retry.Retry``.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
         """
-        pass
+        pass  # pragma: NO COVER
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -2,9 +2,11 @@
 
 {% block content %}
 
+import functools
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import grpc_helpers   # type: ignore
 {% if service.has_lro %}
 from google.api_core import operations_v1  # type: ignore
@@ -106,6 +108,8 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
         {% if service.has_lro %}
@@ -152,12 +156,16 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
             credentials_file=credentials_file,
             scopes=scopes,
             quota_project_id=quota_project_id,
-            client_info=client_info,
+            client_info=self._client_info,
             always_use_jwt_access=always_use_jwt_access,
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -169,9 +177,10 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
 
     @classmethod
@@ -224,6 +233,32 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Intended to be passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
     {% if service.has_lro %}
 
     @property

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc.py.j2
@@ -253,7 +253,7 @@ class {{ service.name }}GrpcTransport({{ service.name }}Transport):
         """Checks for a broken gRPC channel and creates a new one if
         that is the case.
 
-        Intended to be passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
         """
         if isinstance(
             exc, core_exceptions.ServiceUnavailable

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -2,9 +2,11 @@
 
 {% block content %}
 
+import functools
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 {% if service.has_lro %}
@@ -152,6 +154,8 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
         {% if service.has_lro %}
@@ -202,7 +206,11 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -214,9 +222,10 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -227,6 +236,33 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         """
         # Return the channel from cache.
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Intended to be passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
+
     {% if service.has_lro %}
 
     @property

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -256,7 +256,7 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         """Checks for a broken gRPC channel and creates a new one if
         that is the case.
 
-        Intended to be passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
         """
         if isinstance(
             exc, core_exceptions.ServiceUnavailable

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -452,6 +452,51 @@ def test_{{ service.client_name|snake_case }}_client_options_from_dict():
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
         )
+
+@pytest.mark.parametrize("transport_class", [
+    transports.{{ service.grpc_transport_name }},
+    transports.{{ service.grpc_asyncio_transport_name }}, 
+])
+def test__refresh_transport(transport_class):
+    transport = transport_class()
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
+    transport._refresh_transport(exc)
+    new_channel = transport.grpc_channel
+
+    assert original_channel is not new_channel
+    assert len(transport._stubs) > 0
+    # Check stubs are associated with new channel
+    assert list(transport._stubs.values())[0]._channel == new_channel._channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.{{ service.grpc_transport_name }},
+    transports.{{ service.grpc_asyncio_transport_name }}, 
+])
+def test__refresh_transport_different_exception(transport_class):
+    transport = transport_class()
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Unrelated error message")
+    transport._refresh_transport(exc)
+    assert original_channel is transport.grpc_channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.{{ service.grpc_transport_name }},
+    transports.{{ service.grpc_asyncio_transport_name }}, 
+])
+def test_reinitialize_grpc_channel_custom_channel(transport_class):
+    transport = transport_class(
+        channel=grpc_helpers.create_channel("foo.googleapis.com")
+    )
+    original_channel = transport.grpc_channel
+
+    transport.reinitialize_grpc_channel()
+    assert original_channel is transport.grpc_channel    
+
 {% endif %}
 
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -458,7 +458,7 @@ def test_{{ service.client_name|snake_case }}_client_options_from_dict():
     transports.{{ service.grpc_asyncio_transport_name }}, 
 ])
 def test__refresh_transport(transport_class):
-    transport = transport_class()
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
     original_channel = transport.grpc_channel
 
     exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
@@ -476,7 +476,7 @@ def test__refresh_transport(transport_class):
     transports.{{ service.grpc_asyncio_transport_name }}, 
 ])
 def test__refresh_transport_different_exception(transport_class):
-    transport = transport_class()
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
     original_channel = transport.grpc_channel
 
     exc = core_exceptions.ServiceUnavailable("Unrelated error message")
@@ -490,7 +490,10 @@ def test__refresh_transport_different_exception(transport_class):
 ])
 def test_reinitialize_grpc_channel_custom_channel(transport_class):
     transport = transport_class(
-        channel=grpc_helpers.create_channel("foo.googleapis.com")
+        channel=grpc_helpers.create_channel(
+            "foo.googleapis.com", 
+            credentials=ga_credentials.AnonymousCredentials()
+        )
     )
     original_channel = transport.grpc_channel
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -146,6 +146,14 @@ class AssetServiceTransport(abc.ABC):
 
         return scopes_kwargs
 
+    def _refresh_transport(self, exc: Exception) -> None:
+        """If the exception indicates the connection has been lost,
+        this function attempts to re-establish it.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        pass  # pragma: NO COVER
+
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
         self._wrapped_methods = {
@@ -167,6 +175,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -184,6 +193,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -196,6 +206,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -213,6 +224,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -225,6 +237,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=15.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=15.0,
                 client_info=client_info,
@@ -237,6 +250,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=15.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=15.0,
                 client_info=client_info,
@@ -248,6 +262,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=300.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=300.0,
                 client_info=client_info,

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import grpc_helpers   # type: ignore
 from google.api_core import operations_v1  # type: ignore
 from google.api_core import gapic_v1       # type: ignore
@@ -108,6 +110,8 @@ class AssetServiceGrpcTransport(AssetServiceTransport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
         self._operations_client = None
@@ -152,12 +156,16 @@ class AssetServiceGrpcTransport(AssetServiceTransport):
             credentials_file=credentials_file,
             scopes=scopes,
             quota_project_id=quota_project_id,
-            client_info=client_info,
+            client_info=self._client_info,
             always_use_jwt_access=always_use_jwt_access,
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -169,9 +177,10 @@ class AssetServiceGrpcTransport(AssetServiceTransport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @classmethod
     def create_channel(cls,
@@ -223,6 +232,32 @@ class AssetServiceGrpcTransport(AssetServiceTransport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def operations_client(self) -> operations_v1.OperationsClient:

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.api_core import operations_v1              # type: ignore
@@ -154,6 +156,8 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
         self._operations_client = None
@@ -202,7 +206,11 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -214,9 +222,10 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -227,6 +236,32 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
         """
         # Return the channel from cache.
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def operations_client(self) -> operations_v1.OperationsAsyncClient:

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -395,6 +395,53 @@ def test_asset_service_client_client_options_from_dict():
             always_use_jwt_access=True,
         )
 
+@pytest.mark.parametrize("transport_class", [
+    transports.AssetServiceGrpcTransport,
+    transports.AssetServiceGrpcAsyncIOTransport,
+])
+def test__refresh_transport(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
+    transport._refresh_transport(exc)
+    new_channel = transport.grpc_channel
+
+    assert original_channel is not new_channel
+    assert len(transport._stubs) > 0
+    # Check stubs are associated with new channel
+    assert list(transport._stubs.values())[0]._channel == new_channel._channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.AssetServiceGrpcTransport,
+    transports.AssetServiceGrpcAsyncIOTransport,
+])
+def test__refresh_transport_different_exception(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Unrelated error message")
+    transport._refresh_transport(exc)
+    assert original_channel is transport.grpc_channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.AssetServiceGrpcTransport,
+    transports.AssetServiceGrpcAsyncIOTransport,
+])
+def test_reinitialize_grpc_channel_custom_channel(transport_class):
+    transport = transport_class(
+        channel=grpc_helpers.create_channel(
+            "foo.googleapis.com",
+            credentials=ga_credentials.AnonymousCredentials()
+        )
+    )
+    original_channel = transport.grpc_channel
+
+    transport.reinitialize_grpc_channel()
+    assert original_channel is transport.grpc_channel
+
 
 def test_export_assets(transport: str = 'grpc', request_type=asset_service.ExportAssetsRequest):
     client = AssetServiceClient(

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
@@ -143,6 +143,14 @@ class IAMCredentialsTransport(abc.ABC):
 
         return scopes_kwargs
 
+    def _refresh_transport(self, exc: Exception) -> None:
+        """If the exception indicates the connection has been lost,
+        this function attempts to re-establish it.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        pass  # pragma: NO COVER
+
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
         self._wrapped_methods = {
@@ -154,6 +162,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -166,6 +175,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -178,6 +188,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -190,6 +201,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import grpc_helpers   # type: ignore
 from google.api_core import gapic_v1       # type: ignore
 import google.auth                         # type: ignore
@@ -114,6 +116,8 @@ class IAMCredentialsGrpcTransport(IAMCredentialsTransport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
 
@@ -157,12 +161,16 @@ class IAMCredentialsGrpcTransport(IAMCredentialsTransport):
             credentials_file=credentials_file,
             scopes=scopes,
             quota_project_id=quota_project_id,
-            client_info=client_info,
+            client_info=self._client_info,
             always_use_jwt_access=always_use_jwt_access,
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -174,9 +182,10 @@ class IAMCredentialsGrpcTransport(IAMCredentialsTransport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @classmethod
     def create_channel(cls,
@@ -228,6 +237,32 @@ class IAMCredentialsGrpcTransport(IAMCredentialsTransport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def generate_access_token(self) -> Callable[

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
@@ -160,6 +162,8 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
 
@@ -207,7 +211,11 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -219,9 +227,10 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -232,6 +241,32 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
         """
         # Return the channel from cache.
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def generate_access_token(self) -> Callable[

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -387,6 +387,53 @@ def test_iam_credentials_client_client_options_from_dict():
             always_use_jwt_access=True,
         )
 
+@pytest.mark.parametrize("transport_class", [
+    transports.IAMCredentialsGrpcTransport,
+    transports.IAMCredentialsGrpcAsyncIOTransport,
+])
+def test__refresh_transport(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
+    transport._refresh_transport(exc)
+    new_channel = transport.grpc_channel
+
+    assert original_channel is not new_channel
+    assert len(transport._stubs) > 0
+    # Check stubs are associated with new channel
+    assert list(transport._stubs.values())[0]._channel == new_channel._channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.IAMCredentialsGrpcTransport,
+    transports.IAMCredentialsGrpcAsyncIOTransport,
+])
+def test__refresh_transport_different_exception(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Unrelated error message")
+    transport._refresh_transport(exc)
+    assert original_channel is transport.grpc_channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.IAMCredentialsGrpcTransport,
+    transports.IAMCredentialsGrpcAsyncIOTransport,
+])
+def test_reinitialize_grpc_channel_custom_channel(transport_class):
+    transport = transport_class(
+        channel=grpc_helpers.create_channel(
+            "foo.googleapis.com",
+            credentials=ga_credentials.AnonymousCredentials()
+        )
+    )
+    original_channel = transport.grpc_channel
+
+    transport.reinitialize_grpc_channel()
+    assert original_channel is transport.grpc_channel
+
 
 def test_generate_access_token(transport: str = 'grpc', request_type=common.GenerateAccessTokenRequest):
     client = IAMCredentialsClient(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -147,6 +147,14 @@ class ConfigServiceV2Transport(abc.ABC):
 
         return scopes_kwargs
 
+    def _refresh_transport(self, exc: Exception) -> None:
+        """If the exception indicates the connection has been lost,
+        this function attempts to re-establish it.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        pass  # pragma: NO COVER
+
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
         self._wrapped_methods = {
@@ -214,6 +222,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -227,6 +236,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -245,6 +255,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -258,6 +269,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -271,6 +283,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -284,6 +297,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -307,6 +321,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import grpc_helpers   # type: ignore
 from google.api_core import gapic_v1       # type: ignore
 import google.auth                         # type: ignore
@@ -106,6 +108,8 @@ class ConfigServiceV2GrpcTransport(ConfigServiceV2Transport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
 
@@ -149,12 +153,16 @@ class ConfigServiceV2GrpcTransport(ConfigServiceV2Transport):
             credentials_file=credentials_file,
             scopes=scopes,
             quota_project_id=quota_project_id,
-            client_info=client_info,
+            client_info=self._client_info,
             always_use_jwt_access=always_use_jwt_access,
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -166,9 +174,10 @@ class ConfigServiceV2GrpcTransport(ConfigServiceV2Transport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @classmethod
     def create_channel(cls,
@@ -220,6 +229,32 @@ class ConfigServiceV2GrpcTransport(ConfigServiceV2Transport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def list_buckets(self) -> Callable[

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
@@ -152,6 +154,8 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
 
@@ -199,7 +203,11 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -211,9 +219,10 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -224,6 +233,32 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
         """
         # Return the channel from cache.
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def list_buckets(self) -> Callable[

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -148,6 +148,14 @@ class LoggingServiceV2Transport(abc.ABC):
 
         return scopes_kwargs
 
+    def _refresh_transport(self, exc: Exception) -> None:
+        """If the exception indicates the connection has been lost,
+        this function attempts to re-establish it.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        pass  # pragma: NO COVER
+
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
         self._wrapped_methods = {
@@ -160,6 +168,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -173,6 +182,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -186,6 +196,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -199,6 +210,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -212,6 +224,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -225,6 +238,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=3600.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=3600.0,
                 client_info=client_info,

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
@@ -152,6 +154,8 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
 
@@ -199,7 +203,11 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -211,9 +219,10 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -224,6 +233,32 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
         """
         # Return the channel from cache.
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def delete_log(self) -> Callable[

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -148,6 +148,14 @@ class MetricsServiceV2Transport(abc.ABC):
 
         return scopes_kwargs
 
+    def _refresh_transport(self, exc: Exception) -> None:
+        """If the exception indicates the connection has been lost,
+        this function attempts to re-establish it.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        pass  # pragma: NO COVER
+
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
         self._wrapped_methods = {
@@ -160,6 +168,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -173,6 +182,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -191,6 +201,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,
@@ -204,6 +215,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                    predicate=retries.if
                         core_exceptions.ServiceUnavailable,
                     ),
                     deadline=60.0,
+                    on_error=self._refresh_transport,
                 ),
                 default_timeout=60.0,
                 client_info=client_info,

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import grpc_helpers   # type: ignore
 from google.api_core import gapic_v1       # type: ignore
 import google.auth                         # type: ignore
@@ -106,6 +108,8 @@ class MetricsServiceV2GrpcTransport(MetricsServiceV2Transport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
 
@@ -149,12 +153,16 @@ class MetricsServiceV2GrpcTransport(MetricsServiceV2Transport):
             credentials_file=credentials_file,
             scopes=scopes,
             quota_project_id=quota_project_id,
-            client_info=client_info,
+            client_info=self._client_info,
             always_use_jwt_access=always_use_jwt_access,
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -166,9 +174,10 @@ class MetricsServiceV2GrpcTransport(MetricsServiceV2Transport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @classmethod
     def create_channel(cls,
@@ -220,6 +229,32 @@ class MetricsServiceV2GrpcTransport(MetricsServiceV2Transport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def list_log_metrics(self) -> Callable[

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
@@ -152,6 +154,8 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
 
@@ -199,7 +203,11 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -211,9 +219,10 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -224,6 +233,32 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
         """
         # Return the channel from cache.
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def list_log_metrics(self) -> Callable[

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -388,6 +388,53 @@ def test_config_service_v2_client_client_options_from_dict():
             always_use_jwt_access=True,
         )
 
+@pytest.mark.parametrize("transport_class", [
+    transports.ConfigServiceV2GrpcTransport,
+    transports.ConfigServiceV2GrpcAsyncIOTransport,
+])
+def test__refresh_transport(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
+    transport._refresh_transport(exc)
+    new_channel = transport.grpc_channel
+
+    assert original_channel is not new_channel
+    assert len(transport._stubs) > 0
+    # Check stubs are associated with new channel
+    assert list(transport._stubs.values())[0]._channel == new_channel._channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.ConfigServiceV2GrpcTransport,
+    transports.ConfigServiceV2GrpcAsyncIOTransport,
+])
+def test__refresh_transport_different_exception(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Unrelated error message")
+    transport._refresh_transport(exc)
+    assert original_channel is transport.grpc_channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.ConfigServiceV2GrpcTransport,
+    transports.ConfigServiceV2GrpcAsyncIOTransport,
+])
+def test_reinitialize_grpc_channel_custom_channel(transport_class):
+    transport = transport_class(
+        channel=grpc_helpers.create_channel(
+            "foo.googleapis.com",
+            credentials=ga_credentials.AnonymousCredentials()
+        )
+    )
+    original_channel = transport.grpc_channel
+
+    transport.reinitialize_grpc_channel()
+    assert original_channel is transport.grpc_channel
+
 
 def test_list_buckets(transport: str = 'grpc', request_type=logging_config.ListBucketsRequest):
     client = ConfigServiceV2Client(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -394,6 +394,53 @@ def test_logging_service_v2_client_client_options_from_dict():
             always_use_jwt_access=True,
         )
 
+@pytest.mark.parametrize("transport_class", [
+    transports.LoggingServiceV2GrpcTransport,
+    transports.LoggingServiceV2GrpcAsyncIOTransport,
+])
+def test__refresh_transport(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
+    transport._refresh_transport(exc)
+    new_channel = transport.grpc_channel
+
+    assert original_channel is not new_channel
+    assert len(transport._stubs) > 0
+    # Check stubs are associated with new channel
+    assert list(transport._stubs.values())[0]._channel == new_channel._channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.LoggingServiceV2GrpcTransport,
+    transports.LoggingServiceV2GrpcAsyncIOTransport,
+])
+def test__refresh_transport_different_exception(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Unrelated error message")
+    transport._refresh_transport(exc)
+    assert original_channel is transport.grpc_channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.LoggingServiceV2GrpcTransport,
+    transports.LoggingServiceV2GrpcAsyncIOTransport,
+])
+def test_reinitialize_grpc_channel_custom_channel(transport_class):
+    transport = transport_class(
+        channel=grpc_helpers.create_channel(
+            "foo.googleapis.com",
+            credentials=ga_credentials.AnonymousCredentials()
+        )
+    )
+    original_channel = transport.grpc_channel
+
+    transport.reinitialize_grpc_channel()
+    assert original_channel is transport.grpc_channel
+
 
 def test_delete_log(transport: str = 'grpc', request_type=logging.DeleteLogRequest):
     client = LoggingServiceV2Client(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -392,6 +392,53 @@ def test_metrics_service_v2_client_client_options_from_dict():
             always_use_jwt_access=True,
         )
 
+@pytest.mark.parametrize("transport_class", [
+    transports.MetricsServiceV2GrpcTransport,
+    transports.MetricsServiceV2GrpcAsyncIOTransport,
+])
+def test__refresh_transport(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
+    transport._refresh_transport(exc)
+    new_channel = transport.grpc_channel
+
+    assert original_channel is not new_channel
+    assert len(transport._stubs) > 0
+    # Check stubs are associated with new channel
+    assert list(transport._stubs.values())[0]._channel == new_channel._channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.MetricsServiceV2GrpcTransport,
+    transports.MetricsServiceV2GrpcAsyncIOTransport,
+])
+def test__refresh_transport_different_exception(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Unrelated error message")
+    transport._refresh_transport(exc)
+    assert original_channel is transport.grpc_channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.MetricsServiceV2GrpcTransport,
+    transports.MetricsServiceV2GrpcAsyncIOTransport,
+])
+def test_reinitialize_grpc_channel_custom_channel(transport_class):
+    transport = transport_class(
+        channel=grpc_helpers.create_channel(
+            "foo.googleapis.com",
+            credentials=ga_credentials.AnonymousCredentials()
+        )
+    )
+    original_channel = transport.grpc_channel
+
+    transport.reinitialize_grpc_channel()
+    assert original_channel is transport.grpc_channel
+
 
 def test_list_log_metrics(transport: str = 'grpc', request_type=logging_metrics.ListLogMetricsRequest):
     client = MetricsServiceV2Client(

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -145,6 +145,14 @@ class CloudRedisTransport(abc.ABC):
 
         return scopes_kwargs
 
+    def _refresh_transport(self, exc: Exception) -> None:
+        """If the exception indicates the connection has been lost,
+        this function attempts to re-establish it.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        pass  # pragma: NO COVER
+
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.
         self._wrapped_methods = {

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import grpc_helpers   # type: ignore
 from google.api_core import operations_v1  # type: ignore
 from google.api_core import gapic_v1       # type: ignore
@@ -127,6 +129,8 @@ class CloudRedisGrpcTransport(CloudRedisTransport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
         self._operations_client = None
@@ -171,12 +175,16 @@ class CloudRedisGrpcTransport(CloudRedisTransport):
             credentials_file=credentials_file,
             scopes=scopes,
             quota_project_id=quota_project_id,
-            client_info=client_info,
+            client_info=self._client_info,
             always_use_jwt_access=always_use_jwt_access,
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -188,9 +196,10 @@ class CloudRedisGrpcTransport(CloudRedisTransport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @classmethod
     def create_channel(cls,
@@ -242,6 +251,32 @@ class CloudRedisGrpcTransport(CloudRedisTransport):
         """Return the channel designed to connect to this service.
         """
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def operations_client(self) -> operations_v1.OperationsClient:

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
@@ -13,9 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
+from google.api_core import exceptions as core_exceptions  # type: ignore
 from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.api_core import operations_v1              # type: ignore
@@ -173,6 +175,8 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
               and ``credentials_file`` are passed.
         """
         self._grpc_channel = None
+        self._default_grpc_channel = False
+        self._client_info = client_info
         self._ssl_channel_credentials = ssl_channel_credentials
         self._stubs: Dict[str, Callable] = {}
         self._operations_client = None
@@ -221,7 +225,11 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
         )
 
         if not self._grpc_channel:
-            self._grpc_channel = type(self).create_channel(
+            self._default_grpc_channel = True
+            # Save the original arguments so a channel can be
+            # re-created with the same settings
+            self._create_default_channel = functools.partial(
+                type(self).create_channel,
                 self._host,
                 credentials=self._credentials,
                 credentials_file=credentials_file,
@@ -233,9 +241,10 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
                     ("grpc.max_receive_message_length", -1),
                 ],
             )
+            self._grpc_channel = self._create_default_channel()
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
+        self._prep_wrapped_messages(self._client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -246,6 +255,32 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
         """
         # Return the channel from cache.
         return self._grpc_channel
+
+    def reinitialize_grpc_channel(self):
+        """Create a new gRPC channel with the same settings as when the
+        transport was first initialized.
+
+        This method will have no effect if a custom channel was used
+        to initialize the transport.
+        """
+        if self._default_grpc_channel:
+            self._grpc_channel = self._create_default_channel()
+
+            # Clear self._stubs and re-populate with methods
+            # that use the newly created channel.
+            self._stubs = {}
+            self._prep_wrapped_messages(self._client_info)
+
+    def _refresh_transport(self, exc):
+        """Checks for a broken gRPC channel and creates a new one if
+        that is the case.
+
+        Passed to ``on_error`` on ``google.api_core.retry.Retry``.
+        """
+        if isinstance(
+            exc, core_exceptions.ServiceUnavailable
+        ) and "Socket Operation on non-socket" in str(exc):
+            self.reinitialize_grpc_channel()
 
     @property
     def operations_client(self) -> operations_v1.OperationsAsyncClient:

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -392,6 +392,53 @@ def test_cloud_redis_client_client_options_from_dict():
             always_use_jwt_access=True,
         )
 
+@pytest.mark.parametrize("transport_class", [
+    transports.CloudRedisGrpcTransport,
+    transports.CloudRedisGrpcAsyncIOTransport,
+])
+def test__refresh_transport(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Socket Operation on non-socket")
+    transport._refresh_transport(exc)
+    new_channel = transport.grpc_channel
+
+    assert original_channel is not new_channel
+    assert len(transport._stubs) > 0
+    # Check stubs are associated with new channel
+    assert list(transport._stubs.values())[0]._channel == new_channel._channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.CloudRedisGrpcTransport,
+    transports.CloudRedisGrpcAsyncIOTransport,
+])
+def test__refresh_transport_different_exception(transport_class):
+    transport = transport_class(credentials=ga_credentials.AnonymousCredentials())
+    original_channel = transport.grpc_channel
+
+    exc = core_exceptions.ServiceUnavailable("Unrelated error message")
+    transport._refresh_transport(exc)
+    assert original_channel is transport.grpc_channel
+
+
+@pytest.mark.parametrize("transport_class", [
+    transports.CloudRedisGrpcTransport,
+    transports.CloudRedisGrpcAsyncIOTransport,
+])
+def test_reinitialize_grpc_channel_custom_channel(transport_class):
+    transport = transport_class(
+        channel=grpc_helpers.create_channel(
+            "foo.googleapis.com",
+            credentials=ga_credentials.AnonymousCredentials()
+        )
+    )
+    original_channel = transport.grpc_channel
+
+    transport.reinitialize_grpc_channel()
+    assert original_channel is transport.grpc_channel
+
 
 def test_list_instances(transport: str = 'grpc', request_type=cloud_redis.ListInstancesRequest):
     client = CloudRedisClient(


### PR DESCRIPTION
Under some specific conditions in Cloud Functions, the original gRPC channel will become unusable and the method call will return `google.api_core.exceptions.ServiceUnavailable: 503 Socket operation on non-socket`.

This PR:

- Adds a function `reinitialize_grpc_channel` that re-creates the gRPC channel with the original arguments
- Automatically calls `reinitialize_grpc_channel` before retrying if the exception is `google.api_core.exceptions.ServiceUnavailable: 503 Socket operation on non-socket` https://googleapis.dev/python/google-api-core/latest/retry.html

**Note:** the automatic grpc channel creation before retry is only being added to methods _with an existing retry policy_. This is not all methods, since most gRPC configs have methods that [only specify a deadline](https://github.com/googleapis/googleapis/blob/master/google/privacy/dlp/v2/dlp_grpc_service_config.json). I believe omitting methods with no retry policy is necessary to comply with https://google.aip.dev/client-libraries/4221 and https://google.aip.dev/194. Please let me know if my interpretation is incorrect! I've left `reintialize_grpc_channel` as a public method so users can call it in their own retry objects.

Googlers see b/199551791.

CC @lidizheng 