### PR TITLE
fix: add additional reserved names for disambiguation

### DIFF
--- a/gapic/utils/reserved_names.py
+++ b/gapic/utils/reserved_names.py
@@ -25,5 +25,8 @@ RESERVED_NAMES = frozenset(
         keyword.kwlist,
         # We make SOME exceptions for certain names that collide with builtins.
         set(dir(builtins)) - {"filter", "map", "id", "input", "property"},
+        # "mapping" and "ignore_unknown_fields" have special uses
+        # in the constructor of proto.Message
+        {"mapping", "ignore_unknown_fields"},
     )
 )

--- a/tests/unit/samplegen/test_integration.py
+++ b/tests/unit/samplegen/test_integration.py
@@ -23,7 +23,7 @@ from gapic.samplegen import samplegen
 from gapic.samplegen_utils import (types, utils as gapic_utils)
 from gapic.schema import (naming, wrappers)
 
-from tests.unit.samplegen.common_types import (DummyField, DummyMessage,
+from common_types import (DummyField, DummyMessage,
 
                           DummyMessageTypePB, DummyMethod, DummyService, DummyIdent,
                           DummyApiSchema, DummyNaming, enum_factory, message_factory)

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -21,7 +21,7 @@ import gapic.utils as utils
 
 from gapic.samplegen_utils.types import CallingForm
 from textwrap import dedent
-from tests.unit.samplegen import common_types
+import common_types
 
 
 def check_template(template_fragment, expected_output, **kwargs):

--- a/tests/unit/schema/wrappers/test_field.py
+++ b/tests/unit/schema/wrappers/test_field.py
@@ -357,6 +357,9 @@ def test_field_name_kword_disambiguation():
     )
     assert frum_field.name == "frum"
 
+    mapping_field = make_field(name="mapping")
+    assert mapping_field.name == "mapping_"
+
 
 def test_field_resource_reference():
     field = make_field(name='parent', type='TYPE_STRING')

--- a/tests/unit/schema/wrappers/test_field.py
+++ b/tests/unit/schema/wrappers/test_field.py
@@ -360,6 +360,9 @@ def test_field_name_kword_disambiguation():
     mapping_field = make_field(name="mapping")
     assert mapping_field.name == "mapping_"
 
+    ignore_field = make_field(name="ignore_unknown_fields")
+    assert ignore_field.name == "ignore_unknown_fields_"
+
 
 def test_field_resource_reference():
     field = make_field(name='parent', type='TYPE_STRING')


### PR DESCRIPTION
The monikers "mapping" and "ignore_unknown_fields" have reserved
meaning in the constructor of proto.Message and therefore any fields
with those names need disambiguation.