### PR TITLE
fix: unit test generation for boolean query prams

### DIFF
--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1213,6 +1213,8 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                     "{{ req_field.name | camel_case }}",
                     {% if req_field.field_pb.type == 9 %}
                     "{{ req_field.field_pb.default_value }}",
+                    {% elif  %}
+                    str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}).lower(),
                     {% else %}
                     str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}),
                     {% endif %}{# default is str #}

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1213,7 +1213,7 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                     "{{ req_field.name | camel_case }}",
                     {% if req_field.field_pb.type == 9 %}
                     "{{ req_field.field_pb.default_value }}",
-                    {% elif  %}
+                    {% elif req_field.field_pb.type == 8 %}
                     str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}).lower(),
                     {% else %}
                     str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}),

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1102,6 +1102,8 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                     "{{ req_field.name | camel_case }}",
                     {% if req_field.field_pb.type == 9 %}
                     "{{ req_field.field_pb.default_value }}",
+                    {% elif req_field.field_pb.type == 8 %}
+                    str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}).lower(),
                     {% else %}
                     str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}),
                     {% endif %}{# default is str #}


### PR DESCRIPTION
Without this fix the current compute engine tests are failing. Also 3 other APIs in googleapis would have failed if grpc+rest transport was enabled on them.

