### PR TITLE
chore: disable mtls showcase tests

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,8 +10,10 @@ branchProtectionRules:
     - 'mypy'
     - 'showcase (showcase)'
     - 'showcase (showcase_alternative_templates)'
-    - 'showcase-mtls (showcase_mtls)'
-    - 'showcase-mtls (showcase_mtls_alternative_templates)'
+    # TODO(dovs): reenable these when the mtls tests have been debugged and fixed
+    # See #1218 for details
+    # - 'showcase-mtls (showcase_mtls)'
+    # - 'showcase-mtls (showcase_mtls_alternative_templates)'
     - 'showcase-mypy'
     - 'showcase-mypy (_alternative_templates)'
     - 'showcase-unit (3.6)'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -81,6 +81,7 @@ jobs:
       - name: Run showcase tests.
         run: nox -s ${{ matrix.target }}
   showcase-mtls:
+    if: ${{ false }}            # TODO(dovs): reenable when #1218 is fixed
     strategy:
       matrix:
         target: [showcase_mtls, showcase_mtls_alternative_templates]


### PR DESCRIPTION
The mtls showcase_mtls and showcase_mtls_alternative_templates tests
have started timing out in CI and are blocking PRs. Disable them until
further notice.

See #1218 for details.