### PR TITLE
feat: note that "rest" transport support is beta.

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -233,6 +233,11 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             transport (Union[str, {{ service.name }}Transport]): The
                 transport to use. If set to None, a transport is chosen
                 automatically.
+                {% if 'rest' in opts.transport and not opts.rest_numeric_enums %}
+                NOTE: "rest" transport functionality is currently in a
+                beta state (preview). We welcome your feedback via an
+                issue in this library's source repository.
+                {% endif %}
             client_options (google.api_core.client_options.ClientOptions): Custom options for the
                 client. It won't take effect if a ``transport`` instance is provided.
                 (1) The ``api_endpoint`` property can be used to override the

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
@@ -128,6 +128,12 @@ class {{service.name}}RestTransport({{service.name}}Transport):
     and call it.
 
     It sends JSON representations of protocol buffers over HTTP/1.1
+
+    {% if not opts.rest_numeric_enums %}
+    NOTE: This REST transport functionality is currently in a beta
+    state (preview). We welcome your feedback via an issue in this
+    library's source repository. Thank you!
+    {% endif %}
     """
 
 
@@ -146,6 +152,12 @@ class {{service.name}}RestTransport({{service.name}}Transport):
             interceptor: Optional[{{ service.name }}RestInterceptor] = None,
             ) -> None:
         """Instantiate the transport.
+
+       {% if not opts.rest_numeric_enums %}
+       NOTE: This REST transport functionality is currently in a beta
+       state (preview). We welcome your feedback via a GitHub issue in
+       this library's repository. Thank you!
+       {% endif %}
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -290,6 +290,11 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             transport (Union[str, {{ service.name }}Transport]): The
                 transport to use. If set to None, a transport is chosen
                 automatically.
+                {% if 'rest' in opts.transport and not opts.rest_numeric_enums %}
+                NOTE: "rest" transport functionality is currently in a
+                beta state (preview). We welcome your feedback via an
+                issue in this library's source repository.
+                {% endif %}
             client_options (google.api_core.client_options.ClientOptions): Custom options for the
                 client. It won't take effect if a ``transport`` instance is provided.
                 (1) The ``api_endpoint`` property can be used to override the

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -134,6 +134,12 @@ class {{service.name}}RestTransport({{service.name}}Transport):
     and call it.
 
     It sends JSON representations of protocol buffers over HTTP/1.1
+
+    {% if not opts.rest_numeric_enums %}
+    NOTE: This REST transport functionality is currently in a beta
+    state (preview). We welcome your feedback via an issue in this
+    library's source repository. Thank you!
+    {% endif %}
     """
 
 
@@ -153,6 +159,12 @@ class {{service.name}}RestTransport({{service.name}}Transport):
             api_audience: Optional[str] = None,
             ) -> None:
         """Instantiate the transport.
+
+       {% if not opts.rest_numeric_enums %}
+       NOTE: This REST transport functionality is currently in a beta
+       state (preview). We welcome your feedback via a GitHub issue in
+       this library's repository. Thank you!
+       {% endif %}
 
         Args:
             host ({% if service.host %}Optional[str]{% else %}str{% endif %}):


### PR DESCRIPTION
This beta notice is triggered by having numeric enum support disabled (the default), since numeric enum support is currently the only blocker to supporting REST transport fully.

This condition can be changed if further blockers arise to a GA release of REST transport.

This logic and notice can be removed entirely once we are satisfied that REST transport works with or without numeric enums.

