### PR TITLE
fix(revert): partial revert of #1125

### DIFF
--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -713,7 +713,7 @@ class MessageType:
         references.
         """
         visited_messages = visited_messages or set()
-        visited_messages.add(self)
+        visited_messages = visited_messages | {self}
         return dataclasses.replace(
             self,
             fields={


### PR DESCRIPTION
This PR partially reverts googleapis/gapic-generator-python#1125 to fix the issue captured in googleapis/google-cloud-python#16369. I wasn't able to create a minimal reproduction. We should keep googleapis/google-cloud-python#16369 open until we can create a minimal test for the issue.