### PR TITLE
feat(snippetgen): turn resource path strings into f-strings

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -116,7 +116,7 @@ class TransformedRequest:
     def build(
         cls,
         request_type: wrappers.MessageType,
-        api_schema,
+        api_schema: api.API,
         base: str,
         attrs: List[AttributeRequestSetup],
         is_resource_request: bool,
@@ -163,25 +163,22 @@ class TransformedRequest:
             #
             # It's a precondition that the base field is
             # a valid field of the request message type.
-            resource_typestr = (
-                request_type.fields[base]
-                .options.Extensions[resource_pb2.resource_reference]
-                .type
-            )
+            resource_reference = request_type.fields[base].options.Extensions[resource_pb2.resource_reference]
+            resource_typestr = resource_reference.type or resource_reference.child_type
 
-            resource_message_descriptor = next(
-                (
-                    msg.options.Extensions[resource_pb2.resource]
-                    for msg in api_schema.messages.values()
-                    if msg.options.Extensions[resource_pb2.resource].type
-                    == resource_typestr
-                ),
-                None,
-            )
-            if not resource_message_descriptor:
+            resource_message = None
+            for service in api_schema.services.values():
+                resource_message = service.resource_messages_dict.get(
+                    resource_typestr)
+                if resource_message is not None:
+                    break
+
+            if resource_message is None:
                 raise types.NoSuchResource(
-                    f"No message exists for resource: {resource_typestr}"
+                    f"No message exists for resource: '{resource_typestr}'", base, attrs
                 )
+            resource_message_descriptor = resource_message.options.Extensions[
+                resource_pb2.resource]
 
             # The field is only ever empty for singleton attributes.
             attr_names: List[str] = [a.field for a in attrs]  # type: ignore
@@ -944,6 +941,38 @@ def parse_handwritten_specs(sample_configs: Sequence[str]) -> Generator[Dict[str
                         yield spec
 
 
+def _generate_resource_path_request_object(field_name: str, message: wrappers.MessageType) -> List[Dict[str, str]]:
+    """Given a message that represents a resource, generate request objects that 
+    populate the resource path args.
+
+    Args:
+        field_name (str): The name of the field.
+        message (wrappers.MessageType): The message the field belongs to.
+
+    Returns:
+        List[Dict[str, str]]: A list of dicts that can be turned into TransformedRequests.
+    """
+    request = []
+
+    # Special resource path args that we replace
+    # with more realistic values
+    special_value_dict = {
+        "project": '"my-project-id"',
+        "location": '"us-central1"'
+    }
+
+    for resource_path_arg in message.resource_path_args:
+        value = special_value_dict.get(
+            resource_path_arg, f'"{resource_path_arg}_value"')
+        request.append({
+            # See TransformedRequest.build() for how 'field' is parsed
+            "field": f"{field_name}%{resource_path_arg}",
+            "value": value,
+        })
+
+    return request
+
+
 def generate_request_object(api_schema: api.API, service: wrappers.Service, message: wrappers.MessageType, field_name_prefix: str = ""):
     """Generate dummy input for a given message.
 
@@ -973,11 +1002,14 @@ def generate_request_object(api_schema: api.API, service: wrappers.Service, mess
         # TODO(busunkim): Properly handle map fields
         if field.is_primitive:
             placeholder_value = field.mock_value_original_type
-            # If this field identifies a resource use the resource path
             if service.resource_messages_dict.get(field.resource_reference):
-                placeholder_value = service.resource_messages_dict[
-                    field.resource_reference].resource_path
-            request.append({"field": field_name, "value": placeholder_value})
+                request += _generate_resource_path_request_object(
+                    field_name,
+                    service.resource_messages_dict[field.resource_reference]
+                )
+            else:
+                request.append(
+                    {"field": field_name, "value": placeholder_value})
         elif field.enum:
             # Choose the last enum value in the list since index 0 is often "unspecified"
             request.append(

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -175,7 +175,7 @@ class TransformedRequest:
 
             if resource_message is None:
                 raise types.NoSuchResource(
-                    f"No message exists for resource: '{resource_typestr}'", base, attrs
+                    f"No message exists for resource: {resource_typestr}",
                 )
             resource_message_descriptor = resource_message.options.Extensions[
                 resource_pb2.resource]

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -1001,15 +1001,17 @@ def generate_request_object(api_schema: api.API, service: wrappers.Service, mess
 
         # TODO(busunkim): Properly handle map fields
         if field.is_primitive:
-            placeholder_value = field.mock_value_original_type
-            if service.resource_messages_dict.get(field.resource_reference):
+            resource_reference_message = service.resource_messages_dict.get(field.resource_reference)
+            # Some resource patterns have no resource_path_args
+            # https://github.com/googleapis/gapic-generator-python/issues/701
+            if resource_reference_message and resource_reference_message.resource_path_args:
                 request += _generate_resource_path_request_object(
                     field_name,
-                    service.resource_messages_dict[field.resource_reference]
+                    resource_reference_message
                 )
             else:
                 request.append(
-                    {"field": field_name, "value": placeholder_value})
+                    {"field": field_name, "value": field.mock_value_original_type})
         elif field.enum:
             # Choose the last enum value in the list since index 0 is often "unspecified"
             request.append(

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -954,15 +954,14 @@ def _generate_resource_path_request_object(field_name: str, message: wrappers.Me
     """
     request = []
 
-    # Special resource path args that we replace
-    # with more realistic values
-    special_value_dict = {
+    # Look for specific field names to substitute more realistic values
+    special_values_dict = {
         "project": '"my-project-id"',
         "location": '"us-central1"'
     }
 
     for resource_path_arg in message.resource_path_args:
-        value = special_value_dict.get(
+        value = special_values_dict.get(
             resource_path_arg, f'"{resource_path_arg}_value"')
         request.append({
             # See TransformedRequest.build() for how 'field' is parsed
@@ -1001,7 +1000,8 @@ def generate_request_object(api_schema: api.API, service: wrappers.Service, mess
 
         # TODO(busunkim): Properly handle map fields
         if field.is_primitive:
-            resource_reference_message = service.resource_messages_dict.get(field.resource_reference)
+            resource_reference_message = service.resource_messages_dict.get(
+                field.resource_reference)
             # Some resource patterns have no resource_path_args
             # https://github.com/googleapis/gapic-generator-python/issues/701
             if resource_reference_message and resource_reference_message.resource_path_args:

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -160,9 +160,10 @@ client = {{ module_name }}.{{ client_name }}()
 {# This is a resource-name patterned lookup parameter #}
 {% with formals = [] %}
 {% for attr in parameter_block.body %}
-{% do formals.append("%s=%s"|format(attr.field, attr.input_parameter or attr.value)) %}
+{{ attr.field }} = {{ attr.input_parameter or attr.value }}
 {% endfor %}
-{{ parameter_block.base }} = "{{parameter_block.pattern }}".format({{ formals|join(", ") }})
+{{ parameter_block.base }} = f"{{parameter_block.pattern }}"
+
 {% endwith %}
 {% else %}{# End resource name construction #}
 {{ parameter_block.base }} = {{ module_name }}.{{ request_type.get_field(parameter_block.base).type.name }}()

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_async.py
@@ -35,7 +35,6 @@ async def sample_batch_get_assets_history():
 
     # Initialize request argument(s)
     request = asset_v1.BatchGetAssetsHistoryRequest(
-        parent="*",
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_async.py
@@ -35,6 +35,7 @@ async def sample_batch_get_assets_history():
 
     # Initialize request argument(s)
     request = asset_v1.BatchGetAssetsHistoryRequest(
+        parent="parent_value",
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_sync.py
@@ -35,6 +35,7 @@ def sample_batch_get_assets_history():
 
     # Initialize request argument(s)
     request = asset_v1.BatchGetAssetsHistoryRequest(
+        parent="parent_value",
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_batch_get_assets_history_sync.py
@@ -35,7 +35,6 @@ def sample_batch_get_assets_history():
 
     # Initialize request argument(s)
     request = asset_v1.BatchGetAssetsHistoryRequest(
-        parent="*",
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_async.py
@@ -34,8 +34,12 @@ async def sample_delete_feed():
     client = asset_v1.AssetServiceAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    feed = "feed_value"
+    name = f"projects/{project}/feeds/{feed}"
+
     request = asset_v1.DeleteFeedRequest(
-        name="projects/{project}/feeds/{feed}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_delete_feed_sync.py
@@ -34,8 +34,12 @@ def sample_delete_feed():
     client = asset_v1.AssetServiceClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    feed = "feed_value"
+    name = f"projects/{project}/feeds/{feed}"
+
     request = asset_v1.DeleteFeedRequest(
-        name="projects/{project}/feeds/{feed}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_async.py
@@ -38,7 +38,6 @@ async def sample_export_assets():
     output_config.gcs_destination.uri = "uri_value"
 
     request = asset_v1.ExportAssetsRequest(
-        parent="*",
         output_config=output_config,
     )
 

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_async.py
@@ -38,6 +38,7 @@ async def sample_export_assets():
     output_config.gcs_destination.uri = "uri_value"
 
     request = asset_v1.ExportAssetsRequest(
+        parent="parent_value",
         output_config=output_config,
     )
 

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_sync.py
@@ -38,7 +38,6 @@ def sample_export_assets():
     output_config.gcs_destination.uri = "uri_value"
 
     request = asset_v1.ExportAssetsRequest(
-        parent="*",
         output_config=output_config,
     )
 

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_export_assets_sync.py
@@ -38,6 +38,7 @@ def sample_export_assets():
     output_config.gcs_destination.uri = "uri_value"
 
     request = asset_v1.ExportAssetsRequest(
+        parent="parent_value",
         output_config=output_config,
     )
 

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_get_feed_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_get_feed_async.py
@@ -34,8 +34,12 @@ async def sample_get_feed():
     client = asset_v1.AssetServiceAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    feed = "feed_value"
+    name = f"projects/{project}/feeds/{feed}"
+
     request = asset_v1.GetFeedRequest(
-        name="projects/{project}/feeds/{feed}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_get_feed_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_get_feed_sync.py
@@ -34,8 +34,12 @@ def sample_get_feed():
     client = asset_v1.AssetServiceClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    feed = "feed_value"
+    name = f"projects/{project}/feeds/{feed}"
+
     request = asset_v1.GetFeedRequest(
-        name="projects/{project}/feeds/{feed}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_async.py
@@ -35,7 +35,6 @@ async def sample_list_assets():
 
     # Initialize request argument(s)
     request = asset_v1.ListAssetsRequest(
-        parent="*",
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_async.py
@@ -35,6 +35,7 @@ async def sample_list_assets():
 
     # Initialize request argument(s)
     request = asset_v1.ListAssetsRequest(
+        parent="parent_value",
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_sync.py
@@ -35,7 +35,6 @@ def sample_list_assets():
 
     # Initialize request argument(s)
     request = asset_v1.ListAssetsRequest(
-        parent="*",
     )
 
     # Make the request

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_generated_asset_v1_asset_service_list_assets_sync.py
@@ -35,6 +35,7 @@ def sample_list_assets():
 
     # Initialize request argument(s)
     request = asset_v1.ListAssetsRequest(
+        parent="parent_value",
     )
 
     # Make the request

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_access_token_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_access_token_async.py
@@ -34,8 +34,12 @@ async def sample_generate_access_token():
     client = credentials_v1.IAMCredentialsAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.GenerateAccessTokenRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         scope=['scope_value'],
     )
 

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_access_token_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_access_token_sync.py
@@ -34,8 +34,12 @@ def sample_generate_access_token():
     client = credentials_v1.IAMCredentialsClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.GenerateAccessTokenRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         scope=['scope_value'],
     )
 

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_id_token_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_id_token_async.py
@@ -34,8 +34,12 @@ async def sample_generate_id_token():
     client = credentials_v1.IAMCredentialsAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.GenerateIdTokenRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         audience="audience_value",
     )
 

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_id_token_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_generate_id_token_sync.py
@@ -34,8 +34,12 @@ def sample_generate_id_token():
     client = credentials_v1.IAMCredentialsClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.GenerateIdTokenRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         audience="audience_value",
     )
 

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_blob_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_blob_async.py
@@ -34,8 +34,12 @@ async def sample_sign_blob():
     client = credentials_v1.IAMCredentialsAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.SignBlobRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         payload=b'payload_blob',
     )
 

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_blob_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_blob_sync.py
@@ -34,8 +34,12 @@ def sample_sign_blob():
     client = credentials_v1.IAMCredentialsClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.SignBlobRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         payload=b'payload_blob',
     )
 

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_jwt_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_jwt_async.py
@@ -34,8 +34,12 @@ async def sample_sign_jwt():
     client = credentials_v1.IAMCredentialsAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.SignJwtRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         payload="payload_value",
     )
 

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_jwt_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_generated_credentials_v1_iam_credentials_sign_jwt_sync.py
@@ -34,8 +34,12 @@ def sample_sign_jwt():
     client = credentials_v1.IAMCredentialsClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    service_account = "service_account_value"
+    name = f"projects/{project}/serviceAccounts/{service_account}"
+
     request = credentials_v1.SignJwtRequest(
-        name="projects/{project}/serviceAccounts/{service_account}",
+        name=name,
         payload="payload_value",
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_bucket_async.py
@@ -34,8 +34,13 @@ async def sample_create_bucket():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    parent = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.CreateBucketRequest(
-        parent="projects/{project}/locations/{location}/buckets/{bucket}",
+        parent=parent,
         bucket_id="bucket_id_value",
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_bucket_sync.py
@@ -34,8 +34,13 @@ def sample_create_bucket():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    parent = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.CreateBucketRequest(
-        parent="projects/{project}/locations/{location}/buckets/{bucket}",
+        parent=parent,
         bucket_id="bucket_id_value",
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_exclusion_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_exclusion_async.py
@@ -34,12 +34,16 @@ async def sample_create_exclusion():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    parent = f"projects/{project}/exclusions/{exclusion}"
+
     exclusion = logging_v2.LogExclusion()
     exclusion.name = "name_value"
     exclusion.filter = "filter_value"
 
     request = logging_v2.CreateExclusionRequest(
-        parent="projects/{project}/exclusions/{exclusion}",
+        parent=parent,
         exclusion=exclusion,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_exclusion_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_exclusion_sync.py
@@ -34,12 +34,16 @@ def sample_create_exclusion():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    parent = f"projects/{project}/exclusions/{exclusion}"
+
     exclusion = logging_v2.LogExclusion()
     exclusion.name = "name_value"
     exclusion.filter = "filter_value"
 
     request = logging_v2.CreateExclusionRequest(
-        parent="projects/{project}/exclusions/{exclusion}",
+        parent=parent,
         exclusion=exclusion,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_sink_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_sink_async.py
@@ -34,12 +34,16 @@ async def sample_create_sink():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    parent = f"projects/{project}/sinks/{sink}"
+
     sink = logging_v2.LogSink()
     sink.name = "name_value"
     sink.destination = "destination_value"
 
     request = logging_v2.CreateSinkRequest(
-        parent="projects/{project}/sinks/{sink}",
+        parent=parent,
         sink=sink,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_sink_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_create_sink_sync.py
@@ -34,12 +34,16 @@ def sample_create_sink():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    parent = f"projects/{project}/sinks/{sink}"
+
     sink = logging_v2.LogSink()
     sink.name = "name_value"
     sink.destination = "destination_value"
 
     request = logging_v2.CreateSinkRequest(
-        parent="projects/{project}/sinks/{sink}",
+        parent=parent,
         sink=sink,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_async.py
@@ -34,8 +34,13 @@ async def sample_delete_bucket():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.DeleteBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_bucket_sync.py
@@ -34,8 +34,13 @@ def sample_delete_bucket():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.DeleteBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_async.py
@@ -34,8 +34,12 @@ async def sample_delete_exclusion():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    name = f"projects/{project}/exclusions/{exclusion}"
+
     request = logging_v2.DeleteExclusionRequest(
-        name="projects/{project}/exclusions/{exclusion}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_exclusion_sync.py
@@ -34,8 +34,12 @@ def sample_delete_exclusion():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    name = f"projects/{project}/exclusions/{exclusion}"
+
     request = logging_v2.DeleteExclusionRequest(
-        name="projects/{project}/exclusions/{exclusion}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_async.py
@@ -34,8 +34,12 @@ async def sample_delete_sink():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    sink_name = f"projects/{project}/sinks/{sink}"
+
     request = logging_v2.DeleteSinkRequest(
-        sink_name="projects/{project}/sinks/{sink}",
+        sink_name=sink_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_sink_sync.py
@@ -34,8 +34,12 @@ def sample_delete_sink():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    sink_name = f"projects/{project}/sinks/{sink}"
+
     request = logging_v2.DeleteSinkRequest(
-        sink_name="projects/{project}/sinks/{sink}",
+        sink_name=sink_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_async.py
@@ -34,8 +34,14 @@ async def sample_delete_view():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    view = "view_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}/views/{view}"
+
     request = logging_v2.DeleteViewRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}/views/{view}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_delete_view_sync.py
@@ -34,8 +34,14 @@ def sample_delete_view():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    view = "view_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}/views/{view}"
+
     request = logging_v2.DeleteViewRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}/views/{view}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_bucket_async.py
@@ -34,8 +34,13 @@ async def sample_get_bucket():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.GetBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_bucket_sync.py
@@ -34,8 +34,13 @@ def sample_get_bucket():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.GetBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_cmek_settings_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_cmek_settings_async.py
@@ -34,8 +34,11 @@ async def sample_get_cmek_settings():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    name = f"projects/{project}/cmekSettings"
+
     request = logging_v2.GetCmekSettingsRequest(
-        name="projects/{project}/cmekSettings",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_cmek_settings_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_cmek_settings_sync.py
@@ -34,8 +34,11 @@ def sample_get_cmek_settings():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    name = f"projects/{project}/cmekSettings"
+
     request = logging_v2.GetCmekSettingsRequest(
-        name="projects/{project}/cmekSettings",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_exclusion_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_exclusion_async.py
@@ -34,8 +34,12 @@ async def sample_get_exclusion():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    name = f"projects/{project}/exclusions/{exclusion}"
+
     request = logging_v2.GetExclusionRequest(
-        name="projects/{project}/exclusions/{exclusion}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_exclusion_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_exclusion_sync.py
@@ -34,8 +34,12 @@ def sample_get_exclusion():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    name = f"projects/{project}/exclusions/{exclusion}"
+
     request = logging_v2.GetExclusionRequest(
-        name="projects/{project}/exclusions/{exclusion}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_sink_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_sink_async.py
@@ -34,8 +34,12 @@ async def sample_get_sink():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    sink_name = f"projects/{project}/sinks/{sink}"
+
     request = logging_v2.GetSinkRequest(
-        sink_name="projects/{project}/sinks/{sink}",
+        sink_name=sink_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_sink_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_sink_sync.py
@@ -34,8 +34,12 @@ def sample_get_sink():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    sink_name = f"projects/{project}/sinks/{sink}"
+
     request = logging_v2.GetSinkRequest(
-        sink_name="projects/{project}/sinks/{sink}",
+        sink_name=sink_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_view_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_view_async.py
@@ -34,8 +34,14 @@ async def sample_get_view():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    view = "view_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}/views/{view}"
+
     request = logging_v2.GetViewRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}/views/{view}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_view_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_get_view_sync.py
@@ -34,8 +34,14 @@ def sample_get_view():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    view = "view_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}/views/{view}"
+
     request = logging_v2.GetViewRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}/views/{view}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_buckets_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_buckets_async.py
@@ -34,8 +34,13 @@ async def sample_list_buckets():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    parent = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.ListBucketsRequest(
-        parent="projects/{project}/locations/{location}/buckets/{bucket}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_buckets_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_buckets_sync.py
@@ -34,8 +34,13 @@ def sample_list_buckets():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    parent = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.ListBucketsRequest(
-        parent="projects/{project}/locations/{location}/buckets/{bucket}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_exclusions_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_exclusions_async.py
@@ -34,8 +34,12 @@ async def sample_list_exclusions():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    parent = f"projects/{project}/exclusions/{exclusion}"
+
     request = logging_v2.ListExclusionsRequest(
-        parent="projects/{project}/exclusions/{exclusion}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_exclusions_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_exclusions_sync.py
@@ -34,8 +34,12 @@ def sample_list_exclusions():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    parent = f"projects/{project}/exclusions/{exclusion}"
+
     request = logging_v2.ListExclusionsRequest(
-        parent="projects/{project}/exclusions/{exclusion}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_sinks_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_sinks_async.py
@@ -34,8 +34,12 @@ async def sample_list_sinks():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    parent = f"projects/{project}/sinks/{sink}"
+
     request = logging_v2.ListSinksRequest(
-        parent="projects/{project}/sinks/{sink}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_sinks_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_list_sinks_sync.py
@@ -34,8 +34,12 @@ def sample_list_sinks():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    parent = f"projects/{project}/sinks/{sink}"
+
     request = logging_v2.ListSinksRequest(
-        parent="projects/{project}/sinks/{sink}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_async.py
@@ -34,8 +34,13 @@ async def sample_undelete_bucket():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.UndeleteBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_undelete_bucket_sync.py
@@ -34,8 +34,13 @@ def sample_undelete_bucket():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.UndeleteBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_bucket_async.py
@@ -34,8 +34,13 @@ async def sample_update_bucket():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.UpdateBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_bucket_sync.py
@@ -34,8 +34,13 @@ def sample_update_bucket():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    bucket = "bucket_value"
+    name = f"projects/{project}/locations/{location}/buckets/{bucket}"
+
     request = logging_v2.UpdateBucketRequest(
-        name="projects/{project}/locations/{location}/buckets/{bucket}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_exclusion_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_exclusion_async.py
@@ -34,12 +34,16 @@ async def sample_update_exclusion():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    name = f"projects/{project}/exclusions/{exclusion}"
+
     exclusion = logging_v2.LogExclusion()
     exclusion.name = "name_value"
     exclusion.filter = "filter_value"
 
     request = logging_v2.UpdateExclusionRequest(
-        name="projects/{project}/exclusions/{exclusion}",
+        name=name,
         exclusion=exclusion,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_exclusion_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_exclusion_sync.py
@@ -34,12 +34,16 @@ def sample_update_exclusion():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    exclusion = "exclusion_value"
+    name = f"projects/{project}/exclusions/{exclusion}"
+
     exclusion = logging_v2.LogExclusion()
     exclusion.name = "name_value"
     exclusion.filter = "filter_value"
 
     request = logging_v2.UpdateExclusionRequest(
-        name="projects/{project}/exclusions/{exclusion}",
+        name=name,
         exclusion=exclusion,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_sink_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_sink_async.py
@@ -34,12 +34,16 @@ async def sample_update_sink():
     client = logging_v2.ConfigServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    sink_name = f"projects/{project}/sinks/{sink}"
+
     sink = logging_v2.LogSink()
     sink.name = "name_value"
     sink.destination = "destination_value"
 
     request = logging_v2.UpdateSinkRequest(
-        sink_name="projects/{project}/sinks/{sink}",
+        sink_name=sink_name,
         sink=sink,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_sink_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_config_service_v2_update_sink_sync.py
@@ -34,12 +34,16 @@ def sample_update_sink():
     client = logging_v2.ConfigServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    sink = "sink_value"
+    sink_name = f"projects/{project}/sinks/{sink}"
+
     sink = logging_v2.LogSink()
     sink.name = "name_value"
     sink.destination = "destination_value"
 
     request = logging_v2.UpdateSinkRequest(
-        sink_name="projects/{project}/sinks/{sink}",
+        sink_name=sink_name,
         sink=sink,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_async.py
@@ -34,8 +34,12 @@ async def sample_delete_log():
     client = logging_v2.LoggingServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    log = "log_value"
+    log_name = f"projects/{project}/logs/{log}"
+
     request = logging_v2.DeleteLogRequest(
-        log_name="projects/{project}/logs/{log}",
+        log_name=log_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_delete_log_sync.py
@@ -34,8 +34,12 @@ def sample_delete_log():
     client = logging_v2.LoggingServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    log = "log_value"
+    log_name = f"projects/{project}/logs/{log}"
+
     request = logging_v2.DeleteLogRequest(
-        log_name="projects/{project}/logs/{log}",
+        log_name=log_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_log_entries_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_log_entries_async.py
@@ -34,8 +34,12 @@ async def sample_list_log_entries():
     client = logging_v2.LoggingServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    log = "log_value"
+    resource_names = f"projects/{project}/logs/{log}"
+
     request = logging_v2.ListLogEntriesRequest(
-        resource_names="projects/{project}/logs/{log}",
+        resource_names=resource_names,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_log_entries_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_log_entries_sync.py
@@ -34,8 +34,12 @@ def sample_list_log_entries():
     client = logging_v2.LoggingServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    log = "log_value"
+    resource_names = f"projects/{project}/logs/{log}"
+
     request = logging_v2.ListLogEntriesRequest(
-        resource_names="projects/{project}/logs/{log}",
+        resource_names=resource_names,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_logs_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_logs_async.py
@@ -34,8 +34,12 @@ async def sample_list_logs():
     client = logging_v2.LoggingServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    log = "log_value"
+    parent = f"projects/{project}/logs/{log}"
+
     request = logging_v2.ListLogsRequest(
-        parent="projects/{project}/logs/{log}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_logs_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_logging_service_v2_list_logs_sync.py
@@ -34,8 +34,12 @@ def sample_list_logs():
     client = logging_v2.LoggingServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    log = "log_value"
+    parent = f"projects/{project}/logs/{log}"
+
     request = logging_v2.ListLogsRequest(
-        parent="projects/{project}/logs/{log}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_create_log_metric_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_create_log_metric_async.py
@@ -34,12 +34,16 @@ async def sample_create_log_metric():
     client = logging_v2.MetricsServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    parent = f"projects/{project}/metrics/{metric}"
+
     metric = logging_v2.LogMetric()
     metric.name = "name_value"
     metric.filter = "filter_value"
 
     request = logging_v2.CreateLogMetricRequest(
-        parent="projects/{project}/metrics/{metric}",
+        parent=parent,
         metric=metric,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_create_log_metric_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_create_log_metric_sync.py
@@ -34,12 +34,16 @@ def sample_create_log_metric():
     client = logging_v2.MetricsServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    parent = f"projects/{project}/metrics/{metric}"
+
     metric = logging_v2.LogMetric()
     metric.name = "name_value"
     metric.filter = "filter_value"
 
     request = logging_v2.CreateLogMetricRequest(
-        parent="projects/{project}/metrics/{metric}",
+        parent=parent,
         metric=metric,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_async.py
@@ -34,8 +34,12 @@ async def sample_delete_log_metric():
     client = logging_v2.MetricsServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    metric_name = f"projects/{project}/metrics/{metric}"
+
     request = logging_v2.DeleteLogMetricRequest(
-        metric_name="projects/{project}/metrics/{metric}",
+        metric_name=metric_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_delete_log_metric_sync.py
@@ -34,8 +34,12 @@ def sample_delete_log_metric():
     client = logging_v2.MetricsServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    metric_name = f"projects/{project}/metrics/{metric}"
+
     request = logging_v2.DeleteLogMetricRequest(
-        metric_name="projects/{project}/metrics/{metric}",
+        metric_name=metric_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_get_log_metric_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_get_log_metric_async.py
@@ -34,8 +34,12 @@ async def sample_get_log_metric():
     client = logging_v2.MetricsServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    metric_name = f"projects/{project}/metrics/{metric}"
+
     request = logging_v2.GetLogMetricRequest(
-        metric_name="projects/{project}/metrics/{metric}",
+        metric_name=metric_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_get_log_metric_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_get_log_metric_sync.py
@@ -34,8 +34,12 @@ def sample_get_log_metric():
     client = logging_v2.MetricsServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    metric_name = f"projects/{project}/metrics/{metric}"
+
     request = logging_v2.GetLogMetricRequest(
-        metric_name="projects/{project}/metrics/{metric}",
+        metric_name=metric_name,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_list_log_metrics_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_list_log_metrics_async.py
@@ -34,8 +34,11 @@ async def sample_list_log_metrics():
     client = logging_v2.MetricsServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    parent = f"projects/{project}"
+
     request = logging_v2.ListLogMetricsRequest(
-        parent="projects/{project}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_list_log_metrics_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_list_log_metrics_sync.py
@@ -34,8 +34,11 @@ def sample_list_log_metrics():
     client = logging_v2.MetricsServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    parent = f"projects/{project}"
+
     request = logging_v2.ListLogMetricsRequest(
-        parent="projects/{project}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_update_log_metric_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_update_log_metric_async.py
@@ -34,12 +34,16 @@ async def sample_update_log_metric():
     client = logging_v2.MetricsServiceV2AsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    metric_name = f"projects/{project}/metrics/{metric}"
+
     metric = logging_v2.LogMetric()
     metric.name = "name_value"
     metric.filter = "filter_value"
 
     request = logging_v2.UpdateLogMetricRequest(
-        metric_name="projects/{project}/metrics/{metric}",
+        metric_name=metric_name,
         metric=metric,
     )
 

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_update_log_metric_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_generated_logging_v2_metrics_service_v2_update_log_metric_sync.py
@@ -34,12 +34,16 @@ def sample_update_log_metric():
     client = logging_v2.MetricsServiceV2Client()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    metric = "metric_value"
+    metric_name = f"projects/{project}/metrics/{metric}"
+
     metric = logging_v2.LogMetric()
     metric.name = "name_value"
     metric.filter = "filter_value"
 
     request = logging_v2.UpdateLogMetricRequest(
-        metric_name="projects/{project}/metrics/{metric}",
+        metric_name=metric_name,
         metric=metric,
     )
 

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_create_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_create_instance_async.py
@@ -34,13 +34,17 @@ async def sample_create_instance():
     client = redis_v1.CloudRedisAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    parent = f"projects/{project}/locations/{location}"
+
     instance = redis_v1.Instance()
     instance.name = "name_value"
     instance.tier = "STANDARD_HA"
     instance.memory_size_gb = 1499
 
     request = redis_v1.CreateInstanceRequest(
-        parent="projects/{project}/locations/{location}",
+        parent=parent,
         instance_id="instance_id_value",
         instance=instance,
     )

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_create_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_create_instance_sync.py
@@ -34,13 +34,17 @@ def sample_create_instance():
     client = redis_v1.CloudRedisClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    parent = f"projects/{project}/locations/{location}"
+
     instance = redis_v1.Instance()
     instance.name = "name_value"
     instance.tier = "STANDARD_HA"
     instance.memory_size_gb = 1499
 
     request = redis_v1.CreateInstanceRequest(
-        parent="projects/{project}/locations/{location}",
+        parent=parent,
         instance_id="instance_id_value",
         instance=instance,
     )

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_delete_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_delete_instance_async.py
@@ -34,8 +34,13 @@ async def sample_delete_instance():
     client = redis_v1.CloudRedisAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.DeleteInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_delete_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_delete_instance_sync.py
@@ -34,8 +34,13 @@ def sample_delete_instance():
     client = redis_v1.CloudRedisClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.DeleteInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_failover_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_failover_instance_async.py
@@ -34,8 +34,13 @@ async def sample_failover_instance():
     client = redis_v1.CloudRedisAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.FailoverInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_failover_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_failover_instance_sync.py
@@ -34,8 +34,13 @@ def sample_failover_instance():
     client = redis_v1.CloudRedisClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.FailoverInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_get_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_get_instance_async.py
@@ -34,8 +34,13 @@ async def sample_get_instance():
     client = redis_v1.CloudRedisAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.GetInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_get_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_get_instance_sync.py
@@ -34,8 +34,13 @@ def sample_get_instance():
     client = redis_v1.CloudRedisClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.GetInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_list_instances_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_list_instances_async.py
@@ -34,8 +34,12 @@ async def sample_list_instances():
     client = redis_v1.CloudRedisAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    parent = f"projects/{project}/locations/{location}"
+
     request = redis_v1.ListInstancesRequest(
-        parent="projects/{project}/locations/{location}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_list_instances_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_list_instances_sync.py
@@ -34,8 +34,12 @@ def sample_list_instances():
     client = redis_v1.CloudRedisClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    parent = f"projects/{project}/locations/{location}"
+
     request = redis_v1.ListInstancesRequest(
-        parent="projects/{project}/locations/{location}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_upgrade_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_upgrade_instance_async.py
@@ -34,8 +34,13 @@ async def sample_upgrade_instance():
     client = redis_v1.CloudRedisAsyncClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.UpgradeInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
         redis_version="redis_version_value",
     )
 

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_upgrade_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_generated_redis_v1_cloud_redis_upgrade_instance_sync.py
@@ -34,8 +34,13 @@ def sample_upgrade_instance():
     client = redis_v1.CloudRedisClient()
 
     # Initialize request argument(s)
+    project = "my-project-id"
+    location = "us-central1"
+    instance = "instance_value"
+    name = f"projects/{project}/locations/{location}/instances/{instance}"
+
     request = redis_v1.UpgradeInstanceRequest(
-        name="projects/{project}/locations/{location}/instances/{instance}",
+        name=name,
         redis_version="redis_version_value",
     )
 

--- a/tests/snippetgen/goldens/mollusca_generated_mollusca_v1_snippets_list_resources_async.py
+++ b/tests/snippetgen/goldens/mollusca_generated_mollusca_v1_snippets_list_resources_async.py
@@ -34,8 +34,12 @@ async def sample_list_resources():
     client = mollusca_v1.SnippetsAsyncClient()
 
     # Initialize request argument(s)
+    item_id = "item_id_value"
+    part_id = "part_id_value"
+    parent = f"items/{item_id}/parts/{part_id}"
+
     request = mollusca_v1.ListResourcesRequest(
-        parent="items/{item_id}/parts/{part_id}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/snippetgen/goldens/mollusca_generated_mollusca_v1_snippets_list_resources_sync.py
+++ b/tests/snippetgen/goldens/mollusca_generated_mollusca_v1_snippets_list_resources_sync.py
@@ -34,8 +34,12 @@ def sample_list_resources():
     client = mollusca_v1.SnippetsClient()
 
     # Initialize request argument(s)
+    item_id = "item_id_value"
+    part_id = "part_id_value"
+    parent = f"items/{item_id}/parts/{part_id}"
+
     request = mollusca_v1.ListResourcesRequest(
-        parent="items/{item_id}/parts/{part_id}",
+        parent=parent,
     )
 
     # Make the request

--- a/tests/unit/samplegen/common_types.py
+++ b/tests/unit/samplegen/common_types.py
@@ -85,6 +85,10 @@ class DummyMessage:
     def required_fields(self):
         return [field for field in self.fields.values() if field.required]
 
+    @property
+    def resource_path_args(self):
+        return wrappers.MessageType.PATH_ARG_RE.findall(self.resource_path or '')
+
 
 DummyService = namedtuple("DummyService", [
                           "methods", "client_name", "async_client_name", "resource_messages_dict"])

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -193,8 +193,8 @@ def test_preprocess_sample_resource_message_field():
     # assert mock request is created
     assert sample["request"] == [
         {
-            "field": "parent",
-            "value": "projects/{project}"
+            "field": "parent%project",
+            "value": '"my-project-id"'
         }
     ]
 
@@ -1861,7 +1861,16 @@ def test_validate_request_resource_name():
                 request_descriptor,
                 phylum_descriptor,
             ])
-        }
+        },
+        services={
+            "Mollusc": DummyService(
+                methods={},
+                client_name="MolluscClient",
+                resource_messages_dict={
+                    resource_type: phylum_descriptor
+                }
+            )
+        },
     )
 
     v = samplegen.Validator(method=method, api_schema=api_schema)
@@ -1981,7 +1990,7 @@ def test_validate_request_no_such_attr(dummy_api_schema):
         v.validate_and_transform_request(types.CallingForm.Request, request)
 
 
-def test_validate_request_no_such_resource(dummy_api_schema):
+def test_validate_request_no_such_resource():
     request = [
         {"field": "taxon%kingdom", "value": "animalia"}
     ]
@@ -1993,7 +2002,14 @@ def test_validate_request_no_such_resource(dummy_api_schema):
 
     method = DummyMethod(input=request_descriptor)
     api_schema = DummyApiSchema(
-        messages={k: v for k, v in enumerate([request_descriptor])}
+        messages={k: v for k, v in enumerate([request_descriptor])},
+        services={
+            "Mollusc": DummyService(
+                methods={},
+                client_name="MolluscClient",
+                resource_messages_dict={}
+            )
+        },
     )
 
     v = samplegen.Validator(method=method, api_schema=api_schema)
@@ -2028,7 +2044,16 @@ def test_validate_request_no_such_pattern():
                 request_descriptor,
                 phylum_descriptor,
             ])
-        }
+        },
+        services={
+            "Mollusc": DummyService(
+                methods={},
+                client_name="MolluscClient",
+                resource_messages_dict={
+                    resource_type: phylum_descriptor
+                }
+            )
+        },
     )
 
     v = samplegen.Validator(method=method, api_schema=api_schema)

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -301,7 +301,10 @@ def test_render_request_resource_name():
         ''',
         '''
         # Initialize request argument(s)
-        taxon = "kingdom/{kingdom}/phylum/{phylum}".format(kingdom="animalia", phylum=mollusca)
+        kingdom = "animalia"
+        phylum = mollusca
+        taxon = f"kingdom/{kingdom}/phylum/{phylum}"
+
         ''',
         request=samplegen.FullRequest(
             request_list=[


### PR DESCRIPTION
Fixes #965.

Uses the already-existing resource path logic for autogen snippets.

Previous:
```py
    # Initialize request argument(s)
    request = asset_v1.DeleteFeedRequest(
        name="projects/{project}/feeds/{feed}",
    )
```

Now:
```py
    # Initialize request argument(s)
    project = "my-project-id"
    feed = "feed_value"
    name = f"projects/{project}/feeds/{feed}"

    request = asset_v1.DeleteFeedRequest(
        name=name,
    )
```

Note: The logic may result in multiple variables with the same name (it doesn't happen for any of the golden APIs, but might for an API with more required fields).