### PR TITLE
refactor: cleanup and boost dependency reqs in generated clients

### DIFF
--- a/gapic/ads-templates/noxfile.py.j2
+++ b/gapic/ads-templates/noxfile.py.j2
@@ -7,7 +7,7 @@ import os
 import nox  # type: ignore
 
 
-@nox.session(python=['3.7', '3.8'])
+@nox.session(python=['3.7', '3.8', '3.9'])
 def unit(session):
     """Run the unit test suite."""
 
@@ -25,7 +25,7 @@ def unit(session):
     )
 
 
-@nox.session(python=['3.7', '3.8'])
+@nox.session(python=['3.7', '3.8', '3.9'])
 def mypy(session):
     """Run the type checker."""
     session.install('mypy')

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -17,12 +17,12 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        {# TODO(dovs): remove when 1.x deprecation is complete -#}
-        {% if 'rest' in opts.transport -%}
+        {#- TODO(dovs): remove when 1.x deprecation is complete #}
+        {%- if 'rest' in opts.transport %}
         'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
-        {% else -%}
+        {%- else %}
         'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-        {% endif -%}
+        {%- endif %}
         'googleapis-common-protos >= 1.53.0',
         'grpcio >= 1.10.0',
         'proto-plus >= 1.19.4',

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -17,12 +17,12 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        {#- TODO(dovs): remove when 1.x deprecation is complete #}
-        {%- if 'rest' in opts.transport %}
+        {# TODO(dovs): remove when 1.x deprecation is complete #}
+        {% if 'rest' in opts.transport %}
         'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
-        {%- else %}
+        {% else %}
         'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-        {%- endif %}
+        {% endif %}
         'googleapis-common-protos >= 1.53.0',
         'grpcio >= 1.10.0',
         'proto-plus >= 1.19.4',

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -38,6 +38,8 @@ setuptools.setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -17,7 +17,12 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core >= 2.1.0, < 3.0.0dev',
+        {# TODO(dovs): remove when 1.x deprecation is complete -#}
+        {% if 'rest' in opts.transport -%}
+        'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
+        {% else -%}
+        'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+        {% endif -%}
         'googleapis-common-protos >= 1.53.0',
         'grpcio >= 1.10.0',
         'proto-plus >= 1.19.4',
@@ -39,7 +44,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -17,10 +17,10 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core >= 1.22.2, < 3.0.0dev',
-        'googleapis-common-protos >= 1.5.8',
+        'google-api-core >= 2.1.0, < 3.0.0dev',
+        'googleapis-common-protos >= 1.53.0',
         'grpcio >= 1.10.0',
-        'proto-plus >= 1.15.0',
+        'proto-plus >= 1.19.4',
     {% if api.requires_package(('google', 'iam', 'v1')) %}
         'grpc-google-iam-v1',
     {% endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -38,15 +38,6 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = google.auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
 
 class {{ service.name }}Transport(abc.ABC):
     """Abstract transport class for {{ service.name }}."""
@@ -99,7 +90,7 @@ class {{ service.name }}Transport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -125,28 +116,6 @@ class {{ service.name }}Transport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
-
-
-    # TODO(busunkim): This method is in the base transport
-    # to avoid duplicating code across the transport classes. These functions
-    # should be deleted once the minimum required versions of google-auth is increased.
-
-    # TODO: Remove this function once google-auth >= 1.25.0 is required
-    @classmethod
-    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
-        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
-
-        scopes_kwargs = {}
-
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-
-        return scopes_kwargs
 
 
     def _prep_wrapped_messages(self, client_info):

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -4,7 +4,6 @@
 
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import packaging.version
 import pkg_resources
 
 import google.auth  # type: ignore

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -12,7 +12,6 @@ from google.api_core import operations_v1              # type: ignore
 {% endif %}
 from google.auth import credentials as ga_credentials   # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -44,7 +44,7 @@ def unit(session):
     )
 
 
-@nox.session(python='3.7')
+@nox.session(python='3.9')
 def cover(session):
     """Run the final coverage report.
     This outputs the coverage report aggregating coverage from the unit
@@ -56,7 +56,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=['3.6', '3.7'])
+@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
 def mypy(session):
     """Run the type checker."""
     session.install('mypy', 'types-pkg_resources')
@@ -103,7 +103,7 @@ def check_lower_bounds(session):
         str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 
-@nox.session(python='3.6')
+@nox.session(python='3.9')
 def docs(session):
     """Build the docs for this library."""
 

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -27,7 +27,12 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
+        {# TODO(dovs): remove when 1.x deprecation is complete -#}
+        {% if 'rest' in opts.transport -%}
         'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
+        {% else -%}
+        'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+        {% endif -%}
         'libcst >= 0.2.5',
         'proto-plus >= 1.19.4',
         'packaging >= 14.3',
@@ -44,7 +49,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -27,9 +27,9 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.27.0, < 3.0.0dev',
+        'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
         'libcst >= 0.2.5',
-        'proto-plus >= 1.15.0',
+        'proto-plus >= 1.19.4',
         'packaging >= 14.3',
     {%- if api.requires_package(('google', 'iam', 'v1')) or opts.add_iam_methods %}
         'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -27,18 +27,17 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        {#- TODO(dovs): remove when 1.x deprecation is complete #}
-        {%- if 'rest' in opts.transport %}
+        {# TODO(dovs): remove when 1.x deprecation is complete #}
+        {% if 'rest' in opts.transport %}
         'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
-        {%- else %}
+        {% else %}
         'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-        {%- endif %}
+        {% endif %}
         'libcst >= 0.2.5',
         'proto-plus >= 1.19.4',
-        'packaging >= 14.3',
-    {%- if api.requires_package(('google', 'iam', 'v1')) or opts.add_iam_methods %}
+    {% if api.requires_package(('google', 'iam', 'v1')) or opts.add_iam_methods %}
         'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',
-    {%- endif %}
+    {% endif %}
     ),
     python_requires='>=3.6',
     classifiers=[

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -27,12 +27,12 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        {# TODO(dovs): remove when 1.x deprecation is complete -#}
-        {% if 'rest' in opts.transport -%}
+        {#- TODO(dovs): remove when 1.x deprecation is complete #}
+        {%- if 'rest' in opts.transport %}
         'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
-        {% else -%}
+        {%- else %}
         'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-        {% endif -%}
+        {%- endif %}
         'libcst >= 0.2.5',
         'proto-plus >= 1.19.4',
         'packaging >= 14.3',

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -55,11 +55,6 @@ from google.iam.v1 import policy_pb2  # type: ignore
 {% endfilter %}
 
 
-# TODO(busunkim): Once google-auth >= 1.25.0 is required transitively
-# through google-api-core:
-# - Delete the auth "less than" test cases
-# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -28,7 +28,7 @@ from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + ser
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import {{ service.async_client_name }}
 {% endif %}
 from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }} import transports
-from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.base import _GOOGLE_AUTH_VERSION
+
 from google.api_core import client_options
 from google.api_core import exceptions as core_exceptions
 from google.api_core import grpc_helpers
@@ -59,14 +59,6 @@ from google.iam.v1 import policy_pb2  # type: ignore
 # through google-api-core:
 # - Delete the auth "less than" test cases
 # - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth < 1.25.0",
-)
-requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth >= 1.25.0",
-)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -1527,7 +1519,6 @@ def test_{{ service.name|snake_case }}_base_transport():
     {% endif %}
 
 
-@requires_google_auth_gte_1_25_0
 def test_{{ service.name|snake_case }}_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
@@ -1547,25 +1538,6 @@ def test_{{ service.name|snake_case }}_base_transport_with_credentials_file():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_{{ service.name|snake_case }}_base_transport_with_credentials_file_old_google_auth():
-    # Instantiate the base transport with a credentials file
-    with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport = transports.{{ service.name }}Transport(
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
-            {% for scope in service.oauth_scopes %}
-            '{{ scope }}',
-            {% endfor %}
-            ),
-            quota_project_id="octopus",
-        )
-
-
 def test_{{ service.name|snake_case }}_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc, mock.patch('{{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + service.meta.address.subpackage)|join(".") }}.services.{{ service.name|snake_case }}.transports.{{ service.name }}Transport._prep_wrapped_messages') as Transport:
@@ -1575,7 +1547,6 @@ def test_{{ service.name|snake_case }}_base_transport_with_adc():
         adc.assert_called_once()
 
 
-@requires_google_auth_gte_1_25_0
 def test_{{ service.name|snake_case }}_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc:
@@ -1591,21 +1562,6 @@ def test_{{ service.name|snake_case }}_auth_adc():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_{{ service.name|snake_case }}_auth_adc_old_google_auth():
-    # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        {{ service.client_name }}()
-        adc.assert_called_once_with(
-            scopes=(
-                {%- for scope in service.oauth_scopes %}
-                '{{ scope }}',
-                {%- endfor %}),
-            quota_project_id=None,
-        )
-
-
 {% if 'grpc' in opts.transport %}
 @pytest.mark.parametrize(
     "transport_class",
@@ -1614,7 +1570,6 @@ def test_{{ service.name|snake_case }}_auth_adc_old_google_auth():
         transports.{{ service.name }}GrpcAsyncIOTransport,
     ],
 )
-@requires_google_auth_gte_1_25_0
 def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
@@ -1631,26 +1586,6 @@ def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
         )
 
 
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.{{ service.name }}GrpcTransport,
-        transports.{{ service.name }}GrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_lt_1_25_0
-def test_{{ service.name|snake_case }}_transport_auth_adc_old_google_auth(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            {% for scope in service.oauth_scopes %}
-            '{{ scope }}',
-            {% endfor %}),
-            quota_project_id="octopus",
-        )
 
 
 @pytest.mark.parametrize(

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -4,7 +4,6 @@
 
 import os
 import mock
-import packaging.version
 
 import grpc
 from grpc.experimental import aio

--- a/noxfile.py
+++ b/noxfile.py
@@ -213,24 +213,7 @@ def showcase_unit(
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
         session.chdir(lib)
-
-        # Unit tests are run twice with different dependencies to exercise
-        # all code paths.
-        # TODO(busunkim): remove when default templates require google-auth>=1.25.0
-
-        # 1. Run tests at lower bound of dependencies
-        session.install("nox")
-        session.run("nox", "-s", "update_lower_bounds")
-        session.install(".", "--force-reinstall", "-c", "constraints.txt")
-        # Some code paths require an older version of google-auth.
-        # google-auth is a transitive dependency so it isn't in the
-        # lower bound constraints file produced above.
-        session.install("google-auth==1.21.1")
-        run_showcase_unit_tests(session, fail_under=0)
-
-        # 2. Run the tests again with latest version of dependencies
-        session.install(".", "--upgrade", "--force-reinstall")
-        run_showcase_unit_tests(session, fail_under=100)
+        run_showcase_unit_tests(session)
 
 
 @nox.session(python=["3.7", "3.8", "3.9"])
@@ -240,7 +223,7 @@ def showcase_unit_alternative_templates(session):
         run_showcase_unit_tests(session)
 
 
-@nox.session(python=["3.8"])
+@nox.session(python=["3.9"])
 def showcase_unit_add_iam_methods(session):
     with showcase_library(session, other_opts=("add-iam-methods",)) as lib:
         session.chdir(lib)

--- a/noxfile.py
+++ b/noxfile.py
@@ -124,7 +124,7 @@ def showcase_library(
         yield tmp_dir
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def showcase(
     session,
     templates="DEFAULT",
@@ -141,7 +141,7 @@ def showcase(
         )
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def showcase_mtls(
     session,
     templates="DEFAULT",
@@ -161,7 +161,7 @@ def showcase_mtls(
         )
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def showcase_alternative_templates(session):
     templates = path.join(path.dirname(__file__), "gapic", "ads-templates")
     showcase(
@@ -172,7 +172,7 @@ def showcase_alternative_templates(session):
     )
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def showcase_mtls_alternative_templates(session):
     templates = path.join(path.dirname(__file__), "gapic", "ads-templates")
     showcase_mtls(
@@ -213,7 +213,24 @@ def showcase_unit(
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
         session.chdir(lib)
-        run_showcase_unit_tests(session)
+
+        # Unit tests are run twice with different dependencies to exercise
+        # all code paths.
+        # TODO(busunkim): remove when default templates require google-auth>=1.25.0
+
+        # 1. Run tests at lower bound of dependencies
+        session.install("nox")
+        session.run("nox", "-s", "update_lower_bounds")
+        session.install(".", "--force-reinstall", "-c", "constraints.txt")
+        # Some code paths require an older version of google-auth.
+        # google-auth is a transitive dependency so it isn't in the
+        # lower bound constraints file produced above.
+        session.install("google-auth==1.28.0")
+        run_showcase_unit_tests(session, fail_under=0)
+
+        # 2. Run the tests again with latest version of dependencies
+        session.install(".", "--upgrade", "--force-reinstall")
+        run_showcase_unit_tests(session, fail_under=100)
 
 
 @nox.session(python=["3.7", "3.8", "3.9"])
@@ -228,26 +245,19 @@ def showcase_unit_add_iam_methods(session):
     with showcase_library(session, other_opts=("add-iam-methods",)) as lib:
         session.chdir(lib)
 
-        # Unit tests are run twice with different dependencies to exercise
-        # all code paths.
-        # TODO(busunkim): remove when default templates require google-auth>=1.25.0
-
-        # 1. Run tests at lower bound of dependencies
+        # Unit tests are run twice with different dependencies.
+        # 1. Run tests at lower bound of dependencies.
         session.install("nox")
         session.run("nox", "-s", "update_lower_bounds")
         session.install(".", "--force-reinstall", "-c", "constraints.txt")
-        # Some code paths require an older version of google-auth.
-        # google-auth is a transitive dependency so it isn't in the
-        # lower bound constraints file produced above.
-        session.install("google-auth==1.21.1")
         run_showcase_unit_tests(session, fail_under=0)
 
-        # 2. Run the tests again with latest version of dependencies
+        # 2. Run the tests again with latest version of dependencies.
         session.install(".", "--upgrade", "--force-reinstall")
         run_showcase_unit_tests(session, fail_under=100)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def showcase_mypy(
     session, templates="DEFAULT", other_opts: typing.Iterable[str] = (),
 ):
@@ -263,12 +273,12 @@ def showcase_mypy(
         session.run("mypy", "--explicit-package-bases", "google")
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def showcase_mypy_alternative_templates(session):
     showcase_mypy(session, templates=ADS_TEMPLATES, other_opts=("old-naming",))
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def snippetgen(session):
     # Clone googleapis/api-common-protos which are referenced by the snippet
     # protos
@@ -296,7 +306,7 @@ def snippetgen(session):
     )
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def docs(session):
     """Build the docs."""
 

--- a/setup.py
+++ b/setup.py
@@ -44,11 +44,11 @@ setup(
     include_package_data=True,
     install_requires=(
         "click >= 6.7",
-        "google-api-core >= 1.17.0",
+        "google-api-core >= 2.1.0",
         "googleapis-common-protos >= 1.53.0",
         "grpcio >= 1.24.3",
         "jinja2 >= 2.10",
-        "protobuf >= 3.12.0",
+        "protobuf >= 3.18.0",
         "pypandoc >= 1.4",
         "PyYAML >= 5.1.1",
         "dataclasses < 0.8; python_version < '3.7'"

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -40,15 +40,6 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = google.auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
 
 class AssetServiceTransport(abc.ABC):
     """Abstract transport class for AssetService."""
@@ -98,7 +89,7 @@ class AssetServiceTransport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -124,27 +115,6 @@ class AssetServiceTransport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
-
-    # TODO(busunkim): This method is in the base transport
-    # to avoid duplicating code across the transport classes. These functions
-    # should be deleted once the minimum required versions of google-auth is increased.
-
-    # TODO: Remove this function once google-auth >= 1.25.0 is required
-    @classmethod
-    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
-        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
-
-        scopes_kwargs = {}
-
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-
-        return scopes_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -15,7 +15,6 @@
 #
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import packaging.version
 import pkg_resources
 
 import google.auth  # type: ignore

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -21,7 +21,6 @@ from google.api_core import grpc_helpers_async         # type: ignore
 from google.api_core import operations_v1              # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -55,7 +55,7 @@ def unit(session):
     )
 
 
-@nox.session(python='3.7')
+@nox.session(python='3.9')
 def cover(session):
     """Run the final coverage report.
     This outputs the coverage report aggregating coverage from the unit
@@ -67,7 +67,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=['3.6', '3.7'])
+@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
 def mypy(session):
     """Run the type checker."""
     session.install('mypy', 'types-pkg_resources')
@@ -110,7 +110,7 @@ def check_lower_bounds(session):
         str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 
-@nox.session(python='3.6')
+@nox.session(python='3.9')
 def docs(session):
     """Build the docs for this library."""
 

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -34,9 +34,9 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.27.0, < 3.0.0dev',
-        'libcst >= 0.2.5',
-        'proto-plus >= 1.15.0',
+'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+'libcst >= 0.2.5',
+        'proto-plus >= 1.19.4',
         'packaging >= 14.3',        'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',    ),
     python_requires='>=3.6',
     classifiers=[
@@ -47,7 +47,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -34,10 +34,11 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-'libcst >= 0.2.5',
+        'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+        'libcst >= 0.2.5',
         'proto-plus >= 1.19.4',
-        'packaging >= 14.3',        'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',    ),
+        'grpc-google-iam-v1 >= 0.12.3, < 0.13dev',
+    ),
     python_requires='>=3.6',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -39,7 +39,6 @@ from google.cloud.asset_v1.services.asset_service import AssetServiceAsyncClient
 from google.cloud.asset_v1.services.asset_service import AssetServiceClient
 from google.cloud.asset_v1.services.asset_service import pagers
 from google.cloud.asset_v1.services.asset_service import transports
-from google.cloud.asset_v1.services.asset_service.transports.base import _GOOGLE_AUTH_VERSION
 from google.cloud.asset_v1.types import asset_service
 from google.cloud.asset_v1.types import assets
 from google.longrunning import operations_pb2
@@ -50,19 +49,6 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from google.type import expr_pb2  # type: ignore
 import google.auth
 
-
-# TODO(busunkim): Once google-auth >= 1.25.0 is required transitively
-# through google-api-core:
-# - Delete the auth "less than" test cases
-# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth < 1.25.0",
-)
-requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth >= 1.25.0",
-)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -3560,7 +3546,6 @@ def test_asset_service_base_transport():
         transport.operations_client
 
 
