### PR TITLE
feat: Add support for python 312 (ads templates)

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/gapic_version.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/gapic_version.py.j2
@@ -1,0 +1,5 @@
+{% extends '_base.py.j2' %}
+{% block content %}
+
+__version__ = "0.0.0"
+{% endblock %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -6,7 +6,6 @@ from collections import OrderedDict
 import os
 import re
 from typing import Callable, Dict, Mapping, MutableMapping, MutableSequence, Optional, {% if service.any_server_streaming %}Iterable, {% endif %}{% if service.any_client_streaming %}Iterator, {% endif %}Sequence, Tuple, Type, Union, cast
-import pkg_resources
 {% if service.any_deprecated %}
 import warnings
 {% endif %}
@@ -20,6 +19,9 @@ from google.auth.transport import mtls                            # type: ignore
 from google.auth.transport.grpc import SslCredentials             # type: ignore
 from google.auth.exceptions import MutualTLSChannelError          # type: ignore
 from google.oauth2 import service_account                         # type: ignore
+
+{% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
+from {{package_path}} import gapic_version as package_version
 
 try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault]
@@ -806,14 +808,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
     {% endif %}
 
 
-try:
-    DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            "{{ api.naming.warehouse_package_name }}",
-        ).version,
-    )
-except pkg_resources.DistributionNotFound:
-    DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
 
 __all__ = (

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
@@ -4,7 +4,6 @@
 
 import abc
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
-import pkg_resources
 
 import google.auth  # type: ignore
 import google.api_core  # type: ignore
@@ -42,14 +41,10 @@ from google.longrunning import operations_pb2 # type: ignore
 {% endif %}
 {% endfilter %}
 
-try:
-    DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
-        gapic_version=pkg_resources.get_distribution(
-            '{{ api.naming.warehouse_package_name }}',
-        ).version,
-    )
-except pkg_resources.DistributionNotFound:
-    DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo()
+{% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
+from {{package_path}} import gapic_version as package_version
+
+DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
 
 class {{ service.name }}Transport(abc.ABC):

--- a/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/__init__.py.j2
@@ -5,6 +5,11 @@
 import importlib
 import sys
 
+{% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
+from {{package_path}} import gapic_version as package_version
+
+__version__ = package_version.__version__
+
 
 if sys.version_info < (3, 7):
     raise ImportError('This module requires Python 3.7 or later.')

--- a/gapic/ads-templates/.coveragerc.j2
+++ b/gapic/ads-templates/.coveragerc.j2
@@ -11,11 +11,6 @@ exclude_lines =
     pragma: NO COVER
     # Ignore debug-only repr
     def __repr__
-    # Ignore pkg_resources exceptions.
-    # This is added at the module level as a safeguard for if someone
-    # generates the code and tries to run it without pip installing. This
-    # makes it virtually impossible to test properly.
-    except pkg_resources.DistributionNotFound
     # This is used to indicate a python version mismatch,
     # which is not easily tested in unit tests.
     raise ImportError

--- a/gapic/ads-templates/setup.py.j2
+++ b/gapic/ads-templates/setup.py.j2
@@ -2,36 +2,58 @@
 
 {% block content %}
 
+import os
+import re
+
 import setuptools  # type: ignore
 
+package_root = os.path.abspath(os.path.dirname(__file__))
+
+name = '{{ api.naming.warehouse_package_name }}'
+
+{% set warehouse_description = api.naming.warehouse_package_name.replace('-',' ')|title %}
+{% set package_path = api.naming.module_namespace|join('/') + "/" + api.naming.module_name + "/" + api.naming.version %}
+
+description = "{{ warehouse_description }} API client library"
+
+version = None
+
+with open(os.path.join(package_root, '{{ package_path }}/gapic_version.py')) as fp:
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert (len(version_candidates) == 1)
+    version = version_candidates[0]
+
+if version[0] == "0":
+    release_status = "Development Status :: 4 - Beta"
+else:
+    release_status = "Development Status :: 5 - Production/Stable"
+
+dependencies = [
+    "google-api-core[grpc] >= 2.10.0, < 3.0.0dev",
+    "googleapis-common-protos >= 1.53.0",
+    "grpcio >= 1.10.0",
+    "proto-plus >= 1.19.4, <2.0.0dev",
+    "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",
+    {% if api.requires_package(('google', 'iam', 'v1')) %}
+    "grpc-google-iam-v1",
+    {% endif %}
+]
+
+package_root = os.path.abspath(os.path.dirname(__file__))
+
+packages = [
+    package
+    for package in setuptools.find_namespace_packages()
+    if package.startswith("{{ api.naming.namespace_packages|first }}")
+]
 
 setuptools.setup(
-    name='{{ api.naming.warehouse_package_name }}',
-    version='0.0.1',
-    {% if api.naming.namespace %}
-    packages=setuptools.PEP420PackageFinder.find(),
-    namespace_packages={{ api.naming.namespace_packages }},
-    {% else %}
-    packages=setuptools.find_packages(),
-    {% endif %}
-    platforms='Posix; MacOS X; Windows',
-    include_package_data=True,
-    install_requires=(
-        {# TODO(dovs): remove when 1.x deprecation is complete #}
-        {% if 'rest' in opts.transport %}
-        "google-api-core[grpc] >= 2.10.0, < 3.0.0dev",
-        {% else %}
-        "google-api-core[grpc] >= 1.28.0, < 3.0.0dev",
-        {% endif %}
-        "googleapis-common-protos >= 1.53.0",
-        "grpcio >= 1.10.0",
-        "proto-plus >= 1.19.4, <2.0.0dev",
-        "proto-plus >= 1.22.2, <2.0.0dev; python_version>='3.11'",
-    {% if api.requires_package(('google', 'iam', 'v1')) %}
-        'grpc-google-iam-v1',
-    {% endif %}
-    ),
-    python_requires='>=3.7',{# Lazy import requires module-level getattr #}
+    name=name,
+    version=version,
+    description=description,
+    author="Google LLC",
+    author_email="googleapis-packages@google.com",
+    license="Apache 2.0",
     setup_requires=[
         'libcst >= 0.2.5',
     ],
@@ -39,18 +61,25 @@ setuptools.setup(
         'scripts/fixup_{{ api.naming.versioned_module_name }}_keywords.py',
     ],
     classifiers=[
-        'Development Status :: 3 - Alpha',
-        'Intended Audience :: Developers',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Topic :: Internet',
-        'Topic :: Software Development :: Libraries :: Python Modules',
+        release_status,
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Operating System :: OS Independent",
+        "Topic :: Internet",
     ],
+    platforms="Posix; MacOS X; Windows",
+    packages=packages,
+    python_requires=">=3.7",
+    install_requires=dependencies,
+    include_package_data=True,
     zip_safe=False,
 )
 {% endblock %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -4,6 +4,7 @@
 
 import io
 import os
+import re
 
 import setuptools # type: ignore
 
@@ -16,10 +17,12 @@ name = '{{ api.naming.warehouse_package_name }}'
 
 description = "{{ warehouse_description }} API client library"
 
-version = {}
+version = None
+
 with open(os.path.join(package_root, '{{ package_path }}/gapic_version.py')) as fp:
-    exec(fp.read(), version)
-version = version["__version__"]
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert (len(version_candidates) == 1)
+    version = version_candidates[0]
 
 if version[0] == "0":
     release_status = "Development Status :: 4 - Beta"

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -15,6 +15,7 @@
 #
 import io
 import os
+import re
 
 import setuptools # type: ignore
 
@@ -25,10 +26,12 @@ name = 'google-cloud-asset'
 
 description = "Google Cloud Asset API client library"
 
-version = {}
+version = None
+
 with open(os.path.join(package_root, 'google/cloud/asset/gapic_version.py')) as fp:
-    exec(fp.read(), version)
-version = version["__version__"]
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert (len(version_candidates) == 1)
+    version = version_candidates[0]
 
 if version[0] == "0":
     release_status = "Development Status :: 4 - Beta"

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -15,6 +15,7 @@
 #
 import io
 import os
+import re
 
 import setuptools # type: ignore
 
@@ -25,10 +26,12 @@ name = 'google-iam-credentials'
 
 description = "Google Iam Credentials API client library"
 
-version = {}
+version = None
+
 with open(os.path.join(package_root, 'google/iam/credentials/gapic_version.py')) as fp:
-    exec(fp.read(), version)
-version = version["__version__"]
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert (len(version_candidates) == 1)
+    version = version_candidates[0]
 
 if version[0] == "0":
     release_status = "Development Status :: 4 - Beta"

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -15,6 +15,7 @@
 #
 import io
 import os
+import re
 
 import setuptools # type: ignore
 
@@ -25,10 +26,12 @@ name = 'google-cloud-eventarc'
 
 description = "Google Cloud Eventarc API client library"
 
-version = {}
+version = None
+
 with open(os.path.join(package_root, 'google/cloud/eventarc/gapic_version.py')) as fp:
-    exec(fp.read(), version)
-version = version["__version__"]
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert (len(version_candidates) == 1)
+    version = version_candidates[0]
 
 if version[0] == "0":
     release_status = "Development Status :: 4 - Beta"

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -15,6 +15,7 @@
 #
 import io
 import os
+import re
 
 import setuptools # type: ignore
 
@@ -25,10 +26,12 @@ name = 'google-cloud-logging'
 
 description = "Google Cloud Logging API client library"
 
-version = {}
+version = None
+
 with open(os.path.join(package_root, 'google/cloud/logging/gapic_version.py')) as fp:
-    exec(fp.read(), version)
-version = version["__version__"]
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert (len(version_candidates) == 1)
+    version = version_candidates[0]
 
 if version[0] == "0":
     release_status = "Development Status :: 4 - Beta"

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -15,6 +15,7 @@
 #
 import io
 import os
+import re
 
 import setuptools # type: ignore
 
@@ -25,10 +26,12 @@ name = 'google-cloud-redis'
 
 description = "Google Cloud Redis API client library"
 
-version = {}
+version = None
+
 with open(os.path.join(package_root, 'google/cloud/redis/gapic_version.py')) as fp:
-    exec(fp.read(), version)
-version = version["__version__"]
+    version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
+    assert (len(version_candidates) == 1)
+    version = version_candidates[0]
 
 if version[0] == "0":
     release_status = "Development Status :: 4 - Beta"


### PR DESCRIPTION
Fixes #1858 🦕
Fixes #1859 🦕

This PR: 
- Removes usage of `exec` in both ads and standard templates
- Updates the `setup.py` of Ads to be similar to the standard templates
- Removes usage of `pkg_resources`
- Add support for python 3.12 in Ads templates
- Adds version module `gapic_version.py` to Ads templates
- Adds `__version__` to `__init__.py` for Ads templates