### PR TITLE
chore: fix docs build

### DIFF
--- a/gapic/templates/docs/%name_%version/types.rst.j2
+++ b/gapic/templates/docs/%name_%version/types.rst.j2
@@ -3,5 +3,4 @@ Types for {{ api.naming.long_name }} {{ api.naming.version }} API
 
 .. automodule:: {{ api.naming.namespace|join('.')|lower }}.{{ api.naming.versioned_module_name }}.types
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/tests/integration/goldens/asset/docs/asset_v1/types.rst
+++ b/tests/integration/goldens/asset/docs/asset_v1/types.rst
@@ -3,5 +3,4 @@ Types for Google Cloud Asset v1 API
 
 .. automodule:: google.cloud.asset_v1.types
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/tests/integration/goldens/credentials/docs/credentials_v1/types.rst
+++ b/tests/integration/goldens/credentials/docs/credentials_v1/types.rst
@@ -3,5 +3,4 @@ Types for Google Iam Credentials v1 API
 
 .. automodule:: google.iam.credentials_v1.types
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/tests/integration/goldens/eventarc/docs/eventarc_v1/types.rst
+++ b/tests/integration/goldens/eventarc/docs/eventarc_v1/types.rst
@@ -3,5 +3,4 @@ Types for Google Cloud Eventarc v1 API
 
 .. automodule:: google.cloud.eventarc_v1.types
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/tests/integration/goldens/logging/docs/logging_v2/types.rst
+++ b/tests/integration/goldens/logging/docs/logging_v2/types.rst
@@ -3,5 +3,4 @@ Types for Google Cloud Logging v2 API
 
 .. automodule:: google.cloud.logging_v2.types
     :members:
-    :undoc-members:
     :show-inheritance:

--- a/tests/integration/goldens/redis/docs/redis_v1/types.rst
+++ b/tests/integration/goldens/redis/docs/redis_v1/types.rst
@@ -3,5 +3,4 @@ Types for Google Cloud Redis v1 API
 
 .. automodule:: google.cloud.redis_v1.types
     :members:
-    :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
This PR removes the `undoc-members` option of sphinx to address the error `duplicate object description` seen in the docs build for downstream clients. See build log [here](https://github.com/googleapis/python-access-approval/actions/runs/3438234164/jobs/5734028967) 

See the definition for `undoc-members` here:
> :undoc-members: (no value)[¶](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-option-automodule-undoc-members)
If set, autodoc will also generate document for the members not having docstrings:

https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#directive-option-automodule-undoc-members