### PR TITLE
chore: add service client initialization

### DIFF
--- a/gapic/configurable_snippetgen/configured_snippet.py
+++ b/gapic/configurable_snippetgen/configured_snippet.py
@@ -22,6 +22,24 @@ from gapic.configurable_snippetgen import snippet_config_language_pb2
 from gapic.schema import api
 
 
+class _AppendToSampleFunctionBody(libcst.CSTTransformer):
+    def __init__(self, statement: libcst.BaseStatement):
+        self.statement = statement
+
+    def visit_IndentedBlock(self, node: libcst.IndentedBlock) -> bool:
+        # Do not visit any nested indented blocks.
+        return False
+
+    def leave_IndentedBlock(
+        self, original_node: libcst.IndentedBlock, updated_node: libcst.IndentedBlock
+    ) -> libcst.IndentedBlock:
+        del original_node
+        # FunctionDef.body is an IndentedBlock, and IndentedBlock.body
+        # is the actual sequence of statements.
+        new_body = list(updated_node.body) + [self.statement]
+        return updated_node.with_changes(body=new_body)
+
+
 @dataclasses.dataclass
 class ConfiguredSnippet:
     api_schema: api.API
@@ -29,7 +47,7 @@ class ConfiguredSnippet:
     api_version: str
     is_sync: bool
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         self._module: libcst.Module = libcst_utils.empty_module()
         self._sample_function_def: libcst.FunctionDef = libcst_utils.base_function_def(
             function_name=self.sample_function_name, is_sync=self.is_sync
@@ -101,6 +119,18 @@ class ConfiguredSnippet:
         sync_or_async = "sync" if self.is_sync else "async"
         return f"{self.gapic_module_name}_generated_{service_name}_{snake_case_rpc_name}_{config_id}_{sync_or_async}.py"
 
+    def _append_to_sample_function_def_body(
+        self, statement: libcst.BaseStatement
+    ) -> None:
+        """Appends the statement node to the current sample function def."""
+        transformer = _AppendToSampleFunctionBody(statement)
+
+        # The result of applying a transformer could be of a different type
+        # in general, but we will only update the sample function def here.
+        self._sample_function_def = self._sample_function_def.visit(
+            transformer
+        )  # type: ignore
+
     def _add_sample_function_parameters(self) -> None:
         # TODO: https://github.com/googleapis/gapic-generator-python/issues/1537, add typing annotation in sample function parameters.
         params = []
@@ -115,12 +145,7 @@ class ConfiguredSnippet:
         initialization_call = libcst.parse_statement(
             f"client = {self.gapic_module_name}.{self.client_class_name}()"
         )
-
-        # It seems not a good practice to mutate libcst nodes, but the code
-        # is much simpler this way.
-        # FunctionDef.body is an IndentedBlock, and IndentedBlock.body
-        # is the actual list of statements.
-        self._sample_function_def.body.body.append(initialization_call)
+        self._append_to_sample_function_def_body(initialization_call)
 
     def _add_sample_function_body(self) -> None:
         # TODO: https://github.com/googleapis/gapic-generator-python/issues/1539, add sample function body.

--- a/gapic/configurable_snippetgen/configured_snippet.py
+++ b/gapic/configurable_snippetgen/configured_snippet.py
@@ -113,7 +113,7 @@ class ConfiguredSnippet:
 
     def _append_service_client_initialization(self) -> None:
         initialization_call = libcst.parse_statement(
-            f"client = {self.gapic_module_name}.{self.gapic_module_name}.{self.client_class_name}()"
+            f"client = {self.gapic_module_name}.{self.client_class_name}()"
         )
 
         # It seems not a good practice to mutate libcst nodes, but the code

--- a/tests/unit/configurable_snippetgen/test_configured_snippet.py
+++ b/tests/unit/configurable_snippetgen/test_configured_snippet.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from google.protobuf import json_format
 from google.protobuf.compiler import plugin_pb2
+import libcst
 import pytest
 
 from gapic import utils
@@ -129,6 +130,18 @@ def test_filename(is_sync, expected):
         SPEECH_V1_REQUEST_PATH, CONFIG_JSON_PATH, api_version="v1", is_sync=is_sync
     )
     assert snippet.filename == expected
