### PR TITLE
fix: HTTP body field messages with enums or recursive fields

### DIFF
--- a/test_utils/test_utils.py
+++ b/test_utils/test_utils.py
@@ -297,7 +297,7 @@ def make_enum(
     name: str,
     package: str = 'foo.bar.v1',
     module: str = 'baz',
-    values: typing.Tuple[str, int] = (),
+    values: typing.Sequence[typing.Tuple[str, int]] = (),
     meta: metadata.Metadata = None,
     options: desc.EnumOptions = None,
 ) -> wrappers.EnumType:

--- a/tests/fragments/test_non_primitive_body.proto
+++ b/tests/fragments/test_non_primitive_body.proto
@@ -29,6 +29,20 @@ service SmallCompute {
       post: "/computation/v1/first_name/{first_name}/last_name/{last_name}"
     };
   };
+
+  rpc EnumBody(EnumBodyRequest) returns (EnumBodyResponse) {
+    option (google.api.http) = {
+      body: "resource"
+      post: "/enum_body/v1/names/{name}"
+    };
+  }
+
+  rpc RecursiveBody(RecursiveBodyRequest) returns (RecursiveBodyResponse) {
+    option (google.api.http) = {
+      body: "resource"
+      post: "/recursive_body/v1/names/{name}"
+    };
+  }
 }
 
 message SerialNumber {
@@ -50,4 +64,38 @@ message MethodRequest {
 
 message MethodResponse {
   string name = 1;
+}
+
+message EnumBodyRequest {
+  message Resource{
+    enum Ordering {
+      UNKNOWN = 0;
+      CHRONOLOGICAL = 1;
+      ALPHABETICAL = 2;
+      DIFFICULTY = 3;
+    }
+
+    Ordering ordering = 1;
+  }
+
+  string name = 1;
+  Resource resource = 2;
+}
+
+message EnumBodyResponse {
+  string data = 1;
+}
+
+message RecursiveBodyRequest {
+  message Resource {
+    int32 depth = 1;
+    Resource child_resource = 2;
+  }
+
+  string name = 1;
+  Resource resource = 2;
+}
+
+message RecursiveBodyResponse {
+  string data = 1;
 }


### PR DESCRIPTION
Minor fix for a generating unit tests for methods where the message
that is the body field has a field that is an enum or a recursive
field message type.