-@requires_google_auth_gte_1_25_0
 def test_asset_service_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.asset_v1.services.asset_service.transports.AssetServiceTransport._prep_wrapped_messages') as Transport:
@@ -3579,23 +3564,6 @@ def test_asset_service_base_transport_with_credentials_file():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_asset_service_base_transport_with_credentials_file_old_google_auth():
-    # Instantiate the base transport with a credentials file
-    with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.asset_v1.services.asset_service.transports.AssetServiceTransport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport = transports.AssetServiceTransport(
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            ),
-            quota_project_id="octopus",
-        )
-
-
 def test_asset_service_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc, mock.patch('google.cloud.asset_v1.services.asset_service.transports.AssetServiceTransport._prep_wrapped_messages') as Transport:
@@ -3605,7 +3573,6 @@ def test_asset_service_base_transport_with_adc():
         adc.assert_called_once()
 
 
-@requires_google_auth_gte_1_25_0
 def test_asset_service_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc:
@@ -3620,18 +3587,6 @@ def test_asset_service_auth_adc():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_asset_service_auth_adc_old_google_auth():
-    # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        AssetServiceClient()
-        adc.assert_called_once_with(
-            scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id=None,
-        )
-
-
 @pytest.mark.parametrize(
     "transport_class",
     [
@@ -3639,7 +3594,6 @@ def test_asset_service_auth_adc_old_google_auth():
         transports.AssetServiceGrpcAsyncIOTransport,
     ],
 )
