### PR TITLE
fix: add `google-apps-card` dependency

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -6,6 +6,7 @@ PyPI package name, the minimum allowed version and the maximum allowed version.
 Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has support for `barcode` in `google.cloud.documentai.types`
 -->
 {% set pypi_packages = {
+    ("google", "apps", "card"): {"package_name": "google-apps-card", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
     ("google", "apps", "script", "type"): {"package_name": "google-apps-script-type", "lower_bound": "0.2.0", "upper_bound": "1.0.0dev"},
     ("google", "geo", "type"): {"package_name": "google-geo-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
     ("google", "identity", "accesscontextmanager", "v1"): {"package_name": "google-cloud-access-context-manager", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},


### PR DESCRIPTION
This PRs adds the necessary dependency for generating `google-apps-chat`. See the setup.py here: which is missing the dependency:
https://github.com/googleapis/googleapis-gen/blob/01518d8fd1e17facedcba2fe8e6bc2856145b957/google/chat/v1/chat-v1-py/setup.py#L41

google.apps.card.v1 is used here:
https://github.com/googleapis/googleapis-gen/blob/01518d8fd1e17facedcba2fe8e6bc2856145b957/google/chat/v1/chat-v1-py/google/apps/chat_v1/types/message.py#L22