### PR TITLE
chore: fix snippet metadata filename and add placeholder library version

### DIFF
--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -217,9 +217,10 @@ class Generator:
 
         if index.metadata_index.snippets:
             # NOTE(busunkim): Not all fields are yet populated in the snippet metadata.
-            # Expected filename: snippet_metadata_{apishortname}_{apiversion}.json
+            # Expected filename: snippet_metadata.{proto_package}.json
+            # For example: snippet_metadata.google.cloud.aiplatform.v1.json
             snippet_metadata_path = str(pathlib.Path(
-                out_dir) / f"snippet_metadata_{api_schema.naming.name}_{api_schema.naming.version}.json").lower()
+                out_dir) / f"snippet_metadata.{api_schema.naming.proto_package}.json").lower()
             output_files[snippet_metadata_path] = CodeGeneratorResponse.File(
                 content=formatter.fix_whitespace(index.get_metadata_json()), name=snippet_metadata_path)
 

--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -218,9 +218,9 @@ class Generator:
         if index.metadata_index.snippets:
             # NOTE(busunkim): Not all fields are yet populated in the snippet metadata.
             # Expected filename: snippet_metadata.{proto_package}.json
-            # For example: snippet_metadata.google.cloud.aiplatform.v1.json
+            # For example: snippet_metadata_google.cloud.aiplatform.v1.json
             snippet_metadata_path = str(pathlib.Path(
-                out_dir) / f"snippet_metadata.{api_schema.naming.proto_package}.json").lower()
+                out_dir) / f"snippet_metadata_{api_schema.naming.proto_package}.json").lower()
             output_files[snippet_metadata_path] = CodeGeneratorResponse.File(
                 content=formatter.fix_whitespace(index.get_metadata_json()), name=snippet_metadata_path)
 

--- a/gapic/samplegen_utils/snippet_index.py
+++ b/gapic/samplegen_utils/snippet_index.py
@@ -104,6 +104,10 @@ class SnippetIndex:
         self.metadata_index.client_library.name = api_schema.naming.warehouse_package_name
         self.metadata_index.client_library.language = snippet_metadata_pb2.Language.PYTHON  # type: ignore
 
+        # This is just a placeholder.  release-please is responsible for
+        # updating the metadata file to the correct library version.
+        self.metadata_index.client_library.version = "0.1.0"
+
         self.metadata_index.client_library.apis.append(snippet_metadata_pb2.Api(  # type: ignore
             id=api_schema.naming.proto_package,
             version=api_schema.naming.version

--- a/tests/integration/goldens/asset/samples/generated_samples/snippet_metadata_google.cloud.asset.v1.json
+++ b/tests/integration/goldens/asset/samples/generated_samples/snippet_metadata_google.cloud.asset.v1.json
@@ -7,7 +7,8 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-asset"
+    "name": "google-cloud-asset",
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/tests/integration/goldens/credentials/samples/generated_samples/snippet_metadata_google.iam.credentials.v1.json
+++ b/tests/integration/goldens/credentials/samples/generated_samples/snippet_metadata_google.iam.credentials.v1.json
@@ -7,7 +7,8 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-iam-credentials"
+    "name": "google-iam-credentials",
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/tests/integration/goldens/eventarc/samples/generated_samples/snippet_metadata_google.cloud.eventarc.v1.json
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/snippet_metadata_google.cloud.eventarc.v1.json
@@ -7,7 +7,8 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-eventarc"
+    "name": "google-cloud-eventarc",
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/tests/integration/goldens/logging/samples/generated_samples/snippet_metadata_google.logging.v2.json
+++ b/tests/integration/goldens/logging/samples/generated_samples/snippet_metadata_google.logging.v2.json
@@ -7,7 +7,8 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-logging"
+    "name": "google-cloud-logging",
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/tests/integration/goldens/redis/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
+++ b/tests/integration/goldens/redis/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
@@ -7,7 +7,8 @@
       }
     ],
     "language": "PYTHON",
