### PR TITLE
feat: Add rest-numeric-enums option

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -52,6 +52,12 @@ DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     rest_version=requests_version,
 )
 
+{% if opts.rest_numeric_enums %}
+# TODO (numeric enums): This file was generated with the option to
+#   request that the server respond with enums JSON-encoded as
+#   numbers. The code below does not implement that functionality yet.
+
+{% endif %}
 
 class {{ service.name }}RestInterceptor:
     """Interceptor for {{ service.name }}.

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -64,7 +64,8 @@ class Options:
         # transport type(s) delineated by '+' (i.e. grpc, rest, custom.[something], etc?)
         'transport',
         'warehouse-package-name',  # change the package name on PyPI
-        'rest-numeric-enums',   # when transport includes "rest", request response enums be JSON-encoded as numbers
+        # when transport includes "rest", request response enums be JSON-encoded as numbers
+        'rest-numeric-enums',
     ))
 
     @classmethod

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -48,6 +48,7 @@ class Options:
     transport: List[str] = dataclasses.field(default_factory=lambda: [])
     service_yaml_config: Dict[str, Any] = dataclasses.field(
         default_factory=dict)
+    rest_numeric_enums: bool = False
 
     # Class constants
     PYTHON_GAPIC_PREFIX: str = 'python-gapic-'
@@ -63,6 +64,7 @@ class Options:
         # transport type(s) delineated by '+' (i.e. grpc, rest, custom.[something], etc?)
         'transport',
         'warehouse-package-name',  # change the package name on PyPI
+        'rest-numeric-enums',   # when transport includes "rest", request response enums be JSON-encoded as numbers
     ))
 
     @classmethod
@@ -178,6 +180,7 @@ class Options:
             # transport should include desired transports delimited by '+', e.g. transport='grpc+rest'
             transport=opts.pop('transport', ['grpc'])[0].split('+'),
             service_yaml_config=service_yaml_config,
+            rest_numeric_enums=bool(opts.pop('rest-numeric-enums', False)),
         )
 
         # Note: if we ever need to recursively check directories for sample

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -64,7 +64,7 @@ class Options:
         # transport type(s) delineated by '+' (i.e. grpc, rest, custom.[something], etc?)
         'transport',
         'warehouse-package-name',  # change the package name on PyPI
-        # when transport includes "rest", request response enums be JSON-encoded as numbers
+        # when transport includes "rest", request that response enums be JSON-encoded as numbers
         'rest-numeric-enums',
     ))
 

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -181,6 +181,7 @@ def test_options_bool_flags():
          "add-iam-methods",
          "metadata",
          "warehouse-package-name",
+         "rest-numeric-enums",
          ]}
 
     for opt, attr in opt_str_to_attr_name.items():

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -169,6 +169,18 @@ def test_options_service_yaml_config(fs):
     }
     assert opts.service_yaml_config == expected_config
 
+def test_options_transport():
+    opts = Options.build("")
+    assert opts.transport == ["grpc"]
+
+    opts = Options.build("transport=rest")
+    assert opts.transport == ["rest"]
+
+    opts = Options.build("transport=grpc+rest")
+    assert opts.transport == ["grpc","rest"]
+
+    opts = Options.build("transport=alpha+beta+gamma")
+    assert opts.transport == ["alpha","beta","gamma"]
 
 def test_options_bool_flags():
     # Most options are default False.

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -169,6 +169,7 @@ def test_options_service_yaml_config(fs):
     }
     assert opts.service_yaml_config == expected_config
 
+
 def test_options_transport():
     opts = Options.build("")
     assert opts.transport == ["grpc"]
@@ -177,10 +178,11 @@ def test_options_transport():
     assert opts.transport == ["rest"]
 
     opts = Options.build("transport=grpc+rest")
-    assert opts.transport == ["grpc","rest"]
+    assert opts.transport == ["grpc", "rest"]
 
     opts = Options.build("transport=alpha+beta+gamma")
-    assert opts.transport == ["alpha","beta","gamma"]
+    assert opts.transport == ["alpha", "beta", "gamma"]
+
 
 def test_options_bool_flags():
     # Most options are default False.


### PR DESCRIPTION
This option is currently a no-op. 

In an upcoming commit, it will be used to request, when `transport=rest`, that the server JSON-encode enum values as numbers.

This also adds tests for the `transport=rest` option being processed correctly as an option.