### PR TITLE
chore: restore 100% coverage for generated clients

### DIFF
--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -395,42 +395,6 @@ def test_{{ service.client_name|snake_case }}_client_options_credentials_file(cl
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
         )
-
-    {% if 'grpc' in opts.transport %}
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            {% with host = (service.host|default('localhost', true)) %}
-            create_channel.assert_called_with(
-                "{{ host }}{% if ":" not in service.host %}:443{% endif %}",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    {% for scope in service.oauth_scopes %}
-                    '{{ scope }}',
-                    {% endfor %}),
-                scopes=None,
-                default_host="{{ host }}",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-            {% endwith %}
-    {% endif %}
 {% if 'grpc' in opts.transport %}
 {# TODO(dovs): genericize this function#}
 
@@ -450,6 +414,63 @@ def test_{{ service.client_name|snake_case }}_client_options_from_dict():
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
         )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name", [
+    ({{ service.client_name }}, transports.{{ service.grpc_transport_name }}, "grpc"),
+])
+def test_{{ service.client_name|snake_case }}_create_channel_credentials_file(client_class, transport_class, transport_name):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        {% with host = (service.host|default('localhost', true)) %}
+        create_channel.assert_called_with(
+            "{{ host }}{% if ":" not in service.host %}:443{% endif %}",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                {% for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {% endfor %}),
+            scopes=None,
+            default_host="{{ host }}",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+        {% endwith %}
 {% endif %}
 
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -476,42 +476,6 @@ def test_{{ service.client_name|snake_case }}_client_options_credentials_file(cl
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
         )
-
-    {% if 'grpc' in opts.transport %}
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            {% with host = (service.host|default('localhost', true)) %}
-            create_channel.assert_called_with(
-                "{{ host }}{% if ":" not in service.host %}:443{% endif %}",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    {% for scope in service.oauth_scopes %}
-                    '{{ scope }}',
-                    {% endfor %}),
-                scopes=None,
-                default_host="{{ host }}",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-            {% endwith %}
-    {% endif %}
 {% if 'grpc' in opts.transport %}
 {# TODO(dovs): genericize this function#}
 
@@ -531,6 +495,64 @@ def test_{{ service.client_name|snake_case }}_client_options_from_dict():
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
         )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name,grpc_helpers", [
+    ({{ service.client_name }}, transports.{{ service.grpc_transport_name }}, "grpc", grpc_helpers),
+    ({{ service.async_client_name }}, transports.{{ service.grpc_asyncio_transport_name }}, "grpc_asyncio", grpc_helpers_async),
+])
+def test_{{ service.client_name|snake_case }}_create_channel_credentials_file(client_class, transport_class, transport_name, grpc_helpers):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        {% with host = (service.host|default('localhost', true)) %}
+        create_channel.assert_called_with(
+            "{{ host }}{% if ":" not in service.host %}:443{% endif %}",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                {% for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {% endfor %}),
+            scopes=None,
+            default_host="{{ host }}",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
+        )
+        {% endwith %}
 {% endif %}
 
 

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -418,37 +418,6 @@ def test_asset_service_client_client_options_credentials_file(client_class, tran
             always_use_jwt_access=True,
         )
 
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            create_channel.assert_called_with(
-                "cloudasset.googleapis.com:443",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-),
-                scopes=None,
-                default_host="cloudasset.googleapis.com",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-
 def test_asset_service_client_client_options_from_dict():
     with mock.patch('google.cloud.asset_v1.services.asset_service.transports.AssetServiceGrpcTransport.__init__') as grpc_transport:
         grpc_transport.return_value = None
@@ -464,6 +433,61 @@ def test_asset_service_client_client_options_from_dict():
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
+        )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name,grpc_helpers", [
+    (AssetServiceClient, transports.AssetServiceGrpcTransport, "grpc", grpc_helpers),
+    (AssetServiceAsyncClient, transports.AssetServiceGrpcAsyncIOTransport, "grpc_asyncio", grpc_helpers_async),
+])
+def test_asset_service_client_create_channel_credentials_file(client_class, transport_class, transport_name, grpc_helpers):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        create_channel.assert_called_with(
+            "cloudasset.googleapis.com:443",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                'https://www.googleapis.com/auth/cloud-platform',
+),
+            scopes=None,
+            default_host="cloudasset.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
         )
 
 

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -409,37 +409,6 @@ def test_iam_credentials_client_client_options_credentials_file(client_class, tr
             always_use_jwt_access=True,
         )
 
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            create_channel.assert_called_with(
-                "iamcredentials.googleapis.com:443",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-),
-                scopes=None,
-                default_host="iamcredentials.googleapis.com",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-
 def test_iam_credentials_client_client_options_from_dict():
     with mock.patch('google.iam.credentials_v1.services.iam_credentials.transports.IAMCredentialsGrpcTransport.__init__') as grpc_transport:
         grpc_transport.return_value = None