-    "name": "google-cloud-redis"
+    "name": "google-cloud-redis",
+    "version": "0.1.0"
   },
   "snippets": [
     {

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -464,7 +464,7 @@ def test_samplegen_config_to_output_files(mock_gmtime, fs):
             },
             )},
         naming=DummyNaming(name="mollusc", version="v1", warehouse_package_name="mollusc-cephalopod-teuthida-",
-                           versioned_module_name="teuthida_v1", module_namespace="mollusc.cephalopod", proto_package="google.mollusca"),
+                           versioned_module_name="teuthida_v1", module_namespace="mollusc.cephalopod", proto_package="google.mollusca.v1"),
     )
 
     with mock.patch("gapic.samplegen.samplegen.generate_sample", side_effect=mock_generate_sample):
@@ -474,11 +474,12 @@ def test_samplegen_config_to_output_files(mock_gmtime, fs):
     expected_snippet_index_json = {
         "clientLibrary": {
             "apis": [{
-                "id": "google.mollusca",
+                "id": "google.mollusca.v1",
                 "version": "v1"
             }],
             "language": "PYTHON",
-            "name": "mollusc-cephalopod-teuthida-"
+            "name": "mollusc-cephalopod-teuthida-",
+            "version": "0.1.0"
             },
         "snippets": [
             {
@@ -532,7 +533,7 @@ def test_samplegen_config_to_output_files(mock_gmtime, fs):
     assert actual_response.file[1] == CodeGeneratorResponse.File(
         name="samples/generated_samples/clam_sample.py", content="\n",)
 
-    assert actual_response.file[2].name == "samples/generated_samples/snippet_metadata_mollusc_v1.json"
+    assert actual_response.file[2].name == "samples/generated_samples/snippet_metadata_google.mollusca.v1.json"
 
     assert json.loads(
         actual_response.file[2].content) == expected_snippet_index_json
@@ -616,7 +617,7 @@ def test_samplegen_id_disambiguation(mock_gmtime, fs):
             },
             )},
         naming=DummyNaming(name="mollusc", version="v1", warehouse_package_name="mollusc-cephalopod-teuthida-",
-                           versioned_module_name="teuthida_v1", module_namespace="mollusc.cephalopod", proto_package="google.mollusca"),
+                           versioned_module_name="teuthida_v1", module_namespace="mollusc.cephalopod", proto_package="google.mollusca.v1"),
     )
     with mock.patch("gapic.samplegen.samplegen.generate_sample", side_effect=mock_generate_sample):
         actual_response = g.get_response(api_schema,
@@ -626,12 +627,13 @@ def test_samplegen_id_disambiguation(mock_gmtime, fs):
         "clientLibrary": {
             "apis": [
                 {
-                    "id": "google.mollusca",
+                    "id": "google.mollusca.v1",
                     "version": "v1"
                     }
             ],
             "language": "PYTHON",
-            "name": "mollusc-cephalopod-teuthida-"
+            "name": "mollusc-cephalopod-teuthida-",
+            "version": "0.1.0"
         },
         "snippets": [
             {
@@ -709,7 +711,7 @@ def test_samplegen_id_disambiguation(mock_gmtime, fs):
         name="samples/generated_samples/7384949e.py", content="\n",
     )
     print(actual_response.file[3].content)
-    assert actual_response.file[3].name == "samples/generated_samples/snippet_metadata_mollusc_v1.json"
+    assert actual_response.file[3].name == "samples/generated_samples/snippet_metadata_google.mollusca.v1.json"
     assert json.loads(
         actual_response.file[3].content) == expected_snippet_metadata_json
 

--- a/tests/unit/samplegen/test_snippet_index.py
+++ b/tests/unit/samplegen/test_snippet_index.py
@@ -255,7 +255,8 @@ def test_get_metadata_json(sample_str):
                     }
                 ],
             "language": "PYTHON",
-            "name": "google-mollusca"
+            "name": "google-mollusca",
+            "version": "0.1.0"
             },
         "snippets": [
             {


### PR DESCRIPTION
1. Fix snippet metadata filename.  Example: `snippet_metadata_asset_v1.json` --> `snippet_metadata_google.cloud.asset.v1.json`.
2. Add client_library.version placeholder in snippet metadata.  For individual libraries this gets updated to the correct version number by release-please.