### PR TITLE
fix: femove `vars` and `set`from reserved names

### DIFF
--- a/gapic/utils/reserved_names.py
+++ b/gapic/utils/reserved_names.py
@@ -24,7 +24,8 @@ RESERVED_NAMES = frozenset(
         # We CANNOT make exceptions for keywords.
         keyword.kwlist,
         # We make SOME exceptions for certain names that collide with builtins.
-        set(dir(builtins)) - {"filter", "map", "id", "input", "property", "vars", "set"},
+        set(dir(builtins)) - {"filter", "map", "id",
+            "input", "property", "vars", "set"},
         # "mapping" and "ignore_unknown_fields" have special uses
         # in the constructor of proto.Message
         {"mapping", "ignore_unknown_fields"},

--- a/gapic/utils/reserved_names.py
+++ b/gapic/utils/reserved_names.py
@@ -24,7 +24,7 @@ RESERVED_NAMES = frozenset(
         # We CANNOT make exceptions for keywords.
         keyword.kwlist,
         # We make SOME exceptions for certain names that collide with builtins.
-        set(dir(builtins)) - {"filter", "map", "id", "input", "property"},
+        set(dir(builtins)) - {"filter", "map", "id", "input", "property", "vars", "set"},
         # "mapping" and "ignore_unknown_fields" have special uses
         # in the constructor of proto.Message
         {"mapping", "ignore_unknown_fields"},


### PR DESCRIPTION
This fixes https://github.com/googleapis/gapic-generator-python/issues/1348. This is also backwar compatible with already released clients dataform and network-services, because removal of unnecessary `_` is already happening in ppostprocesing scripts for those two affected apis.