@@ -455,6 +424,61 @@ def test_iam_credentials_client_client_options_from_dict():
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
+        )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name,grpc_helpers", [
+    (IAMCredentialsClient, transports.IAMCredentialsGrpcTransport, "grpc", grpc_helpers),
+    (IAMCredentialsAsyncClient, transports.IAMCredentialsGrpcAsyncIOTransport, "grpc_asyncio", grpc_helpers_async),
+])
+def test_iam_credentials_client_create_channel_credentials_file(client_class, transport_class, transport_name, grpc_helpers):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        create_channel.assert_called_with(
+            "iamcredentials.googleapis.com:443",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                'https://www.googleapis.com/auth/cloud-platform',
+),
+            scopes=None,
+            default_host="iamcredentials.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
         )
 
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -410,40 +410,6 @@ def test_config_service_v2_client_client_options_credentials_file(client_class, 
             always_use_jwt_access=True,
         )
 
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            create_channel.assert_called_with(
-                "logging.googleapis.com:443",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-),
-                scopes=None,
-                default_host="logging.googleapis.com",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-
 def test_config_service_v2_client_client_options_from_dict():
     with mock.patch('google.cloud.logging_v2.services.config_service_v2.transports.ConfigServiceV2GrpcTransport.__init__') as grpc_transport:
         grpc_transport.return_value = None
@@ -459,6 +425,64 @@ def test_config_service_v2_client_client_options_from_dict():
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
+        )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name,grpc_helpers", [
+    (ConfigServiceV2Client, transports.ConfigServiceV2GrpcTransport, "grpc", grpc_helpers),
+    (ConfigServiceV2AsyncClient, transports.ConfigServiceV2GrpcAsyncIOTransport, "grpc_asyncio", grpc_helpers_async),
+])
+def test_config_service_v2_client_create_channel_credentials_file(client_class, transport_class, transport_name, grpc_helpers):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        create_channel.assert_called_with(
+            "logging.googleapis.com:443",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                'https://www.googleapis.com/auth/cloud-platform',
+                'https://www.googleapis.com/auth/cloud-platform.read-only',
+                'https://www.googleapis.com/auth/logging.admin',
+                'https://www.googleapis.com/auth/logging.read',
+),
+            scopes=None,
+            default_host="logging.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
         )
 
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -416,41 +416,6 @@ def test_logging_service_v2_client_client_options_credentials_file(client_class,
             always_use_jwt_access=True,
         )
 
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            create_channel.assert_called_with(
-                "logging.googleapis.com:443",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                    'https://www.googleapis.com/auth/logging.write',
-),
-                scopes=None,
-                default_host="logging.googleapis.com",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-
 def test_logging_service_v2_client_client_options_from_dict():
     with mock.patch('google.cloud.logging_v2.services.logging_service_v2.transports.LoggingServiceV2GrpcTransport.__init__') as grpc_transport:
         grpc_transport.return_value = None
@@ -466,6 +431,65 @@ def test_logging_service_v2_client_client_options_from_dict():
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
+        )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name,grpc_helpers", [
+    (LoggingServiceV2Client, transports.LoggingServiceV2GrpcTransport, "grpc", grpc_helpers),
+    (LoggingServiceV2AsyncClient, transports.LoggingServiceV2GrpcAsyncIOTransport, "grpc_asyncio", grpc_helpers_async),
+])
+def test_logging_service_v2_client_create_channel_credentials_file(client_class, transport_class, transport_name, grpc_helpers):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        create_channel.assert_called_with(
+            "logging.googleapis.com:443",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                'https://www.googleapis.com/auth/cloud-platform',
+                'https://www.googleapis.com/auth/cloud-platform.read-only',
+                'https://www.googleapis.com/auth/logging.admin',
+                'https://www.googleapis.com/auth/logging.read',
+                'https://www.googleapis.com/auth/logging.write',
+),
+            scopes=None,
+            default_host="logging.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
         )
 
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -414,41 +414,6 @@ def test_metrics_service_v2_client_client_options_credentials_file(client_class,
             always_use_jwt_access=True,
         )
 
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            create_channel.assert_called_with(
-                "logging.googleapis.com:443",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-                    'https://www.googleapis.com/auth/cloud-platform.read-only',
-                    'https://www.googleapis.com/auth/logging.admin',
-                    'https://www.googleapis.com/auth/logging.read',
-                    'https://www.googleapis.com/auth/logging.write',
-),
-                scopes=None,
-                default_host="logging.googleapis.com",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-
 def test_metrics_service_v2_client_client_options_from_dict():
     with mock.patch('google.cloud.logging_v2.services.metrics_service_v2.transports.MetricsServiceV2GrpcTransport.__init__') as grpc_transport:
         grpc_transport.return_value = None
