### PR TITLE
test: fix issue in tests related to json serialization

### DIFF
--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1311,7 +1311,7 @@ def test_{{ method_name }}_rest_interceptors(null_interceptor):
         req.return_value.status_code = 200
         req.return_value.request = PreparedRequest()
         {% if not method.void %}
-        req.return_value._content = {% if method.output.ident.package == method.ident.package %}{{ method.output.ident }}.to_json({{ method.output.ident }}()){% else %}json_format.MessageToJson({{ method.output.ident }}()){% endif %}
+        req.return_value._content = {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json({{ method.output.ident }}()){% else %}json_format.MessageToJson({{ method.output.ident }}()){% endif %}
 
         {% if method.server_streaming %}
         req.return_value._content = "[{}]".format(req.return_value._content)

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1206,7 +1206,7 @@ def test_{{ method_name }}_rest_interceptors(null_interceptor):
         req.return_value.status_code = 200
         req.return_value.request = PreparedRequest()
         {% if not method.void %}
-        req.return_value._content = {% if method.output.ident.package == method.ident.package %}{{ method.output.ident }}.to_json({{ method.output.ident }}()){% else %}json_format.MessageToJson({{ method.output.ident }}()){% endif %}
+        req.return_value._content = {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json({{ method.output.ident }}()){% else %}json_format.MessageToJson({{ method.output.ident }}()){% endif %}
 
         {% if method.server_streaming %}
         req.return_value._content = "[{}]".format(req.return_value._content)


### PR DESCRIPTION
Fixes #1683 

The issue is that there is an incorrect assumption that dependencies will always have `pb2` types instead of `proto-plus` types. 