### PR TITLE
test: use unittest.mock

### DIFF
--- a/gapic/ads-templates/noxfile.py.j2
+++ b/gapic/ads-templates/noxfile.py.j2
@@ -18,7 +18,7 @@ ALL_PYTHON = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'mock', 'pytest', 'pytest-cov')
+    session.install('coverage', 'pytest', 'pytest-cov')
     session.install('-e', '.')
 
     session.run(

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -3,7 +3,12 @@
 {% block content %}
 
 import os
-from unittest import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -3,7 +3,7 @@
 {% block content %}
 
 import os
-import mock
+from unittest import mock
 
 import grpc
 from grpc.experimental import aio

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -44,7 +44,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python_version < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -44,7 +44,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'asyncmock', 'pytest-asyncio')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -4,7 +4,12 @@
 {% import "tests/unit/gapic/%name_%version/%sub/test_macros.j2" as test_macros %}
 
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/noxfile.py
+++ b/noxfile.py
@@ -138,7 +138,6 @@ def fragment(session, use_ads_templates=False):
         "pytest",
         "pytest-cov",
         "pytest-xdist",
-        "asyncmock",
         "pytest-asyncio",
         "grpcio-tools",
     )
@@ -246,7 +245,7 @@ def showcase(
     """Run the Showcase test suite."""
 
     with showcase_library(session, templates=templates, other_opts=other_opts):
-        session.install("mock", "pytest", "pytest-asyncio")
+        session.install("pytest", "pytest-asyncio")
         session.run(
             "py.test",
             "--quiet",
@@ -265,7 +264,7 @@ def showcase_mtls(
     """Run the Showcase mtls test suite."""
 
     with showcase_library(session, templates=templates, other_opts=other_opts):
-        session.install("mock", "pytest", "pytest-asyncio")
+        session.install("pytest", "pytest-asyncio")
         session.run(
             "py.test",
             "--quiet",
@@ -303,7 +302,6 @@ def run_showcase_unit_tests(session, fail_under=100):
         "pytest",
         "pytest-cov",
         "pytest-xdist",
-        "asyncmock",
         "pytest-asyncio",
     )
 
@@ -417,7 +415,7 @@ def snippetgen(session):
     # Install gapic-generator-python
     session.install("-e", ".")
 
-    session.install("grpcio-tools", "mock", "pytest", "pytest-asyncio")
+    session.install("grpcio-tools", "pytest", "pytest-asyncio")
 
     session.run("py.test", "-vv", "tests/snippetgen")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -302,6 +302,7 @@ def run_showcase_unit_tests(session, fail_under=100):
         "pytest",
         "pytest-cov",
         "pytest-xdist",
+        "asyncmock; python_version < '3.8'",
         "pytest-asyncio",
     )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -138,6 +138,7 @@ def fragment(session, use_ads_templates=False):
         "pytest",
         "pytest-cov",
         "pytest-xdist",
+        "asyncmock; python_version < '3.8'",
         "pytest-asyncio",
         "grpcio-tools",
     )

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'asyncmock', 'pytest-asyncio')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python_version < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'asyncmock', 'pytest-asyncio')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python_version < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'asyncmock', 'pytest-asyncio')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python_version < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'asyncmock', 'pytest-asyncio')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python_version < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'asyncmock', 'pytest-asyncio')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -55,7 +55,7 @@ nox.sessions = [
 def unit(session):
     """Run the unit test suite."""
 
-    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python < "3.8"')
+    session.install('coverage', 'pytest', 'pytest-cov', 'pytest-asyncio', 'asyncmock; python_version < "3.8"')
     session.install('-e', '.')
 
     session.run(

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -14,7 +14,12 @@
 # limitations under the License.
 #
 import os
-import mock
+# try/except added for compatibility with python < 3.8
+try:
+    from unittest import mock
+    from unittest.mock import AsyncMock
+except ImportError:
+    import mock
 
 import grpc
 from grpc.experimental import aio

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -14,7 +14,7 @@
 
 import collections
 import grpc
-import mock
+from unittest import mock
 import os
 import pytest
 

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -14,7 +14,6 @@
 
 import collections
 
-from typing import Sequence
 from unittest import mock
 
 import pytest

--- a/tests/unit/utils/test_uri_conv.py
+++ b/tests/unit/utils/test_uri_conv.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from unittest import mock
 
 import pypandoc
 


### PR DESCRIPTION
`mock` is deprecated and it’s recommended to use `unittest.mock`. `unittest.mock` is available from python 3.3.

`unittest.mock.AsyncMock` is only available from python 3.8+ so we need to use the `asyncmock` package for python<3.8

Fixes https://github.com/googleapis/python-bigquery-connection/issues/212
Fixes https://github.com/googleapis/python-security-private-ca/issues/231
Fixes https://github.com/googleapis/python-billing/issues/182
Fixes https://github.com/googleapis/python-bigquery-reservation/issues/267
Fixes https://github.com/googleapis/python-deploy/issues/75
Fixes https://github.com/googleapis/python-firestore/issues/576
Fixes https://github.com/googleapis/python-dlp/issues/389
Fixes https://github.com/googleapis/python-asset/issues/427