### PR TITLE
chore(test): test receiving known and unknown enums

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -277,6 +277,8 @@ def test_{{ method_name }}_field_headers():
 
     # Establish that the field header was sent.
     _, _, kw = call.mock_calls[0]
+
+    print(f"*** FIXME-kw ***\n{kw['metadata']}\n*** ***\n")
     assert (
         'x-goog-request-params',
         '{% for field_header in method.field_headers -%}

--- a/noxfile.py
+++ b/noxfile.py
@@ -224,6 +224,7 @@ def showcase_library(
             f"google/showcase/v1beta1/echo.proto",
             f"google/showcase/v1beta1/identity.proto",
             f"google/showcase/v1beta1/messaging.proto",
+            f"google/showcase/v1beta1/compliance.proto",
         )
         session.run(
             *cmd_tup, external=True,
@@ -231,7 +232,6 @@ def showcase_library(
 
         # Install the library.
         session.install("-e", tmp_dir)
-
         yield tmp_dir
 
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -23,6 +23,8 @@ from google.auth import credentials
 from google.showcase import EchoClient
 from google.showcase import IdentityClient
 from google.showcase import MessagingClient
+from google.showcase import ComplianceClient
+
 
 if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
     from grpc.experimental import aio
@@ -132,6 +134,11 @@ def use_mtls(request):
 @pytest.fixture(params=["grpc", "rest"])
 def echo(use_mtls, request):
     return construct_client(EchoClient, use_mtls, transport_name=request.param)
+
+
+@pytest.fixture(params=["grpc", "rest"])
+def compliance(use_mtls, request):
+    return construct_client(ComplianceClient, use_mtls, transport_name=request.param)
 
 
 @pytest.fixture(params=["grpc", "rest"])

--- a/tests/system/test_compliance.py
+++ b/tests/system/test_compliance.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/system/test_compliance.py
+++ b/tests/system/test_compliance.py
@@ -20,6 +20,11 @@ from grpc_status import rpc_status
 from google.api_core import exceptions
 
 
-def test_serialize_boolean(compliance):
+def test_requesting_known_and_unknown_enums(compliance):
     request = showcase.EnumRequest(unknown_enum = True)
-    compliance.get_enum(request=request)
+    response = compliance.get_enum(request)
+    verify = compliance.verify_enum(response)
+
+    request = showcase.EnumRequest(unknown_enum = False)
+    response = compliance.get_enum(request)
+    verify = compliance.verify_enum(response)

--- a/tests/system/test_serialization.py
+++ b/tests/system/test_serialization.py
@@ -22,4 +22,4 @@ from google.api_core import exceptions
 
 def test_serialize_boolean(compliance):
     request = showcase.EnumRequest(unknown_enum = True)
-    compliance.get_enum(request)
+    compliance.get_enum(request=request)

--- a/tests/system/test_serialization.py
+++ b/tests/system/test_serialization.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from google import showcase
+from google.rpc import error_details_pb2
+from google.protobuf import any_pb2
+from grpc_status import rpc_status
+from google.api_core import exceptions
+
+
+def test_serialize_boolean(compliance):
+    request = showcase.EnumRequest(unknown_enum = True)
+    compliance.get_enum(request)


### PR DESCRIPTION
This provides test for #1407 

In a subsequent PR, it will be expanded to include compliance_suite testing.

This is based heavily on @atulep 's [PR#1424](https://github.com/googleapis/gapic-generator-python/pull/1424 )
