### PR TITLE
fix: correct import for request message type

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -305,6 +305,14 @@ class Validator:
         # the MessageType of the request object passed to the rpc e.g, `ListRequest`
         sample["request_type"] = rpc.input
 
+        # We check if the request object is part of the service proto package.
+        # If not, it comes from a different module.
+        address = rpc.input.meta.address
+        if address.proto_package.startswith(address.api_naming.proto_package):
+            sample["request_module_name"] = sample["module_name"]
+        else:
+            sample["request_module_name"] = address.python_import.module
+
         # If no request was specified in the config
         # Add reasonable default values as placeholders
         if "request" not in sample:
@@ -1079,18 +1087,20 @@ def _fill_sample_metadata(sample: dict, api_schema: api.API):
     return snippet_metadata
 
 
-def _get_sample_imports(sample: Dict, rpc: wrappers.Method):
-    """Returns sorted sample import statements"""
+def _get_sample_imports(sample: Dict, rpc: wrappers.Method) -> List[str]:
+    """Returns sorted sample import statements."""
     module_namespace = ".".join(sample["module_namespace"])
     module_name = sample["module_name"]
     module_import = f"from {module_namespace} import {module_name}"
 
-    # TODO: extract request import as:
-    # str(rpc.input.meta.address.python_import)
-    del rpc
-
-    imports = [module_import]
-    return sorted(set(imports))
+    address = rpc.input.meta.address
+    # This checks if the request message is part of the service proto package.
+    # If not, we should try to include a separate import statement.
+    if address.proto_package.startswith(address.api_naming.proto_package):
+        return [module_import]
+    else:
+        request_import = str(address.python_import)
+        return sorted([module_import, request_import])
 
 
 def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tuple[str, Any]:
@@ -1120,7 +1130,6 @@ def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tup
         )
 
     calling_form = types.CallingForm.method_default(rpc)
-    imports = _get_sample_imports(sample, rpc)
 
     v = Validator(rpc, api_schema)
     # Tweak some small aspects of the sample to set defaults for optional
@@ -1133,6 +1142,7 @@ def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tup
     v.validate_response(sample["response"])
 
     snippet_metadata = _fill_sample_metadata(sample, api_schema)
+    imports = _get_sample_imports(sample, rpc)
 
     return sample_template.render(
         sample=sample,

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -1079,8 +1079,8 @@ def _fill_sample_metadata(sample: dict, api_schema: api.API):
     return snippet_metadata
 
 
-def _populate_sample_imports(sample: Dict, rpc: wrappers.Method):
-    """Populates sample's sorted list of imports."""
+def _get_sample_imports(sample: Dict, rpc: wrappers.Method):
+    """Returns sorted sample import statements"""
     module_namespace = ".".join(sample["module_namespace"])
     module_name = sample["module_name"]
     module_import = f"from {module_namespace} import {module_name}"
@@ -1090,7 +1090,7 @@ def _populate_sample_imports(sample: Dict, rpc: wrappers.Method):
     del rpc
 
     imports = [module_import]
-    sample['imports'] = sorted(set(imports))
+    return sorted(set(imports))
 
 
 def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tuple[str, Any]:
@@ -1120,6 +1120,7 @@ def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tup
         )
 
     calling_form = types.CallingForm.method_default(rpc)
+    imports = _get_sample_imports(sample, rpc)
 
     v = Validator(rpc, api_schema)
     # Tweak some small aspects of the sample to set defaults for optional
