### PR TITLE
add http annotation to fragment proto

### DIFF
--- a/tests/fragments/test_rest_streaming.proto
+++ b/tests/fragments/test_rest_streaming.proto
@@ -17,11 +17,16 @@ syntax = "proto3";
 package google.fragment;
 
 import "google/api/client.proto";
+import "google/api/annotations.proto";
 
 service MyService {
   option (google.api.default_host) = "my.example.com";
 
   rpc MyMethod(MethodRequest) returns (stream MethodResponse) {
+    option (google.api.http) = {
+      post: "/v2/some/path/{import}/mymethod"
+      body: "license"
+    };
     option (google.api.method_signature) = "from,class,import,any,license,type";
   }
 }


### PR DESCRIPTION
Updating fragment proto to reproduce error in https://github.com/googleapis/python-debugger-client/pull/151. 

See build log [here](https://github.com/googleapis/python-debugger-client/actions/runs/4129085698/jobs/7134304785).

From https://github.com/googleapis/python-debugger-client/pull/151,
```
E       ValueError: Invalid request.
E       Some of the fields of the request message are either not initialized or initialized with an invalid value.
E       Please make sure your request matches at least one accepted HTTP binding.
E       To match a binding the request message must have all the required fields initialized with values matching their patterns as listed below:
E       	URI: "/v2/debugger/debuggees/{debuggee_id}/breakpoints/set"
E       	Required request fields:
E       		field: "debuggee_id", pattern: "*"
``` 