### PR TITLE
feat: Add BUILD rule parameter to allow setting numeric enums

### DIFF
--- a/docs/getting-started/bazel.rst
+++ b/docs/getting-started/bazel.rst
@@ -94,6 +94,16 @@ your ``BUILD.bazel`` file. You can use the Python section of the Document AI
             ":documentai_py_gapic",
         ],
     )
+
+Some of the ``py_gapic_library`` rule that may be of interest:
+  * ``transport``: the desired transport(s) to generate, delimited by ``+`` e.g. ``grpc+rest``.
+    - Acceptable values are ``grpc`` and ``rest``.
+    - Defaults to ``grpc``.
+
+  * ``rest_numeric_enums``: if ``True``, enables generation of system parameter requesting response enums be encoded as numbers.
+    - Default is ``False``.
+    - Only effective when ``rest`` is included as a ``transport`` to be generated.
+      
 .. _BUILD.bazel: https://github.com/googleapis/googleapis/blob/master/google/cloud/documentai/v1beta2/BUILD.bazel
 
 Compiling an API

--- a/rules_python_gapic/py_gapic.bzl
+++ b/rules_python_gapic/py_gapic.bzl
@@ -43,6 +43,7 @@ def py_gapic_library(
         metadata = True,
         service_yaml = None,
         transport = None,
+        rest_numeric_enums = False,
         deps = [],
         **kwargs):
     srcjar_target_name = "%s_srcjar" % name
@@ -62,6 +63,9 @@ def py_gapic_library(
 
     if transport:
         opt_args = opt_args + ["transport=%s" % transport]
+
+    if rest_numeric_enums:
+        opt_args = opt_args + ["rest-numeric-enums"]
 
     proto_custom_library(
         name = srcjar_target_name,


### PR DESCRIPTION
This allows generator users to set the numeric-enum-response parameter at generation time via the BUILD rule. The default is `False` for backward compatibility.

