### PR TITLE
fix: add `help` as a reserved word

### DIFF
--- a/gapic/utils/reserved_names.py
+++ b/gapic/utils/reserved_names.py
@@ -87,6 +87,7 @@ RESERVED_NAMES = frozenset(
         "try",
         "type",
         "exec",
+        "help",
         # Comes from Protoplus
         "ignore_unknown_fields"
     ]


### PR DESCRIPTION
`help` was removed in #1575 

Fixes #1681 🦕