-@requires_google_auth_gte_1_25_0
 def test_asset_service_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
@@ -3649,27 +3603,6 @@ def test_asset_service_transport_auth_adc(transport_class):
         adc.assert_called_once_with(
             scopes=["1", "2"],
             default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.AssetServiceGrpcTransport,
-        transports.AssetServiceGrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_lt_1_25_0
-def test_asset_service_transport_auth_adc_old_google_auth(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-),
             quota_project_id="octopus",
         )
 

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -15,7 +15,6 @@
 #
 import os
 import mock
-import packaging.version
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
@@ -37,15 +37,6 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = google.auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
 
 class IAMCredentialsTransport(abc.ABC):
     """Abstract transport class for IAMCredentials."""
@@ -95,7 +86,7 @@ class IAMCredentialsTransport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -121,27 +112,6 @@ class IAMCredentialsTransport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
-
-    # TODO(busunkim): This method is in the base transport
-    # to avoid duplicating code across the transport classes. These functions
-    # should be deleted once the minimum required versions of google-auth is increased.
-
-    # TODO: Remove this function once google-auth >= 1.25.0 is required
-    @classmethod
-    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
-        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
-
-        scopes_kwargs = {}
-
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-
-        return scopes_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
@@ -15,7 +15,6 @@
 #
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import packaging.version
 import pkg_resources
 
 import google.auth  # type: ignore

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
@@ -20,7 +20,6 @@ from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -55,7 +55,7 @@ def unit(session):
     )
 
 
