### PR TITLE
chore(revert): Revert use strict encoding to lowercase query string bools

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
@@ -364,7 +364,7 @@ class {{service.name}}RestTransport({{service.name}}Transport):
                 "{host}{uri}".format(host=self._host, uri=uri),
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
+                params=rest_helpers.flatten_query_params(query_params),
                 {% if body_spec %}
                 data=body,
                 {% endif %}

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -19,7 +19,7 @@ setuptools.setup(
     install_requires=(
         {# TODO(dovs): remove when 1.x deprecation is complete #}
         {% if 'rest' in opts.transport %}
-        'google-api-core[grpc] >= 2.10.0, < 3.0.0dev',
+        'google-api-core[grpc] >= 2.4.0, < 3.0.0dev',
         {% else %}
         'google-api-core[grpc] >= 1.28.0, < 3.0.0dev',
         {% endif %}

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1216,7 +1216,7 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                     {% elif req_field.field_pb.type == 8 %}
                     str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}).lower(),
                     {% else %}
-                    str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}),
+                    {{ req_field.type.python_type(req_field.field_pb.default_value or 0) }},
                     {% endif %}{# default is str #}
                 ),
               {% endfor %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -398,7 +398,7 @@ class {{service.name}}RestTransport({{service.name}}Transport):
                 "{host}{uri}".format(host=self._host, uri=uri),
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
+                params=rest_helpers.flatten_query_params(query_params),
                 {% if body_spec %}
                 data=body,
                 {% endif %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -30,7 +30,12 @@ setuptools.setup(
     platforms='Posix; MacOS X; Windows',
     include_package_data=True,
     install_requires=(
+        {# TODO(dovs): remove when 1.x deprecation is complete #}
+        {% if 'rest' in opts.transport %}
         'google-api-core[grpc] >= 2.10.0, < 3.0.0dev',
+        {% else %}
+        'google-api-core[grpc] >= 2.10.0, < 3.0.0dev',
+        {% endif %}
         'libcst >= 0.2.5',
         'googleapis-common-protos >= 1.55.0, <2.0.0dev',
         'proto-plus >= 1.19.7',

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1105,7 +1105,7 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                     {% elif req_field.field_pb.type == 8 %}
                     str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}).lower(),
                     {% else %}
-                    str({{ req_field.type.python_type(req_field.field_pb.default_value or 0) }}),
+                    {{ req_field.type.python_type(req_field.field_pb.default_value or 0) }},
                     {% endif %}{# default is str #}
                 ),
               {% endfor %}


### PR DESCRIPTION
Reverts googleapis/gapic-generator-python#1436 which causes generated unit tests to fail for compute