### PR TITLE
fix: resolve issue where flattened tests fail with multiple nested fields

### DIFF
--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -756,6 +756,26 @@ def test_{{ method_name }}_flattened():
         rule = ValueRule(marshal=Marshal(name="Test"))
         mock_val = rule.to_python(mock_val)
         {% endif %}{# struct_pb2.Value #}
+        {% if field.field_pb.type == 11 and "struct_pb2.Value" not in field.ident|string() %}{# For messages, ensure that only the first field is checked #}
+        # See https://github.com/googleapis/gapic-generator-python/issues/1956
+        # Mocked values for messages only include a single nested field.
+        # In the case that the api signature contains multiple nested fields,
+        # modify the message in the argument before comparing to the mocked value.
+        # Create a new message to avoid changing the original argument
+        arg_message = type(args[0].{{ key }})()
+        # Get all fields for the message
+        {% if field.meta.address.is_proto_plus_type %}
+        message_fields = {{ field.mock_value }}._pb.ListFields()
+        {% else %}
+        message_fields = {{ field.mock_value }}.ListFields()
+        {% endif %}
+        # Only set the first nested field
+        for mock_sub_field, _ in message_fields:
+            nested_field_value = getattr(args[0].{{ key }}, mock_sub_field.name)
+            setattr(arg_message, mock_sub_field.name, nested_field_value)
+            break
+        arg = arg_message
+        {% endif %}{# field.field_pb.type == 11 and "struct_pb2.Value" not in field.ident|string() #}
         assert arg == mock_val
         {% endif %}
         {% endif %}{% endfor %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -435,6 +435,26 @@ def test_{{ method_name }}_flattened():
         rule = ValueRule(marshal=Marshal(name="Test"))
         mock_val = rule.to_python(mock_val)
         {% endif %}{# struct_pb2.Value #}
+        {% if field.field_pb.type == 11 and "struct_pb2.Value" not in field.ident|string() %}{# For messages, ensure that only the first field is checked #}
+        # See https://github.com/googleapis/gapic-generator-python/issues/1956
+        # Mocked values for messages only include a single nested field.
+        # In the case that the api signature contains multiple nested fields,
+        # modify the message in the argument before comparing to the mocked value.
+        # Create a new message to avoid changing the original argument
+        arg_message = type(args[0].{{ key }})()
+        # Get all fields for the message
+        {% if field.meta.address.is_proto_plus_type %}
+        message_fields = {{ field.mock_value }}._pb.ListFields()
+        {% else %}
+        message_fields = {{ field.mock_value }}.ListFields()
+        {% endif %}
+        # Only set the first nested field
+        for mock_sub_field, _ in message_fields:
+            nested_field_value = getattr(args[0].{{ key }}, mock_sub_field.name)
+            setattr(arg_message, mock_sub_field.name, nested_field_value)
+            break
+        arg = arg_message
+        {% endif %}{# field.field_pb.type == 11 and "struct_pb2.Value" not in field.ident|string() #}
         assert arg == mock_val
         {% endif %}
         {% endif %}{% endfor %}
@@ -532,6 +552,26 @@ async def test_{{ method_name }}_flattened_async():
         rule = ValueRule(marshal=Marshal(name="Test"))
         mock_val = rule.to_python(mock_val)
         {% endif %}{# struct_pb2.Value #}
+        {% if field.field_pb.type == 11 and "struct_pb2.Value" not in field.ident|string() %}{# For messages, ensure that only the first field is checked #}
+        # See https://github.com/googleapis/gapic-generator-python/issues/1956
+        # Mocked values for messages only include a single nested field.
+        # In the case that the api signature contains multiple nested fields,
+        # modify the message in the argument before comparing to the mocked value.
+        # Create a new message to avoid changing the original argument
+        arg_message = type(args[0].{{ key }})()
+        # Get all fields for the message
+        {% if field.meta.address.is_proto_plus_type %}
+        message_fields = {{ field.mock_value }}._pb.ListFields()
+        {% else %}
+        message_fields = {{ field.mock_value }}.ListFields()
+        {% endif %}
+        # Only set the first nested field
+        for mock_sub_field, _ in message_fields:
+            nested_field_value = getattr(args[0].{{ key }}, mock_sub_field.name)
+            setattr(arg_message, mock_sub_field.name, nested_field_value)
+            break
+        arg = arg_message
+        {% endif %}{# field.field_pb.type == 11 and "struct_pb2.Value" not in field.ident|string() #}
         assert arg == mock_val
         {% endif %}
         {% endif %}{% endfor %}

--- a/tests/fragments/test_flattened_value.proto
+++ b/tests/fragments/test_flattened_value.proto
@@ -23,13 +23,20 @@ service MyService {
   option (google.api.default_host) = "my.example.com";
 
   rpc MyMethod(MethodRequest) returns (MethodResponse) {
-    option (google.api.method_signature) = "parameter,items";
+    option (google.api.method_signature) = "parameter,items,some_message";
+    option (google.api.method_signature) = "some_message.foo,some_message.bar";
   }
 }
 
 message MethodRequest {
+  message SomeNestedMessage {
+    string foo = 1;
+    string bar = 2;
+  }
+
   google.protobuf.Value parameter = 1;
   repeated google.protobuf.Value items = 2;
+  SomeNestedMessage some_message = 3;
 }
 
 message MethodResponse {


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-python/issues/1955

I created https://github.com/googleapis/gapic-generator-python/issues/1956 as a follow up question to determine if we want `mock_value` to populate multiple nested fields.