### PR TITLE
chore: disable dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "extends": [
       "config:base",
-      "docker:disable"
+      "docker:disable",
+      ":disableDependencyDashboard"
   ]
 }


### PR DESCRIPTION
Closes #980

The dependency dashboard was enabled by default in Renovate v26.0.0.