### PR TITLE
fix: fix unit test with float comparison

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -402,6 +402,8 @@ def test_{{ method_name }}_flattened():
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
         {% elif (field.ident|string()).startswith('wrappers_pb2.') %}
         assert wrappers.{{ (field.ident|string())[13:] }}Rule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
+        {% elif field.field_pb.type == 2 %}{# Use approx eq for floats #}
+        assert math.isclose(args[0].{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
         {% else %}
         arg = args[0].{{ key }}
         mock_val = {{ field.mock_value }}
@@ -497,6 +499,8 @@ async def test_{{ method_name }}_flattened_async():
         assert DurationRule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
         {% elif (field.ident|string()).startswith('wrappers_pb2.') %}
         assert wrappers.{{ (field.ident|string())[13:] }}Rule().to_proto(args[0].{{ key }}) == {{ field.mock_value }}
+        {% elif field.field_pb.type == 2 %}{# Use approx eq for floats #}
+        assert math.isclose(args[0].{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
         {% else %}
         arg = args[0].{{ key }}
         mock_val = {{ field.mock_value }}


### PR DESCRIPTION
Fixes the issue reported in YAQS #1168910602697965568 where the generated unit tests for google/cloud/contactcenterinsights/v1 fail due to an issue with float comparison. There is a known issue with precision in float fields according to https://github.com/protocolbuffers/protobuf/issues/8269.

```
=========================================================================================================================================== FAILURES ===========================================================================================================================================
__________________________________________________________________________________________________________________________ test_bulk_analyze_conversations_flattened ___________________________________________________________________________________________________________________________

    def test_bulk_analyze_conversations_flattened():
        client = ContactCenterInsightsClient(
            credentials=ga_credentials.AnonymousCredentials(),
        )
    
        # Mock the actual call within the gRPC stub, and fake the request.
        with mock.patch.object(
            type(client.transport.bulk_analyze_conversations), "__call__"
        ) as call:
            # Designate an appropriate return value for the call.
            call.return_value = operations_pb2.Operation(name="operations/op")
            # Call the method with a truthy value for each flattened field,
            # using the keyword arguments to the method.
            client.bulk_analyze_conversations(
                parent="parent_value",
                filter="filter_value",
                analysis_percentage=0.20170000000000002,
            )
    
            # Establish that the underlying call was made with the expected
            # request object values.
            assert len(call.mock_calls) == 1
            _, args, _ = call.mock_calls[0]
            arg = args[0].parent
            mock_val = "parent_value"
            assert arg == mock_val
            arg = args[0].filter
            mock_val = "filter_value"
            assert arg == mock_val
            arg = args[0].analysis_percentage
            mock_val = 0.20170000000000002
>           assert arg == mock_val
E           assert 0.20170000195503235 == 0.20170000000000002

tests/unit/gapic/contact_center_insights_v1/test_contact_center_insights.py:3542: AssertionError
_______________________________________________________________________________________________________________________ test_bulk_analyze_conversations_flattened_async ________________________________________________________________________________________________________________________

    @pytest.mark.asyncio
    async def test_bulk_analyze_conversations_flattened_async():
        client = ContactCenterInsightsAsyncClient(
            credentials=ga_credentials.AnonymousCredentials(),
        )
    
        # Mock the actual call within the gRPC stub, and fake the request.
        with mock.patch.object(
            type(client.transport.bulk_analyze_conversations), "__call__"
        ) as call:
            # Designate an appropriate return value for the call.
            call.return_value = operations_pb2.Operation(name="operations/op")
    
            call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
                operations_pb2.Operation(name="operations/spam")
            )
            # Call the method with a truthy value for each flattened field,
            # using the keyword arguments to the method.
            response = await client.bulk_analyze_conversations(
                parent="parent_value",
                filter="filter_value",
                analysis_percentage=0.20170000000000002,
            )
    
            # Establish that the underlying call was made with the expected
            # request object values.
            assert len(call.mock_calls)
            _, args, _ = call.mock_calls[0]
            arg = args[0].parent
            mock_val = "parent_value"
            assert arg == mock_val
            arg = args[0].filter
            mock_val = "filter_value"
            assert arg == mock_val
            arg = args[0].analysis_percentage
            mock_val = 0.20170000000000002
>           assert arg == mock_val
E           assert 0.20170000195503235 == 0.20170000000000002
```