### PR TITLE
fix: suppress type error for fallback def of OptionalRetry

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -25,7 +25,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% filter sort_lines %}
 {% for method in service.methods.values() %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -24,7 +24,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% filter sort_lines %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -21,7 +21,7 @@ from google.oauth2 import service_account              # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% filter sort_lines %}
 {% for method in service.methods.values() %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -20,7 +20,7 @@ from google.oauth2 import service_account              # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% filter sort_lines %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -25,7 +25,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% filter sort_lines %}
 {% for method in service.methods.values() %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -24,7 +24,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% filter sort_lines %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -18,7 +18,7 @@ import warnings
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% extends '_base.py.j2' %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -17,7 +17,7 @@ import warnings
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 {% extends '_base.py.j2' %}

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -28,7 +28,7 @@ from google.oauth2 import service_account              # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -29,7 +29,7 @@ from google.oauth2 import service_account              # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore
 from google.api_core import operation_async  # type: ignore

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -32,7 +32,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -33,7 +33,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore
 from google.api_core import operation_async  # type: ignore

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
@@ -28,7 +28,7 @@ from google.oauth2 import service_account              # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.iam.credentials_v1.types import common

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
@@ -29,7 +29,7 @@ from google.oauth2 import service_account              # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.iam.credentials_v1.types import common
 from google.protobuf import duration_pb2  # type: ignore

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -33,7 +33,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.iam.credentials_v1.types import common
 from google.protobuf import duration_pb2  # type: ignore

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -32,7 +32,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.iam.credentials_v1.types import common

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -28,7 +28,7 @@ from google.oauth2 import service_account              # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.cloud.logging_v2.services.config_service_v2 import pagers

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -29,7 +29,7 @@ from google.oauth2 import service_account              # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.cloud.logging_v2.services.config_service_v2 import pagers
 from google.cloud.logging_v2.types import logging_config

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -33,7 +33,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.cloud.logging_v2.services.config_service_v2 import pagers
 from google.cloud.logging_v2.types import logging_config

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -32,7 +32,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.cloud.logging_v2.services.config_service_v2 import pagers

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -28,7 +28,7 @@ from google.oauth2 import service_account              # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import monitored_resource_pb2  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -29,7 +29,7 @@ from google.oauth2 import service_account              # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import monitored_resource_pb2  # type: ignore
 from google.cloud.logging_v2.services.logging_service_v2 import pagers

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -32,7 +32,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import monitored_resource_pb2  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -33,7 +33,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import monitored_resource_pb2  # type: ignore
 from google.cloud.logging_v2.services.logging_service_v2 import pagers

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -29,7 +29,7 @@ from google.oauth2 import service_account              # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import distribution_pb2  # type: ignore
 from google.api import metric_pb2  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -28,7 +28,7 @@ from google.oauth2 import service_account              # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import distribution_pb2  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -33,7 +33,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import distribution_pb2  # type: ignore
 from google.api import metric_pb2  # type: ignore

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -32,7 +32,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api import distribution_pb2  # type: ignore

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -28,7 +28,7 @@ from google.oauth2 import service_account              # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -29,7 +29,7 @@ from google.oauth2 import service_account              # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore
 from google.api_core import operation_async  # type: ignore

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -32,7 +32,7 @@ from google.oauth2 import service_account                         # type: ignore
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
-except AttributeError:
+except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -33,7 +33,7 @@ from google.oauth2 import service_account                         # type: ignore
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
 except AttributeError:
-    OptionalRetry = Union[retries.Retry, object]
+    OptionalRetry = Union[retries.Retry, object]  # type: ignore
 
 from google.api_core import operation  # type: ignore
 from google.api_core import operation_async  # type: ignore


### PR DESCRIPTION
Introduced in #1032.

`mypy` balks at rebinding a typename in the fallback:

```
google/cloud/datastore_v1/services/datastore/client.py:38: error: Cannot assign multiple types to name "OptionalRetry" without an explicit "Type[...]" annotation
```

Since the `object` fallback is only for older versions of `google-api-core`, which needed to be ignored anyway, ignoring the reassignment is safe.