### PR TITLE
fix: mark server_streaming method as async

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -192,7 +192,7 @@ class {{ service.async_client_name }}:
 
     {% for method in service.methods.values() %}
       {% with method_name = method.safe_name|snake_case + "_unary" if method.operation_service else method.safe_name|snake_case %}
-    {%+ if not method.server_streaming %}async {% endif %}def {{ method_name }}(self,
+    async def {{ method_name }}(self,
       {% endwith %}
             {% if not method.client_streaming %}
             request: Optional[Union[{{ method.input.ident }}, dict]] = None,
@@ -343,7 +343,7 @@ class {{ service.async_client_name }}:
 
         # Send the request.
         {%+ if not method.void %}response = {% endif %}
-        {% if not method.server_streaming %}await {% endif %}rpc(
+        await rpc(
             {% if not method.client_streaming %}
             request,
             {% else %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -343,7 +343,7 @@ class {{ service.async_client_name }}:
 
         # Send the request.
         {%+ if not method.void %}response = {% endif %}
-        await rpc(
+rpc(
             {% if not method.client_streaming %}
             request,
             {% else %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -183,6 +183,7 @@ async def test_{{ method_name }}_async(transport: str = 'grpc_asyncio', request_
     message = await response.read()
     assert isinstance(message, {{ method.output.ident }})
     {% else %}
+    response = await response
     assert isinstance(response, {{ method.client_output_async.ident }})
     {% for field in method_output.fields.values() | rejectattr('message') %}
     {% if not field.oneof or field.proto3_optional %}


### PR DESCRIPTION
As found in https://github.com/googleapis/python-bigtable/pull/702/files#diff-cefca7c885a9bf43a6cc4769c788d30041fcffc582df926b7240e03beea308ebR529 

In `google/cloud/bigtable_v2/services/bigtable/async_client.py` file, `mutate_rows` should become a coroutine.
and the call to the rpc should be awaited.


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/gapic-generator-python/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #1503  🦕
