### PR TITLE
fix: Update the lower bound for `google-apps-card`

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -7,7 +7,7 @@ allowed version.
 Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has support for `barcode` in `google.cloud.documentai.types`
 -->
 {% set pypi_packages = {
-    ("google", "apps", "card", "v1"): {"package_name": "google-apps-card", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
+    ("google", "apps", "card", "v1"): {"package_name": "google-apps-card", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},
     ("google", "apps", "script", "type"): {"package_name": "google-apps-script-type", "lower_bound": "0.2.0", "upper_bound": "1.0.0dev"},
     ("google", "geo", "type"): {"package_name": "google-geo-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
     ("google", "identity", "accesscontextmanager", "v1"): {"package_name": "google-cloud-access-context-manager", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},


### PR DESCRIPTION
Fixes #2011 🦕
