### PR TITLE
fix: snippetgen should call await on the operation coroutine before calling result

### DIFF
--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -242,6 +242,14 @@ client.{{ sample.rpc|snake_case }}({{ render_request_params_unary(sample.request
 {% endif %}
 {% endmacro %}
 
+{% macro operation_text(transport) %}
+{% if transport == "grpc-async" %}
+(await operation)
+{% else %}
+operation
+{% endif %}
+{% endmacro %}
+
 {# Setting up the method invocation is the responsibility of the caller: #}
 {# it's just easier to set up client side streaming and other things from outside this macro. #}
 {% macro render_calling_form(method_invocation_text, calling_form, calling_form_enum, transport, response_statements ) %}
@@ -286,7 +294,9 @@ operation = {{ method_invocation_text|trim }}
 
 print("Waiting for operation to complete...")
 
-response = {% if transport == "grpc-async" %}await {% endif %}operation.result()
+{% with operation_text = operation_text(transport) %}
+response = {{ operation_text|trim }}.result()
+{% endwith %}
 
 # Handle the response
 {% for statement in response_statements %}

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -239,7 +239,7 @@ class AssetServiceAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -1610,7 +1610,7 @@ initial=0.1,maximum=60.0,multiplier=1.3,                predicate=retries.if_exc
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_async.py
@@ -55,7 +55,7 @@ async def sample_analyze_iam_policy_longrunning():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_async.py
@@ -52,7 +52,7 @@ async def sample_export_assets():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
@@ -459,7 +459,7 @@ class EventarcAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -593,7 +593,7 @@ class EventarcAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -730,7 +730,7 @@ class EventarcAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_async.py
@@ -58,7 +58,7 @@ async def sample_create_trigger():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_async.py
@@ -49,7 +49,7 @@ async def sample_delete_trigger():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_async.py
@@ -48,7 +48,7 @@ async def sample_update_trigger():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -491,7 +491,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -643,7 +643,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -778,7 +778,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -917,7 +917,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -1052,7 +1052,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -1181,7 +1181,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)
@@ -1309,7 +1309,7 @@ class CloudRedisAsyncClient:
 
                 print("Waiting for operation to complete...")
 
-                response = await operation.result()
+                response = (await operation).result()
 
                 # Handle the response
                 print(response)

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_async.py
@@ -55,7 +55,7 @@ async def sample_create_instance():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_async.py
@@ -48,7 +48,7 @@ async def sample_delete_instance():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_async.py
@@ -52,7 +52,7 @@ async def sample_export_instance():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_async.py
@@ -48,7 +48,7 @@ async def sample_failover_instance():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_async.py
@@ -52,7 +52,7 @@ async def sample_import_instance():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_async.py
@@ -53,7 +53,7 @@ async def sample_update_instance():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_async.py
@@ -49,7 +49,7 @@ async def sample_upgrade_instance():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_lro_signatures_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_lro_signatures_async.py
@@ -56,7 +56,7 @@ async def sample_method_lro_signatures():
 
     print("Waiting for operation to complete...")
 
-    response = await operation.result()
+    response = (await operation).result()
 
     # Handle the response
     print(response)

--- a/tests/unit/samplegen/test_template.py
+++ b/tests/unit/samplegen/test_template.py
@@ -902,7 +902,7 @@ def test_render_calling_form_longrunning_async():
 
                    print("Waiting for operation to complete...")
 
-                   response = await operation.result()
+                   response = (await operation).result()
 
                    # Handle the response
                    print("Test print statement")


### PR DESCRIPTION
Currently the generated snippet contains the following code for **async** client that returns a **long running operation**, such as Vision API's `import_product_sets`:

```
    ...
    operation = client.import_product_sets(request=request)
    ...
    response = await operation.result()
    ...
```

This is incorrect since `operation` is a coroutine that needs to be `await`ed to return an actual operation (which has the `result` attribute).

The proposed fix is to change the generated code to:
```
     response = (await operation).result()
```