-@nox.session(python='3.7')
+@nox.session(python='3.9')
 def cover(session):
     """Run the final coverage report.
     This outputs the coverage report aggregating coverage from the unit
@@ -67,7 +67,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=['3.6', '3.7'])
+@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
 def mypy(session):
     """Run the type checker."""
     session.install('mypy', 'types-pkg_resources')
@@ -110,7 +110,7 @@ def check_lower_bounds(session):
         str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 
-@nox.session(python='3.6')
+@nox.session(python='3.9')
 def docs(session):
     """Build the docs for this library."""
 

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -34,10 +34,10 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-'libcst >= 0.2.5',
+        'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+        'libcst >= 0.2.5',
         'proto-plus >= 1.19.4',
-        'packaging >= 14.3',    ),
+    ),
     python_requires='>=3.6',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -34,9 +34,9 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.27.0, < 3.0.0dev',
-        'libcst >= 0.2.5',
-        'proto-plus >= 1.15.0',
+'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+'libcst >= 0.2.5',
+        'proto-plus >= 1.19.4',
         'packaging >= 14.3',    ),
     python_requires='>=3.6',
     classifiers=[
@@ -47,7 +47,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -15,7 +15,6 @@
 #
 import os
 import mock
-import packaging.version
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -35,26 +35,12 @@ from google.auth.exceptions import MutualTLSChannelError
 from google.iam.credentials_v1.services.iam_credentials import IAMCredentialsAsyncClient
 from google.iam.credentials_v1.services.iam_credentials import IAMCredentialsClient
 from google.iam.credentials_v1.services.iam_credentials import transports
-from google.iam.credentials_v1.services.iam_credentials.transports.base import _GOOGLE_AUTH_VERSION
 from google.iam.credentials_v1.types import common
 from google.oauth2 import service_account
 from google.protobuf import duration_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
 import google.auth
 
-
-# TODO(busunkim): Once google-auth >= 1.25.0 is required transitively
-# through google-api-core:
-# - Delete the auth "less than" test cases
-# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth < 1.25.0",
-)
-requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth >= 1.25.0",
-)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -1489,7 +1475,6 @@ def test_iam_credentials_base_transport():
         transport.close()
 
 
-@requires_google_auth_gte_1_25_0
 def test_iam_credentials_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.iam.credentials_v1.services.iam_credentials.transports.IAMCredentialsTransport._prep_wrapped_messages') as Transport:
@@ -1508,23 +1493,6 @@ def test_iam_credentials_base_transport_with_credentials_file():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_iam_credentials_base_transport_with_credentials_file_old_google_auth():
-    # Instantiate the base transport with a credentials file
-    with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.iam.credentials_v1.services.iam_credentials.transports.IAMCredentialsTransport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport = transports.IAMCredentialsTransport(
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            ),
-            quota_project_id="octopus",
-        )
-
-
 def test_iam_credentials_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc, mock.patch('google.iam.credentials_v1.services.iam_credentials.transports.IAMCredentialsTransport._prep_wrapped_messages') as Transport:
@@ -1534,7 +1502,6 @@ def test_iam_credentials_base_transport_with_adc():
         adc.assert_called_once()
 
 
-@requires_google_auth_gte_1_25_0
 def test_iam_credentials_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc:
@@ -1549,18 +1516,6 @@ def test_iam_credentials_auth_adc():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_iam_credentials_auth_adc_old_google_auth():
-    # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        IAMCredentialsClient()
-        adc.assert_called_once_with(
-            scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id=None,
-        )
-
-
 @pytest.mark.parametrize(
     "transport_class",
     [
@@ -1568,7 +1523,6 @@ def test_iam_credentials_auth_adc_old_google_auth():
         transports.IAMCredentialsGrpcAsyncIOTransport,
     ],
 )
-@requires_google_auth_gte_1_25_0
 def test_iam_credentials_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
@@ -1578,27 +1532,6 @@ def test_iam_credentials_transport_auth_adc(transport_class):
         adc.assert_called_once_with(
             scopes=["1", "2"],
             default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.IAMCredentialsGrpcTransport,
-        transports.IAMCredentialsGrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_lt_1_25_0
-def test_iam_credentials_transport_auth_adc_old_google_auth(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-),
             quota_project_id="octopus",
         )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -38,15 +38,6 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = google.auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
 
 class ConfigServiceV2Transport(abc.ABC):
     """Abstract transport class for ConfigServiceV2."""
@@ -99,7 +90,7 @@ class ConfigServiceV2Transport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -125,27 +116,6 @@ class ConfigServiceV2Transport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
-
-    # TODO(busunkim): This method is in the base transport
-    # to avoid duplicating code across the transport classes. These functions
-    # should be deleted once the minimum required versions of google-auth is increased.
-
-    # TODO: Remove this function once google-auth >= 1.25.0 is required
-    @classmethod
-    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
-        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
-
-        scopes_kwargs = {}
-
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-
-        return scopes_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -15,7 +15,6 @@
 #
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import packaging.version
 import pkg_resources
 
 import google.auth  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
@@ -20,7 +20,6 @@ from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -38,15 +38,6 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = google.auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
 
 class LoggingServiceV2Transport(abc.ABC):
     """Abstract transport class for LoggingServiceV2."""
@@ -100,7 +91,7 @@ class LoggingServiceV2Transport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -126,27 +117,6 @@ class LoggingServiceV2Transport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
-
-    # TODO(busunkim): This method is in the base transport
-    # to avoid duplicating code across the transport classes. These functions
-    # should be deleted once the minimum required versions of google-auth is increased.
-
-    # TODO: Remove this function once google-auth >= 1.25.0 is required
-    @classmethod
-    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
-        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
-
-        scopes_kwargs = {}
-
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-
-        return scopes_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -15,7 +15,6 @@
 #
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import packaging.version
 import pkg_resources
 
 import google.auth  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
@@ -20,7 +20,6 @@ from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -38,15 +38,6 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = google.auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
 
 class MetricsServiceV2Transport(abc.ABC):
     """Abstract transport class for MetricsServiceV2."""
@@ -100,7 +91,7 @@ class MetricsServiceV2Transport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -126,27 +117,6 @@ class MetricsServiceV2Transport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
-
-    # TODO(busunkim): This method is in the base transport
-    # to avoid duplicating code across the transport classes. These functions
-    # should be deleted once the minimum required versions of google-auth is increased.
-
-    # TODO: Remove this function once google-auth >= 1.25.0 is required
-    @classmethod
-    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
-        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
-
-        scopes_kwargs = {}
-
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-
-        return scopes_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -15,7 +15,6 @@
 #
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import packaging.version
 import pkg_resources
 
 import google.auth  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
@@ -20,7 +20,6 @@ from google.api_core import gapic_v1                   # type: ignore
 from google.api_core import grpc_helpers_async         # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -55,7 +55,7 @@ def unit(session):
     )
 
 
-@nox.session(python='3.7')
+@nox.session(python='3.9')
 def cover(session):
     """Run the final coverage report.
     This outputs the coverage report aggregating coverage from the unit
