### PR TITLE
fix: fix rest unit test

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1293,7 +1293,7 @@ def test_{{ method.name|snake_case }}_rest_flattened(transport: str = 'rest'):
         assert len(req.mock_calls) == 1
         _, args, _ = req.mock_calls[0]
         {% with uri = method.http_options[0].uri %}
-        assert path_template.validate("https://{{ service.host }}{{ uri }}", args[1])
+        assert path_template.validate("https://%s{{ uri }}" % client.transport._host, args[1])
         {% endwith %}
         {# TODO(kbandes) - reverse-transcode request args to check all request fields #}
 


### PR DESCRIPTION
In some cases `hostname:port` format was expected.