@@ -464,6 +429,65 @@ def test_metrics_service_v2_client_client_options_from_dict():
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
+        )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name,grpc_helpers", [
+    (MetricsServiceV2Client, transports.MetricsServiceV2GrpcTransport, "grpc", grpc_helpers),
+    (MetricsServiceV2AsyncClient, transports.MetricsServiceV2GrpcAsyncIOTransport, "grpc_asyncio", grpc_helpers_async),
+])
+def test_metrics_service_v2_client_create_channel_credentials_file(client_class, transport_class, transport_name, grpc_helpers):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        create_channel.assert_called_with(
+            "logging.googleapis.com:443",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                'https://www.googleapis.com/auth/cloud-platform',
+                'https://www.googleapis.com/auth/cloud-platform.read-only',
+                'https://www.googleapis.com/auth/logging.admin',
+                'https://www.googleapis.com/auth/logging.read',
+                'https://www.googleapis.com/auth/logging.write',
+),
+            scopes=None,
+            default_host="logging.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
         )
 
 

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -415,37 +415,6 @@ def test_cloud_redis_client_client_options_credentials_file(client_class, transp
             always_use_jwt_access=True,
         )
 
-    if "grpc" in transport_name:
-        # test that the credentials from file are saved and used as the credentials.
-        with mock.patch.object(
-            google.auth, "load_credentials_from_file", autospec=True
-        ) as load_creds, mock.patch.object(
-            google.auth, "default", autospec=True
-        ) as adc, mock.patch.object(
-            grpc_helpers, "create_channel"
-        ) as create_channel:
-            creds = ga_credentials.AnonymousCredentials()
-            file_creds = ga_credentials.AnonymousCredentials()
-            load_creds.return_value = (file_creds, None)
-            adc.return_value = (creds, None)
-            client = client_class(client_options=options, transport=transport_name)
-            create_channel.assert_called_with(
-                "redis.googleapis.com:443",
-                credentials=file_creds,
-                credentials_file=None,
-                quota_project_id=None,
-                default_scopes=(
-                    'https://www.googleapis.com/auth/cloud-platform',
-),
-                scopes=None,
-                default_host="redis.googleapis.com",
-                ssl_credentials=None,
-                options=[
-                    ("grpc.max_send_message_length", -1),
-                    ("grpc.max_receive_message_length", -1),
-                ],
-            )
-
 def test_cloud_redis_client_client_options_from_dict():
     with mock.patch('google.cloud.redis_v1.services.cloud_redis.transports.CloudRedisGrpcTransport.__init__') as grpc_transport:
         grpc_transport.return_value = None
@@ -461,6 +430,61 @@ def test_cloud_redis_client_client_options_from_dict():
             quota_project_id=None,
             client_info=transports.base.DEFAULT_CLIENT_INFO,
             always_use_jwt_access=True,
+        )
+
+
+@pytest.mark.parametrize("client_class,transport_class,transport_name,grpc_helpers", [
+    (CloudRedisClient, transports.CloudRedisGrpcTransport, "grpc", grpc_helpers),
+    (CloudRedisAsyncClient, transports.CloudRedisGrpcAsyncIOTransport, "grpc_asyncio", grpc_helpers_async),
+])
+def test_cloud_redis_client_create_channel_credentials_file(client_class, transport_class, transport_name, grpc_helpers):
+    # Check the case credentials file is provided.
+    options = client_options.ClientOptions(
+        credentials_file="credentials.json"
+    )
+
+    with mock.patch.object(transport_class, '__init__') as patched:
+        patched.return_value = None
+        client = client_class(client_options=options, transport=transport_name)
+        patched.assert_called_once_with(
+            credentials=None,
+            credentials_file="credentials.json",
+            host=client.DEFAULT_ENDPOINT,
+            scopes=None,
+            client_cert_source_for_mtls=None,
+            quota_project_id=None,
+            client_info=transports.base.DEFAULT_CLIENT_INFO,
+            always_use_jwt_access=True,
+        )
+
+    # test that the credentials from file are saved and used as the credentials.
+    with mock.patch.object(
+        google.auth, "load_credentials_from_file", autospec=True
+    ) as load_creds, mock.patch.object(
+        google.auth, "default", autospec=True
+    ) as adc, mock.patch.object(
+        grpc_helpers, "create_channel"
+    ) as create_channel:
+        creds = ga_credentials.AnonymousCredentials()
+        file_creds = ga_credentials.AnonymousCredentials()
+        load_creds.return_value = (file_creds, None)
+        adc.return_value = (creds, None)
+        client = client_class(client_options=options, transport=transport_name)
+        create_channel.assert_called_with(
+            "redis.googleapis.com:443",
+            credentials=file_creds,
+            credentials_file=None,
+            quota_project_id=None,
+            default_scopes=(
+                'https://www.googleapis.com/auth/cloud-platform',
+),
+            scopes=None,
+            default_host="redis.googleapis.com",
+            ssl_credentials=None,
+            options=[
+                ("grpc.max_send_message_length", -1),
+                ("grpc.max_receive_message_length", -1),
+            ],
         )
 
 


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/googleapis/gapic-generator-python/pull/1159 where code coverage for the generated client dropped to 99%.

![image](https://user-images.githubusercontent.com/5184014/151659296-03d9bcac-f01e-4f06-a561-a1a80727f25b.png)
