### PR TITLE
fix: resolve docs issue when API has a service called services

### DIFF
--- a/gapic/generator/generator.py
+++ b/gapic/generator/generator.py
@@ -410,6 +410,18 @@ class Generator:
         # (e.g. no %version); handle this.
         filename = re.sub(r"/+", "/", filename)
 
+        # Check if the API contains a service called "Services" so we can avoid a
+        # conflict with the templated RST file which lives at
+        # `gapic/templates/docs/%name_%version/services.rst.j2`.
+        # Use `services_.rst.j2` instead of `services.rst.j2` when there is a service
+        # called `services`.
+        # See https://github.com/googleapis/gapic-generator-python/issues/825
+        if template_name.endswith("services.rst.j2"):
+            if any(
+                [service.name == "Services" for service in api_schema.services.values()]
+            ):
+                filename = filename.replace("services.rst", "services_.rst")
+
         # Done, return the filename.
         return filename
 

--- a/gapic/templates/docs/index.rst.j2
+++ b/gapic/templates/docs/index.rst.j2
@@ -2,6 +2,16 @@ API Reference
 -------------
 .. toctree::
     :maxdepth: 2
-    
+
+    {% set index_ns = namespace(has_services_api=false) %}    
+    {% for service in api.services.values() | selectattr('name') %}
+    {% if service.name == "Services" %}
+    {% set index_ns.has_services_api = True %}
+    {% endif %}
+    {% endfor %}
+    {% if index_ns.has_services_api %}
+    {{ api.naming.versioned_module_name }}/services_
+    {% else %}
     {{ api.naming.versioned_module_name }}/services
+    {% endif %}
     {{ api.naming.versioned_module_name }}/types

--- a/tests/unit/generator/test_generator.py
+++ b/tests/unit/generator/test_generator.py
@@ -357,6 +357,55 @@ def test_get_filename_with_service():
     )
 
 
+# See https://github.com/googleapis/gapic-generator-python/issues/825
+def test_get_filename_with_service_named_services():
+    g = make_generator()
+    template_name = "docs/%name_%version/services.rst.j2"
+    assert (
+        g._get_filename(
+            template_name,
+            api_schema=api.API.build(
+                [
+                    descriptor_pb2.FileDescriptorProto(
+                        name="services.proto",
+                        package="foo.v1",
+                        service=[
+                            descriptor_pb2.ServiceDescriptorProto(
+                                name="Services"
+                            )
+                        ],
+                    )
+                ]
+            )
+        )
+        == "docs/foo_v1/services_.rst"
+    )
+
+
+def test_get_filename_with_service_not_named_services():
+    g = make_generator()
+    template_name = "docs/%name_%version/services.rst.j2"
+    assert (
+        g._get_filename(
+            template_name,
+            api_schema=api.API.build(
+                [
+                    descriptor_pb2.FileDescriptorProto(
+                        name="some_service.proto",
+                        package="foo.v1",
+                        service=[
+                            descriptor_pb2.ServiceDescriptorProto(
+                                name="SomeService"
+                            )
+                        ],
+                    )
+                ]
+            )
+        )
+        == "docs/foo_v1/services.rst"
+    )
+
+
 def test_get_filename_with_proto():
     file_pb2 = descriptor_pb2.FileDescriptorProto(
         name="bacon.proto", package="foo.bar.v1",


### PR DESCRIPTION
This PR removes the need for workarounds [here](https://github.com/googleapis/python-run/blob/082e5630fd574aa467cf03b601d5166203d64052/owlbot.py#L40) and [here](https://github.com/googleapis/python-appengine-admin/blob/b66d7f5a75b39e5b82cb0228fddd0ae0a72be5d3/owlbot.py#L42) where the autogenerated `docs/index.rst` and `docs/<API>/services.rst` are excluded.

Fixes https://github.com/googleapis/gapic-generator-python/issues/825 🦕
