### PR TITLE
fix: leave a newline between field description and oneof line

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
@@ -19,6 +19,7 @@ class {{ message.name }}({{ p }}.Message):
         {{ field.name }} ({{ field.ident.sphinx }}):
             {{ field.meta.doc|rst(indent=12, nl=False) }}
             {% if field.oneof %}
+
             This field is a member of `oneof`_ ``{{ field.oneof }}``.
             {% endif %}
     {% endfor %}

--- a/gapic/templates/%namespace/%name_%version/%sub/types/_message.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/_message.py.j2
@@ -19,6 +19,7 @@ class {{ message.name }}({{ p }}.Message):
         {{ field.name }} ({{ field.ident.sphinx }}):
             {{ field.meta.doc|rst(indent=12, nl=False) }}
             {% if field.oneof %}
+
             This field is a member of `oneof`_ ``{{ field.oneof }}``.
             {% endif %}
     {% endfor %}

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/types/asset_service.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/types/asset_service.py
@@ -522,11 +522,13 @@ class OutputConfig(proto.Message):
     Attributes:
         gcs_destination (google.cloud.asset_v1.types.GcsDestination):
             Destination on Cloud Storage.
+
             This field is a member of `oneof`_ ``destination``.
         bigquery_destination (google.cloud.asset_v1.types.BigQueryDestination):
             Destination on BigQuery. The output table
             stores the fields in asset proto as columns in
             BigQuery.
+
             This field is a member of `oneof`_ ``destination``.
     """
 
@@ -552,6 +554,7 @@ class OutputResult(proto.Message):
     Attributes:
         gcs_result (google.cloud.asset_v1.types.GcsOutputResult):
             Export result on Cloud Storage.
+
             This field is a member of `oneof`_ ``result``.
     """
 
@@ -600,6 +603,7 @@ class GcsDestination(proto.Message):
             there is no
             `hold <https://cloud.google.com/storage/docs/object-holds>`__,
             it will be overwritten with the exported result.
+
             This field is a member of `oneof`_ ``object_uri``.
         uri_prefix (str):
             The uri prefix of all generated Cloud Storage objects.
@@ -611,6 +615,7 @@ class GcsDestination(proto.Message):
             compute.googleapis.com/Disk assets. An INVALID_ARGUMENT
             error will be returned if file with the same name
             "gs://bucket_name/object_name_prefix" already exists.
+
             This field is a member of `oneof`_ ``object_uri``.
     """
 
@@ -777,6 +782,7 @@ class FeedOutputConfig(proto.Message):
     Attributes:
         pubsub_destination (google.cloud.asset_v1.types.PubsubDestination):
             Destination on Pub/Sub.
+
             This field is a member of `oneof`_ ``destination``.
     """
 
@@ -1452,6 +1458,7 @@ class IamPolicyAnalysisQuery(proto.Message):
                 conditions. Note that this value must not be earlier than
                 the current time; otherwise, an INVALID_ARGUMENT error will
                 be returned.
+
                 This field is a member of `oneof`_ ``TimeContext``.
         """
 
@@ -1617,9 +1624,11 @@ class IamPolicyAnalysisOutputConfig(proto.Message):
     Attributes:
         gcs_destination (google.cloud.asset_v1.types.IamPolicyAnalysisOutputConfig.GcsDestination):
             Destination on Cloud Storage.
+
             This field is a member of `oneof`_ ``destination``.
         bigquery_destination (google.cloud.asset_v1.types.IamPolicyAnalysisOutputConfig.BigQueryDestination):
             Destination on BigQuery.
+
             This field is a member of `oneof`_ ``destination``.
     """
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/types/assets.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/types/assets.py
@@ -178,14 +178,17 @@ class Asset(proto.Message):
         access_policy (google.identity.accesscontextmanager.v1.access_policy_pb2.AccessPolicy):
             Please also refer to the `access policy user
             guide <https://cloud.google.com/access-context-manager/docs/overview#access-policies>`__.
+
             This field is a member of `oneof`_ ``access_context_policy``.
         access_level (google.identity.accesscontextmanager.v1.access_level_pb2.AccessLevel):
             Please also refer to the `access level user
             guide <https://cloud.google.com/access-context-manager/docs/overview#access-levels>`__.
+
             This field is a member of `oneof`_ ``access_context_policy``.
         service_perimeter (google.identity.accesscontextmanager.v1.service_perimeter_pb2.ServicePerimeter):
             Please also refer to the `service perimeter user
             guide <https://cloud.google.com/vpc-service-controls/docs/overview>`__.
+
             This field is a member of `oneof`_ ``access_context_policy``.
         os_inventory (google.cloud.osconfig.v1.inventory_pb2.Inventory):
             A representation of runtime OS Inventory information. See
@@ -902,9 +905,11 @@ class IamPolicyAnalysisResult(proto.Message):
         Attributes:
             role (str):
                 The role.
+
                 This field is a member of `oneof`_ ``oneof_access``.
             permission (str):
                 The permission.
+
                 This field is a member of `oneof`_ ``oneof_access``.
             analysis_state (google.cloud.asset_v1.types.IamPolicyAnalysisState):
                 The analysis state of this access.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/types/log_entry.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/types/log_entry.py
@@ -91,14 +91,17 @@ class LogEntry(proto.Message):
 
             "type.googleapis.com/google.cloud.audit.AuditLog"
             "type.googleapis.com/google.appengine.logging.v1.RequestLog".
+
             This field is a member of `oneof`_ ``payload``.
         text_payload (str):
             The log entry payload, represented as a
             Unicode string (UTF-8).
+
             This field is a member of `oneof`_ ``payload``.
         json_payload (google.protobuf.struct_pb2.Struct):
             The log entry payload, represented as a
             structure that is expressed as a JSON object.
+
             This field is a member of `oneof`_ ``payload``.
         timestamp (google.protobuf.timestamp_pb2.Timestamp):
             Optional. The time the event described by the log entry

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/types/logging_config.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/types/logging_config.py
@@ -282,6 +282,7 @@ class LogSink(proto.Message):
         bigquery_options (google.cloud.logging_v2.types.BigQueryOptions):
             Optional. Options that affect sinks exporting
             data to BigQuery.
+
             This field is a member of `oneof`_ ``options``.
         create_time (google.protobuf.timestamp_pb2.Timestamp):
             Output only. The creation timestamp of the

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/types/cloud_redis.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/types/cloud_redis.py
@@ -507,6 +507,7 @@ class InputConfig(proto.Message):
         gcs_source (google.cloud.redis_v1.types.GcsSource):
             Google Cloud Storage location where input
             content is located.
+
             This field is a member of `oneof`_ ``source``.
     """
 
@@ -567,6 +568,7 @@ class OutputConfig(proto.Message):
         gcs_destination (google.cloud.redis_v1.types.GcsDestination):
             Google Cloud Storage destination for output
             content.
+
             This field is a member of `oneof`_ ``destination``.
     """
 


### PR DESCRIPTION
Fixes #1064.

Always adding a blank line is the easiest way to fix #1064. I looked at some generated docs and this seems better for readability when the attribute description is longer than 2-3 sentences.

It looks a little strange in the code if the description is short but does not break sphinx.