### PR TITLE
[not for review] add gdch support

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -95,7 +95,8 @@ class {{ service.name }}Transport(abc.ABC):
         {% if service.any_extended_operations_methods %}
         self._extended_operations_services: Dict[str, Any] = {}
         {% endif %}
-
+        audience = host
+    
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
         if ':' not in host:
             host += ':443'
@@ -120,7 +121,7 @@ class {{ service.name }}Transport(abc.ABC):
         elif credentials is None:
             credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
             if hasattr(credentials, "with_audience"):
-                credentials = credentials.with_audience(host)
+                credentials = credentials.with_audience(audience)
 
         # If the credentials are service account credentials, then always try to use self signed JWT.
         if always_use_jwt_access and isinstance(credentials, service_account.Credentials) and hasattr(service_account.Credentials, "with_always_use_jwt_access"):

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -119,6 +119,8 @@ class {{ service.name }}Transport(abc.ABC):
                             )
         elif credentials is None:
             credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            if hasattr(credentials, "with_audience"):
+                credentials = credentials.with_audience(host)
 
         # If the credentials are service account credentials, then always try to use self signed JWT.
         if always_use_jwt_access and isinstance(credentials, service_account.Credentials) and hasattr(service_account.Credentials, "with_always_use_jwt_access"):


### PR DESCRIPTION
User experience:

In python code:
```
options =  google.api_core.client_options.ClientOptions()
options.api_endpoint = "<the endpoint>"

client = ImageAnnotatorClient(client_options=options)
```

To use gdch creds, set ADC
```
export GOOGLE_APPLICATION_CREDENTIALS="<gdch_json_file_path>"
```