### PR TITLE
chore: remove actools@ from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,5 +4,5 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-* @googleapis/actools @googleapis/actools-python @googleapis/yoshi-python
-*.yaml @googleapis/actools @googleapis/yoshi-python @googleapis/actools-python
+* @googleapis/actools-python @googleapis/yoshi-python
+*.yaml @googleapis/yoshi-python @googleapis/actools-python


### PR DESCRIPTION
Removes actools@ from CODEOWNERS. Vadym, Aza, Sijun, Victor, and Dov should be able to approve things via actools-python.

This makes things a little less noisy for the rest of the team and ensures that we cannot approve things we shouldn't be able to. 