### PR TITLE
fix: do not generate _flattened() unit tests for client streaming methods

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -363,7 +363,7 @@ def test_{{ method_name }}_from_dict_foreign():
 
 {% endif %}
 
-{% if method.flattened_fields %}
+{% if method.flattened_fields and not method.client_streaming %}
 def test_{{ method_name }}_flattened():
     client = {{ service.client_name }}(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -1224,7 +1224,7 @@ def test_{{ method_name }}_rest_bad_request(transport: str = 'rest', request_typ
         {% endif %}
 
 
-{% if method.flattened_fields %}
+{% if method.flattened_fields and not method.client_streaming %}
 def test_{{ method_name }}_rest_flattened():
     client = {{ service.client_name }}(
         credentials=ga_credentials.AnonymousCredentials(),


### PR DESCRIPTION
This fixes https://github.com/googleapis/gapic-generator-python/issues/1374

The generator does not generate flattened parameters for client streamin methods, so generating unit tests for them does not make sense. The flattened structure generation is explicitly disabled in client code generation: https://github.com/googleapis/gapic-generator-python/blob/main/gapic/templates/%25namespace/%25name_%25version/%25sub/services/%25service/_client_macros.j2#L19


