### PR TITLE
feat: enable snippetgen for default templates

### DIFF
--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -38,7 +38,7 @@ class Options:
     warehouse_package_name: str = ''
     retry: Optional[Dict[str, Any]] = None
     sample_configs: Tuple[str, ...] = dataclasses.field(default=())
-    autogen_snippets: bool = False
+    autogen_snippets: bool = True
     templates: Tuple[str, ...] = dataclasses.field(default=('DEFAULT',))
     lazy_import: bool = False
     old_naming: bool = False
@@ -146,6 +146,17 @@ class Options:
         # Build the options instance.
         sample_paths = opts.pop('samples', [])
 
+        # autogen-snippets is True by default, so make sure users can disable
+        # by passing `autogen-snippets=false`
+        autogen_snippets = opts.pop(
+            "autogen-snippets", ["True"])[0] in ("True", "true", "T", "t", "TRUE")
+
+        # NOTE: Snippets are not currently correct for the alternative (Ads) templates
+        # so always disable snippetgen in that case
+        # https://github.com/googleapis/gapic-generator-python/issues/1052
+        if opts.get("old-naming"):
+            autogen_snippets = False
+
         answer = Options(
             name=opts.pop('name', ['']).pop(),
             namespace=tuple(opts.pop('namespace', [])),
@@ -157,7 +168,7 @@ class Options:
                 for s in sample_paths
                 for cfg_path in samplegen_utils.generate_all_sample_fpaths(s)
             ),
-            autogen_snippets=bool(opts.pop("autogen-snippets", False)),
+            autogen_snippets=autogen_snippets,
             templates=tuple(path.expanduser(i) for i in templates),
             lazy_import=bool(opts.pop('lazy-import', False)),
             old_naming=bool(opts.pop('old-naming', False)),

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -154,7 +154,7 @@ class Options:
         # NOTE: Snippets are not currently correct for the alternative (Ads) templates
         # so always disable snippetgen in that case
         # https://github.com/googleapis/gapic-generator-python/issues/1052
-        old_naming=bool(opts.pop('old-naming', False))
+        old_naming = bool(opts.pop('old-naming', False))
         if old_naming:
             autogen_snippets = False
 

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -154,7 +154,8 @@ class Options:
         # NOTE: Snippets are not currently correct for the alternative (Ads) templates
         # so always disable snippetgen in that case
         # https://github.com/googleapis/gapic-generator-python/issues/1052
-        if opts.get("old-naming"):
+        old_naming=bool(opts.pop('old-naming', False))
+        if old_naming:
             autogen_snippets = False
 
         answer = Options(
@@ -171,7 +172,7 @@ class Options:
             autogen_snippets=autogen_snippets,
             templates=tuple(path.expanduser(i) for i in templates),
             lazy_import=bool(opts.pop('lazy-import', False)),
-            old_naming=bool(opts.pop('old-naming', False)),
+            old_naming=old_naming,
             add_iam_methods=bool(opts.pop('add-iam-methods', False)),
             metadata=bool(opts.pop('metadata', False)),
             # transport should include desired transports delimited by '+', e.g. transport='grpc+rest'

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -255,7 +255,10 @@ def test_get_response_enumerates_proto():
 
 
 def test_get_response_divides_subpackages():
-    g = make_generator()
+    # NOTE: autogen-snippets is intentionally disabled for this test
+    # The API schema below is incomplete and will result in errors when the
+    # snippetgen logic tries to parse it.
+    g = make_generator("autogen-snippets=false")
     api_schema = api.API.build(
         [
             descriptor_pb2.FileDescriptorProto(
@@ -290,7 +293,7 @@ def test_get_response_divides_subpackages():
             """.strip()
             )
             cgr = g.get_response(api_schema=api_schema,
-                                 opts=Options.build(""))
+                                 opts=Options.build("autogen-snippets=false"))
             assert len(cgr.file) == 6
             assert {i.name for i in cgr.file} == {
                 "foo/types/top.py",

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -469,7 +469,7 @@ def test_samplegen_config_to_output_files(mock_gmtime, fs):
 
     with mock.patch("gapic.samplegen.samplegen.generate_sample", side_effect=mock_generate_sample):
         actual_response = g.get_response(
-            api_schema, opts=Options.build(""))
+            api_schema, opts=Options.build("autogen-snippets=False"))
 
     expected_snippet_index_json = {
         "snippets": [
@@ -609,7 +609,7 @@ def test_samplegen_id_disambiguation(mock_gmtime, fs):
     )
     with mock.patch("gapic.samplegen.samplegen.generate_sample", side_effect=mock_generate_sample):
         actual_response = g.get_response(api_schema,
-                                     opts=Options.build(""))
+                                     opts=Options.build("autogen-snippets=False"))
 
     expected_snippet_metadata_json = {
         "snippets": [

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -171,9 +171,7 @@ def test_options_service_yaml_config(fs):
 
 
 def test_options_bool_flags():
-    # All these options are default False.
-    # If new options violate this assumption,
-    # this test may need to be tweaked.
+    # Most options are default False.
     # New options should follow the dash-case/snake_case convention.
     opt_str_to_attr_name = {
         name: re.sub(r"-", "_", name)
@@ -191,3 +189,22 @@ def test_options_bool_flags():
 
         options = Options.build(opt)
         assert getattr(options, attr)
+
+    # Check autogen-snippets separately, as it is default True
+    options = Options.build("")
+    assert options.autogen_snippets
+
+    options = Options.build("autogen-snippets=False")
+    assert not options.autogen_snippets
+
+
+def test_options_autogen_snippets_false_for_old_naming():
+    # NOTE: Snippets are not currently correct for the alternative (Ads) templates
+    # so always disable snippetgen in that case
+    # https://github.com/googleapis/gapic-generator-python/issues/1052
+    options = Options.build("old-naming")
+    assert not options.autogen_snippets
+
+    # Even if autogen-snippets is set to True, do not enable snippetgen
+    options = Options.build("old-naming,autogen-snippets=True")
+    assert not options.autogen_snippets


### PR DESCRIPTION
Enable snippetgen for the default (non-Ads) templates.

This reverts commit 8bdb70931a9ecb1c89fda9608697b0762770bc12 (which was a revert of #1044 and #1055).

I've checked that the changes are OK (don't break generation for any APIs) by creating a [tag](https://github.com/googleapis/gapic-generator-python/commits/v0.62.0b1) and running the [presubmit](https://critique.corp.google.com/cl/424921742). 