### PR TITLE
chore: prepare to implement snippetgen for standard call

### DIFF
--- a/gapic/configurable_snippetgen/configured_snippet.py
+++ b/gapic/configurable_snippetgen/configured_snippet.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import dataclasses
-from typing import Optional
+from typing import List, Optional
 
 import inflection
 import libcst
@@ -154,19 +154,29 @@ class ConfiguredSnippet:
             # Either the default or HTTPS, in which case the schema is not needed.
             return host_maybe_with_port_and_region
 
-    def _append_to_sample_function_def_body(
-        self, statement: libcst.BaseStatement
+    def _extend_sample_function_def_body(
+        self, statements: List[libcst.BaseStatement]
     ) -> None:
-        """Appends the statement node to the current sample function def."""
-        transformer = _AppendToSampleFunctionBody(statement)
+        """Appends the statements to the current sample function def."""
+        for statement in statements:
+            transformer = _AppendToSampleFunctionBody(statement)
 
-        # The result of applying a transformer could be of a different type
-        # in general, but we will only update the sample function def here.
-        self._sample_function_def = self._sample_function_def.visit(
-            transformer
-        )  # type: ignore
+            # The result of applying a transformer could be of a different type
+            # in general, but we will only update the sample function def here.
+            self._sample_function_def = self._sample_function_def.visit(
+                transformer
+            )  # type: ignore
 
     def _add_sample_function_parameters(self) -> None:
+        """Adds sample function parameters.
+
+        Before:
+            def sample_create_custom_class_Basic():
+                ...
+        After:
+            def sample_create_custom_class_Basic(parent = "projects/..."):
+                ...
+        """
         # TODO: https://github.com/googleapis/gapic-generator-python/issues/1537, add typing annotation in sample function parameters.
         params = []
         for config_parameter in self.config.signature.parameters:
@@ -176,7 +186,14 @@ class ConfiguredSnippet:
             params=parameters
         )
 
-    def _get_service_client_initialization(self) -> libcst.BaseStatement:
+    def _get_service_client_initialization(self) -> List[libcst.BaseStatement]:
+        """Returns the service client initialization statements.
+
+        Examples:
+            client = speech_v1.AdaptationClient()
+
+            client = speech_v1.AdaptationClient(client_options = {"api_endpoint": "us-speech.googleapis.com"})
+        """
         if self.api_endpoint is not None:
             client_options_arg = libcst.Arg(
                 keyword=libcst.Name("client_options"),
@@ -193,15 +210,29 @@ class ConfiguredSnippet:
                 f"client = {self.gapic_module_name}.{self.client_class_name}()"
             )
 
-        return service_client_initialization
+        # TODO: https://github.com/googleapis/gapic-generator-python/issues/1539, support pre_client_initialization statements.
+        return [service_client_initialization]
+
+    def _get_standard_call(self) -> List[libcst.BaseStatement]:
+        """Returns the standard call statements."""
+        # TODO: https://github.com/googleapis/gapic-generator-python/issues/1539, support standard call statements.
+        return []
+
+    def _get_call(self) -> List[libcst.BaseStatement]:
+        """Returns the snippet call statements."""
+        call_type = self.config.snippet.WhichOneof("call")
+        if call_type == "standard":
+            return self._get_standard_call()
+        else:
+            raise ValueError(f"Snippet call type {call_type} not supported.")
 
     def _build_sample_function(self) -> None:
         # TODO: https://github.com/googleapis/gapic-generator-python/issues/1536, add return type.
         # TODO: https://github.com/googleapis/gapic-generator-python/issues/1538, add docstring.
         self._add_sample_function_parameters()
-        self._append_to_sample_function_def_body(
-            self._get_service_client_initialization()
-        )
+        self._extend_sample_function_def_body(
+            self._get_service_client_initialization())
+        self._extend_sample_function_def_body(self._get_call())
 
     def _add_sample_function(self) -> None:
         self._module = self._module.with_changes(

--- a/gapic/configurable_snippetgen/configured_snippet.py
+++ b/gapic/configurable_snippetgen/configured_snippet.py
@@ -198,7 +198,6 @@ class ConfiguredSnippet:
     def _build_sample_function(self) -> None:
         # TODO: https://github.com/googleapis/gapic-generator-python/issues/1536, add return type.
         # TODO: https://github.com/googleapis/gapic-generator-python/issues/1538, add docstring.
-        # TODO: https://github.com/googleapis/gapic-generator-python/issues/1539, add sample function body.
         self._add_sample_function_parameters()
         self._append_to_sample_function_def_body(
             self._get_service_client_initialization()

--- a/tests/unit/configurable_snippetgen/test_configured_snippet.py
+++ b/tests/unit/configurable_snippetgen/test_configured_snippet.py
@@ -237,6 +237,18 @@ def test_AppendToSampleFunctionBody():
     assert updated_function_def.deep_equals(expected_function_def)
 
 
+def test_AppendToSampleFunctionBody():
+    # Start with a function def with nonempty body to we can be sure the
+    # transformer appends the statement.
+    function_def = libcst.parse_statement("def f():\n    'hello'")
+    statement = libcst.parse_statement("'world'")
+    transformer = configured_snippet._AppendToSampleFunctionBody(statement)
+    updated_function_def = function_def.visit(transformer)
+    expected_function_def = libcst.parse_statement(
+        "def f():\n    'hello'\n    'world'")
+    assert updated_function_def.deep_equals(expected_function_def)
+
+
 def test_code(snippet):
     snippet.generate()
 

--- a/tests/unit/configurable_snippetgen/test_configured_snippet.py
+++ b/tests/unit/configurable_snippetgen/test_configured_snippet.py
@@ -278,6 +278,6 @@ def test_code_without_endpoint(snippet_without_endpoint):
     assert snippet_without_endpoint.code == expected_code
 
 
-def test_generate_should_raise_error_if_unsopported(snippet_bidi_streaming):
+def test_generate_should_raise_error_if_unsupported(snippet_bidi_streaming):
     with pytest.raises(ValueError):
         snippet_bidi_streaming.generate()

--- a/tests/unit/configurable_snippetgen/test_configured_snippet.py
+++ b/tests/unit/configurable_snippetgen/test_configured_snippet.py
@@ -202,6 +202,21 @@ def test_api_endpoint(custom_service_endpoint_dict, expected):
     snippet_config = json_format.ParseDict(
         snippet_config_dict, snippet_config_language_pb2.SnippetConfig()
     )
+    assert snippet.client_class_name == expected
+
+
+@pytest.mark.parametrize(
+    "is_sync,expected",
+    [
+        (True, "speech_v1_generated_Adaptation_create_custom_class_Basic_sync.py"),
+        (False, "speech_v1_generated_Adaptation_create_custom_class_Basic_async.py"),
+    ],
+)
+def test_filename(is_sync, expected):
+    snippet = _make_configured_snippet(
+        SPEECH_V1_REQUEST_PATH, CONFIG_JSON_PATH, api_version="v1", is_sync=is_sync
+    )
+    assert snippet.filename == expected
 
     snippet = configured_snippet.ConfiguredSnippet(
         api_schema, snippet_config, api_version, is_sync


### PR DESCRIPTION
Internal changes only, without effect on the generated code:

1. Add docstrings.
2. Replace internal utility method `_append_to_sample_function_def_body` with `_extend_sample_function_def_body `.  (But the low-level libcst implementation of the actual code modification remains "append" for now).
3. Add top-level switch for `call` type, in preparation to implement code generation for standard call.