### PR TITLE
fix(rest): Use strict encoding to lowercase query string bools

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
@@ -364,7 +364,7 @@ class {{service.name}}RestTransport({{service.name}}Transport):
                 "{host}{uri}".format(host=self._host, uri=uri),
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params),
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 {% if body_spec %}
                 data=body,
                 {% endif %}

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -19,7 +19,7 @@ setuptools.setup(
     install_requires=(
         {# TODO(dovs): remove when 1.x deprecation is complete #}
         {% if 'rest' in opts.transport %}
-        'google-api-core[grpc] >= 2.4.0, < 3.0.0dev',
+        'google-api-core[grpc] >= 2.10.0, < 3.0.0dev',
         {% else %}
         'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
         {% endif %}

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1214,7 +1214,7 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                     {% if req_field.field_pb.type == 9 %}
                     "{{ req_field.field_pb.default_value }}",
                     {% else %}
-                    {{ req_field.type.python_type(req_field.field_pb.default_value or 0) }},
+                    str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}),
                     {% endif %}{# default is str #}
                 ),
               {% endfor %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -398,7 +398,7 @@ class {{service.name}}RestTransport({{service.name}}Transport):
                 "{host}{uri}".format(host=self._host, uri=uri),
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params),
+                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 {% if body_spec %}
                 data=body,
                 {% endif %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -30,12 +30,7 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
-        {# TODO(dovs): remove when 1.x deprecation is complete #}
-        {% if 'rest' in opts.transport %}
         'google-api-core[grpc] >= 2.10.0, < 3.0.0dev',
-        {% else %}
-        'google-api-core[grpc] >= 2.10.0, < 3.0.0dev',
-        {% endif %}
         'libcst >= 0.2.5',
         'googleapis-common-protos >= 1.55.0, <2.0.0dev',
         'proto-plus >= 1.19.7',

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1099,7 +1099,7 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                     {% if req_field.field_pb.type == 9 %}
                     "{{ req_field.field_pb.default_value }}",
                     {% else %}
-                    {{ req_field.type.python_type(req_field.field_pb.default_value or 0) }},
+                    str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}),
                     {% endif %}{# default is str #}
                 ),
               {% endfor %}


### PR DESCRIPTION
- depend on google-api-core >= 2.10.0 for REST transport
- use `strict` to force query string booleans to be JSON encoded in lower case

Fixes #1407 
