### PR TITLE
fix: resolve issue where rest test appears in grpc-only client

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -929,7 +929,16 @@ def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
         )
 
 
-{% if 'grpc' in opts.transport %}
+{% if 'grpc' in opts.transport and 'rest' in opts.transport %}
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.{{ service.name }}GrpcTransport,
+        transports.{{ service.name }}GrpcAsyncIOTransport,
+        transports.{{ service.name }}RestTransport,
+    ],
+)
+{% elif 'grpc' in opts.transport %}
 @pytest.mark.parametrize(
     "transport_class",
     [

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -929,14 +929,22 @@ def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
         )
 
 
+{% if 'grpc' in opts.transport %}
 @pytest.mark.parametrize(
     "transport_class",
     [
         transports.{{ service.name }}GrpcTransport,
         transports.{{ service.name }}GrpcAsyncIOTransport,
+    ],
+)
+{% elif 'rest' in opts.transport %}
+@pytest.mark.parametrize(
+    "transport_class",
+    [
         transports.{{ service.name }}RestTransport,
     ],
 )
+{% endif %}
 def test_{{ service.name|snake_case }}_transport_auth_gdch_credentials(transport_class):
     host = 'https://language.com'
     api_audience_tests = [None, 'https://language2.com']

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -3816,7 +3816,6 @@ def test_asset_service_transport_auth_adc(transport_class):
     [
         transports.AssetServiceGrpcTransport,
         transports.AssetServiceGrpcAsyncIOTransport,
-        transports.AssetServiceRestTransport,
     ],
 )
 def test_asset_service_transport_auth_gdch_credentials(transport_class):

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -1762,7 +1762,6 @@ def test_iam_credentials_transport_auth_adc(transport_class):
     [
         transports.IAMCredentialsGrpcTransport,
         transports.IAMCredentialsGrpcAsyncIOTransport,
-        transports.IAMCredentialsRestTransport,
     ],
 )
 def test_iam_credentials_transport_auth_gdch_credentials(transport_class):

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -2152,7 +2152,6 @@ def test_eventarc_transport_auth_adc(transport_class):
     [
         transports.EventarcGrpcTransport,
         transports.EventarcGrpcAsyncIOTransport,
-        transports.EventarcRestTransport,
     ],
 )
 def test_eventarc_transport_auth_gdch_credentials(transport_class):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -6186,7 +6186,6 @@ def test_config_service_v2_transport_auth_adc(transport_class):
     [
         transports.ConfigServiceV2GrpcTransport,
         transports.ConfigServiceV2GrpcAsyncIOTransport,
-        transports.ConfigServiceV2RestTransport,
     ],
 )
 def test_config_service_v2_transport_auth_gdch_credentials(transport_class):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -2307,7 +2307,6 @@ def test_logging_service_v2_transport_auth_adc(transport_class):
     [
         transports.LoggingServiceV2GrpcTransport,
         transports.LoggingServiceV2GrpcAsyncIOTransport,
-        transports.LoggingServiceV2RestTransport,
     ],
 )
 def test_logging_service_v2_transport_auth_gdch_credentials(transport_class):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2158,7 +2158,6 @@ def test_metrics_service_v2_transport_auth_adc(transport_class):
     [
         transports.MetricsServiceV2GrpcTransport,
         transports.MetricsServiceV2GrpcAsyncIOTransport,
-        transports.MetricsServiceV2RestTransport,
     ],
 )
 def test_metrics_service_v2_transport_auth_gdch_credentials(transport_class):

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -3142,7 +3142,6 @@ def test_cloud_redis_transport_auth_adc(transport_class):
     [
         transports.CloudRedisGrpcTransport,
         transports.CloudRedisGrpcAsyncIOTransport,
-        transports.CloudRedisRestTransport,
     ],
 )
 def test_cloud_redis_transport_auth_gdch_credentials(transport_class):


### PR DESCRIPTION
Some APIs are failing with errors related to rest transport.

This is because one of the tests is missing conditional check on `opts.transport`.

See example of the failing test: https://github.com/googleapis/python-resource-settings/pull/118.
