### PR TITLE
fix: fix code coverage in async test

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -848,6 +848,8 @@ async def test_{{ method_name }}_async_pages():
         {% endif %}
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.{{ method_name }}(request={})).pages: # pragma: no branch

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -850,11 +850,10 @@ async def test_{{ method_name }}_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.{{ method_name }}(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.{{ method_name }}(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 {% elif method.lro and "next_page_token" in method.lro.response_type.fields.keys() %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -848,8 +848,11 @@ async def test_{{ method_name }}_async_pages():
         {% endif %}
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.{{ method_name }}(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 {% elif method.lro and "next_page_token" in method.lro.response_type.fields.keys() %}

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -1112,11 +1112,10 @@ async def test_list_assets_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_assets(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_assets(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -2889,11 +2888,10 @@ async def test_search_all_resources_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.search_all_resources(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.search_all_resources(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -3324,11 +3322,10 @@ async def test_search_all_iam_policies_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.search_all_iam_policies(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.search_all_iam_policies(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -1110,8 +1110,11 @@ async def test_list_assets_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_assets(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -2882,8 +2885,11 @@ async def test_search_all_resources_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.search_all_resources(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -3312,8 +3318,11 @@ async def test_search_all_iam_policies_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.search_all_iam_policies(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -1110,6 +1110,8 @@ async def test_list_assets_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_assets(request={})).pages: # pragma: no branch
@@ -2885,6 +2887,8 @@ async def test_search_all_resources_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.search_all_resources(request={})).pages: # pragma: no branch
@@ -3318,6 +3322,8 @@ async def test_search_all_iam_policies_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.search_all_iam_policies(request={})).pages: # pragma: no branch

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -1217,11 +1217,10 @@ async def test_list_triggers_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_triggers(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_triggers(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -1215,6 +1215,8 @@ async def test_list_triggers_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_triggers(request={})).pages: # pragma: no branch

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -1215,8 +1215,11 @@ async def test_list_triggers_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_triggers(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -961,11 +961,10 @@ async def test_list_buckets_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_buckets(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_buckets(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -2172,11 +2171,10 @@ async def test_list_views_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_views(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_views(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -3215,11 +3213,10 @@ async def test_list_sinks_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_sinks(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_sinks(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -4679,11 +4676,10 @@ async def test_list_exclusions_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_exclusions(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_exclusions(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -959,6 +959,8 @@ async def test_list_buckets_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_buckets(request={})).pages: # pragma: no branch
@@ -2168,6 +2170,8 @@ async def test_list_views_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_views(request={})).pages: # pragma: no branch
@@ -3209,6 +3213,8 @@ async def test_list_sinks_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_sinks(request={})).pages: # pragma: no branch
@@ -4671,6 +4677,8 @@ async def test_list_exclusions_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_exclusions(request={})).pages: # pragma: no branch

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -959,8 +959,11 @@ async def test_list_buckets_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_buckets(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -2165,8 +2168,11 @@ async def test_list_views_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_views(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -3203,8 +3209,11 @@ async def test_list_sinks_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_sinks(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -4662,8 +4671,11 @@ async def test_list_exclusions_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_exclusions(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -1339,6 +1339,8 @@ async def test_list_log_entries_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_log_entries(request={})).pages: # pragma: no branch
@@ -1612,6 +1614,8 @@ async def test_list_monitored_resource_descriptors_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_monitored_resource_descriptors(request={})).pages: # pragma: no branch
@@ -2039,6 +2043,8 @@ async def test_list_logs_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_logs(request={})).pages: # pragma: no branch

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -1339,8 +1339,11 @@ async def test_list_log_entries_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_log_entries(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -1609,8 +1612,11 @@ async def test_list_monitored_resource_descriptors_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_monitored_resource_descriptors(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -2033,8 +2039,11 @@ async def test_list_logs_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_logs(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -1341,11 +1341,10 @@ async def test_list_log_entries_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_log_entries(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_log_entries(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -1616,11 +1615,10 @@ async def test_list_monitored_resource_descriptors_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_monitored_resource_descriptors(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_monitored_resource_descriptors(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
@@ -2045,11 +2043,10 @@ async def test_list_logs_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_logs(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_logs(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -966,11 +966,10 @@ async def test_list_log_metrics_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_log_metrics(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_log_metrics(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -964,8 +964,11 @@ async def test_list_log_metrics_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_log_metrics(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -964,6 +964,8 @@ async def test_list_log_metrics_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_log_metrics(request={})).pages: # pragma: no branch

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -968,11 +968,10 @@ async def test_list_instances_async_pages():
         pages = []
         # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
         # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
-        # Turn off code formatting as `# pragma: no branch` does not work on multilines
-        # fmt: off
-        async for page_ in (await client.list_instances(request={})).pages: # pragma: no branch
+        async for page_ in ( # pragma: no branch
+            await client.list_instances(request={})
+        ).pages:
             pages.append(page_)
-        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -966,8 +966,11 @@ async def test_list_instances_async_pages():
             RuntimeError,
         )
         pages = []
+        # Turn off code formatting as `# pragma: no branch` does not work on multilines
+        # fmt: off
         async for page_ in (await client.list_instances(request={})).pages: # pragma: no branch
             pages.append(page_)
+        # fmt: on
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -966,6 +966,8 @@ async def test_list_instances_async_pages():
             RuntimeError,
         )
         pages = []
+        # Workaround issue in python 3.9 related to code coverage by adding `# pragma: no branch`
+        # See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372
         # Turn off code formatting as `# pragma: no branch` does not work on multilines
         # fmt: off
         async for page_ in (await client.list_instances(request={})).pages: # pragma: no branch


### PR DESCRIPTION
Towards https://github.com/googleapis/gapic-generator-python/issues/1644

See https://github.com/googleapis/gapic-generator-python/pull/1174#issuecomment-1025132372 for background on why `# pragma: no branch` is used.