### PR TITLE
fix: remove REST methods for rpcs which do not have http annotations

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
@@ -267,7 +267,7 @@ class {{service.name}}RestTransport({{service.name}}Transport):
         def __hash__(self):
             return hash("{{method.name}}")
 
-        {% if not method.client_streaming %}
+        {% if method.http_options and not method.client_streaming %}
         {% if method.input.required_fields %}
         __REQUIRED_FIELDS_DEFAULT_VALUES: Dict[str, Any] =  {
         {% for req_field in method.input.required_fields if req_field.name in method.query_params %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -301,7 +301,7 @@ class {{service.name}}RestTransport({{service.name}}Transport):
         def __hash__(self):
             return hash("{{method.name}}")
 
-        {% if not method.client_streaming %}
+        {% if method.http_options and not method.client_streaming %}
         {% if method.input.required_fields %}
         __REQUIRED_FIELDS_DEFAULT_VALUES: Dict[str, Any] =  {
         {% for req_field in method.input.required_fields if req_field.name in method.query_params %}


### PR DESCRIPTION
Towards https://github.com/googleapis/gapic-generator-python/issues/1644