### PR TITLE
docs: fix docstring with proto-plus dependency

### DIFF
--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -173,7 +173,7 @@ class Address(BaseAddress):
         """Return the proto package for this type."""
         return '.'.join(self.package)
 
-    def convert_to_versioned_package(self) -> Tuple[str]:
+    def convert_to_versioned_package(self) -> Tuple[str, ...]:
         # We need to change the import statement to use an
         # underscore between the module and the version. For example,
         # change google.cloud.documentai.v1 to google.cloud.documentai_v1.

--- a/gapic/schema/metadata.py
+++ b/gapic/schema/metadata.py
@@ -173,6 +173,19 @@ class Address(BaseAddress):
         """Return the proto package for this type."""
         return '.'.join(self.package)
 
+    def convert_to_versioned_package(self) -> Tuple[str]:
+        # We need to change the import statement to use an
+        # underscore between the module and the version. For example,
+        # change google.cloud.documentai.v1 to google.cloud.documentai_v1.
+        # Check if the package name contains a version.
+        version_regex = "^v\d[^/]*$"
+        regex_match = re.match(version_regex, self.package[-1])
+        if regex_match and len(self.package) > 1:
+            versioned_module = f"{self.package[-2]}_{regex_match[0]}"
+            return self.package[:-2] + (versioned_module,)
+        else:
+            return self.package
+
     @cached_property
     def python_import(self) -> imp.Import:
         """Return the Python import for this type."""
@@ -203,27 +216,11 @@ class Address(BaseAddress):
             )
 
         if self.is_proto_plus_type:
-            # We need to change the import statement to use an
-            # underscore between the module and the version. For example,
-            # change google.cloud.documentai.v1 to google.cloud.documentai_v1.
-            # Check if the package name contains a version.
-            version_regex = "^v\d[^/]*$"
-            regex_match = re.match(version_regex, self.package[-1])
-
-            if regex_match and len(self.package) > 1:
-                versioned_module = f"{self.package[-2]}_{regex_match[0]}"
-                return imp.Import(
-                    package=self.package[:-2] +
-                    (versioned_module, 'types'),
-                    module=self.module,
-                    alias=self.module_alias,
-                )
-            else:
-                return imp.Import(
-                    package=self.package + ('types',),
-                    module=self.module,
-                    alias=self.module_alias,
-                )
+            return imp.Import(
+                package=self.convert_to_versioned_package() + ('types',),
+                module=self.module,
+                alias=self.module_alias,
+            )
 
         # Return the standard import.
         return imp.Import(
@@ -247,6 +244,13 @@ class Address(BaseAddress):
             return '.'.join(self.api_naming.module_namespace + (
                 self.api_naming.versioned_module_name,
             ) + self.subpackage + ('types',) + self.parent + (self.name, ))
+        elif self.is_proto_plus_type:
+            return ".".join(
+                self.convert_to_versioned_package()
+                + ("types",)
+                + self.parent
+                + (self.name,)
+            )
 
         # Anything left is a standard _pb2 type
         return f'{self.proto_package}.{self.module}_pb2.{self.name}'

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -1024,6 +1024,7 @@ def test_python_modules_nested():
         == "google.baf_v20beta.types.ImportedMessageBaf"
     )
 
