### PR TITLE
fix(deps): require setuptools<=60.5.0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -380,7 +380,7 @@ def showcase_mypy(
     """Perform typecheck analysis on the generated Showcase library."""
 
     # Install pytest and gapic-generator-python
-    session.install("mypy", "types-pkg-resources", "types-protobuf<=3.19.7", "types-requests", "types-dataclasses")
+    session.install("mypy", "types-pkg-resources", "types-protobuf", "types-requests", "types-dataclasses")
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
         session.chdir(lib)
@@ -443,6 +443,6 @@ def docs(session):
 def mypy(session):
     """Perform typecheck analysis."""
 
-    session.install("mypy", "types-protobuf", "types-PyYAML", "types-dataclasses")
+    session.install("mypy", "types-protobuf<=3.19.7", "types-PyYAML", "types-dataclasses")
     session.install(".")
     session.run("mypy", "gapic")

--- a/noxfile.py
+++ b/noxfile.py
@@ -380,7 +380,7 @@ def showcase_mypy(
     """Perform typecheck analysis on the generated Showcase library."""
 
     # Install pytest and gapic-generator-python
-    session.install("mypy", "types-pkg-resources", "types-protobuf", "types-requests", "types-dataclasses")
+    session.install("mypy", "types-pkg-resources", "types-protobuf<=3.19.7", "types-requests", "types-dataclasses")
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
         session.chdir(lib)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ protobuf==3.19.4
 pypandoc==1.7.2
 PyYAML==6.0
 dataclasses==0.6  # TODO(busunkim) remove when 3.6 support is dropped
+setuptools<=60.5.0 # pin setuptools to workaround https://github.com/pypa/setuptools/issues/3072


### PR DESCRIPTION
- pin setuptools<=60.5.0. See https://github.com/pypa/setuptools/issues/3072
- pin types-protobuf<=3.19.7 in `mypy` nox session. See https://github.com/googleapis/gapic-generator-python/issues/1180