### PR TITLE
fix: add compatibility with bazel 6; use protobuf 3.21.12 in bazel build rules

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -9,16 +9,16 @@ toolchain_type(
 
 pandoc_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:linux",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
     ],
     platform = "linux",
 )
 
 pandoc_toolchain(
     exec_compatible_with = [
-        "@bazel_tools//platforms:osx",
-        "@bazel_tools//platforms:x86_64",
+        "@platforms//os:osx",
+        "@platforms//cpu:x86_64",
     ],
     platform = "macOS",
 )

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -15,14 +15,14 @@ def gapic_generator_python():
         requirements = "@gapic_generator_python//:requirements.txt",
     )
 
-    _protobuf_version = "3.19.2"
-    _protobuf_sha256 = "9ceef0daf7e8be16cd99ac759271eb08021b53b1c7b6edd399953a76390234cd"
+    _protobuf_version = "3.21.12"
+    _protobuf_sha256 = "930c2c3b5ecc6c9c12615cf5ad93f1cd6e12d0aba862b572e076259970ac3a53"
     _protobuf_version_in_link = "v{}".format(_protobuf_version)
     _maybe(
         http_archive,
         name = "com_google_protobuf",
         sha256 = _protobuf_sha256,
-        url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/{}.zip".format(_protobuf_version_in_link),
+        url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/{}.tar.gz".format(_protobuf_version_in_link),
         strip_prefix = "protobuf-{}".format(_protobuf_version),
     )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -1348,9 +1348,6 @@ class CloudRedisAsyncClient:
 
                       }
 
-                   The JSON representation for Empty is empty JSON
-                   object {}.
-
         """
         # Create or coerce a protobuf request object.
         # Quick check: If we got a request object, we should *not* have

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -1542,9 +1542,6 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
                       }
 
-                   The JSON representation for Empty is empty JSON
-                   object {}.
-
         """
         # Create or coerce a protobuf request object.
         # Quick check: If we got a request object, we should *not* have


### PR DESCRIPTION
Fixes #1583 🦕