### PR TITLE
fix: allow pb2 files to be included in the output of py_gapic_assembly_pkg

### DIFF
--- a/rules_python_gapic/py_gapic_pkg.bzl
+++ b/rules_python_gapic/py_gapic_pkg.bzl
@@ -24,6 +24,7 @@ def _py_gapic_src_pkg_impl(ctx):
                 dir_srcs.append(f)
             elif f.extension in ("srcjar", "jar", "zip"):
                 srcjar_srcs.append(f)
+            # Exclude *.py files for external packages
             elif f.extension in ("py") and 'external' not in f.path:
                 py_srcs.append(f)
 

--- a/rules_python_gapic/py_gapic_pkg.bzl
+++ b/rules_python_gapic/py_gapic_pkg.bzl
@@ -24,8 +24,8 @@ def _py_gapic_src_pkg_impl(ctx):
                 dir_srcs.append(f)
             elif f.extension in ("srcjar", "jar", "zip"):
                 srcjar_srcs.append(f)
-            # Exclude *.py files for external packages
-            elif f.extension in ("py") and 'external' not in f.path:
+            # Exclude source files and files for external packages
+            elif f.extension in ("py") and not f.is_source and 'external' not in f.path:
                 py_srcs.append(f)
 
     paths = construct_package_dir_paths(ctx.attr.package_dir, ctx.outputs.pkg, ctx.label.name)

--- a/rules_python_gapic/py_gapic_pkg.bzl
+++ b/rules_python_gapic/py_gapic_pkg.bzl
@@ -24,7 +24,7 @@ def _py_gapic_src_pkg_impl(ctx):
                 dir_srcs.append(f)
             elif f.extension in ("srcjar", "jar", "zip"):
                 srcjar_srcs.append(f)
-            elif f.extension in ("py") and not f.is_source and 'external' not in f.path:
+            elif f.extension in ("py") and 'external' not in f.path:
                 py_srcs.append(f)
 
     paths = construct_package_dir_paths(ctx.attr.package_dir, ctx.outputs.pkg, ctx.label.name)

--- a/rules_python_gapic/py_gapic_pkg.bzl
+++ b/rules_python_gapic/py_gapic_pkg.bzl
@@ -17,12 +17,15 @@ load("@rules_gapic//:gapic_pkg.bzl", "construct_package_dir_paths")
 def _py_gapic_src_pkg_impl(ctx):
     srcjar_srcs = []
     dir_srcs = []
+    py_srcs = []
     for dep in ctx.attr.deps:
         for f in dep.files.to_list():
             if f.is_directory:
                 dir_srcs.append(f)
             elif f.extension in ("srcjar", "jar", "zip"):
                 srcjar_srcs.append(f)
+            elif f.extension in ("py") and not f.is_source and 'external' not in f.path:
+                py_srcs.append(f)
 
     paths = construct_package_dir_paths(ctx.attr.package_dir, ctx.outputs.pkg, ctx.label.name)
 
@@ -34,6 +37,9 @@ def _py_gapic_src_pkg_impl(ctx):
     for dir_src in {dir_srcs}; do
         cp -rT -L $dir_src {package_dir_path}
     done
+    for py_src in {py_srcs}; do
+        cp $py_src {package_dir_path}
+    done
     # Replace 555 (forced by Bazel) permissions with 644
     find {package_dir_path} -type f -exec chmod 644 {{}} \\;
     cd {package_dir_path}/..
@@ -44,6 +50,7 @@ def _py_gapic_src_pkg_impl(ctx):
     """.format(
         srcjar_srcs = " ".join(["'%s'" % f.path for f in srcjar_srcs]),
         dir_srcs = " ".join(["'%s'" % f.path for f in dir_srcs]),
+        py_srcs =  " ".join(["'%s'" % f.path for f in py_srcs]),
         package_dir_path = paths.package_dir_path,
         package_dir = paths.package_dir,
         pkg = ctx.outputs.pkg.path,
@@ -51,7 +58,7 @@ def _py_gapic_src_pkg_impl(ctx):
     )
 
     ctx.actions.run_shell(
-        inputs = srcjar_srcs + dir_srcs,
+        inputs = srcjar_srcs + dir_srcs + py_srcs,
         command = script,
         outputs = [ctx.outputs.pkg],
     )


### PR DESCRIPTION
This PR is needed to unblock https://github.com/googleapis/python-api-common-protos/issues/3.

Fixes #1854 🦕

To validate the changes,

1. Check out the code in this branch
2. In the WORKSPACE file of googleapis/googleapis,  make the following change
```
#http_archive(
#    name = "gapic_generator_python",
#    strip_prefix = "gapic-generator-python-%s" % _gapic_generator_python_version,
#    urls = ["https://github.com/googleapis/gapic-generator-python/archive/v%s.zip" % _gapic_generator_python_version],
#)
local_repository (
  name = "gapic_generator_python",
  path = "<absolute path to your clone of gapic-generator-python>",
)
``` 
3. Add the following code to [BUILD.bazel](https://github.com/googleapis/googleapis/blob/master/google/type/BUILD.bazel)
4. Run `bazel build //google/type:google-type-py`
```
py_gapic_assembly_pkg(
    name = "google-type-py",
    deps = [
        ":calendar_period_py_proto",
    ],
)
```
5. Confirm that pb2 files appear in the tar file at `<path to googleapis>/bazel-bin/google/type/google-type-py.tar.gz`

```
(py31013) partheniou@partheniou-vm-3:~/git/googleapis$ bazel build //google/type:google-type-py
INFO: Analyzed target //google/type:google-type-py (1 packages loaded, 4 targets configured).
INFO: Found 1 target...
INFO: From Action google/type/google-type-py.tar.gz:
tar: google-type-py: file changed as we read it
/usr/local/google/home/partheniou/.cache/bazel/_bazel_partheniou/9063cec94a6a99d93035235cd3e5a885/sandbox/linux-sandbox/4/execroot/com_google_googleapis
Target //google/type:google-type-py up-to-date:
  bazel-bin/google/type/google-type-py.tar.gz
INFO: Elapsed time: 0.328s, Critical Path: 0.04s
INFO: 2 processes: 1 internal, 1 linux-sandbox.
INFO: Build completed successfully, 2 total actions
(py31013) partheniou@partheniou-vm-3:~/git/googleapis$ tar -tf bazel-bin/google/type/google-type-py.tar.gz
google-type-py/
google-type-py/calendar_period_pb2.py
```