### PR TITLE
fix: Unit test for nested fields in url path

### DIFF
--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1001,7 +1001,7 @@ def test_{{ method.name|snake_case }}_rest(request_type):
     {% for field in method.body_fields.values() %}
     {% if not field.oneof or field.proto3_optional %}
     {# ignore oneof fields that might conflict with sample_request #}
-    request_init["{{ field.name }}"] = {{ field.mock_value_original_type }}
+    request_init["{{ field.name }}"] = {{ field.merged_mock_value(method.http_options[0].sample_request(method).get(field.name)) }}
     {% endif %}
     {% endfor %}
     request = request_type(request_init)
@@ -1293,7 +1293,7 @@ def test_{{ method_name }}_rest_bad_request(transport: str = 'rest', request_typ
     {% for field in method.body_fields.values() %}
     {% if not field.oneof or field.proto3_optional %}
     {# ignore oneof fields that might conflict with sample_request #}
-    request_init["{{ field.name }}"] = {{ field.mock_value_original_type }}
+    request_init["{{ field.name }}"] = {{ field.merged_mock_value(method.http_options[0].sample_request(method).get(field.name)) }}
     {% endif %}
     {% endfor %}
     request = request_type(request_init)

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -28,6 +28,7 @@ Documentation is consistently at ``{thing}.meta.doc``.
 """
 
 import collections
+import copy
 import dataclasses
 import json
 import keyword
@@ -150,6 +151,13 @@ class Field:
             return answer
 
         return recursive_mock_original_type(self)
+
+    def merged_mock_value(self, other_mock: Dict[Any, Any]):
+        mock = self.mock_value_original_type
+        if isinstance(mock, dict) and isinstance(other_mock, dict):
+            mock = copy.deepcopy(mock)
+            mock.update(other_mock)
+        return mock
 
     @utils.cached_property
     def mock_value(self) -> str:

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -852,7 +852,7 @@ def test_{{ method_name }}_rest(request_type):
     {% for field in method.body_fields.values() %}
     {% if not field.oneof or field.proto3_optional %}
     {# ignore oneof fields that might conflict with sample_request #}
-    request_init["{{ field.name }}"] = {{ field.mock_value_original_type }}
+    request_init["{{ field.name }}"] = {{ field.merged_mock_value(method.http_options[0].sample_request(method).get(field.name)) }}
     {% endif %}
     {% endfor %}
     request = request_type(request_init)
@@ -1158,7 +1158,7 @@ def test_{{ method_name }}_rest_bad_request(transport: str = 'rest', request_typ
     {% for field in method.body_fields.values() %}
     {% if not field.oneof or field.proto3_optional %}
     {# ignore oneof fields that might conflict with sample_request #}
-    request_init["{{ field.name }}"] = {{ field.mock_value_original_type }}
+    request_init["{{ field.name }}"] = {{ field.merged_mock_value(method.http_options[0].sample_request(method).get(field.name)) }}
     {% endif %}
     {% endfor %}
     request = request_type(request_init)

--- a/tests/unit/schema/wrappers/test_field.py
+++ b/tests/unit/schema/wrappers/test_field.py
@@ -435,6 +435,7 @@ def test_merged_mock_value_message():
     mock = field.merged_mock_value(None)
     assert mock == {"bar": "bar_value", "foo": 324}
 
+
 def test_mock_value_original_type_enum():
     mollusc_field = make_field(
         name="class",

--- a/tests/unit/schema/wrappers/test_field.py
+++ b/tests/unit/schema/wrappers/test_field.py
@@ -404,6 +404,37 @@ def test_mock_value_original_type_message():
     assert entry_field.mock_value_original_type == {}
 
 
+def test_merged_mock_value_message():
+    subfields = collections.OrderedDict((
+        ('foo', make_field(name='foo', type='TYPE_INT32')),
+        ('bar', make_field(name='bar', type='TYPE_STRING'))
+    ))
+
+    message = wrappers.MessageType(
+        fields=subfields,
+        message_pb=descriptor_pb2.DescriptorProto(name="Message", field=[
+            i.field_pb for i in subfields.values()
+        ]),
+        meta=metadata.Metadata(address=metadata.Address(
+            module="bogus",
+            name="Message",
+        )),
+        nested_enums={},
+        nested_messages={},
+    )
+
+    field = make_field(
+        type="TYPE_MESSAGE",
+        type_name="bogus.Message",
+        message=message,
+    )
+
+    mock = field.merged_mock_value({"foo": 777, "another": "another_value"})
+    assert mock == {"foo": 777, "bar": "bar_value", "another": "another_value"}
+
+    mock = field.merged_mock_value(None)
+    assert mock == {"bar": "bar_value", "foo": 324}
+
 def test_mock_value_original_type_enum():
     mollusc_field = make_field(
         name="class",


### PR DESCRIPTION
This fixes https://github.com/googleapis/gapic-generator-python/issues/1386

