### PR TITLE
chore: set package version to 0.60.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ from setuptools import find_packages, setup  # type: ignore
 
 PACKAGE_ROOT = os.path.abspath(os.path.dirname(__file__))
 
-version = "0.35.10"
+version = "0.60.0"
 
 with io.open(os.path.join(PACKAGE_ROOT, "README.rst")) as file_obj:
     README = file_obj.read()


### PR DESCRIPTION
I'm hoping this will fix the versioning issue with release please where it shows version 0.39.1 instead of 0.60.1 [here](https://github.com/googleapis/gapic-generator-python/pull/1160).