@@ -67,7 +67,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=['3.6', '3.7'])
+@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
 def mypy(session):
     """Run the type checker."""
     session.install('mypy', 'types-pkg_resources')
@@ -110,7 +110,7 @@ def check_lower_bounds(session):
         str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 
-@nox.session(python='3.6')
+@nox.session(python='3.9')
 def docs(session):
     """Build the docs for this library."""
 

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -34,10 +34,10 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-'libcst >= 0.2.5',
+        'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+        'libcst >= 0.2.5',
         'proto-plus >= 1.19.4',
-        'packaging >= 14.3',    ),
+    ),
     python_requires='>=3.6',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -34,9 +34,9 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.27.0, < 3.0.0dev',
-        'libcst >= 0.2.5',
-        'proto-plus >= 1.15.0',
+'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+'libcst >= 0.2.5',
+        'proto-plus >= 1.19.4',
         'packaging >= 14.3',    ),
     python_requires='>=3.6',
     classifiers=[
@@ -47,7 +47,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -36,26 +36,12 @@ from google.cloud.logging_v2.services.config_service_v2 import ConfigServiceV2As
 from google.cloud.logging_v2.services.config_service_v2 import ConfigServiceV2Client
 from google.cloud.logging_v2.services.config_service_v2 import pagers
 from google.cloud.logging_v2.services.config_service_v2 import transports
-from google.cloud.logging_v2.services.config_service_v2.transports.base import _GOOGLE_AUTH_VERSION
 from google.cloud.logging_v2.types import logging_config
 from google.oauth2 import service_account
 from google.protobuf import field_mask_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
 import google.auth
 
-
-# TODO(busunkim): Once google-auth >= 1.25.0 is required transitively
-# through google-api-core:
-# - Delete the auth "less than" test cases
-# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth < 1.25.0",
-)
-requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth >= 1.25.0",
-)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -5911,7 +5897,6 @@ def test_config_service_v2_base_transport():
         transport.close()
 
 
-@requires_google_auth_gte_1_25_0
 def test_config_service_v2_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.logging_v2.services.config_service_v2.transports.ConfigServiceV2Transport._prep_wrapped_messages') as Transport:
