### PR TITLE
build: include error information when integration test fails

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -297,7 +297,7 @@ jobs:
           echo "and it will start over with a clean cache."
           echo "The old one will disappear after 7 days."
       - name: Integration Tests
-        run: bazel test //tests/integration/...
+        run: bazel test //tests/integration/... --test_output=errors
 
   goldens-lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-python/issues/1711 🦕
