### PR TITLE
[WIP] fix: upgrade protobuf to 22.3

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,16 +2,6 @@ workspace(name = "gapic_generator_python")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-_bazel_skylib_version = "0.9.0"
-
-_bazel_skylib_sha256 = "1dde365491125a3db70731e25658dfdd3bc5dbdfd11b840b3e987ecf043c7ca0"
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = _bazel_skylib_sha256,
-    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel_skylib-{0}.tar.gz".format(_bazel_skylib_version),
-)
-
 _io_bazel_rules_go_version = "0.33.0"
 http_archive(
     name = "io_bazel_rules_go",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,20 @@ workspace(name = "gapic_generator_python")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+_bazel_skylib_version = "1.4.1"
+
+_bazel_skylib_sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7"
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = _bazel_skylib_sha256,
+    urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(_bazel_skylib_version)],
+)
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
+
 _io_bazel_rules_go_version = "0.33.0"
 http_archive(
     name = "io_bazel_rules_go",

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -15,8 +15,8 @@ def gapic_generator_python():
         requirements = "@gapic_generator_python//:requirements.txt",
     )
 
-    _protobuf_version = "22.1"
-    _protobuf_sha256 = "0b6494b6e1a8d197f6626ca0c5aa9ab35fc1e5aa3f724787133ce4fa4aa78499"
+    _protobuf_version = "22.3"
+    _protobuf_sha256 = "786bf22c8fd3f20b7242df3b9649900714b0ba77b24a4971573088f41dfe9f8a"
     _protobuf_version_in_link = "v{}".format(_protobuf_version)
     _maybe(
         http_archive,

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -15,8 +15,8 @@ def gapic_generator_python():
         requirements = "@gapic_generator_python//:requirements.txt",
     )
 
-    _protobuf_version = "3.21.12"
-    _protobuf_sha256 = "930c2c3b5ecc6c9c12615cf5ad93f1cd6e12d0aba862b572e076259970ac3a53"
+    _protobuf_version = "22.1"
+    _protobuf_sha256 = "0b6494b6e1a8d197f6626ca0c5aa9ab35fc1e5aa3f724787133ce4fa4aa78499"
     _protobuf_version_in_link = "v{}".format(_protobuf_version)
     _maybe(
         http_archive,
@@ -26,11 +26,15 @@ def gapic_generator_python():
         strip_prefix = "protobuf-{}".format(_protobuf_version),
     )
 
+    _bazel_skylib_version = "1.4.0"
+
+    _bazel_skylib_sha256 = "f24ab666394232f834f74d19e2ff142b0af17466ea0c69a3f4c276ee75f6efce"
+
     _maybe(
         http_archive,
         name = "bazel_skylib",
-        strip_prefix = "bazel-skylib-2169ae1c374aab4a09aa90e65efe1a3aad4e279b",
-        urls = ["https://github.com/bazelbuild/bazel-skylib/archive/2169ae1c374aab4a09aa90e65efe1a3aad4e279b.tar.gz"],
+        sha256 = _bazel_skylib_sha256,
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel_skylib-{0}.tar.gz".format(_bazel_skylib_version)],
     )
 
     _grpc_version = "1.47.0"

--- a/repositories.bzl
+++ b/repositories.bzl
@@ -26,15 +26,15 @@ def gapic_generator_python():
         strip_prefix = "protobuf-{}".format(_protobuf_version),
     )
 
-    _bazel_skylib_version = "1.4.0"
+    _bazel_skylib_version = "1.4.1"
 
-    _bazel_skylib_sha256 = "f24ab666394232f834f74d19e2ff142b0af17466ea0c69a3f4c276ee75f6efce"
+    _bazel_skylib_sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7"
 
     _maybe(
         http_archive,
         name = "bazel_skylib",
         sha256 = _bazel_skylib_sha256,
-        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel_skylib-{0}.tar.gz".format(_bazel_skylib_version)],
+        urls = ["https://github.com/bazelbuild/bazel-skylib/releases/download/{0}/bazel-skylib-{0}.tar.gz".format(_bazel_skylib_version)],
     )
 
     _grpc_version = "1.47.0"


### PR DESCRIPTION
Fork from https://github.com/googleapis/gapic-generator-python/pull/1615 with latest version 22.3

- fix: upgrade protobuf to 22.1 and bazel skylib to 1.4.0
- use bazel skylib 1.4.1
- deps: protobuf 22.3
