### PR TITLE
fix: remove grpc only rpcs from rest.py

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
@@ -84,7 +84,7 @@ class {{ service.name }}RestInterceptor:
 
 
     """
-    {% for method in service.methods.values()|sort(attribute="name") if not method.client_streaming %}
+    {% for method in service.methods.values()|sort(attribute="name") if not method.client_streaming and method.http_options %}
     def pre_{{ method.name|snake_case }}(self, request: {{method.input.ident}}, metadata: Sequence[Tuple[str, str]]) -> Tuple[{{method.input.ident}}, Sequence[Tuple[str, str]]]:
         """Pre-rpc interceptor for {{ method.name|snake_case }}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -100,7 +100,7 @@ class {{ service.name }}RestInterceptor:
 
 
     """
-    {% for method in service.methods.values()|sort(attribute="name") if not method.client_streaming %}
+    {% for method in service.methods.values()|sort(attribute="name") if not method.client_streaming and method.http_options %}
     def pre_{{ method.name|snake_case }}(self, request: {{method.input.ident}}, metadata: Sequence[Tuple[str, str]]) -> Tuple[{{method.input.ident}}, Sequence[Tuple[str, str]]]:
         """Pre-rpc interceptor for {{ method.name|snake_case }}
 


### PR DESCRIPTION
This PR fixes an issue where rpcs which do not have the `google.api.http` annotation are included in `rest.py`