### PR TITLE
fix: add missing dependency google-shopping-type

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -13,6 +13,7 @@ Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has sup
     ("google", "cloud", "kms", "v1"): {"package_name": "google-cloud-kms", "lower_bound": "2.3.0", "upper_bound": "3.0.0dev"},
     ("google", "cloud", "osconfig", "v1"): {"package_name": "google-cloud-os-config", "lower_bound": "1.0.0", "upper_bound": "2.0.0dev"},
     ("google", "iam", "v1"): {"package_name": "grpc-google-iam-v1", "lower_bound": "0.12.4", "upper_bound": "1.0.0dev"},
-    ("google", "iam", "v2"): {"package_name": "google-cloud-iam", "lower_bound": "2.12.2", "upper_bound": "3.0.0dev"}
+    ("google", "iam", "v2"): {"package_name": "google-cloud-iam", "lower_bound": "2.12.2", "upper_bound": "3.0.0dev"},
+    ("google", "shopping", "type"): {"package_name": "google-shopping-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"}
 }
 %}


### PR DESCRIPTION
This PRs adds the necessary dependency for generating `google-shopping-merchant-inventories`. See the setup.py here: which is missing the dependency:
https://github.com/googleapis/googleapis-gen/blob/eb6ccc3702b6cb3fc8485c65f6c4991d87575a9c/google/shopping/merchant/inventories/v1beta/merchant-inventories-v1beta-py/setup.py#L38-L43

`google.shopping.type` is used here:
https://github.com/googleapis/googleapis-gen/blob/eb6ccc3702b6cb3fc8485c65f6c4991d87575a9c/google/shopping/merchant/inventories/v1beta/merchant-inventories-v1beta-py/google/shopping/merchant_inventories_v1beta/types/localinventory.py#L22