### PR TITLE
fix: fix case for expected field names in required fields test.

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1323,7 +1323,7 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
             expected_params = [
                 {% for req_field in method.input.required_fields if req_field.is_primitive %}
                 (
-                    "{{ req_field.name }}",
+                    "{{ req_field.name | camel_case }}",
                     {% if req_field.field_pb.default_value is string %}
                     "{{ req_field.field_pb.default_value }}",
                     {% else %}


### PR DESCRIPTION
The generated test for methods with required fields should have expected the field names to use camel case, but did not.  This should correct that.