+
 def test_services():
     L = descriptor_pb2.SourceCodeInfo.Location
 

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -734,46 +734,6 @@ def test_python_modules_nested():
             messages=(make_message_pb2(name="ImportedMessageBab", fields=()),),
         ),
         make_file_pb2(
-            name="bac.v10.proto",
-            package="google.bac.v10",
-            messages=(make_message_pb2(name="ImportedMessageBac", fields=()),),
-        ),
-        make_file_pb2(
-            name="bad.v2beta.proto",
-            package="google.bad.v2beta",
-            messages=(make_message_pb2(name="ImportedMessageBad", fields=()),),
-        ),
-        make_file_pb2(
-            name="bae.v2beta20.proto",
-            package="google.bae.v2beta20",
-            messages=(make_message_pb2(name="ImportedMessageBae", fields=()),),
-        ),
-        make_file_pb2(
-            name="baf.v20beta.proto",
-            package="google.baf.v20beta",
-            messages=(make_message_pb2(name="ImportedMessageBaf", fields=()),),
-        ),
-        make_file_pb2(
-            name="bag.v20p1.proto",
-            package="google.bag.v20p1",
-            messages=(make_message_pb2(name="ImportedMessageBag", fields=()),),
-        ),
-        make_file_pb2(
-            name="bah.v20p1alpha3p5.proto",
-            package="google.bah.v20p1alpha3p5",
-            messages=(make_message_pb2(name="ImportedMessageBah", fields=()),),
-        ),
-        make_file_pb2(
-            name="bah.v20p1.bai.proto",
-            package="google.bah.v20p1.bai",
-            messages=(make_message_pb2(name="ImportedMessageBai", fields=()),),
-        ),
-        make_file_pb2(
-            name="bah.v20p1.baj.v3.proto",
-            package="google.bah.v20p1.baj.v3",
-            messages=(make_message_pb2(name="ImportedMessageBaj", fields=()),),
-        ),
-        make_file_pb2(
             name="common.proto",
             package="google.example.v1.common",
             messages=(make_message_pb2(name="Bar"),),
@@ -824,86 +784,6 @@ def test_python_modules_nested():
                                 ),
                             ),
                         ),
-                        make_message_pb2(
-                            name="Bac",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_bac",
-                                    number=1,
-                                    type_name=".google.bac.v10.ImportedMessageBac",
-                                ),
-                            ),
-                        ),
-                        make_message_pb2(
-                            name="Bad",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_bad",
-                                    number=1,
-                                    type_name=".google.bad.v2beta.ImportedMessageBad",
-                                ),
-                            ),
-                        ),
-                        make_message_pb2(
-                            name="Bae",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_bae",
-                                    number=1,
-                                    type_name=".google.bae.v2beta20.ImportedMessageBae",
-                                ),
-                            ),
-                        ),
-                        make_message_pb2(
-                            name="Baf",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_baf",
-                                    number=1,
-                                    type_name=".google.baf.v20beta.ImportedMessageBaf",
-                                ),
-                            ),
-                        ),
-                        make_message_pb2(
-                            name="Bag",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_bag",
-                                    number=1,
-                                    type_name=".google.bag.v20p1.ImportedMessageBag",
-                                ),
-                            ),
-                        ),
-                        make_message_pb2(
-                            name="Bah",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_bah",
-                                    number=1,
-                                    type_name=".google.bah.v20p1alpha3p5.ImportedMessageBah",
-                                ),
-                            ),
-                        ),
-                        make_message_pb2(
-                            name="Bai",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_bai",
-                                    number=1,
-                                    type_name=".google.bah.v20p1.bai.ImportedMessageBai",
-                                ),
-                            ),
-                        ),
-                        make_message_pb2(
-                            name="Baj",
-                            fields=(
-                                make_field_pb2(
-                                    name="imported_message_baj",
-                                    number=1,
-                                    type_name=".google.bah.v20p1.baj.v3.ImportedMessageBaj",
-                                ),
-                            ),
-                        ),
                     ),
                 ),
                 make_message_pb2(
@@ -937,33 +817,14 @@ def test_python_modules_nested():
     assert api_schema.protos["foo.proto"].python_modules == (
         imp.Import(package=("google", "baa"), module="baa_pb2"),
         imp.Import(package=("google", "bab", "v1"), module="bab_v1_pb2"),
-        imp.Import(package=("google", "bac", "v10"), module="bac_v10_pb2"),
-        imp.Import(package=("google", "bad", "v2beta"),
-                   module="bad_v2beta_pb2"),
-        imp.Import(package=("google", "bae", "v2beta20"),
-                   module="bae_v2beta20_pb2"),
-        imp.Import(package=("google", "baf", "v20beta"),
-                   module="baf_v20beta_pb2"),
-        imp.Import(package=("google", "bag", "v20p1"), module="bag_v20p1_pb2"),
-        imp.Import(
-            package=("google", "bah", "v20p1", "bai"),
-            module="bah_v20p1_bai_pb2"
-        ),
-        imp.Import(
-            package=("google", "bah", "v20p1", "baj", "v3"),
-            module="bah_v20p1_baj_v3_pb2",
-        ),
-        imp.Import(
-            package=("google", "bah", "v20p1alpha3p5"), module="bah_v20p1alpha3p5_pb2"
-        ),
         imp.Import(package=("google", "dep"), module="dep_pb2"),
     )
     assert (
         api_schema.protos["foo.proto"]
-        .all_messages["google.example.v1.GetFooRequest.Baf"]
-        .fields["imported_message_baf"]
+        .all_messages["google.example.v1.GetFooRequest.Bab"]
+        .fields["imported_message_bab"]
         .ident.sphinx
-        == "google.baf.v20beta.baf_v20beta_pb2.ImportedMessageBaf"
+        == "google.bab.v1.bab_v1_pb2.ImportedMessageBab"
     )
 
     # Ensure that we can change the import statements to cater for a
@@ -979,14 +840,6 @@ def test_python_modules_nested():
                 (
                     "google.baa",
                     "google.bab.v1",
-                    "google.bac.v10",
-                    "google.bad.v2beta",
-                    "google.bae.v2beta20",
-                    "google.baf.v20beta",
-                    "google.bag.v20p1",
-                    "google.bah.v20p1alpha3p5",
-                    "google.bah.v20p1.bai",
-                    "google.bah.v20p1.baj.v3",
                 )
             )
         ),
