### PR TITLE
fix: add `exec` as a reserved word

### DIFF
--- a/gapic/utils/reserved_names.py
+++ b/gapic/utils/reserved_names.py
@@ -86,6 +86,7 @@ RESERVED_NAMES = frozenset(
         "None",
         "try",
         "type",
+        "exec",
         # Comes from Protoplus
         "ignore_unknown_fields"
     ]


### PR DESCRIPTION
`exec` was removed in #1575


Fixes https://github.com/googleapis/gapic-generator-python/issues/1672 🦕
