### PR TITLE
docs: sync README with synthtool templates

### DIFF
--- a/gapic/schema/naming.py
+++ b/gapic/schema/naming.py
@@ -37,11 +37,14 @@ class Naming(abc.ABC):
     An concrete child of this object is made available to every template
     (as ``api.naming``).
     """
+    api_description: str = ''
+    documentation_uri: str = ''
     name: str = ''
     namespace: Tuple[str, ...] = dataclasses.field(default_factory=tuple)
     version: str = ''
     product_name: str = ''
     proto_package: str = ''
+    title: str = ''
     _warehouse_package_name: str = ''
 
     def __post_init__(self):
@@ -146,6 +149,16 @@ class Naming(abc.ABC):
             package_info = dataclasses.replace(package_info,
                 _warehouse_package_name=opts.warehouse_package_name
                                                )
+        if opts.api_description:
+            package_info = dataclasses.replace(
+                package_info, api_description=opts.api_description)
+
+        if opts.documentation_uri:
+            package_info = dataclasses.replace(
+                package_info, documentation_uri=opts.documentation_uri)
+
+        if opts.title:
+            package_info = dataclasses.replace(package_info, title=opts.title)
 
         # Done; return the naming information.
         return package_info

--- a/gapic/templates/README.rst.j2
+++ b/gapic/templates/README.rst.j2
@@ -1,5 +1,20 @@
-Python Client for {{ api.naming.long_name }} API
-=================================================
+Python Client for {{ api.naming.title }}
+=================={% for i in range( api.naming.title | length ) %}={% endfor %}
+
+|pypi| |versions|
+
+`{{ api.naming.title }}`_: {% if api.naming.api_description %}{{ api.naming.api_description.replace("\n", " ") }}{% endif %}
+
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. |pypi| image:: https://img.shields.io/pypi/v/{{ api.naming.warehouse_package_name }}.svg
+   :target: https://pypi.org/project/{{ api.naming.warehouse_package_name }}/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/{{ api.naming.warehouse_package_name }}.svg
+   :target: https://pypi.org/project/{{ api.naming.warehouse_package_name }}/
+.. _{{ api.naming.title }}: {{ api.naming.documentation_uri }}
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/{{ api.naming.name | lower }}/latest
+.. _Product Documentation:  {{ api.naming.documentation_uri }}
 
 Quick Start
 -----------
@@ -8,11 +23,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. Enable the {{ api.naming.long_name }} API.
+3. `Enable the {{ api.naming.title }}.`_
 4. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the {{ api.naming.title }}.:  {{ api.naming.documentation_uri }}
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -29,14 +45,40 @@ dependencies.
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
 
 
+Code samples and snippets
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Code samples and snippets live in the `samples/` folder.
+
+
+Supported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
+Python.
+
+Python >= 3.7
+
+.. _active: https://devguide.python.org/devcycle/#in-development-main-branch
+.. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
+
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python <= 3.6
+
+If you are using an `end-of-life`_
+version of Python, we recommend that you update as soon as possible to an actively supported version.
+
+.. _end-of-life: https://devguide.python.org/devcycle/#end-of-life-branches
+
 Mac/Linux
 ^^^^^^^^^
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install /path/to/library
+    <your-env>/bin/pip install {{ api.naming.warehouse_package_name }}
 
 
 Windows
@@ -44,7 +86,20 @@ Windows
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install \path\to\library
+    <your-env>\Scripts\pip.exe install {{ api.naming.warehouse_package_name }}
 
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for {{ api.naming.title }}
+   to see other available methods on the client.
+-  Read the `{{ api.naming.title }} Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _{{ api.naming.title }} Product documentation:  {{ api.naming.documentation_uri }}
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst

--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -49,6 +49,9 @@ class Options:
     service_yaml_config: Dict[str, Any] = dataclasses.field(
         default_factory=dict)
     rest_numeric_enums: bool = False
+    title: str = ''
+    documentation_uri: str = ''
+    api_description: str = ''
 
     # Class constants
     PYTHON_GAPIC_PREFIX: str = 'python-gapic-'
@@ -146,6 +149,14 @@ class Options:
         # but it is not a field in the gogle.api.Service proto.
         service_yaml_config.pop('type', None)
 
+        title = service_yaml_config.pop('title', '')
+
+        documentation_uri = service_yaml_config.pop(
+            'publishing', {}).pop('documentation_uri', '')
+
+        api_description = service_yaml_config.pop(
+            'documentation', {}).pop('summary', '')
+
         # Build the options instance.
         sample_paths = opts.pop('samples', [])
 
@@ -182,6 +193,9 @@ class Options:
             transport=opts.pop('transport', ['grpc'])[0].split('+'),
             service_yaml_config=service_yaml_config,
             rest_numeric_enums=bool(opts.pop('rest-numeric-enums', False)),
+            title=title,
+            documentation_uri=documentation_uri,
+            api_description=api_description,
         )
 
         # Note: if we ever need to recursively check directories for sample

--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -55,6 +55,7 @@ py_gapic_library(
     opt_args = [
         "autogen-snippets",
     ],
+    service_yaml = "cloudasset_v1.yaml",
     transport = "grpc+rest",
 )
 
@@ -66,6 +67,7 @@ py_gapic_library(
     opt_args = [
         "autogen-snippets",
     ],
+    service_yaml = "iamcredentials_v1.yaml",
     transport = "grpc+rest",
 )
 
@@ -91,6 +93,7 @@ py_gapic_library(
         "python-gapic-name=eventarc",
         "autogen-snippets",
     ],
+    service_yaml = "eventarc_v1.yaml",
     transport = "grpc+rest",
 )
 
@@ -116,6 +119,7 @@ py_gapic_library(
         "python-gapic-name=logging",
         "autogen-snippets",
     ],
+    service_yaml = "logging_v2.yaml",
     transport = "grpc+rest",
 )
 
@@ -138,6 +142,7 @@ py_gapic_library(
     opt_args = [
         "autogen-snippets",
     ],
+    service_yaml = "redis_v1.yaml",
     transport = "grpc+rest",
 )
 

--- a/tests/integration/cloudasset_v1.yaml
+++ b/tests/integration/cloudasset_v1.yaml
@@ -1,0 +1,14 @@
+type: google.api.Service
+config_version: 3
+name: cloudasset.googleapis.com
+title: Cloud Asset API
+
+publishing:
+  organization: CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED
+  new_issue_uri: ''
+  documentation_uri: 'https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview'
+  api_short_name: ''
+  github_label: ''
+  doc_tag_prefix: ''
+  codeowner_github_teams:
+  library_settings:

--- a/tests/integration/eventarc_v1.yaml
+++ b/tests/integration/eventarc_v1.yaml
@@ -1,0 +1,14 @@
+type: google.api.Service
+config_version: 3
+name: eventarc.googleapis.com
+title: Eventarc API
+
+publishing:
+  organization: CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED
+  new_issue_uri: ''
+  documentation_uri: 'https://cloud.google.com/eventarc'
+  api_short_name: ''
+  github_label: ''
+  doc_tag_prefix: ''
+  codeowner_github_teams:
+  library_settings:

--- a/tests/integration/goldens/asset/README.rst
+++ b/tests/integration/goldens/asset/README.rst
@@ -1,5 +1,18 @@
-Python Client for Google Cloud Asset API
-=================================================
+Python Client for Cloud Asset API
+=================================
+|pypi| |versions|
+
+`Cloud Asset API`_:
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-asset.svg
+   :target: https://pypi.org/project/google-cloud-asset/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-asset.svg
+   :target: https://pypi.org/project/google-cloud-asset/
+.. _Cloud Asset API: https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/asset/latest
+.. _Product Documentation:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
 
 Quick Start
 -----------
@@ -8,11 +21,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. Enable the Google Cloud Asset API.
+3. `Enable the Cloud Asset API.`_
 4. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the Cloud Asset API.:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -29,14 +43,40 @@ dependencies.
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
 
 
+Code samples and snippets
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Code samples and snippets live in the `samples/` folder.
+
+
+Supported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
+Python.
+
+Python >= 3.7
+
+.. _active: https://devguide.python.org/devcycle/#in-development-main-branch
+.. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
+
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python <= 3.6
+
+If you are using an `end-of-life`_
+version of Python, we recommend that you update as soon as possible to an actively supported version.
+
+.. _end-of-life: https://devguide.python.org/devcycle/#end-of-life-branches
+
 Mac/Linux
 ^^^^^^^^^
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install /path/to/library
+    <your-env>/bin/pip install google-cloud-asset
 
 
 Windows
@@ -44,6 +84,20 @@ Windows
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install \path\to\library
+    <your-env>\Scripts\pip.exe install google-cloud-asset
+
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for Cloud Asset API
+   to see other available methods on the client.
+-  Read the `Cloud Asset API Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _Cloud Asset API Product documentation:  https://cloud.google.com/resource-manager/docs/cloud-asset-inventory/overview
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst

--- a/tests/integration/goldens/credentials/README.rst
+++ b/tests/integration/goldens/credentials/README.rst
@@ -1,5 +1,18 @@
-Python Client for Google Iam Credentials API
-=================================================
+Python Client for IAM Service Account Credentials API
+=====================================================
+|pypi| |versions|
+
+`IAM Service Account Credentials API`_:
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-iam-credentials.svg
+   :target: https://pypi.org/project/google-iam-credentials/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-iam-credentials.svg
+   :target: https://pypi.org/project/google-iam-credentials/
+.. _IAM Service Account Credentials API: https://cloud.google.com/iam/docs/reference/credentials/rest
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/credentials/latest
+.. _Product Documentation:  https://cloud.google.com/iam/docs/reference/credentials/rest
 
 Quick Start
 -----------
@@ -8,11 +21,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. Enable the Google Iam Credentials API.
+3. `Enable the IAM Service Account Credentials API.`_
 4. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the IAM Service Account Credentials API.:  https://cloud.google.com/iam/docs/reference/credentials/rest
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -29,14 +43,40 @@ dependencies.
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
 
 
+Code samples and snippets
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Code samples and snippets live in the `samples/` folder.
+
+
+Supported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
+Python.
+
+Python >= 3.7
+
+.. _active: https://devguide.python.org/devcycle/#in-development-main-branch
+.. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
+
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python <= 3.6
+
+If you are using an `end-of-life`_
+version of Python, we recommend that you update as soon as possible to an actively supported version.
+
+.. _end-of-life: https://devguide.python.org/devcycle/#end-of-life-branches
+
 Mac/Linux
 ^^^^^^^^^
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install /path/to/library
+    <your-env>/bin/pip install google-iam-credentials
 
 
 Windows
@@ -44,6 +84,20 @@ Windows
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install \path\to\library
+    <your-env>\Scripts\pip.exe install google-iam-credentials
+
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for IAM Service Account Credentials API
+   to see other available methods on the client.
+-  Read the `IAM Service Account Credentials API Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _IAM Service Account Credentials API Product documentation:  https://cloud.google.com/iam/docs/reference/credentials/rest
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst

--- a/tests/integration/goldens/eventarc/README.rst
+++ b/tests/integration/goldens/eventarc/README.rst
@@ -1,5 +1,18 @@
-Python Client for Google Cloud Eventarc API
-=================================================
+Python Client for Eventarc API
+==============================
+|pypi| |versions|
+
+`Eventarc API`_:
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-eventarc.svg
+   :target: https://pypi.org/project/google-cloud-eventarc/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-eventarc.svg
+   :target: https://pypi.org/project/google-cloud-eventarc/
+.. _Eventarc API: https://cloud.google.com/eventarc
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/eventarc/latest
+.. _Product Documentation:  https://cloud.google.com/eventarc
 
 Quick Start
 -----------
@@ -8,11 +21,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. Enable the Google Cloud Eventarc API.
+3. `Enable the Eventarc API.`_
 4. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the Eventarc API.:  https://cloud.google.com/eventarc
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -29,14 +43,40 @@ dependencies.
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
 
 
+Code samples and snippets
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Code samples and snippets live in the `samples/` folder.
+
+
+Supported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
+Python.
+
+Python >= 3.7
+
+.. _active: https://devguide.python.org/devcycle/#in-development-main-branch
+.. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
+
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python <= 3.6
+
+If you are using an `end-of-life`_
+version of Python, we recommend that you update as soon as possible to an actively supported version.
+
+.. _end-of-life: https://devguide.python.org/devcycle/#end-of-life-branches
+
 Mac/Linux
 ^^^^^^^^^
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install /path/to/library
+    <your-env>/bin/pip install google-cloud-eventarc
 
 
 Windows
@@ -44,6 +84,20 @@ Windows
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install \path\to\library
+    <your-env>\Scripts\pip.exe install google-cloud-eventarc
+
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for Eventarc API
+   to see other available methods on the client.
+-  Read the `Eventarc API Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _Eventarc API Product documentation:  https://cloud.google.com/eventarc
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst

--- a/tests/integration/goldens/logging/README.rst
+++ b/tests/integration/goldens/logging/README.rst
@@ -1,5 +1,18 @@
-Python Client for Google Cloud Logging API
-=================================================
+Python Client for Cloud Logging API
+===================================
+|pypi| |versions|
+
+`Cloud Logging API`_:
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-logging.svg
+   :target: https://pypi.org/project/google-cloud-logging/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-logging.svg
+   :target: https://pypi.org/project/google-cloud-logging/
+.. _Cloud Logging API: https://cloud.google.com/logging/docs
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/logging/latest
+.. _Product Documentation:  https://cloud.google.com/logging/docs
 
 Quick Start
 -----------
@@ -8,11 +21,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. Enable the Google Cloud Logging API.
+3. `Enable the Cloud Logging API.`_
 4. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the Cloud Logging API.:  https://cloud.google.com/logging/docs
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -29,14 +43,40 @@ dependencies.
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
 
 
+Code samples and snippets
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Code samples and snippets live in the `samples/` folder.
+
+
+Supported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
+Python.
+
+Python >= 3.7
+
+.. _active: https://devguide.python.org/devcycle/#in-development-main-branch
+.. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
+
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python <= 3.6
+
+If you are using an `end-of-life`_
+version of Python, we recommend that you update as soon as possible to an actively supported version.
+
+.. _end-of-life: https://devguide.python.org/devcycle/#end-of-life-branches
+
 Mac/Linux
 ^^^^^^^^^
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install /path/to/library
+    <your-env>/bin/pip install google-cloud-logging
 
 
 Windows
@@ -44,6 +84,20 @@ Windows
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install \path\to\library
+    <your-env>\Scripts\pip.exe install google-cloud-logging
+
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for Cloud Logging API
+   to see other available methods on the client.
+-  Read the `Cloud Logging API Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _Cloud Logging API Product documentation:  https://cloud.google.com/logging/docs
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst

--- a/tests/integration/goldens/redis/README.rst
+++ b/tests/integration/goldens/redis/README.rst
@@ -1,5 +1,18 @@
-Python Client for Google Cloud Redis API
-=================================================
+Python Client for Google Cloud Memorystore for Redis API
+========================================================
+|pypi| |versions|
+
+`Google Cloud Memorystore for Redis API`_:
+- `Client Library Documentation`_
+- `Product Documentation`_
+
+.. |pypi| image:: https://img.shields.io/pypi/v/google-cloud-redis.svg
+   :target: https://pypi.org/project/google-cloud-redis/
+.. |versions| image:: https://img.shields.io/pypi/pyversions/google-cloud-redis.svg
+   :target: https://pypi.org/project/google-cloud-redis/
+.. _Google Cloud Memorystore for Redis API: https://cloud.google.com/memorystore/docs/redis/
+.. _Client Library Documentation: https://cloud.google.com/python/docs/reference/redis/latest
+.. _Product Documentation:  https://cloud.google.com/memorystore/docs/redis/
 
 Quick Start
 -----------
@@ -8,11 +21,12 @@ In order to use this library, you first need to go through the following steps:
 
 1. `Select or create a Cloud Platform project.`_
 2. `Enable billing for your project.`_
-3. Enable the Google Cloud Redis API.
+3. `Enable the Google Cloud Memorystore for Redis API.`_
 4. `Setup Authentication.`_
 
 .. _Select or create a Cloud Platform project.: https://console.cloud.google.com/project
 .. _Enable billing for your project.: https://cloud.google.com/billing/docs/how-to/modify-project#enable_billing_for_a_project
+.. _Enable the Google Cloud Memorystore for Redis API.:  https://cloud.google.com/memorystore/docs/redis/
 .. _Setup Authentication.: https://googleapis.dev/python/google-api-core/latest/auth.html
 
 Installation
@@ -29,14 +43,40 @@ dependencies.
 .. _`virtualenv`: https://virtualenv.pypa.io/en/latest/
 
 
+Code samples and snippets
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Code samples and snippets live in the `samples/` folder.
+
+
+Supported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^
+Our client libraries are compatible with all current `active`_ and `maintenance`_ versions of
+Python.
+
+Python >= 3.7
+
+.. _active: https://devguide.python.org/devcycle/#in-development-main-branch
+.. _maintenance: https://devguide.python.org/devcycle/#maintenance-branches
+
+Unsupported Python Versions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Python <= 3.6
+
+If you are using an `end-of-life`_
+version of Python, we recommend that you update as soon as possible to an actively supported version.
+
+.. _end-of-life: https://devguide.python.org/devcycle/#end-of-life-branches
+
 Mac/Linux
 ^^^^^^^^^
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     source <your-env>/bin/activate
-    <your-env>/bin/pip install /path/to/library
+    <your-env>/bin/pip install google-cloud-redis
 
 
 Windows
@@ -44,6 +84,20 @@ Windows
 
 .. code-block:: console
 
-    python3 -m venv <your-env>
+    pip install virtualenv
+    virtualenv <your-env>
     <your-env>\Scripts\activate
-    <your-env>\Scripts\pip.exe install \path\to\library
+    <your-env>\Scripts\pip.exe install google-cloud-redis
+
+Next Steps
+~~~~~~~~~~
+
+-  Read the `Client Library Documentation`_ for Google Cloud Memorystore for Redis API
+   to see other available methods on the client.
+-  Read the `Google Cloud Memorystore for Redis API Product documentation`_ to learn
+   more about the product and see How-to Guides.
+-  View this `README`_ to see the full list of Cloud
+   APIs that we cover.
+
+.. _Google Cloud Memorystore for Redis API Product documentation:  https://cloud.google.com/memorystore/docs/redis/
+.. _README: https://github.com/googleapis/google-cloud-python/blob/main/README.rst

--- a/tests/integration/iamcredentials_v1.yaml
+++ b/tests/integration/iamcredentials_v1.yaml
@@ -1,0 +1,14 @@
+type: google.api.Service
+config_version: 3
+name: iamcredentials.googleapis.com
+title: IAM Service Account Credentials API
+
+publishing:
+  organization: CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED
+  new_issue_uri: ''
+  documentation_uri: 'https://cloud.google.com/iam/docs/reference/credentials/rest'
+  api_short_name: ''
+  github_label: ''
+  doc_tag_prefix: ''
+  codeowner_github_teams:
+  library_settings:

--- a/tests/integration/logging_v2.yaml
+++ b/tests/integration/logging_v2.yaml
@@ -1,0 +1,14 @@
+type: google.api.Service
+config_version: 3
+name: logging.googleapis.com
+title: Cloud Logging API
+
+publishing:
+  organization: CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED
+  new_issue_uri: ''
+  documentation_uri: 'https://cloud.google.com/logging/docs'
+  api_short_name: ''
+  github_label: ''
+  doc_tag_prefix: ''
+  codeowner_github_teams:
+  library_settings:

--- a/tests/integration/redis_v1.yaml
+++ b/tests/integration/redis_v1.yaml
@@ -1,0 +1,14 @@
+type: google.api.Service
+config_version: 3
+name: redis.googleapis.com
+title: Google Cloud Memorystore for Redis API
+
+publishing:
+  organization: CLIENT_LIBRARY_ORGANIZATION_UNSPECIFIED
+  new_issue_uri: ''
+  documentation_uri: 'https://cloud.google.com/memorystore/docs/redis/'
+  api_short_name: ''
+  github_label: ''
+  doc_tag_prefix: ''
+  codeowner_github_teams:
+  library_settings:

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -223,3 +223,41 @@ def test_options_autogen_snippets_false_for_old_naming():
     # Even if autogen-snippets is set to True, do not enable snippetgen
     options = Options.build("old-naming,autogen-snippets=True")
     assert not options.autogen_snippets
+
+
+def test_read_documentation_uri(fs):
+    service_yaml_fpath = "testapi.yaml"
+    fs.create_file(service_yaml_fpath,
+                   contents=("config_version: 3\n"
+                             "name: testapi.googleapis.com\n"
+                             "publishing:\n"
+                             "  documentation_uri: https://cloud.google.com/test\n"))
+    opt_string = f"service-yaml={service_yaml_fpath}"
+    opts = Options.build(opt_string)
+    assert opts.documentation_uri == "https://cloud.google.com/test"
+
+
+def test_read_api_description(fs):
+    service_yaml_fpath = "testapi.yaml"
+    fs.create_file(service_yaml_fpath,
+                   contents=("config_version: 3\n"
+                             "name: testapi.googleapis.com\n"
+                             "documentation:\n"
+                             "  summary: |-\n"
+                             "    The Google VMware Engine API lets you programmatically manage VMware\n"
+                             "    environments."))
+    opt_string = f"service-yaml={service_yaml_fpath}"
+    opts = Options.build(opt_string)
+    assert opts.api_description.replace("\n", " ") == \
+        "The Google VMware Engine API lets you programmatically manage VMware environments."
+
+
+def test_read_title(fs):
+    service_yaml_fpath = "testapi.yaml"
+    fs.create_file(service_yaml_fpath,
+                   contents=("config_version: 3\n"
+                             "name: testapi.googleapis.com\n"
+                             "title: Test Title"))
+    opt_string = f"service-yaml={service_yaml_fpath}"
+    opts = Options.build(opt_string)
+    assert opts.title == "Test Title"

--- a/tests/unit/schema/test_naming.py
+++ b/tests/unit/schema/test_naming.py
@@ -27,6 +27,16 @@ def test_long_name():
     assert n.long_name == 'Agrabah Lamp Genie'
 
 
+def test_title():
+    n = make_naming(title='Test Title')
+    n.title == 'Test Title'
+
+
+def test_api_descriptin():
+    n = make_naming(api_description='Test Description')
+    n.api_description == 'Test Description'
+
+
 def test_module_name():
     n = make_naming(
         name='Genie',
@@ -226,6 +236,37 @@ def test_cli_override_warehouse_package_name():
         opts=Options(warehouse_package_name='google-cloud-foo'),
     )
     assert n.warehouse_package_name == "google-cloud-foo"
+
+
+def test_cli_override_title():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.translation')
+    n = naming.Naming.build(
+        proto1,
+        opts=Options(title='Test Title Override'),
+    )
+    assert n.title == "Test Title Override"
+
+
+def test_cli_override_api_description():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.translation')
+    n = naming.Naming.build(
+        proto1,
+        opts=Options(api_description='Test Api Description Override'),
+    )
+    assert n.api_description == "Test Api Description Override"
+
+
+def test_cli_override_documentation_uri():
+    FileDesc = descriptor_pb2.FileDescriptorProto
+    proto1 = FileDesc(package='google.translation')
+    n = naming.Naming.build(
+        proto1,
+        opts=Options(
+            documentation_uri='https://cloud.google.com/testoverride'),
+    )
+    assert n.documentation_uri == "https://cloud.google.com/testoverride"
 
 
 def test_build_factory():


### PR DESCRIPTION
This PR updates the README.md in gapic-generator-python to match the templated README in synthtool [here](https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/README.rst).

This PR also adds the ability to read and override `api_description`, `documentation_uri` and `title` from the service yaml file.