### PR TITLE
fix: more fixes for rest transport

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -29,7 +29,7 @@ setuptools.setup(
     install_requires=(
         {# TODO(dovs): remove when 1.x deprecation is complete #}
         {% if 'rest' in opts.transport %}
-        'google-api-core[grpc] >= 2.1.0, < 3.0.0dev',
+        'google-api-core[grpc] >= 2.2.0, < 3.0.0dev',
         {% else %}
         'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
         {% endif %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1337,6 +1337,13 @@ def test_{{ method.name|snake_case }}_rest_pager():
             req.side_effect = return_values
 
             sample_request = {{ method.http_options[0].sample_request }}
+            {% for field in method.body_fields.values() %}
+            {% if not field.oneof or field.proto3_optional %}
+            {# ignore oneof fields that might conflict with sample_request #}
+            sample_request["{{ field.name }}"] = {{ field.mock_value }}
+            {% endif %}
+            {% endfor %}
+
             pager = client.{{ method.name|snake_case }}(request=sample_request)
 
             {% if method.paged_result_field.map %}

--- a/gapic/utils/uri_sample.py
+++ b/gapic/utils/uri_sample.py
@@ -71,6 +71,8 @@ def sample_from_path_fields(paths: List[Tuple[str, str]]) -> Dict[Any, Any]:
 
     for path, template in paths:
         sample_value = re.sub(
-            r"(\*\*|\*)", lambda n: next(sample_names), template)
+            r"(\*\*|\*)",
+            lambda n: next(sample_names), template if template else '*'
+        )
         add_field(request, path, sample_value)
     return request

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     include_package_data=True,
     install_requires=(
         "click >= 6.7",
-        "google-api-core >= 2.1.0",
+        "google-api-core >= 2.2.0",
         "googleapis-common-protos >= 1.53.0",
         "grpcio >= 1.24.3",
         "jinja2 >= 2.10",

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -475,7 +475,7 @@ def test_method_http_options_generate_sample():
         'id': 'projects/sample1/regions/sample2/id/sample3'}}
 
 
-def test_method_http_options_generate_sample_immplicit_template():
+def test_method_http_options_generate_sample_implicit_template():
     http_rule = http_pb2.HttpRule(
         get='/v1/{resource.id}/stuff',
     )

--- a/tests/unit/schema/wrappers/test_method.py
+++ b/tests/unit/schema/wrappers/test_method.py
@@ -475,6 +475,16 @@ def test_method_http_options_generate_sample():
         'id': 'projects/sample1/regions/sample2/id/sample3'}}
 
 
+def test_method_http_options_generate_sample_immplicit_template():
+    http_rule = http_pb2.HttpRule(
+        get='/v1/{resource.id}/stuff',
+    )
+    method = make_method('DoSomething', http_rule=http_rule)
+    sample = method.http_options[0].sample_request
+    assert json.loads(sample) == {'resource': {
+        'id': 'sample1'}}
+
+
 def test_method_query_params():
     # tests only the basic case of grpc transcoding
     http_rule = http_pb2.HttpRule(


### PR DESCRIPTION
This includes:
1) Implicit template support for grpc transcodding (accept `/v1/{project}/stuff` whichis equivalent to `/v1/{project=*}/stuff`)
2) Proper request message construction for paginated methods test
3) Depend on `google-api-core 2.2.0` for rest to accommodate the `int64` support fixes