### PR TITLE
fix: use gapic_version from versioned module

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -2,7 +2,7 @@
 
 {% block content %}
 
-{% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.module_name %}
+{% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}} import gapic_version as package_version
 
 __version__ = package_version.__version__

--- a/gapic/templates/.coveragerc.j2
+++ b/gapic/templates/.coveragerc.j2
@@ -5,6 +5,7 @@ branch = True
 show_missing = True
 omit =
     {{ api.naming.module_namespace|join("/") }}/{{ api.naming.module_name }}/__init__.py
+    {{ api.naming.module_namespace|join("/") }}/{{ api.naming.module_name }}/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/tests/integration/goldens/asset/.coveragerc
+++ b/tests/integration/goldens/asset/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 show_missing = True
 omit =
     google/cloud/asset/__init__.py
+    google/cloud/asset/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from google.cloud.asset import gapic_version as package_version
+from google.cloud.asset_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
 

--- a/tests/integration/goldens/credentials/.coveragerc
+++ b/tests/integration/goldens/credentials/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 show_missing = True
 omit =
     google/iam/credentials/__init__.py
+    google/iam/credentials/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from google.iam.credentials import gapic_version as package_version
+from google.iam.credentials_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
 

--- a/tests/integration/goldens/eventarc/.coveragerc
+++ b/tests/integration/goldens/eventarc/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 show_missing = True
 omit =
     google/cloud/eventarc/__init__.py
+    google/cloud/eventarc/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from google.cloud.eventarc import gapic_version as package_version
+from google.cloud.eventarc_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
 

--- a/tests/integration/goldens/logging/.coveragerc
+++ b/tests/integration/goldens/logging/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 show_missing = True
 omit =
     google/cloud/logging/__init__.py
+    google/cloud/logging/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from google.cloud.logging import gapic_version as package_version
+from google.cloud.logging_v2 import gapic_version as package_version
 
 __version__ = package_version.__version__
 

--- a/tests/integration/goldens/redis/.coveragerc
+++ b/tests/integration/goldens/redis/.coveragerc
@@ -5,6 +5,7 @@ branch = True
 show_missing = True
 omit =
     google/cloud/redis/__init__.py
+    google/cloud/redis/gapic_version.py
 exclude_lines =
     # Re-enable the standard pragma
     pragma: NO COVER

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from google.cloud.redis import gapic_version as package_version
+from google.cloud.redis_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
 


### PR DESCRIPTION
Update `__init__.py` to import `gapic_version` from a versioned module instead of the un-versioned module.