@@ -5933,26 +5918,6 @@ def test_config_service_v2_base_transport_with_credentials_file():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_config_service_v2_base_transport_with_credentials_file_old_google_auth():
-    # Instantiate the base transport with a credentials file
-    with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.logging_v2.services.config_service_v2.transports.ConfigServiceV2Transport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport = transports.ConfigServiceV2Transport(
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            'https://www.googleapis.com/auth/cloud-platform.read-only',
-            'https://www.googleapis.com/auth/logging.admin',
-            'https://www.googleapis.com/auth/logging.read',
-            ),
-            quota_project_id="octopus",
-        )
-
-
 def test_config_service_v2_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc, mock.patch('google.cloud.logging_v2.services.config_service_v2.transports.ConfigServiceV2Transport._prep_wrapped_messages') as Transport:
@@ -5962,7 +5927,6 @@ def test_config_service_v2_base_transport_with_adc():
         adc.assert_called_once()
 
 
-@requires_google_auth_gte_1_25_0
 def test_config_service_v2_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc:
@@ -5980,18 +5944,6 @@ def test_config_service_v2_auth_adc():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_config_service_v2_auth_adc_old_google_auth():
-    # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        ConfigServiceV2Client()
-        adc.assert_called_once_with(
-            scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',),
-            quota_project_id=None,
-        )
-
-
 @pytest.mark.parametrize(
     "transport_class",
     [
@@ -5999,7 +5951,6 @@ def test_config_service_v2_auth_adc_old_google_auth():
         transports.ConfigServiceV2GrpcAsyncIOTransport,
     ],
 )
-@requires_google_auth_gte_1_25_0
 def test_config_service_v2_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
@@ -6009,30 +5960,6 @@ def test_config_service_v2_transport_auth_adc(transport_class):
         adc.assert_called_once_with(
             scopes=["1", "2"],
             default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.ConfigServiceV2GrpcTransport,
-        transports.ConfigServiceV2GrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_lt_1_25_0
-def test_config_service_v2_transport_auth_adc_old_google_auth(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            'https://www.googleapis.com/auth/cloud-platform.read-only',
-            'https://www.googleapis.com/auth/logging.admin',
-            'https://www.googleapis.com/auth/logging.read',
-),
             quota_project_id="octopus",
         )
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -15,7 +15,6 @@
 #
 import os
 import mock
-import packaging.version
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -37,7 +37,6 @@ from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2
 from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2Client
 from google.cloud.logging_v2.services.logging_service_v2 import pagers
 from google.cloud.logging_v2.services.logging_service_v2 import transports
-from google.cloud.logging_v2.services.logging_service_v2.transports.base import _GOOGLE_AUTH_VERSION
 from google.cloud.logging_v2.types import log_entry
 from google.cloud.logging_v2.types import logging
 from google.logging.type import http_request_pb2  # type: ignore
@@ -49,19 +48,6 @@ from google.protobuf import struct_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
 import google.auth
 
-
-# TODO(busunkim): Once google-auth >= 1.25.0 is required transitively
-# through google-api-core:
-# - Delete the auth "less than" test cases
-# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth < 1.25.0",
-)
-requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth >= 1.25.0",
-)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -2033,7 +2019,6 @@ def test_logging_service_v2_base_transport():
         transport.close()
 
 
-@requires_google_auth_gte_1_25_0
 def test_logging_service_v2_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.logging_v2.services.logging_service_v2.transports.LoggingServiceV2Transport._prep_wrapped_messages') as Transport:
@@ -2056,27 +2041,6 @@ def test_logging_service_v2_base_transport_with_credentials_file():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_logging_service_v2_base_transport_with_credentials_file_old_google_auth():
-    # Instantiate the base transport with a credentials file
-    with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.logging_v2.services.logging_service_v2.transports.LoggingServiceV2Transport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport = transports.LoggingServiceV2Transport(
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            'https://www.googleapis.com/auth/cloud-platform.read-only',
-            'https://www.googleapis.com/auth/logging.admin',
-            'https://www.googleapis.com/auth/logging.read',
-            'https://www.googleapis.com/auth/logging.write',
-            ),
-            quota_project_id="octopus",
-        )
-
-
 def test_logging_service_v2_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc, mock.patch('google.cloud.logging_v2.services.logging_service_v2.transports.LoggingServiceV2Transport._prep_wrapped_messages') as Transport:
@@ -2086,7 +2050,6 @@ def test_logging_service_v2_base_transport_with_adc():
         adc.assert_called_once()
 
 
-@requires_google_auth_gte_1_25_0
 def test_logging_service_v2_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc:
@@ -2105,18 +2068,6 @@ def test_logging_service_v2_auth_adc():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_logging_service_v2_auth_adc_old_google_auth():
-    # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        LoggingServiceV2Client()
-        adc.assert_called_once_with(
-            scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
-            quota_project_id=None,
-        )
-
-
 @pytest.mark.parametrize(
     "transport_class",
     [
@@ -2124,7 +2075,6 @@ def test_logging_service_v2_auth_adc_old_google_auth():
         transports.LoggingServiceV2GrpcAsyncIOTransport,
     ],
 )
-@requires_google_auth_gte_1_25_0
 def test_logging_service_v2_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
@@ -2134,31 +2084,6 @@ def test_logging_service_v2_transport_auth_adc(transport_class):
         adc.assert_called_once_with(
             scopes=["1", "2"],
             default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.LoggingServiceV2GrpcTransport,
-        transports.LoggingServiceV2GrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_lt_1_25_0
-def test_logging_service_v2_transport_auth_adc_old_google_auth(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            'https://www.googleapis.com/auth/cloud-platform.read-only',
-            'https://www.googleapis.com/auth/logging.admin',
-            'https://www.googleapis.com/auth/logging.read',
-            'https://www.googleapis.com/auth/logging.write',
-),
             quota_project_id="octopus",
         )
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -15,7 +15,6 @@
 #
 import os
 import mock
-import packaging.version
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -15,7 +15,6 @@
 #
 import os
 import mock
