### PR TITLE
fix: set `default` argument of `jinja-filters.map()` when looking up attributes

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/types/_message.py.j2
@@ -12,7 +12,7 @@ class {{ message.name }}({{ p }}.Message):
     {% endif %}
     {% endif %}
     {# Use select filter to capture nested values. See https://github.com/googleapis/gapic-generator-python/issues/1083 #} 
-    {%- if message.fields.values() | map(attribute="oneof") | select | list %}
+    {%- if message.fields.values() | map(attribute="oneof", default="") | select | list %}
     .. _oneof: https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields
 
     {% endif %}
@@ -43,7 +43,7 @@ class {{ message.name }}({{ p }}.Message):
         {% endif %}
     {% endfor %}
 
-    {% if "next_page_token" in message.fields.values()|map(attribute='name') %}
+    {% if "next_page_token" in message.fields.values()|map(attribute='name', default="") %}
     @property
     def raw_page(self):
         return self

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -582,7 +582,7 @@ def test_{{ method_name }}(request_type, transport: str = 'grpc'):
     for message in response:
         assert isinstance(message, {{ method.output.ident }})
     {% else %}
-    {% if "next_page_token" in method.output.fields.values()|map(attribute='name') and not method.paged_result_field %}
+    {% if "next_page_token" in method.output.fields.values()|map(attribute='name', default="") and not method.paged_result_field %}
     {# Cheeser assertion to force code coverage for bad paginated methods #}
     assert response.raw_page is response
     {% endif %}
@@ -1138,7 +1138,7 @@ def test_{{ method.name|snake_case }}_rest(request_type):
         response = client.{{ method_name }}(request)
         {% endif %}
 
-    {% if "next_page_token" in method.output.fields.values()|map(attribute='name') and not method.paged_result_field %}
+    {% if "next_page_token" in method.output.fields.values()|map(attribute='name', default="") and not method.paged_result_field %}
     {# Cheeser assertion to force code coverage for bad paginated methods #}
     assert response.raw_page is response
 

--- a/gapic/templates/%namespace/%name_%version/%sub/types/_message.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/types/_message.py.j2
@@ -12,7 +12,7 @@ class {{ message.name }}({{ p }}.Message):
     {% endif %}
     {% endif %}
     {# Use select filter to capture nested values. See https://github.com/googleapis/gapic-generator-python/issues/1083 #} 
-    {%- if message.fields.values() | map(attribute="oneof") | select | list %}
+    {%- if message.fields.values() | map(attribute="oneof", default="") | select | list %}
     .. _oneof: https://proto-plus-python.readthedocs.io/en/stable/fields.html#oneofs-mutually-exclusive-fields
 
     {% endif %}
@@ -43,7 +43,7 @@ class {{ message.name }}({{ p }}.Message):
         {% endif %}
     {% endfor %}
 
-    {% if "next_page_token" in message.fields.values()|map(attribute='name') %}
+    {% if "next_page_token" in message.fields.values()|map(attribute='name', default="") %}
     @property
     def raw_page(self):
         return self

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -72,7 +72,7 @@ def test_{{ method_name }}(request_type, transport: str = 'grpc'):
     for message in response:
         assert isinstance(message, {{ method.output.ident }})
     {% else %}
-    {% if "next_page_token" in method.output.fields.values()|map(attribute='name') and not method.paged_result_field %}
+    {% if "next_page_token" in method.output.fields.values()|map(attribute='name', default="") and not method.paged_result_field %}
     {# Cheeser assertion to force code coverage for bad paginated methods #}
     assert response.raw_page is response
     {% endif %}
@@ -1027,7 +1027,7 @@ def test_{{ method_name }}_rest(request_type):
         response = client.{{ method_name }}(request)
         {% endif %}
 
-    {% if "next_page_token" in method_output.fields.values()|map(attribute='name') and not method.paged_result_field %}
+    {% if "next_page_token" in method_output.fields.values()|map(attribute='name', default="") and not method.paged_result_field %}
     {# Cheeser assertion to force code coverage for bad paginated methods #}
     assert response.raw_page is response
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,10 @@ dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
     "googleapis-common-protos >= 1.55.0",
     "grpcio >= 1.24.3",
-    "jinja2 >= 2.10",
+    # 2.11.0 is required which adds the `default` argument to `jinja-filters.map()`
+    # https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.map
+    # https://jinja.palletsprojects.com/en/2.11.x/changelog/#version-2-11-0
+    "jinja2 >= 2.11",
     "protobuf>=3.19.5,<5.0.0dev,!=3.20.0,!=3.20.1,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     "pypandoc >= 1.4",
     "PyYAML >= 5.1.1",


### PR DESCRIPTION
When[ jinja-filters.map](https://jinja.palletsprojects.com/en/3.0.x/templates/#jinja-filters.map) is used to look up an attribute, the `default` argument should be set in case an object in the list does not have the given attribute.