### PR TITLE
Update Ads templates to set minimum Python version to 3.8.

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
@@ -6,8 +6,8 @@ import importlib
 import sys
 
 
-if sys.version_info < (3, 7):
-    raise ImportError('This module requires Python 3.7 or later.')
+if sys.version_info < (3, 8):
+    raise ImportError('This module requires Python 3.8 or later.')
 
 
 _lazy_type_to_package_map = {
@@ -32,7 +32,7 @@ _lazy_type_to_package_map = {
 
 
 # Background on how this behaves: https://www.python.org/dev/peps/pep-0562/
-def __getattr__(name):  # Requires Python >= 3.7
+def __getattr__(name):  # Requires Python >= 3.8
     if name == '__all__':
         all_names = globals()['__all__'] = sorted(_lazy_type_to_package_map)
         return all_names

--- a/gapic/ads-templates/%namespace/%name/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/__init__.py.j2
@@ -6,8 +6,8 @@ import importlib
 import sys
 
 
-if sys.version_info < (3, 7):
-    raise ImportError('This module requires Python 3.7 or later.')
+if sys.version_info < (3, 8):
+    raise ImportError('This module requires Python 3.8 or later.')
 
 
 _lazy_type_to_package_map = {
@@ -30,7 +30,7 @@ _lazy_type_to_package_map = {
 
 
 # Background on how this behaves: https://www.python.org/dev/peps/pep-0562/
-def __getattr__(name):  # Requires Python >= 3.7
+def __getattr__(name):  # Requires Python >= 3.8
     if name == '__all__':
         all_names = globals()['__all__'] = sorted(_lazy_type_to_package_map)
         return all_names

--- a/gapic/ads-templates/mypy.ini.j2
+++ b/gapic/ads-templates/mypy.ini.j2
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.8
 namespace_packages = True

--- a/gapic/ads-templates/noxfile.py.j2
+++ b/gapic/ads-templates/noxfile.py.j2
@@ -8,7 +8,6 @@ import nox  # type: ignore
 
 
 ALL_PYTHON = [
-    "3.7",
     "3.8",
     "3.9",
     "3.10",

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -31,7 +31,7 @@ setuptools.setup(
         'grpc-google-iam-v1',
     {% endif %}
     ),
-    python_requires='>=3.7',{# Lazy import requires module-level getattr #}
+    python_requires='>=3.8',{# Lazy import requires module-level getattr #}
     setup_requires=[
         'libcst >= 0.2.5',
     ],
@@ -42,7 +42,6 @@ setuptools.setup(
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',

--- a/noxfile.py
+++ b/noxfile.py
@@ -157,8 +157,11 @@ def fragment(session, use_ads_templates=False):
         for frag in frag_files:
             session.log(tester(frag))
 
-
-@nox.session(python=ALL_PYTHON)
+# Removing Python 3.7 from the list of test versions because Ads has
+# deprecated support for it.
+# TODO: once 3.7 is remove from the ALL_PYTHON tuple the below line should be
+# updated.
+@nox.session(python=ALL_PYTHON[1:])
 def fragment_alternative_templates(session):
     fragment(session, use_ads_templates=True)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -337,7 +337,11 @@ def showcase_unit(
         run_showcase_unit_tests(session)
 
 
-@nox.session(python=ALL_PYTHON)
+# Removing Python 3.7 from the list of test versions because Ads has
+# deprecated support for it.
+# TODO: once 3.7 is remove from the ALL_PYTHON tuple the below line should be
+# updated.
+@nox.session(python=ALL_PYTHON[1:])
 def showcase_unit_alternative_templates(session):
     with showcase_library(
         session, templates=ADS_TEMPLATES, other_opts=("old-naming",)
@@ -360,7 +364,11 @@ def showcase_unit_mixins(session):
         run_showcase_unit_tests(session)
 
 
-@nox.session(python=ALL_PYTHON)
+# Removing Python 3.7 from the list of test versions because Ads has
+# deprecated support for it.
+# TODO: once 3.7 is remove from the ALL_PYTHON tuple the below line should be
+# updated.
+@nox.session(python=ALL_PYTHON[1:])
 def showcase_unit_alternative_templates_mixins(session):
     with showcase_library(
         session, templates=ADS_TEMPLATES, other_opts=("old-naming",),


### PR DESCRIPTION
This is in preparation for the deprecation of Python 3.7, which will happen before our next release so we will want 3.8 set as the minimum next time we're generating code. 
