### PR TITLE
fix: upgrade bazel skylib to 1.4.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,19 +2,6 @@ workspace(name = "gapic_generator_python")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_bazel_skylib_version = "1.4.1"
-
-_bazel_skylib_sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7"
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = _bazel_skylib_sha256,
-    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(_bazel_skylib_version)],
-)
-
-load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
-
-bazel_skylib_workspace()
 
 _io_bazel_rules_go_version = "0.33.0"
 http_archive(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,15 +2,19 @@ workspace(name = "gapic_generator_python")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_bazel_skylib_version = "0.9.0"
+_bazel_skylib_version = "1.4.1"
 
-_bazel_skylib_sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0"
+_bazel_skylib_sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7"
 
 http_archive(
     name = "bazel_skylib",
     sha256 = _bazel_skylib_sha256,
-    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel_skylib-{0}.tar.gz".format(_bazel_skylib_version),
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(_bazel_skylib_version)],
 )
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 _io_bazel_rules_go_version = "0.33.0"
 http_archive(

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -26,11 +26,15 @@ def gapic_generator_python():
         strip_prefix = "protobuf-{}".format(_protobuf_version),
     )
 
+    _bazel_skylib_version = "1.4.1"
+
+    _bazel_skylib_sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7"
+
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+        sha256 = _bazel_skylib_sha256,
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(_bazel_skylib_version)],
     )
 
     _grpc_version = "1.47.0"


### PR DESCRIPTION
See the release notes [here](https://github.com/bazelbuild/bazel-skylib/releases/tag/1.4.1) as well as the recommended WORKSPACE setup.