### PR TITLE
fix: add missing dependencies

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -8,8 +8,11 @@ Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has sup
 {% set pypi_packages = {
     ("google", "apps", "script", "type"): {"package_name": "google-apps-script-type", "lower_bound": "0.2.0", "upper_bound": "1.0.0dev"},
     ("google", "geo", "type"): {"package_name": "google-geo-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
+    ("google", "identity", "accesscontextmanager", "v1"): {"package_name": "google-cloud-access-context-manager", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},
     ("google", "cloud", "documentai", "v1"): {"package_name": "google-cloud-documentai", "lower_bound": "2.0.0", "upper_bound": "3.0.0dev"},
     ("google", "cloud", "kms", "v1"): {"package_name": "google-cloud-kms", "lower_bound": "2.3.0", "upper_bound": "3.0.0dev"},
+    ("google", "cloud", "orgpolicy", "v1"): {"package_name": "google-cloud-org-policy", "lower_bound": "0.1.2", "upper_bound": "2.0.0dev"},
+    ("google", "cloud", "osconfig", "v1"): {"package_name": "google-cloud-os-config", "lower_bound": "1.0.0", "upper_bound": "2.0.0dev"},
     ("google", "iam", "v1"): {"package_name": "grpc-google-iam-v1", "lower_bound": "0.12.4", "upper_bound": "1.0.0dev"},
     ("google", "iam", "v2"): {"package_name": "google-cloud-iam", "lower_bound": "2.12.2", "upper_bound": "3.0.0dev"}
 }

--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -11,7 +11,6 @@ Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has sup
     ("google", "identity", "accesscontextmanager", "v1"): {"package_name": "google-cloud-access-context-manager", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},
     ("google", "cloud", "documentai", "v1"): {"package_name": "google-cloud-documentai", "lower_bound": "2.0.0", "upper_bound": "3.0.0dev"},
     ("google", "cloud", "kms", "v1"): {"package_name": "google-cloud-kms", "lower_bound": "2.3.0", "upper_bound": "3.0.0dev"},
-    ("google", "cloud", "orgpolicy", "v1"): {"package_name": "google-cloud-org-policy", "lower_bound": "0.1.2", "upper_bound": "2.0.0dev"},
     ("google", "cloud", "osconfig", "v1"): {"package_name": "google-cloud-os-config", "lower_bound": "1.0.0", "upper_bound": "2.0.0dev"},
     ("google", "iam", "v1"): {"package_name": "grpc-google-iam-v1", "lower_bound": "0.12.4", "upper_bound": "1.0.0dev"},
     ("google", "iam", "v2"): {"package_name": "google-cloud-iam", "lower_bound": "2.12.2", "upper_bound": "3.0.0dev"}

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -40,6 +40,9 @@ dependencies = [
     "proto-plus >= 1.22.0, <2.0.0dev",
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",
     "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "google-cloud-access-context-manager >= 0.1.2, <1.0.0dev",
+    "google-cloud-org-policy >= 0.1.2, <2.0.0dev",
+    "google-cloud-os-config >= 1.0.0, <2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.4, <1.0.0dev",
 ]
 url = "https://github.com/googleapis/python-asset"

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -41,7 +41,6 @@ dependencies = [
     "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",
     "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     "google-cloud-access-context-manager >= 0.1.2, <1.0.0dev",
-    "google-cloud-org-policy >= 0.1.2, <2.0.0dev",
     "google-cloud-os-config >= 1.0.0, <2.0.0dev",
     "grpc-google-iam-v1 >= 0.12.4, <1.0.0dev",
 ]

--- a/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -4,4 +4,7 @@
 google-api-core
 proto-plus
 protobuf
+google-cloud-access-context-manager
+google-cloud-org-policy
+google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -5,6 +5,5 @@ google-api-core
 proto-plus
 protobuf
 google-cloud-access-context-manager
-google-cloud-org-policy
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.11.txt
@@ -4,4 +4,7 @@
 google-api-core
 proto-plus
 protobuf
+google-cloud-access-context-manager
+google-cloud-org-policy
+google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.11.txt
@@ -5,6 +5,5 @@ google-api-core
 proto-plus
 protobuf
 google-cloud-access-context-manager
-google-cloud-org-policy
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.12.txt
@@ -4,4 +4,7 @@
 google-api-core
 proto-plus
 protobuf
+google-cloud-access-context-manager
+google-cloud-org-policy
+google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.12.txt
@@ -5,6 +5,5 @@ google-api-core
 proto-plus
 protobuf
 google-cloud-access-context-manager
-google-cloud-org-policy
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -8,6 +8,5 @@ google-api-core==1.34.0
 proto-plus==1.22.0
 protobuf==3.19.5
 google-cloud-access-context-manager==0.1.2
-google-cloud-org-policy==0.1.2
 google-cloud-os-config==1.0.0
 grpc-google-iam-v1==0.12.4

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -7,4 +7,7 @@
 google-api-core==1.34.0
 proto-plus==1.22.0
 protobuf==3.19.5
+google-cloud-access-context-manager==0.1.2
+google-cloud-org-policy==0.1.2
+google-cloud-os-config==1.0.0
 grpc-google-iam-v1==0.12.4

--- a/tests/integration/goldens/asset/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.8.txt
@@ -4,4 +4,7 @@
 google-api-core
 proto-plus
 protobuf
+google-cloud-access-context-manager
+google-cloud-org-policy
+google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.8.txt
@@ -5,6 +5,5 @@ google-api-core
 proto-plus
 protobuf
 google-cloud-access-context-manager
-google-cloud-org-policy
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.9.txt
@@ -4,4 +4,7 @@
 google-api-core
 proto-plus
 protobuf
+google-cloud-access-context-manager
+google-cloud-org-policy
+google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.9.txt
@@ -5,6 +5,5 @@ google-api-core
 proto-plus
 protobuf
 google-cloud-access-context-manager
-google-cloud-org-policy
 google-cloud-os-config
 grpc-google-iam-v1


### PR DESCRIPTION
This PRs adds the necessary dependencies for generating `google-cloud-asset`. See setup.py here: https://github.com/googleapis/python-asset/blob/7c1f5fec48364889da95d21042278a9d944688c4/setup.py#L41-L43