@@ -994,34 +847,15 @@ def test_python_modules_nested():
     assert api_schema.protos["foo.proto"].python_modules == (
         imp.Import(package=("google", "baa", "types"), module="baa"),
         imp.Import(package=("google", "bab_v1", "types"), module="bab_v1"),
-        imp.Import(package=("google", "bac_v10", "types"), module="bac_v10"),
-        imp.Import(package=("google", "bad_v2beta", "types"),
-                   module="bad_v2beta"),
-        imp.Import(package=("google", "bae_v2beta20", "types"),
-                   module="bae_v2beta20"),
-        imp.Import(package=("google", "baf_v20beta", "types"),
-                   module="baf_v20beta"),
-        imp.Import(package=("google", "bag_v20p1", "types"),
-                   module="bag_v20p1"),
-        imp.Import(
-            package=("google", "bah", "v20p1", "bai", "types"), module="bah_v20p1_bai"
-        ),
-        imp.Import(
-            package=("google", "bah", "v20p1", "baj_v3", "types"),
-            module="bah_v20p1_baj_v3",
-        ),
-        imp.Import(
-            package=("google", "bah_v20p1alpha3p5", "types"), module="bah_v20p1alpha3p5"
-        ),
         imp.Import(package=("google", "dep"), module="dep_pb2"),
     )
 
     assert (
         api_schema.protos["foo.proto"]
-        .all_messages["google.example.v1.GetFooRequest.Baf"]
-        .fields["imported_message_baf"]
+        .all_messages["google.example.v1.GetFooRequest.Bab"]
+        .fields["imported_message_bab"]
         .ident.sphinx
-        == "google.baf_v20beta.types.ImportedMessageBaf"
+        == "google.bab_v1.types.ImportedMessageBab"
     )
 
 

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -958,6 +958,13 @@ def test_python_modules_nested():
         ),
         imp.Import(package=("google", "dep"), module="dep_pb2"),
     )
+    assert (
+        api_schema.protos["foo.proto"]
+        .all_messages["google.example.v1.GetFooRequest.Baf"]
+        .fields["imported_message_baf"]
+        .ident.sphinx
+        == "google.baf.v20beta.baf_v20beta_pb2.ImportedMessageBaf"
+    )
 
     # Ensure that we can change the import statements to cater for a
     # dependency that uses proto-plus types.
@@ -1009,6 +1016,13 @@ def test_python_modules_nested():
         imp.Import(package=("google", "dep"), module="dep_pb2"),
     )
 
+    assert (
+        api_schema.protos["foo.proto"]
+        .all_messages["google.example.v1.GetFooRequest.Baf"]
+        .fields["imported_message_baf"]
+        .ident.sphinx
+        == "google.baf_v20beta.types.ImportedMessageBaf"
+    )
 
 def test_services():
     L = descriptor_pb2.SourceCodeInfo.Location

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -67,35 +67,35 @@ def test_address_proto():
 
 
 def test_proto_package_version_parsing():
-    addr = metadata.Address(package=('baa'))
+    addr = metadata.Address(package=("baa"))
     assert addr.convert_to_versioned_package() == ("baa")
 
-    addr = metadata.Address(package=('bab', 'v1'))
+    addr = metadata.Address(package=("bab", "v1"))
     assert addr.convert_to_versioned_package() == ("bab_v1",)
 
