### PR TITLE
Update call to ClientInfo to pass `client_library_version`

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
@@ -23,7 +23,7 @@ from google.auth import credentials as ga_credentials  # type: ignore
 
 try:
     DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
+        client_library_version=pkg_resources.get_distribution(
             '{{ api.naming.warehouse_package_name }}',
         ).version,
     )


### PR DESCRIPTION
This replaces the `gapic_version` kwarg. According to the [refdocs](https://github.com/googleapis/python-api-core/blob/main/google/api_core/client_info.py#L53) for `ClientInfo`, `client_library_version` should be used "if additional functionality was built on top of a gapic client library." Which is true for Ads.

I'm not sure if there are other changes that need to be made to support this, particularly in the tests.