### PR TITLE
fix: use async snippet in async client method docstring

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -211,7 +211,7 @@ class {{ service.async_client_name }}:
             {% endif %}
         r"""{{ method.meta.doc|rst(width=72, indent=8)|trim }}
 
-        {% with snippet = snippet_index.get_snippet(service.name, method.name, sync=True) %}
+        {% with snippet = snippet_index.get_snippet(service.name, method.name, sync=False) %}
         {% if snippet is not none %}
         .. code-block:: python
 

--- a/rules_python_gapic/test/integration_test.bzl
+++ b/rules_python_gapic/test/integration_test.bzl
@@ -114,8 +114,8 @@ def _overwrite_golden_impl(ctx):
     golden_update_script_content = """
     cd ${{BUILD_WORKSPACE_DIRECTORY}}
     # Filename pattern-based removal is needed to preserve the BUILD.bazel file.
-    find tests/Integration/goldens/{api_name}/ -name \\*.py-type f -delete
-    find tests/Integration/goldens/{api_name}/ -name \\*.json -type f -delete
+    find tests/integration/goldens/{api_name}/ -name \\*.py-type f -delete
+    find tests/integration/goldens/{api_name}/ -name \\*.json -type f -delete
     unzip -ao {goldens_output_zip} -d tests/integration/goldens/{api_name}
     """.format(
         goldens_output_zip = goldens_output_zip.path,

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -214,9 +214,9 @@ class AssetServiceAsyncClient:
 
             from google.cloud import asset_v1
 
-            def sample_export_assets():
+            async def sample_export_assets():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 output_config = asset_v1.OutputConfig()
@@ -232,7 +232,7 @@ class AssetServiceAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)
@@ -310,9 +310,9 @@ class AssetServiceAsyncClient:
 
             from google.cloud import asset_v1
 
-            def sample_list_assets():
+            async def sample_list_assets():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 request = asset_v1.ListAssetsRequest(
@@ -323,7 +323,7 @@ class AssetServiceAsyncClient:
                 page_result = client.list_assets(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -423,9 +423,9 @@ class AssetServiceAsyncClient:
 
             from google.cloud import asset_v1
 
-            def sample_batch_get_assets_history():
+            async def sample_batch_get_assets_history():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 request = asset_v1.BatchGetAssetsHistoryRequest(
@@ -433,7 +433,7 @@ class AssetServiceAsyncClient:
                 )
 
                 # Make the request
-                response = client.batch_get_assets_history(request=request)
+                response = await client.batch_get_assets_history(request=request)
 
                 # Handle the response
                 print(response)
@@ -504,9 +504,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_create_feed():
+            async def sample_create_feed():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 feed = asset_v1.Feed()
@@ -519,7 +519,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.create_feed(request=request)
+                response = await client.create_feed(request=request)
 
                 # Handle the response
                 print(response)
@@ -614,9 +614,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_get_feed():
+            async def sample_get_feed():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 request = asset_v1.GetFeedRequest(
@@ -624,7 +624,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.get_feed(request=request)
+                response = await client.get_feed(request=request)
 
                 # Handle the response
                 print(response)
@@ -722,9 +722,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_list_feeds():
+            async def sample_list_feeds():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 request = asset_v1.ListFeedsRequest(
@@ -732,7 +732,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.list_feeds(request=request)
+                response = await client.list_feeds(request=request)
 
                 # Handle the response
                 print(response)
@@ -824,9 +824,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_update_feed():
+            async def sample_update_feed():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 feed = asset_v1.Feed()
@@ -837,7 +837,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.update_feed(request=request)
+                response = await client.update_feed(request=request)
 
                 # Handle the response
                 print(response)
@@ -928,9 +928,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_delete_feed():
+            async def sample_delete_feed():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 request = asset_v1.DeleteFeedRequest(
@@ -938,7 +938,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                client.delete_feed(request=request)
+                await client.delete_feed(request=request)
 
         Args:
             request (Union[google.cloud.asset_v1.types.DeleteFeedRequest, dict]):
@@ -1023,9 +1023,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_search_all_resources():
+            async def sample_search_all_resources():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 request = asset_v1.SearchAllResourcesRequest(
@@ -1036,7 +1036,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 page_result = client.search_all_resources(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -1229,9 +1229,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_search_all_iam_policies():
+            async def sample_search_all_iam_policies():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 request = asset_v1.SearchAllIamPoliciesRequest(
@@ -1242,7 +1242,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 page_result = client.search_all_iam_policies(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -1411,9 +1411,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_analyze_iam_policy():
+            async def sample_analyze_iam_policy():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 analysis_query = asset_v1.IamPolicyAnalysisQuery()
@@ -1424,7 +1424,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.analyze_iam_policy(request=request)
+                response = await client.analyze_iam_policy(request=request)
 
                 # Handle the response
                 print(response)
@@ -1505,9 +1505,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import asset_v1
 
-            def sample_analyze_iam_policy_longrunning():
+            async def sample_analyze_iam_policy_longrunning():
                 # Create a client
-                client = asset_v1.AssetServiceClient()
+                client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
                 analysis_query = asset_v1.IamPolicyAnalysisQuery()
@@ -1526,7 +1526,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
@@ -212,9 +212,9 @@ class IAMCredentialsAsyncClient:
 
             from google.iam import credentials_v1
 
-            def sample_generate_access_token():
+            async def sample_generate_access_token():
                 # Create a client
-                client = credentials_v1.IAMCredentialsClient()
+                client = credentials_v1.IAMCredentialsAsyncClient()
 
                 # Initialize request argument(s)
                 request = credentials_v1.GenerateAccessTokenRequest(
@@ -223,7 +223,7 @@ class IAMCredentialsAsyncClient:
                 )
 
                 # Make the request
-                response = client.generate_access_token(request=request)
+                response = await client.generate_access_token(request=request)
 
                 # Handle the response
                 print(response)
@@ -365,9 +365,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.iam import credentials_v1
 
-            def sample_generate_id_token():
+            async def sample_generate_id_token():
                 # Create a client
-                client = credentials_v1.IAMCredentialsClient()
+                client = credentials_v1.IAMCredentialsAsyncClient()
 
                 # Initialize request argument(s)
                 request = credentials_v1.GenerateIdTokenRequest(
@@ -376,7 +376,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.generate_id_token(request=request)
+                response = await client.generate_id_token(request=request)
 
                 # Handle the response
                 print(response)
@@ -511,9 +511,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.iam import credentials_v1
 
-            def sample_sign_blob():
+            async def sample_sign_blob():
                 # Create a client
-                client = credentials_v1.IAMCredentialsClient()
+                client = credentials_v1.IAMCredentialsAsyncClient()
 
                 # Initialize request argument(s)
                 request = credentials_v1.SignBlobRequest(
@@ -522,7 +522,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.sign_blob(request=request)
+                response = await client.sign_blob(request=request)
 
                 # Handle the response
                 print(response)
@@ -644,9 +644,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.iam import credentials_v1
 
-            def sample_sign_jwt():
+            async def sample_sign_jwt():
                 # Create a client
-                client = credentials_v1.IAMCredentialsClient()
+                client = credentials_v1.IAMCredentialsAsyncClient()
 
                 # Initialize request argument(s)
                 request = credentials_v1.SignJwtRequest(
@@ -655,7 +655,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.sign_jwt(request=request)
+                response = await client.sign_jwt(request=request)
 
                 # Handle the response
                 print(response)

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -207,9 +207,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_list_buckets():
+            async def sample_list_buckets():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListBucketsRequest(
@@ -220,7 +220,7 @@ class ConfigServiceV2AsyncClient:
                 page_result = client.list_buckets(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -322,9 +322,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_get_bucket():
+            async def sample_get_bucket():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.GetBucketRequest(
@@ -332,7 +332,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                response = client.get_bucket(request=request)
+                response = await client.get_bucket(request=request)
 
                 # Handle the response
                 print(response)
@@ -395,9 +395,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_create_bucket():
+            async def sample_create_bucket():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.CreateBucketRequest(
@@ -406,7 +406,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                response = client.create_bucket(request=request)
+                response = await client.create_bucket(request=request)
 
                 # Handle the response
                 print(response)
@@ -477,9 +477,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_update_bucket():
+            async def sample_update_bucket():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.UpdateBucketRequest(
@@ -487,7 +487,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                response = client.update_bucket(request=request)
+                response = await client.update_bucket(request=request)
 
                 # Handle the response
                 print(response)
@@ -550,9 +550,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_delete_bucket():
+            async def sample_delete_bucket():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.DeleteBucketRequest(
@@ -560,7 +560,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                client.delete_bucket(request=request)
+                await client.delete_bucket(request=request)
 
         Args:
             request (Union[google.cloud.logging_v2.types.DeleteBucketRequest, dict]):
@@ -612,9 +612,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_undelete_bucket():
+            async def sample_undelete_bucket():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.UndeleteBucketRequest(
@@ -622,7 +622,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                client.undelete_bucket(request=request)
+                await client.undelete_bucket(request=request)
 
         Args:
             request (Union[google.cloud.logging_v2.types.UndeleteBucketRequest, dict]):
@@ -674,9 +674,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_list_views():
+            async def sample_list_views():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListViewsRequest(
@@ -687,7 +687,7 @@ class ConfigServiceV2AsyncClient:
                 page_result = client.list_views(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -781,9 +781,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_get_view():
+            async def sample_get_view():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.GetViewRequest(
@@ -791,7 +791,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                response = client.get_view(request=request)
+                response = await client.get_view(request=request)
 
                 # Handle the response
                 print(response)
@@ -855,9 +855,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_create_view():
+            async def sample_create_view():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.CreateViewRequest(
@@ -866,7 +866,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                response = client.create_view(request=request)
+                response = await client.create_view(request=request)
 
                 # Handle the response
                 print(response)
@@ -930,9 +930,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_update_view():
+            async def sample_update_view():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.UpdateViewRequest(
@@ -940,7 +940,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                response = client.update_view(request=request)
+                response = await client.update_view(request=request)
 
                 # Handle the response
                 print(response)
@@ -1003,9 +1003,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_delete_view():
+            async def sample_delete_view():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.DeleteViewRequest(
@@ -1013,7 +1013,7 @@ class ConfigServiceV2AsyncClient:
                 )
 
                 # Make the request
-                client.delete_view(request=request)
+                await client.delete_view(request=request)
 
         Args:
             request (Union[google.cloud.logging_v2.types.DeleteViewRequest, dict]):
@@ -1065,9 +1065,9 @@ class ConfigServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_list_sinks():
+            async def sample_list_sinks():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListSinksRequest(
@@ -1078,7 +1078,7 @@ class ConfigServiceV2AsyncClient:
                 page_result = client.list_sinks(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -1185,9 +1185,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_get_sink():
+            async def sample_get_sink():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.GetSinkRequest(
@@ -1195,7 +1195,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.get_sink(request=request)
+                response = await client.get_sink(request=request)
 
                 # Handle the response
                 print(response)
@@ -1306,9 +1306,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_create_sink():
+            async def sample_create_sink():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 sink = logging_v2.LogSink()
@@ -1321,7 +1321,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.create_sink(request=request)
+                response = await client.create_sink(request=request)
 
                 # Handle the response
                 print(response)
@@ -1436,9 +1436,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_update_sink():
+            async def sample_update_sink():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 sink = logging_v2.LogSink()
@@ -1451,7 +1451,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.update_sink(request=request)
+                response = await client.update_sink(request=request)
 
                 # Handle the response
                 print(response)
@@ -1590,9 +1590,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_delete_sink():
+            async def sample_delete_sink():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.DeleteSinkRequest(
@@ -1600,7 +1600,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                client.delete_sink(request=request)
+                await client.delete_sink(request=request)
 
         Args:
             request (Union[google.cloud.logging_v2.types.DeleteSinkRequest, dict]):
@@ -1688,9 +1688,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_list_exclusions():
+            async def sample_list_exclusions():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListExclusionsRequest(
@@ -1701,7 +1701,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 page_result = client.list_exclusions(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -1808,9 +1808,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_get_exclusion():
+            async def sample_get_exclusion():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.GetExclusionRequest(
@@ -1818,7 +1818,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.get_exclusion(request=request)
+                response = await client.get_exclusion(request=request)
 
                 # Handle the response
                 print(response)
@@ -1931,9 +1931,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_create_exclusion():
+            async def sample_create_exclusion():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 exclusion = logging_v2.LogExclusion()
@@ -1946,7 +1946,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.create_exclusion(request=request)
+                response = await client.create_exclusion(request=request)
 
                 # Handle the response
                 print(response)
@@ -2061,9 +2061,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_update_exclusion():
+            async def sample_update_exclusion():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 exclusion = logging_v2.LogExclusion()
@@ -2076,7 +2076,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.update_exclusion(request=request)
+                response = await client.update_exclusion(request=request)
 
                 # Handle the response
                 print(response)
@@ -2203,9 +2203,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_delete_exclusion():
+            async def sample_delete_exclusion():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.DeleteExclusionRequest(
@@ -2213,7 +2213,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                client.delete_exclusion(request=request)
+                await client.delete_exclusion(request=request)
 
         Args:
             request (Union[google.cloud.logging_v2.types.DeleteExclusionRequest, dict]):
@@ -2309,9 +2309,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_get_cmek_settings():
+            async def sample_get_cmek_settings():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.GetCmekSettingsRequest(
@@ -2319,7 +2319,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.get_cmek_settings(request=request)
+                response = await client.get_cmek_settings(request=request)
 
                 # Handle the response
                 print(response)
@@ -2410,9 +2410,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_update_cmek_settings():
+            async def sample_update_cmek_settings():
                 # Create a client
-                client = logging_v2.ConfigServiceV2Client()
+                client = logging_v2.ConfigServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.UpdateCmekSettingsRequest(
@@ -2420,7 +2420,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.update_cmek_settings(request=request)
+                response = await client.update_cmek_settings(request=request)
 
                 # Handle the response
                 print(response)

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -203,9 +203,9 @@ class LoggingServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_delete_log():
+            async def sample_delete_log():
                 # Create a client
-                client = logging_v2.LoggingServiceV2Client()
+                client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.DeleteLogRequest(
@@ -213,7 +213,7 @@ class LoggingServiceV2AsyncClient:
                 )
 
                 # Make the request
-                client.delete_log(request=request)
+                await client.delete_log(request=request)
 
         Args:
             request (Union[google.cloud.logging_v2.types.DeleteLogRequest, dict]):
@@ -313,9 +313,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_write_log_entries():
+            async def sample_write_log_entries():
                 # Create a client
-                client = logging_v2.LoggingServiceV2Client()
+                client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 entries = logging_v2.LogEntry()
@@ -326,7 +326,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.write_log_entries(request=request)
+                response = await client.write_log_entries(request=request)
 
                 # Handle the response
                 print(response)
@@ -500,9 +500,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_list_log_entries():
+            async def sample_list_log_entries():
                 # Create a client
-                client = logging_v2.LoggingServiceV2Client()
+                client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListLogEntriesRequest(
@@ -513,7 +513,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 page_result = client.list_log_entries(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -652,9 +652,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_list_monitored_resource_descriptors():
+            async def sample_list_monitored_resource_descriptors():
                 # Create a client
-                client = logging_v2.LoggingServiceV2Client()
+                client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListMonitoredResourceDescriptorsRequest(
@@ -664,7 +664,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 page_result = client.list_monitored_resource_descriptors(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -741,9 +741,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_list_logs():
+            async def sample_list_logs():
                 # Create a client
-                client = logging_v2.LoggingServiceV2Client()
+                client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListLogsRequest(
@@ -754,7 +754,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 page_result = client.list_logs(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -861,9 +861,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_tail_log_entries():
+            async def sample_tail_log_entries():
                 # Create a client
-                client = logging_v2.LoggingServiceV2Client()
+                client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.TailLogEntriesRequest(
@@ -881,10 +881,10 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                         yield request
 
                 # Make the request
-                stream = client.tail_log_entries(requests=request_generator())
+                stream = await client.tail_log_entries(requests=request_generator())
 
                 # Handle the response
-                for response in stream:
+                async for response in stream:
                     print(response)
 
         Args:

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -200,9 +200,9 @@ class MetricsServiceV2AsyncClient:
 
             from google.cloud import logging_v2
 
-            def sample_list_log_metrics():
+            async def sample_list_log_metrics():
                 # Create a client
-                client = logging_v2.MetricsServiceV2Client()
+                client = logging_v2.MetricsServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.ListLogMetricsRequest(
@@ -213,7 +213,7 @@ class MetricsServiceV2AsyncClient:
                 page_result = client.list_log_metrics(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -317,9 +317,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_get_log_metric():
+            async def sample_get_log_metric():
                 # Create a client
-                client = logging_v2.MetricsServiceV2Client()
+                client = logging_v2.MetricsServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.GetLogMetricRequest(
@@ -327,7 +327,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.get_log_metric(request=request)
+                response = await client.get_log_metric(request=request)
 
                 # Handle the response
                 print(response)
@@ -431,9 +431,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_create_log_metric():
+            async def sample_create_log_metric():
                 # Create a client
-                client = logging_v2.MetricsServiceV2Client()
+                client = logging_v2.MetricsServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 metric = logging_v2.LogMetric()
@@ -446,7 +446,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.create_log_metric(request=request)
+                response = await client.create_log_metric(request=request)
 
                 # Handle the response
                 print(response)
@@ -555,9 +555,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_update_log_metric():
+            async def sample_update_log_metric():
                 # Create a client
-                client = logging_v2.MetricsServiceV2Client()
+                client = logging_v2.MetricsServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 metric = logging_v2.LogMetric()
@@ -570,7 +570,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                response = client.update_log_metric(request=request)
+                response = await client.update_log_metric(request=request)
 
                 # Handle the response
                 print(response)
@@ -685,9 +685,9 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
             from google.cloud import logging_v2
 
-            def sample_delete_log_metric():
+            async def sample_delete_log_metric():
                 # Create a client
-                client = logging_v2.MetricsServiceV2Client()
+                client = logging_v2.MetricsServiceV2AsyncClient()
 
                 # Initialize request argument(s)
                 request = logging_v2.DeleteLogMetricRequest(
@@ -695,7 +695,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
                 )
 
                 # Make the request
-                client.delete_log_metric(request=request)
+                await client.delete_log_metric(request=request)
 
         Args:
             request (Union[google.cloud.logging_v2.types.DeleteLogMetricRequest, dict]):

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -232,9 +232,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_list_instances():
+            async def sample_list_instances():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 request = redis_v1.ListInstancesRequest(
@@ -245,7 +245,7 @@ class CloudRedisAsyncClient:
                 page_result = client.list_instances(request=request)
 
                 # Handle the response
-                for response in page_result:
+                async for response in page_result:
                     print(response)
 
         Args:
@@ -341,9 +341,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_get_instance():
+            async def sample_get_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 request = redis_v1.GetInstanceRequest(
@@ -351,7 +351,7 @@ class CloudRedisAsyncClient:
                 )
 
                 # Make the request
-                response = client.get_instance(request=request)
+                response = await client.get_instance(request=request)
 
                 # Handle the response
                 print(response)
@@ -449,9 +449,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_create_instance():
+            async def sample_create_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 instance = redis_v1.Instance()
@@ -470,7 +470,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)
@@ -596,9 +596,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_update_instance():
+            async def sample_update_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 instance = redis_v1.Instance()
@@ -615,7 +615,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)
@@ -728,9 +728,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_upgrade_instance():
+            async def sample_upgrade_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 request = redis_v1.UpgradeInstanceRequest(
@@ -743,7 +743,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)
@@ -857,9 +857,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_import_instance():
+            async def sample_import_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 input_config = redis_v1.InputConfig()
@@ -875,7 +875,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)
@@ -985,9 +985,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_export_instance():
+            async def sample_export_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 output_config = redis_v1.OutputConfig()
@@ -1003,7 +1003,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)
@@ -1111,9 +1111,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_failover_instance():
+            async def sample_failover_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 request = redis_v1.FailoverInstanceRequest(
@@ -1125,7 +1125,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)
@@ -1232,9 +1232,9 @@ class CloudRedisAsyncClient:
 
             from google.cloud import redis_v1
 
-            def sample_delete_instance():
+            async def sample_delete_instance():
                 # Create a client
-                client = redis_v1.CloudRedisClient()
+                client = redis_v1.CloudRedisAsyncClient()
 
                 # Initialize request argument(s)
                 request = redis_v1.DeleteInstanceRequest(
@@ -1246,7 +1246,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = operation.result()
+                response = await operation.result()
 
                 # Handle the response
                 print(response)


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-python/issues/1279

Other changes:
- Fix rules_python_gapic/test/integration_test.bzl find path `tests/Integration/goldens` -> `tests/integration/goldens`, which prevents the golden metadata.json files from being correctly updated when running `bazel run //tests/integration:asset_update` in certain environments.