-    addr = metadata.Address(package=('bac', 'v10'))
+    addr = metadata.Address(package=("bac", "v10"))
     assert addr.convert_to_versioned_package() == ("bac_v10",)
 
-    addr = metadata.Address(package=('bad', 'v2beta'))
+    addr = metadata.Address(package=("bad", "v2beta"))
     assert addr.convert_to_versioned_package() == ("bad_v2beta",)
 
-    addr = metadata.Address(package=('bae', 'v2beta20'))
+    addr = metadata.Address(package=("bae", "v2beta20"))
     assert addr.convert_to_versioned_package() == ("bae_v2beta20",)
 
-    addr = metadata.Address(package=('baf', 'v20beta'))
+    addr = metadata.Address(package=("baf", "v20beta"))
     assert addr.convert_to_versioned_package() == ("baf_v20beta",)
 
-    addr = metadata.Address(package=('bag', 'v20p1'))
+    addr = metadata.Address(package=("bag", "v20p1"))
     assert addr.convert_to_versioned_package() == ("bag_v20p1",)
 
-    addr = metadata.Address(package=('bah', 'v20p1alpha3p5'))
+    addr = metadata.Address(package=("bah", "v20p1alpha3p5"))
     assert addr.convert_to_versioned_package() == ("bah_v20p1alpha3p5",)
 
-    addr = metadata.Address(package=('bai', 'v20p1'))
+    addr = metadata.Address(package=("bai", "v20p1"))
     assert addr.convert_to_versioned_package() == ("bai_v20p1",)
 
-    addr = metadata.Address(package=('bah', 'v20p1','baj', 'v3'))
-    assert addr.convert_to_versioned_package() == ("bah", 'v20p1', 'baj_v3')
+    addr = metadata.Address(package=("bah", "v20p1", "baj", "v3"))
+    assert addr.convert_to_versioned_package() == ("bah", "v20p1", "baj_v3")
 
 
 def test_address_child_no_parent():

--- a/tests/unit/schema/test_metadata.py
+++ b/tests/unit/schema/test_metadata.py
@@ -66,6 +66,38 @@ def test_address_proto():
     assert addr.proto_package == 'foo.bar'
 
 
+def test_proto_package_version_parsing():
+    addr = metadata.Address(package=('baa'))
+    assert addr.convert_to_versioned_package() == ("baa")
+
+    addr = metadata.Address(package=('bab', 'v1'))
+    assert addr.convert_to_versioned_package() == ("bab_v1",)
+
+    addr = metadata.Address(package=('bac', 'v10'))
+    assert addr.convert_to_versioned_package() == ("bac_v10",)
+
+    addr = metadata.Address(package=('bad', 'v2beta'))
+    assert addr.convert_to_versioned_package() == ("bad_v2beta",)
+
+    addr = metadata.Address(package=('bae', 'v2beta20'))
+    assert addr.convert_to_versioned_package() == ("bae_v2beta20",)
+
+    addr = metadata.Address(package=('baf', 'v20beta'))
+    assert addr.convert_to_versioned_package() == ("baf_v20beta",)
+
+    addr = metadata.Address(package=('bag', 'v20p1'))
+    assert addr.convert_to_versioned_package() == ("bag_v20p1",)
+
+    addr = metadata.Address(package=('bah', 'v20p1alpha3p5'))
+    assert addr.convert_to_versioned_package() == ("bah_v20p1alpha3p5",)
+
+    addr = metadata.Address(package=('bai', 'v20p1'))
+    assert addr.convert_to_versioned_package() == ("bai_v20p1",)
+
+    addr = metadata.Address(package=('bah', 'v20p1','baj', 'v3'))
+    assert addr.convert_to_versioned_package() == ("bah", 'v20p1', 'baj_v3')
+
+
 def test_address_child_no_parent():
     addr = metadata.Address(package=('foo', 'bar'), module='baz')
     child = addr.child('Bacon', path=(4, 0))


### PR DESCRIPTION
This PR fixes an issue where a field has an incorrect type in docstrings when it is a proto-plus type.
Fixes https://github.com/googleapis/gapic-generator-python/issues/1625
Googlers see go/fix-gapic-depends-on-gapic-with-proto-plus-types