+
+
+def test_AppendToSampleFunctionBody():
+    # Start with a function def with nonempty body to we can be sure the
+    # transformer appends the statement.
+    function_def = libcst.parse_statement("def f():\n    'hello'")
+    statement = libcst.parse_statement("'world'")
+    transformer = configured_snippet._AppendToSampleFunctionBody(statement)
+    updated_function_def = function_def.visit(transformer)
+    expected_function_def = libcst.parse_statement(
+        "def f():\n    'hello'\n    'world'")
+    assert updated_function_def.deep_equals(expected_function_def)
 
 
 def test_code(snippet):

--- a/tests/unit/configurable_snippetgen/test_configured_snippet.py
+++ b/tests/unit/configurable_snippetgen/test_configured_snippet.py
@@ -81,21 +81,54 @@ def snippet():
     )
 
 
-def test_region_tag(snippet):
-    assert (
-        snippet.region_tag == "speech_v1_config_Adaptation_CreateCustomClass_Basic_sync"
+def test_gapic_module_name(snippet):
+    assert snippet.gapic_module_name == "speech_v1"
+
+
+@pytest.mark.parametrize(
+    "is_sync,expected",
+    [
+        (True, "speech_v1_config_Adaptation_CreateCustomClass_Basic_sync"),
+        (False, "speech_v1_config_Adaptation_CreateCustomClass_Basic_async"),
+    ],
+)
+def test_region_tag(is_sync, expected):
+    snippet = _make_configured_snippet(
+        SPEECH_V1_REQUEST_PATH, CONFIG_JSON_PATH, api_version="v1", is_sync=is_sync
     )
+    assert snippet.region_tag == expected
 
 
 def test_sample_function_name(snippet):
     assert snippet.sample_function_name == "sample_create_custom_class_Basic"
 
 
-def test_filename(snippet):
-    assert (
-        snippet.filename
-        == "speech_v1_generated_Adaptation_create_custom_class_Basic_sync.py"
+@pytest.mark.parametrize(
+    "is_sync,expected",
+    [
+        (True, "AdaptationClient"),
+        (False, "AdaptationAsyncClient"),
+    ],
+)
+def test_client_class_name(is_sync, expected):
+    snippet = _make_configured_snippet(
+        SPEECH_V1_REQUEST_PATH, CONFIG_JSON_PATH, api_version="v1", is_sync=is_sync
     )
+    assert snippet.client_class_name == expected
+
+
+@pytest.mark.parametrize(
+    "is_sync,expected",
+    [
+        (True, "speech_v1_generated_Adaptation_create_custom_class_Basic_sync.py"),
+        (False, "speech_v1_generated_Adaptation_create_custom_class_Basic_async.py"),
+    ],
+)
+def test_filename(is_sync, expected):
+    snippet = _make_configured_snippet(
+        SPEECH_V1_REQUEST_PATH, CONFIG_JSON_PATH, api_version="v1", is_sync=is_sync
+    )
+    assert snippet.filename == expected
 
 
 def test_code(snippet):
@@ -106,5 +139,6 @@ def test_code(snippet):
     # until the generated code is the same as that of the golden file.
     expected_code = """def sample_create_custom_class_Basic(parent = "projects/[PROJECT]/locations/us", custom_class_id = "passengerships"):
     \"\"
+    client = speech_v1.speech_v1.AdaptationClient()
 """
     assert snippet.code == expected_code

--- a/tests/unit/configurable_snippetgen/test_configured_snippet.py
+++ b/tests/unit/configurable_snippetgen/test_configured_snippet.py
@@ -139,6 +139,6 @@ def test_code(snippet):
     # until the generated code is the same as that of the golden file.
     expected_code = """def sample_create_custom_class_Basic(parent = "projects/[PROJECT]/locations/us", custom_class_id = "passengerships"):
     \"\"
-    client = speech_v1.speech_v1.AdaptationClient()
+    client = speech_v1.AdaptationClient()
 """
     assert snippet.code == expected_code


### PR DESCRIPTION
Add service client initialization call to sample function's body, but without `client_options` (for setting `api_endpoint`), which will be added in the next PR.

This PR also includes the main helper method `_append_to_sample_function_def_body` for appending statements to the sample function.