-import packaging.version
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -40,26 +40,12 @@ from google.cloud.logging_v2.services.metrics_service_v2 import MetricsServiceV2
 from google.cloud.logging_v2.services.metrics_service_v2 import MetricsServiceV2Client
 from google.cloud.logging_v2.services.metrics_service_v2 import pagers
 from google.cloud.logging_v2.services.metrics_service_v2 import transports
-from google.cloud.logging_v2.services.metrics_service_v2.transports.base import _GOOGLE_AUTH_VERSION
 from google.cloud.logging_v2.types import logging_metrics
 from google.oauth2 import service_account
 from google.protobuf import duration_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
 import google.auth
 
-
-# TODO(busunkim): Once google-auth >= 1.25.0 is required transitively
-# through google-api-core:
-# - Delete the auth "less than" test cases
-# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth < 1.25.0",
-)
-requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth >= 1.25.0",
-)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -1898,7 +1884,6 @@ def test_metrics_service_v2_base_transport():
         transport.close()
 
 
-@requires_google_auth_gte_1_25_0
 def test_metrics_service_v2_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.logging_v2.services.metrics_service_v2.transports.MetricsServiceV2Transport._prep_wrapped_messages') as Transport:
@@ -1921,27 +1906,6 @@ def test_metrics_service_v2_base_transport_with_credentials_file():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_metrics_service_v2_base_transport_with_credentials_file_old_google_auth():
-    # Instantiate the base transport with a credentials file
-    with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.logging_v2.services.metrics_service_v2.transports.MetricsServiceV2Transport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport = transports.MetricsServiceV2Transport(
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            'https://www.googleapis.com/auth/cloud-platform.read-only',
-            'https://www.googleapis.com/auth/logging.admin',
-            'https://www.googleapis.com/auth/logging.read',
-            'https://www.googleapis.com/auth/logging.write',
-            ),
-            quota_project_id="octopus",
-        )
-
-
 def test_metrics_service_v2_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc, mock.patch('google.cloud.logging_v2.services.metrics_service_v2.transports.MetricsServiceV2Transport._prep_wrapped_messages') as Transport:
@@ -1951,7 +1915,6 @@ def test_metrics_service_v2_base_transport_with_adc():
         adc.assert_called_once()
 
 
-@requires_google_auth_gte_1_25_0
 def test_metrics_service_v2_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc:
@@ -1970,18 +1933,6 @@ def test_metrics_service_v2_auth_adc():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_metrics_service_v2_auth_adc_old_google_auth():
-    # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        MetricsServiceV2Client()
-        adc.assert_called_once_with(
-            scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
-            quota_project_id=None,
-        )
-
-
 @pytest.mark.parametrize(
     "transport_class",
     [
@@ -1989,7 +1940,6 @@ def test_metrics_service_v2_auth_adc_old_google_auth():
         transports.MetricsServiceV2GrpcAsyncIOTransport,
     ],
 )
-@requires_google_auth_gte_1_25_0
 def test_metrics_service_v2_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
@@ -1999,31 +1949,6 @@ def test_metrics_service_v2_transport_auth_adc(transport_class):
         adc.assert_called_once_with(
             scopes=["1", "2"],
             default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.MetricsServiceV2GrpcTransport,
-        transports.MetricsServiceV2GrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_lt_1_25_0
-def test_metrics_service_v2_transport_auth_adc_old_google_auth(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            'https://www.googleapis.com/auth/cloud-platform.read-only',
-            'https://www.googleapis.com/auth/logging.admin',
-            'https://www.googleapis.com/auth/logging.read',
-            'https://www.googleapis.com/auth/logging.write',
-),
             quota_project_id="octopus",
         )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -39,15 +39,6 @@ try:
 except pkg_resources.DistributionNotFound:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
 
-try:
-    # google.auth.__version__ was added in 1.26.0
-    _GOOGLE_AUTH_VERSION = google.auth.__version__
-except AttributeError:
-    try:  # try pkg_resources if it is available
-        _GOOGLE_AUTH_VERSION = pkg_resources.get_distribution("google-auth").version
-    except pkg_resources.DistributionNotFound:  # pragma: NO COVER
-        _GOOGLE_AUTH_VERSION = None
-
 
 class CloudRedisTransport(abc.ABC):
     """Abstract transport class for CloudRedis."""
@@ -97,7 +88,7 @@ class CloudRedisTransport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = self._get_scopes_kwargs(self._host, scopes)
+        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
 
         # Save the scopes.
         self._scopes = scopes
@@ -123,27 +114,6 @@ class CloudRedisTransport(abc.ABC):
 
         # Save the credentials.
         self._credentials = credentials
-
-    # TODO(busunkim): This method is in the base transport
-    # to avoid duplicating code across the transport classes. These functions
-    # should be deleted once the minimum required versions of google-auth is increased.
-
-    # TODO: Remove this function once google-auth >= 1.25.0 is required
-    @classmethod
-    def _get_scopes_kwargs(cls, host: str, scopes: Optional[Sequence[str]]) -> Dict[str, Optional[Sequence[str]]]:
-        """Returns scopes kwargs to pass to google-auth methods depending on the google-auth version"""
-
-        scopes_kwargs = {}
-
-        if _GOOGLE_AUTH_VERSION and (
-            packaging.version.parse(_GOOGLE_AUTH_VERSION)
-            >= packaging.version.parse("1.25.0")
-        ):
-            scopes_kwargs = {"scopes": scopes, "default_scopes": cls.AUTH_SCOPES}
-        else:
-            scopes_kwargs = {"scopes": scopes or cls.AUTH_SCOPES}
-
-        return scopes_kwargs
 
     def _prep_wrapped_messages(self, client_info):
         # Precompute the wrapped methods.

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -15,7 +15,6 @@
 #
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import packaging.version
 import pkg_resources
 
 import google.auth  # type: ignore

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
@@ -21,7 +21,6 @@ from google.api_core import grpc_helpers_async         # type: ignore
 from google.api_core import operations_v1              # type: ignore
 from google.auth import credentials as ga_credentials   # type: ignore
 from google.auth.transport.grpc import SslCredentials  # type: ignore
-import packaging.version
 
 import grpc                        # type: ignore
 from grpc.experimental import aio  # type: ignore

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -55,7 +55,7 @@ def unit(session):
     )
 
 
