### PR TITLE
fix: fix dependency `google-apps-card`

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -6,7 +6,7 @@ PyPI package name, the minimum allowed version and the maximum allowed version.
 Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has support for `barcode` in `google.cloud.documentai.types`
 -->
 {% set pypi_packages = {
-    ("google", "apps", "card"): {"package_name": "google-apps-card", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
+    ("google", "apps", "card", "v1"): {"package_name": "google-apps-card", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
     ("google", "apps", "script", "type"): {"package_name": "google-apps-script-type", "lower_bound": "0.2.0", "upper_bound": "1.0.0dev"},
     ("google", "geo", "type"): {"package_name": "google-geo-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
     ("google", "identity", "accesscontextmanager", "v1"): {"package_name": "google-cloud-access-context-manager", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},

--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -1,7 +1,8 @@
 <!--
 Dict of PyPI packages available by API in the form <tuple>, <tuple>
-Where the first <tuple> contains the API and the second tuple contains the
-PyPI package name, the minimum allowed version and the maximum allowed version.
+Where the first <tuple> contains the API, including the version and the second
+tuple contains the PyPI package name, the minimum allowed version and the maximum
+allowed version.
 
 Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has support for `barcode` in `google.cloud.documentai.types`
 -->


### PR DESCRIPTION
In https://github.com/googleapis/gapic-generator-python/pull/1964, dependency `google-apps-card` was added to `gapic/templates/_pypi_packages.j2`

https://github.com/googleapis/gapic-generator-python/blob/8fe6db90de7b9a33e7bb7113d494b310771032a2/gapic/templates/_pypi_packages.j2#L8-L9

The entry is `("google", "apps", "card")` but it should have been `("google", "apps", "card", "v1")`
