### PR TITLE
fix: Fix rest transport logic

### DIFF
--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -925,9 +925,21 @@ class Method:
 
         return set(self.input.fields) - params
 
+    @property
+    def body_fields(self) -> Mapping[str, Field]:
+        bindings = self.http_options
+        if bindings and bindings[0].body and bindings[0].body != "*":
+            return self._fields_mapping([bindings[0].body])
+        return {}
+
     # TODO(yon-mg): refactor as there may be more than one method signature
     @utils.cached_property
     def flattened_fields(self) -> Mapping[str, Field]:
+        signatures = self.options.Extensions[client_pb2.method_signature]
+        return self._fields_mapping(signatures)
+
+    # TODO(yon-mg): refactor as there may be more than one method signature
+    def _fields_mapping(self, signatures) -> Mapping[str, Field]:
         """Return the signature defined for this method."""
         cross_pkg_request = self.input.ident.package != self.ident.package
 
@@ -946,7 +958,6 @@ class Method:
 
                 yield name, field
 
-        signatures = self.options.Extensions[client_pb2.method_signature]
         answer: Dict[str, Field] = collections.OrderedDict(
             name_and_field
             for sig in signatures

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -306,9 +306,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 client_cert_source_for_mtls=client_cert_source_func,
                 quota_project_id=client_options.quota_project_id,
                 client_info=client_info,
-                {% if "grpc" in opts.transport %}
                 always_use_jwt_access=True,
-                {% endif %}
             )
 
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -1,14 +1,16 @@
-from google.auth.transport.requests import AuthorizedSession
+from google.auth.transport.requests import AuthorizedSession  # type: ignore
 import json  # type: ignore
 import grpc  # type: ignore
-from google.auth.transport.grpc import SslCredentials      # type: ignore
-from google.auth import credentials as ga_credentials      # type: ignore
+from google.auth.transport.grpc import SslCredentials  # type: ignore
+from google.auth import credentials as ga_credentials  # type: ignore
 from google.api_core import exceptions as core_exceptions  # type: ignore
-from google.api_core import retry as retries                      # type: ignore
-from google.api_core import rest_helpers         # type: ignore
-from google.api_core import path_template         # type: ignore
-from google.api_core import gapic_v1       # type: ignore
+from google.api_core import retry as retries  # type: ignore
+from google.api_core import rest_helpers  # type: ignore
+from google.api_core import path_template  # type: ignore
+from google.api_core import gapic_v1  # type: ignore
+{% if service.has_lro %}
 from google.api_core import operations_v1
+{% endif %}
 from requests import __version__ as requests_version
 from typing import Callable, Dict, Optional, Sequence, Tuple, Union
 import warnings

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -2424,16 +2424,19 @@ async def test_test_iam_permissions_from_dict_async():
         )
         call.assert_called()
 
-  @pytest.mark.asyncio
-  async def test_transport_close_async():
-      client = {{ service.async_client_name }}(
-          credentials=ga_credentials.AnonymousCredentials(),
-          transport="grpc_asyncio",
-      )
-      with mock.patch.object(type(getattr(client.transport, "grpc_channel")), "close") as close:
-          async with client:
-              close.assert_not_called()
-          close.assert_called_once()
+{% endif %}
+
+{% if 'grpc' in opts.transport %}
+@pytest.mark.asyncio
+async def test_transport_close_async():
+    client = {{ service.async_client_name }}(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc_asyncio",
+    )
+    with mock.patch.object(type(getattr(client.transport, "grpc_channel")), "close") as close:
+        async with client:
+            close.assert_not_called()
+        close.assert_called_once()
 {% endif %}
 
 def test_transport_close():

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1106,7 +1106,14 @@ def test_{{ method.name|snake_case }}_rest(transport: str = 'rest', request_type
     )
 
     # send a request that will satisfy transcoding
-    request = request_type({{ method.http_options[0].sample_request}})
+    request_init = {{ method.http_options[0].sample_request}}
+    {% for field in method.body_fields.values() %}
+    {% if not field.oneof or field.proto3_optional %}
+    {# ignore oneof fields that might conflict with sample_request #}
+    request_init["{{ field.name }}"] = {{ field.mock_value }}
+    {% endif %}
+    {% endfor %}
+    request = request_type(request_init)
     {% if method.client_streaming %}
     requests = [request]
     {% endif %}
@@ -2417,18 +2424,17 @@ async def test_test_iam_permissions_from_dict_async():
         )
         call.assert_called()
 
+  @pytest.mark.asyncio
+  async def test_transport_close_async():
+      client = {{ service.async_client_name }}(
+          credentials=ga_credentials.AnonymousCredentials(),
+          transport="grpc_asyncio",
+      )
+      with mock.patch.object(type(getattr(client.transport, "grpc_channel")), "close") as close:
+          async with client:
+              close.assert_not_called()
+          close.assert_called_once()
 {% endif %}
-
-@pytest.mark.asyncio
-async def test_transport_close_async():
-    client = {{ service.async_client_name }}(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="grpc_asyncio",
-    )
-    with mock.patch.object(type(getattr(client.transport, "grpc_channel")), "close") as close:
-        async with client:
-            close.assert_not_called()
-        close.assert_called_once()
 
 def test_transport_close():
     transports = {


### PR DESCRIPTION
This includes
1) Do not include asyncio tests in the generated tests, because rest transport does not have asynio client.
2) Generate body field mock values for generated tests (otherwise grpc transcodding logic would fail).
3) Make `always_use_jwt_access=True` default for rest clients (grpc already does that) to match expected calls in generated tests.
4) Fix mypy errors for `AuthorizedSession` by ignoring it
5) Include operations_v1 conditionally, only if the client has lro

There are few more fixes left, which are expected to be fixed in separate PRs:

1) `message->to_dict->message` roundrtip problem for int64 types is expected to be fixed by https://github.com/googleapis/proto-plus-python/pull/267
2) builtins conflicts (`license_` vs `license` as field name) is expected to be fixed by a TBD PR