@@ -1135,7 +1136,7 @@ def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tup
 
     return sample_template.render(
         sample=sample,
-        imports=[],
+        imports=imports,
         calling_form=calling_form,
         calling_form_enum=types.CallingForm,
         trim_blocks=True,

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -1079,6 +1079,20 @@ def _fill_sample_metadata(sample: dict, api_schema: api.API):
     return snippet_metadata
 
 
+def _populate_sample_imports(sample: Dict, rpc: wrappers.Method):
+    """Populates sample's sorted list of imports."""
+    module_namespace = ".".join(sample["module_namespace"])
+    module_name = sample["module_name"]
+    module_import = f"from {module_namespace} import {module_name}"
+
+    # TODO: extract request import as:
+    # str(rpc.input.meta.address.python_import)
+    del rpc
+
+    imports = [module_import]
+    sample['imports'] = sorted(set(imports))
+
+
 def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tuple[str, Any]:
     """Generate a standalone, runnable sample.
 

--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -1142,6 +1142,8 @@ def generate_sample(sample, api_schema, sample_template: jinja2.Template) -> Tup
     v.validate_response(sample["response"])
 
     snippet_metadata = _fill_sample_metadata(sample, api_schema)
+
+    # The sample must be preprocessed before calling _get_sample_imports.
     imports = _get_sample_imports(sample, rpc)
 
     return sample_template.render(

--- a/gapic/samplegen_utils/snippet_index.py
+++ b/gapic/samplegen_utils/snippet_index.py
@@ -88,7 +88,6 @@ class Snippet:
         """The portion between the START and END region tags."""
         start_idx = self._full_snippet.start - 1
         end_idx = self._full_snippet.end
-        self.sample_lines[start_idx] = self.sample_lines[start_idx].strip()
         return "".join(self.sample_lines[start_idx:end_idx])
 
 

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -27,7 +27,6 @@
 {% for import_statement in imports %}
 {{ import_statement }}
 {% endfor %}
-from {{ sample.module_namespace|join(".") }} import {{ sample.module_name }}
 
 
 {# also need calling form #}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -32,7 +32,7 @@
 {# also need calling form #}
 {% if sample.transport == "grpc-async" %}async {% endif %}def sample_{{ frags.render_method_name(sample.rpc)|trim }}({{ frags.print_input_params(sample.request)|trim }}):
     {{ frags.render_client_setup(sample.module_name, sample.client_name)|indent }}
-    {{ frags.render_request_setup(sample.request, sample.module_name, sample.request_type, calling_form, calling_form_enum)|indent }}
+    {{ frags.render_request_setup(sample.request, sample.request_module_name, sample.request_type, calling_form, calling_form_enum)|indent }}
     {% with method_call = frags.render_method_call(sample, calling_form, calling_form_enum, sample.transport) %}
     {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.transport, sample.response)|indent -}}
     {% endwith %}

--- a/tests/unit/common_types.py
+++ b/tests/unit/common_types.py
@@ -20,6 +20,7 @@ from typing import(Any, Dict, Iterable, Optional)
 
 from google.protobuf import descriptor_pb2
 
+from gapic.schema import metadata
 from gapic.schema import wrappers
 
 # Injected dummy test types
@@ -79,6 +80,7 @@ class DummyMessage:
         self.options = options
         self.ident = ident
         self.resource_path = resource_path
+        self.meta = metadata.Metadata()
 
     def get_field(self, field_name: str):
         return self.fields[field_name]

--- a/tests/unit/common_types.py
+++ b/tests/unit/common_types.py
@@ -74,13 +74,13 @@ class DummyField(DummyFieldBase):
 
 
 class DummyMessage:
-    def __init__(self, *, fields={}, type="", options=False, ident=False, resource_path=False):
+    def __init__(self, *, fields={}, type="", options=False, ident=False, resource_path=False, meta=None):
         self.fields = fields
         self.type = type
         self.options = options
         self.ident = ident
         self.resource_path = resource_path
-        self.meta = metadata.Metadata()
+        self.meta = meta or metadata.Metadata()
 
     def get_field(self, field_name: str):
         return self.fields[field_name]

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -36,7 +36,6 @@ from ..common_types import (DummyApiSchema, DummyField, DummyIdent, DummyNaming,
 from gapic.samplegen_utils import utils
 
 
-# validate_response tests
 @pytest.fixture(scope="module")
 def api_naming():
     return DummyNaming(
@@ -90,7 +89,7 @@ def dummy_api_schema(request_message, api_naming):
 
 @pytest.fixture(scope="module")
 def dummy_api_schema_with_request_from_another_package(
-    request_message_from_another_package, api_naming):
+        request_message_from_another_package, api_naming):
     return DummyApiSchema(
         services={"Mollusc": DummyService(
             methods={}, client_name="MolluscClient",
@@ -318,7 +317,8 @@ def test_preprocess_sample_void_method():
     assert sample["response"] == []
 
 
-def test_preprocess_sample_with_request_module_name(dummy_api_schema_with_request_from_another_package):
+def test_preprocess_sample_with_request_module_name(
+        dummy_api_schema_with_request_from_another_package):
     sample = {"service": "Mollusc", "rpc": "Classify"}
     api_schema = dummy_api_schema_with_request_from_another_package
     rpc = DummyMethod(input=api_schema.messages)
@@ -341,7 +341,7 @@ def test_get_sample_imports(dummy_api_schema):
 
 
 def test_get_sample_imports_with_request_from_another_package(
-    dummy_api_schema_with_request_from_another_package):
+        dummy_api_schema_with_request_from_another_package):
     sample = {"service": "Mollusc", "rpc": "Classify"}
     api_schema = dummy_api_schema_with_request_from_another_package
     rpc = DummyMethod(input=api_schema.messages)

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -37,27 +37,67 @@ from gapic.samplegen_utils import utils
 
 
 # validate_response tests
+@pytest.fixture(scope="module")
+def api_naming():
+    return DummyNaming(
+        warehouse_package_name="mollusc-cephalopod-teuthida-",
+        versioned_module_name="teuthida_v1",
+        module_namespace=("mollusc", "cephalopod"),
+        proto_package="mollusc.cephalopod"
+    )
+
 
 @pytest.fixture(scope="module")
-def dummy_api_schema():
-    # For most of the unit tests in this file the internals of API Schema do not matter
-    classify_request_message = DummyMessage(
+def request_message():
+    return DummyMessage(
         fields={
             "parent": DummyField(is_primitive=True, type=str, required=True, name="parent"),
             },
         type=DummyMessageTypePB(name="ClassifyRequest"),
         ident=DummyIdent(name="ClassifyRequest")
-        )
+    )
 
+
+@pytest.fixture(scope="module")
+def request_message_from_another_package(api_naming):
+    return DummyMessage(
+        fields={
+            "parent": DummyField(is_primitive=True, type=str, required=True, name="parent"),
+            },
+        type=DummyMessageTypePB(name="ClassifyRequest"),
+        ident=DummyIdent(name="ClassifyRequest"),
+        meta=metadata.Metadata(
+            address=metadata.Address(
+                api_naming=api_naming,
+                package=('a', 'b',),
+                module='c'
+            )
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def dummy_api_schema(request_message, api_naming):
     return DummyApiSchema(
         services={"Mollusc": DummyService(
             methods={}, client_name="MolluscClient",
             resource_messages_dict={}
             )},
-        naming=DummyNaming(warehouse_package_name="mollusc-cephalopod-teuthida-",
-                           versioned_module_name="teuthida_v1", module_namespace="mollusc.cephalopod"),
-        messages=classify_request_message,
+        naming=api_naming,
+        messages=request_message,
+    )
 
+
+@pytest.fixture(scope="module")
+def dummy_api_schema_with_request_from_another_package(
+    request_message_from_another_package, api_naming):
+    return DummyApiSchema(
+        services={"Mollusc": DummyService(
+            methods={}, client_name="MolluscClient",
+            resource_messages_dict={}
+            )},
+        naming=api_naming,
+        messages=request_message_from_another_package,
     )
 
 
@@ -276,6 +316,43 @@ def test_preprocess_sample_void_method():
     samplegen.Validator.preprocess_sample(sample, api_schema, rpc)
 
     assert sample["response"] == []
+
+
+def test_preprocess_sample_with_request_module_name(dummy_api_schema_with_request_from_another_package):
+    sample = {"service": "Mollusc", "rpc": "Classify"}
+    api_schema = dummy_api_schema_with_request_from_another_package
+    rpc = DummyMethod(input=api_schema.messages)
+
+    samplegen.Validator.preprocess_sample(sample, api_schema, rpc)
+
+    request_module_name = sample.get("request_module_name")
+    assert request_module_name == 'c_pb2'
+
+
+def test_get_sample_imports(dummy_api_schema):
+    sample = {"service": "Mollusc", "rpc": "Classify"}
+    api_schema = dummy_api_schema
+    rpc = DummyMethod(input=api_schema.messages)
+
+    samplegen.Validator.preprocess_sample(sample, api_schema, rpc)
+    imports = samplegen._get_sample_imports(sample, rpc)
+
+    assert imports == ["from mollusc.cephalopod import teuthida_v1"]
+
+
+def test_get_sample_imports_with_request_from_another_package(
+    dummy_api_schema_with_request_from_another_package):
+    sample = {"service": "Mollusc", "rpc": "Classify"}
+    api_schema = dummy_api_schema_with_request_from_another_package
+    rpc = DummyMethod(input=api_schema.messages)
+
+    samplegen.Validator.preprocess_sample(sample, api_schema, rpc)
+    imports = samplegen._get_sample_imports(sample, rpc)
+
+    assert imports == [
+        "from a.b import c_pb2  # type: ignore",
+        "from mollusc.cephalopod import teuthida_v1"
+    ]
 
 
 def test_define_input_param(dummy_api_schema):

--- a/tests/unit/samplegen/test_snippet_index.py
+++ b/tests/unit/samplegen/test_snippet_index.py
@@ -82,6 +82,7 @@ def test_snippet_init(sample_str):
     # and # [END ...] lines
     expected_full_snipppet = """from molluscs.v1 import molluscclient
 
+
 def sample_classify(video, location):
     # Create a client
     client = molluscclient.MolluscServiceClient()


### PR DESCRIPTION
Fixes: https://github.com/googleapis/gapic-generator-python/issues/1263

The generated snippet where the request message type is external to the client library package now becomes:
```
from google.cloud import resourcemanager_v3
from google.iam.v1 import iam_policy_pb2  # type: ignore


def sample_get_iam_policy():
    # Create a client
    client = resourcemanager_v3.ProjectsClient()

    # Initialize request argument(s)
    request = iam_policy_pb2.GetIamPolicyRequest(
        resource="resource_value",
    )

    # Make the request
    response = client.get_iam_policy(request=request)

    # Handle the response
    print(response)
```

Additional changes:
- pytest fixtures in tests/unit/samplegen/test_samplegen.py are refactored to make it easier to add new unit test code without duplicating much of the code.