### PR TITLE
ci: Make the goldens-prerelease check optional

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -49,7 +49,6 @@ branchProtectionRules:
     - 'showcase-unit-add-iam-methods'
     - 'integration'
     - 'goldens-lint'
-    - 'goldens-prerelease'
     - 'style-check'
     - 'snippetgen'
     - 'unit (3.7)'


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-python/issues/1945