### PR TITLE
fix: add special method parameters to set of reserved module names

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -263,7 +263,8 @@ class API:
         ), opts=opts)
 
         # "metadata", "retry", "timeout", and "request" are reserved words in client methods.
-        invalid_module_names = set(keyword.kwlist) | {"metadata", "retry", "timeout", "request"}
+        invalid_module_names = set(keyword.kwlist) | {
+            "metadata", "retry", "timeout", "request"}
 
         def disambiguate_keyword_fname(
                 full_path: str,

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -262,12 +262,15 @@ class API:
             file_descriptors,
         ), opts=opts)
 
+        # "metadata", "retry", "timeout", and "request" are reserved words in client methods.
+        invalid_module_names = set(keyword.kwlist) | {"metadata", "retry", "timeout", "request"}
+
         def disambiguate_keyword_fname(
                 full_path: str,
                 visited_names: Container[str]) -> str:
             path, fname = os.path.split(full_path)
             name, ext = os.path.splitext(fname)
-            if name in keyword.kwlist or full_path in visited_names:
+            if name in invalid_module_names or full_path in visited_names:
                 name += "_"
                 full_path = os.path.join(path, name + ext)
                 if full_path in visited_names:

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -233,7 +233,27 @@ def test_proto_keyword_fname():
             name='class.proto',
             package='google.keywords.v1',
             messages=(make_message_pb2(name='ClassRequest', fields=()),),
-        )
+        ),
+        make_file_pb2(
+            name='metadata.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='MetadataRequest', fields=()),),
+        ),
+        make_file_pb2(
+            name='retry.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='RetryRequest', fields=()),),
+        ),
+        make_file_pb2(
+            name='timeout.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='TimeoutRequest', fields=()),),
+        ),
+        make_file_pb2(
+            name='request.proto',
+            package='google.keywords.v1',
+            messages=(make_message_pb2(name='RequestRequest', fields=()),),
+        ),
     )
 
     # We can't create new collisions, so check that renames cascade.
@@ -243,6 +263,10 @@ def test_proto_keyword_fname():
         'import__.proto',
         'class_.proto',
         'class__.proto',
+        'metadata_.proto',
+        'retry_.proto',
+        'timeout_.proto',
+        'request_.proto',
     }
 
 


### PR DESCRIPTION
Ignoring flattened parameters, there are four special parameters to
all client methods:
* request
* retry
* timeout
* metadata

These cannot conflict with module names, and so the module names must
be disambiguated.

Fixes #1165 