-@nox.session(python='3.7')
+@nox.session(python='3.9')
 def cover(session):
     """Run the final coverage report.
     This outputs the coverage report aggregating coverage from the unit
@@ -67,7 +67,7 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python=['3.6', '3.7'])
+@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
 def mypy(session):
     """Run the type checker."""
     session.install('mypy', 'types-pkg_resources')
@@ -110,7 +110,7 @@ def check_lower_bounds(session):
         str(LOWER_BOUND_CONSTRAINTS_FILE),
     )
 
-@nox.session(python='3.6')
+@nox.session(python='3.9')
 def docs(session):
     """Build the docs for this library."""
 

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -34,10 +34,10 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
-'libcst >= 0.2.5',
+        'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+        'libcst >= 0.2.5',
         'proto-plus >= 1.19.4',
-        'packaging >= 14.3',    ),
+    ),
     python_requires='>=3.6',
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -34,9 +34,9 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        'google-api-core[grpc] >= 1.27.0, < 3.0.0dev',
-        'libcst >= 0.2.5',
-        'proto-plus >= 1.15.0',
+'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
+'libcst >= 0.2.5',
+        'proto-plus >= 1.19.4',
         'packaging >= 14.3',    ),
     python_requires='>=3.6',
     classifiers=[
@@ -47,7 +47,6 @@ setuptools.setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -15,7 +15,6 @@
 #
 import os
 import mock
-import packaging.version
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -39,7 +39,6 @@ from google.cloud.redis_v1.services.cloud_redis import CloudRedisAsyncClient
 from google.cloud.redis_v1.services.cloud_redis import CloudRedisClient
 from google.cloud.redis_v1.services.cloud_redis import pagers
 from google.cloud.redis_v1.services.cloud_redis import transports
-from google.cloud.redis_v1.services.cloud_redis.transports.base import _GOOGLE_AUTH_VERSION
 from google.cloud.redis_v1.types import cloud_redis
 from google.longrunning import operations_pb2
 from google.oauth2 import service_account
@@ -47,19 +46,6 @@ from google.protobuf import field_mask_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
 import google.auth
 
-
-# TODO(busunkim): Once google-auth >= 1.25.0 is required transitively
-# through google-api-core:
-# - Delete the auth "less than" test cases
-# - Delete these pytest markers (Make the "greater than or equal to" tests the default).
-requires_google_auth_lt_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) >= packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth < 1.25.0",
-)
-requires_google_auth_gte_1_25_0 = pytest.mark.skipif(
-    packaging.version.parse(_GOOGLE_AUTH_VERSION) < packaging.version.parse("1.25.0"),
-    reason="This test requires google-auth >= 1.25.0",
-)
 
 def client_cert_source_callback():
     return b"cert bytes", b"key bytes"
@@ -2869,7 +2855,6 @@ def test_cloud_redis_base_transport():
         transport.operations_client
 
 
-@requires_google_auth_gte_1_25_0
 def test_cloud_redis_base_transport_with_credentials_file():
     # Instantiate the base transport with a credentials file
     with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.redis_v1.services.cloud_redis.transports.CloudRedisTransport._prep_wrapped_messages') as Transport:
@@ -2888,23 +2873,6 @@ def test_cloud_redis_base_transport_with_credentials_file():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_cloud_redis_base_transport_with_credentials_file_old_google_auth():
-    # Instantiate the base transport with a credentials file
-    with mock.patch.object(google.auth, 'load_credentials_from_file', autospec=True) as load_creds, mock.patch('google.cloud.redis_v1.services.cloud_redis.transports.CloudRedisTransport._prep_wrapped_messages') as Transport:
-        Transport.return_value = None
-        load_creds.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport = transports.CloudRedisTransport(
-            credentials_file="credentials.json",
-            quota_project_id="octopus",
-        )
-        load_creds.assert_called_once_with("credentials.json", scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-            ),
-            quota_project_id="octopus",
-        )
-
-
 def test_cloud_redis_base_transport_with_adc():
     # Test the default credentials are used if credentials and credentials_file are None.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc, mock.patch('google.cloud.redis_v1.services.cloud_redis.transports.CloudRedisTransport._prep_wrapped_messages') as Transport:
@@ -2914,7 +2882,6 @@ def test_cloud_redis_base_transport_with_adc():
         adc.assert_called_once()
 
 
-@requires_google_auth_gte_1_25_0
 def test_cloud_redis_auth_adc():
     # If no credentials are provided, we should use ADC credentials.
     with mock.patch.object(google.auth, 'default', autospec=True) as adc:
@@ -2929,18 +2896,6 @@ def test_cloud_redis_auth_adc():
         )
 
 
-@requires_google_auth_lt_1_25_0
-def test_cloud_redis_auth_adc_old_google_auth():
-    # If no credentials are provided, we should use ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        CloudRedisClient()
-        adc.assert_called_once_with(
-            scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id=None,
-        )
-
-
 @pytest.mark.parametrize(
     "transport_class",
     [
@@ -2948,7 +2903,6 @@ def test_cloud_redis_auth_adc_old_google_auth():
         transports.CloudRedisGrpcAsyncIOTransport,
     ],
 )
-@requires_google_auth_gte_1_25_0
 def test_cloud_redis_transport_auth_adc(transport_class):
     # If credentials and host are not provided, the transport class should use
     # ADC credentials.
@@ -2958,27 +2912,6 @@ def test_cloud_redis_transport_auth_adc(transport_class):
         adc.assert_called_once_with(
             scopes=["1", "2"],
             default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.CloudRedisGrpcTransport,
-        transports.CloudRedisGrpcAsyncIOTransport,
-    ],
-)
-@requires_google_auth_lt_1_25_0
-def test_cloud_redis_transport_auth_adc_old_google_auth(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, "default", autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus")
-        adc.assert_called_once_with(scopes=(
-            'https://www.googleapis.com/auth/cloud-platform',
-),
             quota_project_id="octopus",
         )
 


### PR DESCRIPTION
Boost Proto-Plus dependency to 1.19.4
Boost common protos dependency to 1.53.0
Boost Google API core requirement to 2.1.0 (for rest) or 1.28.0 (for grpc) and (transitively) Google
Auth to 1.25.0

Remove logic for handling older auth library versions