### PR TITLE
fix: Add deprecation warning for python 3.7

### DIFF
--- a/gapic/templates/%namespace/%name/__init__.py.j2
+++ b/gapic/templates/%namespace/%name/__init__.py.j2
@@ -1,6 +1,9 @@
 {% extends '_base.py.j2' %}
 {% block content %}
 
+import sys
+import warnings
+
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.module_name %}
 from {{package_path}} import gapic_version as package_version
 
@@ -47,6 +50,27 @@ from {% if api.naming.module_namespace %}{{ api.naming.module_namespace|join('.'
     This requires the full set of imported names, so we iterate over
     them again.
 #}
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # Configure the Python37DeprecationWarning warning so that it is only emitted once.
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
+
 
 __all__ = (
 {%- filter indent %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -2,6 +2,9 @@
 
 {% block content %}
 
+import sys
+import warnings
+
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}} import gapic_version as package_version
 
@@ -35,6 +38,26 @@ from .types.{{ proto.module_name }} import {{ message.name }}
 from .types.{{ proto.module_name }} import {{ enum.name }}
 {% endfor %}
 {% endfor %}
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # print only the first occurrence of Python37DeprecationWarning, regardless of location
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
 
 {#  Define __all__.
     This requires the full set of imported names, so we iterate over

--- a/tests/integration/goldens/asset/google/cloud/asset/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.asset import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -98,6 +101,27 @@ from google.cloud.asset_v1.types.assets import ResourceSearchResult
 from google.cloud.asset_v1.types.assets import TemporalAsset
 from google.cloud.asset_v1.types.assets import TimeWindow
 from google.cloud.asset_v1.types.assets import VersionedResource
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # Configure the Python37DeprecationWarning warning so that it is only emitted once.
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
+
 
 __all__ = ('AssetServiceClient',
     'AssetServiceAsyncClient',

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.asset_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -98,6 +101,26 @@ from .types.assets import ResourceSearchResult
 from .types.assets import TemporalAsset
 from .types.assets import TimeWindow
 from .types.assets import VersionedResource
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # print only the first occurrence of Python37DeprecationWarning, regardless of location
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
 
 __all__ = (
     'AssetServiceAsyncClient',

--- a/tests/integration/goldens/credentials/google/iam/credentials/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.iam.credentials import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -29,6 +32,27 @@ from google.iam.credentials_v1.types.common import SignBlobRequest
 from google.iam.credentials_v1.types.common import SignBlobResponse
 from google.iam.credentials_v1.types.common import SignJwtRequest
 from google.iam.credentials_v1.types.common import SignJwtResponse
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # Configure the Python37DeprecationWarning warning so that it is only emitted once.
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
+
 
 __all__ = ('IAMCredentialsClient',
     'IAMCredentialsAsyncClient',

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.iam.credentials_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -29,6 +32,26 @@ from .types.common import SignBlobRequest
 from .types.common import SignBlobResponse
 from .types.common import SignJwtRequest
 from .types.common import SignJwtResponse
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # print only the first occurrence of Python37DeprecationWarning, regardless of location
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
 
 __all__ = (
     'IAMCredentialsAsyncClient',

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.eventarc import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -58,6 +61,27 @@ from google.cloud.eventarc_v1.types.trigger import Pubsub
 from google.cloud.eventarc_v1.types.trigger import StateCondition
 from google.cloud.eventarc_v1.types.trigger import Transport
 from google.cloud.eventarc_v1.types.trigger import Trigger
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # Configure the Python37DeprecationWarning warning so that it is only emitted once.
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
+
 
 __all__ = ('EventarcClient',
     'EventarcAsyncClient',

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.eventarc_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -58,6 +61,26 @@ from .types.trigger import Pubsub
 from .types.trigger import StateCondition
 from .types.trigger import Transport
 from .types.trigger import Trigger
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # print only the first occurrence of Python37DeprecationWarning, regardless of location
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
 
 __all__ = (
     'EventarcAsyncClient',

--- a/tests/integration/goldens/logging/google/cloud/logging/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.logging import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -101,6 +104,27 @@ from google.cloud.logging_v2.types.logging_metrics import ListLogMetricsRequest
 from google.cloud.logging_v2.types.logging_metrics import ListLogMetricsResponse
 from google.cloud.logging_v2.types.logging_metrics import LogMetric
 from google.cloud.logging_v2.types.logging_metrics import UpdateLogMetricRequest
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # Configure the Python37DeprecationWarning warning so that it is only emitted once.
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
+
 
 __all__ = ('ConfigServiceV2Client',
     'ConfigServiceV2AsyncClient',

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.logging_v2 import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -101,6 +104,26 @@ from .types.logging_metrics import ListLogMetricsRequest
 from .types.logging_metrics import ListLogMetricsResponse
 from .types.logging_metrics import LogMetric
 from .types.logging_metrics import UpdateLogMetricRequest
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # print only the first occurrence of Python37DeprecationWarning, regardless of location
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
 
 __all__ = (
     'ConfigServiceV2AsyncClient',

--- a/tests/integration/goldens/redis/google/cloud/redis/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.redis import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -48,6 +51,27 @@ from google.cloud.redis_v1.types.cloud_redis import UpdateInstanceRequest
 from google.cloud.redis_v1.types.cloud_redis import UpgradeInstanceRequest
 from google.cloud.redis_v1.types.cloud_redis import WeeklyMaintenanceWindow
 from google.cloud.redis_v1.types.cloud_redis import ZoneMetadata
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # Configure the Python37DeprecationWarning warning so that it is only emitted once.
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
+
 
 __all__ = ('CloudRedisClient',
     'CloudRedisAsyncClient',

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import sys
+import warnings
+
 from google.cloud.redis_v1 import gapic_version as package_version
 
 __version__ = package_version.__version__
@@ -48,6 +51,26 @@ from .types.cloud_redis import UpdateInstanceRequest
 from .types.cloud_redis import UpgradeInstanceRequest
 from .types.cloud_redis import WeeklyMaintenanceWindow
 from .types.cloud_redis import ZoneMetadata
+
+
+class Python37DeprecationWarning(DeprecationWarning):
+    """
+    Deprecation warning raised when Python 3.7 runtime is detected.
+    Python 3.7 support will be dropped after January 1, 2024. See
+    https://cloud.google.com/python/docs/python37-sunset/ for more information.
+    """
+    pass
+
+# Checks if the current runtime is Python 3.7.
+if sys.version_info.major == 3 and sys.version_info.minor == 7:
+    message = (
+        "After January 1, 2024, new releases of this client library will drop support "
+        "for Python 3.7. More details about Python 3.7 support for Client Libraries "
+        "can be found at https://cloud.google.com/python/docs/python37-sunset/"
+    )
+    # print only the first occurrence of Python37DeprecationWarning, regardless of location
+    warnings.simplefilter('once', Python37DeprecationWarning)
+    warnings.warn(message, Python37DeprecationWarning)
 
 __all__ = (
     'CloudRedisAsyncClient',


### PR DESCRIPTION
Towards https://github.com/googleapis/google-cloud-python/issues/11437

Using Python 3.7
```
(py3716) partheniou@partheniou-vm-3:~/git/gapic-generator-python/tests/integration/goldens/credentials$ export PYTHONWARNINGS="default"
(py3716) partheniou@partheniou-vm-3:~/git/gapic-generator-python/tests/integration/goldens/credentials$ python3.7
Python 3.7.16 (default, Mar 14 2023, 12:34:43) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import google.iam.credentials_v1
/usr/local/google/home/partheniou/git/gapic-generator-python/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py:54: Python37DeprecationWarning: After January 1, 2024, new releases of this client library will drop support for python 3.7. More details about Python 3.7 support for Client Libraries can be found at https://cloud.google.com/python/docs/python37-sunset/
  warnings.warn(message, Python37DeprecationWarning)
>>> import google.iam.credentials
/usr/local/google/home/partheniou/git/gapic-generator-python/tests/integration/goldens/credentials/google/iam/credentials/__init__.py:54: Python37DeprecationWarning: After January 1, 2024, new releases of this client library will drop support for python 3.7. More details about Python 3.7 support for Client Libraries can be found at https://cloud.google.com/python/docs/python37-sunset/
  warnings.warn(message, Python37DeprecationWarning)
>>> import google.iam.credentials_v1
>>> import google.iam.credentials
>>> 
```

Using Python 3.9
```
(py39) partheniou@partheniou-vm-3:~/git/gapic-generator-python/tests/integration/goldens/credentials$ export PYTHONWARNINGS="default"
(py39) partheniou@partheniou-vm-3:~/git/gapic-generator-python/tests/integration/goldens/credentials$ python3.9
Python 3.9.16 (main, Mar  2 2023, 17:52:22) 
[GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import google.iam.credentials_v1
/usr/local/google/home/partheniou/.pyenv/versions/py39/lib/python3.9/site-packages/google/rpc/__init__.py:18: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html
  import pkg_resources
...
>>> import google.iam.credentials
>>> import google.iam.credentials_v1
```

The warnings that appear with python 3.9 are captured in https://github.com/googleapis/python-api-common-protos/issues/140#issuecomment-1431044543 and https://github.com/googleapis/google-cloud-python/issues/11184