### PR TITLE
fix: retry all search() request pages

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
@@ -209,6 +209,8 @@
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
         {% elif method.extended_lro and full_extended_lro %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
@@ -181,6 +181,17 @@
         )
         {% endif %} {# method.explicit_routing #}
 
+        {% if method.paged_result_field %}
+        # This method is paged; wrap the requests and responses in a
+        # pager, which provides an `__iter__` convenience method.
+        response = {{ method.client_output.ident }}(
+            method=rpc,
+            request=request,
+            retry=retry,
+            timeout=timeout,
+            metadata=metadata,
+        )
+        {% else %}
         # Send the request.
         {%+ if not method.void %}response = {% endif %}rpc(
             {% if not method.client_streaming %}
@@ -201,20 +212,9 @@
             {{ method.lro.response_type.ident }},
             metadata_type={{ method.lro.metadata_type.ident }},
         )
-        {% elif method.paged_result_field %}
-
-        # This method is paged; wrap the response in a pager, which provides
-        # an `__iter__` convenience method.
-        response = {{ method.client_output.ident }}(
-            method=rpc,
-            request=request,
-            response=response,
-            retry=retry,
-            timeout=timeout,
-            metadata=metadata,
-        )
         {% elif method.extended_lro and full_extended_lro %}
 {{ extended_operation_service_setup(api, method) }}
+        {% endif %}
         {% endif %}
         {% if not method.void %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
@@ -44,7 +44,6 @@ class {{ method.name }}Pager:
     def __init__(self,
             method: Callable[..., {{ method.output.ident }}],
             request: {{ method.input.ident }},
-            response: {{ method.output.ident }},
             *,
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: float = None,
@@ -56,27 +55,37 @@ class {{ method.name }}Pager:
                 which instantiated this pager.
             request ({{ method.input.ident.sphinx }}):
                 The initial request object.
-            response ({{ method.output.ident.sphinx }}):
-                The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors, if any,
+                should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = {{ method.input.ident }}(request)
-        self._response = response
+        self._response = None
         self._retry = retry
         self._timeout = timeout
         self._metadata = metadata
 
+    def _send_request(self, prev_response=None):
+        if prev_response:
+            self._request.page_token = prev_response.next_page_token
+        return self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
+
+    def _curr_response(self):
+        if self._response is None:
+            self._response = self._send_request()
+        return self._response
+
     def __getattr__(self, name: str) -> Any:
-        return getattr(self._response, name)
+        return getattr(self._curr_response(), name)
 
     @property
     def pages(self) -> Iterator[{{ method.output.ident }}]:
-        yield self._response
-        while self._response.next_page_token:
-            self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
+        yield self._curr_response()
+        while self._curr_response().next_page_token:
+            self._response = self._send_request(self._response)
             yield self._response
 
     {% if method.paged_result_field.map %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
@@ -9,6 +9,7 @@
  #}
 from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
 
+from google.api_core import gapic_v1
 {% filter sort_lines %}
 {% for method in service.methods.values() | selectattr('paged_result_field') %}
 {{ method.input.ident.python_import }}
@@ -19,6 +20,8 @@ from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Opt
 {% endfor %}
 {% endfilter %}
 {% endif %}
+
+from .client import OptionalRetry
 
 
 class {{ method.name }}Pager:
@@ -43,6 +46,8 @@ class {{ method.name }}Pager:
             request: {{ method.input.ident }},
             response: {{ method.output.ident }},
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: float = None,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -59,6 +64,8 @@ class {{ method.name }}Pager:
         self._method = method
         self._request = {{ method.input.ident }}(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -69,7 +76,7 @@ class {{ method.name }}Pager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     {% if method.paged_result_field.map %}


### PR DESCRIPTION
GoogleAdsService provides `search()`, which accepts a `Retry()`. Apply
the Retry decorator on all request pages, not just the first.

Original-Report: https://github.com/googleads/google-ads-python/issues/597
Resolves: https://github.com/googleapis/gapic-generator-python/issues/1242