### PR TITLE
fix: cater for empty async call

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -326,7 +326,7 @@ class {{ service.async_client_name }}:
         if isinstance(request, dict):
             request = {{ method.input.ident }}(**request)
         elif not request:
-            request = {{ method.input.ident }}({% if method.flattened_fields %}{% for f in method.flattened_fields.values() %}{{ f.name }}={{ f.name }}, {% endfor %}{% endif %})
+            request = {{ method.input.ident }}({% if method.flattened_fields %}{% for f in method.flattened_fields.values() %}{{ f.name }}={{ f.name }}{% if not loop.last %}, {% endif %}{% endfor %}{% endif %})
         {% else %}
         request = {{ method.input.ident }}(request)
         {% endif %} {# different request package #}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -325,10 +325,8 @@ class {{ service.async_client_name }}:
         # so it must be constructed via keyword expansion.
         if isinstance(request, dict):
             request = {{ method.input.ident }}(**request)
-        {% if method.flattened_fields %}{# Cross-package req and flattened fields #}
         elif not request:
-            request = {{ method.input.ident }}({% if method.input.ident.package != method.ident.package %}{% for f in method.flattened_fields.values() %}{{ f.name }}={{ f.name }}, {% endfor %}{% endif %})
-        {% endif %}{# Cross-package req and flattened fields #}
+            request = {{ method.input.ident }}({% if method.flattened_fields %}{% for f in method.flattened_fields.values() %}{{ f.name }}={{ f.name }}, {% endfor %}{% endif %})
         {% else %}
         request = {{ method.input.ident }}(request)
         {% endif %} {# different request package #}


### PR DESCRIPTION
This PR fixes the issue in the stack trace below seen in cl/618127799 which is similar to #791 but for the async client

```
            # Certain fields should be provided within the metadata header;
            # add these here.
            metadata = tuple(metadata) + (
                gapic_v1.routing_header.to_grpc_metadata((
>                   ("resource", request.resource),
                )),
            )
E           AttributeError: 'NoneType' object has no attribute 'resource'
```
