### PR TITLE
fix: ignore_unknown_fields parsing service config

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -341,7 +341,11 @@ class API:
 
         # Parse the google.api.Service proto from the service_yaml data.
         service_yaml_config = service_pb2.Service()
-        ParseDict(opts.service_yaml_config, service_yaml_config, True)
+        ParseDict(
+            opts.service_yaml_config,
+            service_yaml_config,
+            ignore_unknown_fields=True
+        )
 
         # Done; return the API.
         return cls(naming=naming,

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -341,7 +341,7 @@ class API:
 
         # Parse the google.api.Service proto from the service_yaml data.
         service_yaml_config = service_pb2.Service()
-        ParseDict(opts.service_yaml_config, service_yaml_config)
+        ParseDict(opts.service_yaml_config, service_yaml_config, true)
 
         # Done; return the API.
         return cls(naming=naming,

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -341,7 +341,7 @@ class API:
 
         # Parse the google.api.Service proto from the service_yaml data.
         service_yaml_config = service_pb2.Service()
-        ParseDict(opts.service_yaml_config, service_yaml_config, true)
+        ParseDict(opts.service_yaml_config, service_yaml_config, True)
 
         # Done; return the API.
         return cls(naming=naming,


### PR DESCRIPTION
Enables [`ignore_unknown_fields`](https://googleapis.dev/python/protobuf/latest/google/protobuf/json_format.html#google.protobuf.json_format.ParseDict) behavior while parsing the `google.api.Service` config YAML file. This will make the Python generator resilient to parsing a Service config with fields that it hasn't received the updated proto for yet.

cc: @jskeet @alexander-fenster 