### PR TITLE
fix: retry and timeout values do not propagate in requests during pagination

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/client.py.j2
@@ -509,6 +509,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
         {% endif %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
@@ -26,7 +26,6 @@ except AttributeError:  # pragma: NO COVER
 {% endfilter %}
 {% endif %}
 
-
 class {{ method.name }}Pager:
     """A pager for iterating through ``{{ method.name|snake_case }}`` requests.
 

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/pagers.py.j2
@@ -7,7 +7,13 @@
 {# This lives within the loop in order to ensure that this template
    is empty if there are no paged methods.
  -#}
-from typing import Any, Callable, Iterable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, Callable, Iterable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
 
 {% filter sort_lines %}
 {% for method in service.methods.values() | selectattr('paged_result_field') %}
@@ -19,6 +25,7 @@ from typing import Any, Callable, Iterable, Sequence, Tuple, Optional, Iterator
 {% endfor %}
 {% endfilter %}
 {% endif %}
+
 
 class {{ method.name }}Pager:
     """A pager for iterating through ``{{ method.name|snake_case }}`` requests.
@@ -41,6 +48,8 @@ class {{ method.name }}Pager:
             method: Callable[..., {{ method.output.ident }}],
             request: {{ method.input.ident }},
             response: {{ method.output.ident }},
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -51,12 +60,17 @@ class {{ method.name }}Pager:
                 The initial request object.
             response (:class:`{{ method.output.ident.sphinx }}`):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = {{ method.input.ident }}(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -67,7 +81,7 @@ class {{ method.name }}Pager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     {% if method.paged_result_field.map %}

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -45,6 +45,7 @@ from google.api_core import client_options
 from google.api_core import exceptions as core_exceptions
 from google.api_core import grpc_helpers
 from google.api_core import path_template
+from google.api_core import retry as retries
 {% if service.has_lro %}
 from google.api_core import future
 from google.api_core import operation
@@ -938,6 +939,8 @@ def test_{{ method_name }}_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         {% if method.field_headers %}
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
@@ -949,7 +952,7 @@ def test_{{ method_name }}_pager(transport_name: str = "grpc"):
             )),
         )
         {% endif %}
-        pager = client.{{ method_name }}(request={})
+        pager = client.{{ method_name }}(request={}, retry=retry, timeout=timeout)
 
         {% if service.version %}
         if HAS_GOOGLE_API_CORE_VERSION_HEADER:
@@ -958,6 +961,8 @@ def test_{{ method_name }}_pager(transport_name: str = "grpc"):
             )
         {% endif %}
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
@@ -217,6 +217,8 @@
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
         {% elif method.extended_lro and full_extended_lro %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -414,6 +414,8 @@ class {{ service.async_client_name }}:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
         {% endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/pagers.py.j2
@@ -7,7 +7,15 @@
 {# This lives within the loop in order to ensure that this template
    is empty if there are no paged methods.
  #}
-from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+    OptionalAsyncRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+    OptionalAsyncRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
 {% filter sort_lines %}
 {% for method in service.methods.values() | selectattr('paged_result_field') %}
@@ -43,6 +51,8 @@ class {{ method.name }}Pager:
             request: {{ method.input.ident }},
             response: {{ method.output.ident }},
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -53,12 +63,17 @@ class {{ method.name }}Pager:
                 The initial request object.
             response ({{ method.output.ident.sphinx }}):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = {{ method.input.ident }}(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -69,7 +84,7 @@ class {{ method.name }}Pager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     {% if method.paged_result_field.map %}
@@ -113,6 +128,8 @@ class {{ method.name }}AsyncPager:
             request: {{ method.input.ident }},
             response: {{ method.output.ident }},
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -123,12 +140,17 @@ class {{ method.name }}AsyncPager:
                 The initial request object.
             response ({{ method.output.ident.sphinx }}):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = {{ method.input.ident }}(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -139,7 +161,7 @@ class {{ method.name }}AsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     {% if method.paged_result_field.map %}
     def __aiter__(self) -> Iterator[Tuple[str, {{ method.paged_result_field.type.fields.get('value').ident }}]]:

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -176,6 +176,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
         # Ignore release of mypy 1.11.0 which may have a regression
         'mypy!=1.11.0',
         'types-requests',

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -176,7 +176,8 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        'mypy',
+        # Ignore release of mypy 1.11.0 which may have a regression
+        'mypy!=1.11.0',
         'types-requests',
         'types-protobuf'
     )

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -51,6 +51,7 @@ from google.api_core import exceptions as core_exceptions
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import retry as retries
 {% if service.has_lro or service.has_extended_lro %}
 from google.api_core import future
 {% endif %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -850,6 +850,8 @@ def test_{{ method_name }}_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         {% if not method.explicit_routing and method.field_headers %}
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
@@ -867,9 +869,11 @@ def test_{{ method_name }}_pager(transport_name: str = "grpc"):
                 version_header.to_api_version_header("{{ service.version }}"),
             )
         {% endif %}
-        pager = client.{{ method_name }}(request={})
+        pager = client.{{ method_name }}(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6

--- a/noxfile.py
+++ b/noxfile.py
@@ -434,6 +434,7 @@ def showcase_mypy(
     """Perform typecheck analysis on the generated Showcase library."""
 
     # Install pytest and gapic-generator-python
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
     # Ignore release of mypy 1.11.0 which may have a regression
     session.install("mypy!=1.11.0", "types-pkg-resources", "types-protobuf", "types-requests", "types-dataclasses")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -434,7 +434,8 @@ def showcase_mypy(
     """Perform typecheck analysis on the generated Showcase library."""
 
     # Install pytest and gapic-generator-python
-    session.install("mypy", "types-pkg-resources", "types-protobuf", "types-requests", "types-dataclasses")
+    # Ignore release of mypy 1.11.0 which may have a regression
+    session.install("mypy!=1.11.0", "types-pkg-resources", "types-protobuf", "types-requests", "types-dataclasses")
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
         session.chdir(lib)

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -478,6 +478,8 @@ class AssetServiceAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1335,6 +1337,8 @@ class AssetServiceAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1524,6 +1528,8 @@ class AssetServiceAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2276,6 +2282,8 @@ class AssetServiceAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2721,6 +2729,8 @@ class AssetServiceAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2871,6 +2881,8 @@ class AssetServiceAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -3050,6 +3062,8 @@ class AssetServiceAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -874,6 +874,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1725,6 +1727,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1913,6 +1917,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2662,6 +2668,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -3104,6 +3112,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -3253,6 +3263,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -3431,6 +3443,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/pagers.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/pagers.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+    OptionalAsyncRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+    OptionalAsyncRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
 from google.cloud.asset_v1.types import asset_service
 from google.cloud.asset_v1.types import assets
@@ -41,6 +49,8 @@ class ListAssetsPager:
             request: asset_service.ListAssetsRequest,
             response: asset_service.ListAssetsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -51,12 +61,17 @@ class ListAssetsPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.ListAssetsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.ListAssetsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -67,7 +82,7 @@ class ListAssetsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[assets.Asset]:
@@ -100,6 +115,8 @@ class ListAssetsAsyncPager:
             request: asset_service.ListAssetsRequest,
             response: asset_service.ListAssetsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -110,12 +127,17 @@ class ListAssetsAsyncPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.ListAssetsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.ListAssetsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -126,7 +148,7 @@ class ListAssetsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[assets.Asset]:
         async def async_generator():
@@ -162,6 +184,8 @@ class SearchAllResourcesPager:
             request: asset_service.SearchAllResourcesRequest,
             response: asset_service.SearchAllResourcesResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -172,12 +196,17 @@ class SearchAllResourcesPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.SearchAllResourcesResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.SearchAllResourcesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -188,7 +217,7 @@ class SearchAllResourcesPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[assets.ResourceSearchResult]:
@@ -221,6 +250,8 @@ class SearchAllResourcesAsyncPager:
             request: asset_service.SearchAllResourcesRequest,
             response: asset_service.SearchAllResourcesResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -231,12 +262,17 @@ class SearchAllResourcesAsyncPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.SearchAllResourcesResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.SearchAllResourcesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -247,7 +283,7 @@ class SearchAllResourcesAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[assets.ResourceSearchResult]:
         async def async_generator():
@@ -283,6 +319,8 @@ class SearchAllIamPoliciesPager:
             request: asset_service.SearchAllIamPoliciesRequest,
             response: asset_service.SearchAllIamPoliciesResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -293,12 +331,17 @@ class SearchAllIamPoliciesPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.SearchAllIamPoliciesResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.SearchAllIamPoliciesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -309,7 +352,7 @@ class SearchAllIamPoliciesPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[assets.IamPolicySearchResult]:
@@ -342,6 +385,8 @@ class SearchAllIamPoliciesAsyncPager:
             request: asset_service.SearchAllIamPoliciesRequest,
             response: asset_service.SearchAllIamPoliciesResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -352,12 +397,17 @@ class SearchAllIamPoliciesAsyncPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.SearchAllIamPoliciesResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.SearchAllIamPoliciesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -368,7 +418,7 @@ class SearchAllIamPoliciesAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[assets.IamPolicySearchResult]:
         async def async_generator():
@@ -404,6 +454,8 @@ class ListSavedQueriesPager:
             request: asset_service.ListSavedQueriesRequest,
             response: asset_service.ListSavedQueriesResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -414,12 +466,17 @@ class ListSavedQueriesPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.ListSavedQueriesResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.ListSavedQueriesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -430,7 +487,7 @@ class ListSavedQueriesPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[asset_service.SavedQuery]:
@@ -463,6 +520,8 @@ class ListSavedQueriesAsyncPager:
             request: asset_service.ListSavedQueriesRequest,
             response: asset_service.ListSavedQueriesResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -473,12 +532,17 @@ class ListSavedQueriesAsyncPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.ListSavedQueriesResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.ListSavedQueriesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -489,7 +553,7 @@ class ListSavedQueriesAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[asset_service.SavedQuery]:
         async def async_generator():
@@ -525,6 +589,8 @@ class AnalyzeOrgPoliciesPager:
             request: asset_service.AnalyzeOrgPoliciesRequest,
             response: asset_service.AnalyzeOrgPoliciesResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -535,12 +601,17 @@ class AnalyzeOrgPoliciesPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.AnalyzeOrgPoliciesResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.AnalyzeOrgPoliciesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -551,7 +622,7 @@ class AnalyzeOrgPoliciesPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[asset_service.AnalyzeOrgPoliciesResponse.OrgPolicyResult]:
@@ -584,6 +655,8 @@ class AnalyzeOrgPoliciesAsyncPager:
             request: asset_service.AnalyzeOrgPoliciesRequest,
             response: asset_service.AnalyzeOrgPoliciesResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -594,12 +667,17 @@ class AnalyzeOrgPoliciesAsyncPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.AnalyzeOrgPoliciesResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.AnalyzeOrgPoliciesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -610,7 +688,7 @@ class AnalyzeOrgPoliciesAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[asset_service.AnalyzeOrgPoliciesResponse.OrgPolicyResult]:
         async def async_generator():
@@ -646,6 +724,8 @@ class AnalyzeOrgPolicyGovernedContainersPager:
             request: asset_service.AnalyzeOrgPolicyGovernedContainersRequest,
             response: asset_service.AnalyzeOrgPolicyGovernedContainersResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -656,12 +736,17 @@ class AnalyzeOrgPolicyGovernedContainersPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.AnalyzeOrgPolicyGovernedContainersResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.AnalyzeOrgPolicyGovernedContainersRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -672,7 +757,7 @@ class AnalyzeOrgPolicyGovernedContainersPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[asset_service.AnalyzeOrgPolicyGovernedContainersResponse.GovernedContainer]:
@@ -705,6 +790,8 @@ class AnalyzeOrgPolicyGovernedContainersAsyncPager:
             request: asset_service.AnalyzeOrgPolicyGovernedContainersRequest,
             response: asset_service.AnalyzeOrgPolicyGovernedContainersResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -715,12 +802,17 @@ class AnalyzeOrgPolicyGovernedContainersAsyncPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.AnalyzeOrgPolicyGovernedContainersResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.AnalyzeOrgPolicyGovernedContainersRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -731,7 +823,7 @@ class AnalyzeOrgPolicyGovernedContainersAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[asset_service.AnalyzeOrgPolicyGovernedContainersResponse.GovernedContainer]:
         async def async_generator():
@@ -767,6 +859,8 @@ class AnalyzeOrgPolicyGovernedAssetsPager:
             request: asset_service.AnalyzeOrgPolicyGovernedAssetsRequest,
             response: asset_service.AnalyzeOrgPolicyGovernedAssetsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -777,12 +871,17 @@ class AnalyzeOrgPolicyGovernedAssetsPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.AnalyzeOrgPolicyGovernedAssetsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -793,7 +892,7 @@ class AnalyzeOrgPolicyGovernedAssetsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.GovernedAsset]:
@@ -826,6 +925,8 @@ class AnalyzeOrgPolicyGovernedAssetsAsyncPager:
             request: asset_service.AnalyzeOrgPolicyGovernedAssetsRequest,
             response: asset_service.AnalyzeOrgPolicyGovernedAssetsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -836,12 +937,17 @@ class AnalyzeOrgPolicyGovernedAssetsAsyncPager:
                 The initial request object.
             response (google.cloud.asset_v1.types.AnalyzeOrgPolicyGovernedAssetsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = asset_service.AnalyzeOrgPolicyGovernedAssetsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -852,7 +958,7 @@ class AnalyzeOrgPolicyGovernedAssetsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.GovernedAsset]:
         async def async_generator():

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -187,7 +187,8 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        'mypy',
+        # Ignore release of mypy 1.11.0 which may have a regression
+        'mypy!=1.11.0',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -187,6 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
         # Ignore release of mypy 1.11.0 which may have a regression
         'mypy!=1.11.0',
         'types-requests',

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -46,6 +46,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.asset_v1.services.asset_service import AssetServiceAsyncClient
@@ -1433,14 +1434,18 @@ def test_list_assets_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_assets(request={})
+        pager = client.list_assets(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -4061,14 +4066,18 @@ def test_search_all_resources_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('scope', ''),
             )),
         )
-        pager = client.search_all_resources(request={})
+        pager = client.search_all_resources(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -4619,14 +4628,18 @@ def test_search_all_iam_policies_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('scope', ''),
             )),
         )
-        pager = client.search_all_iam_policies(request={})
+        pager = client.search_all_iam_policies(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -7001,14 +7014,18 @@ def test_list_saved_queries_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_saved_queries(request={})
+        pager = client.list_saved_queries(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -8547,14 +8564,18 @@ def test_analyze_org_policies_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('scope', ''),
             )),
         )
-        pager = client.analyze_org_policies(request={})
+        pager = client.analyze_org_policies(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -9115,14 +9136,18 @@ def test_analyze_org_policy_governed_containers_pager(transport_name: str = "grp
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('scope', ''),
             )),
         )
-        pager = client.analyze_org_policy_governed_containers(request={})
+        pager = client.analyze_org_policy_governed_containers(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -9683,14 +9708,18 @@ def test_analyze_org_policy_governed_assets_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('scope', ''),
             )),
         )
-        pager = client.analyze_org_policy_governed_assets(request={})
+        pager = client.analyze_org_policy_governed_assets(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -187,7 +187,8 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        'mypy',
+        # Ignore release of mypy 1.11.0 which may have a regression
+        'mypy!=1.11.0',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -187,6 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
         # Ignore release of mypy 1.11.0 which may have a regression
         'mypy!=1.11.0',
         'types-requests',

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -42,6 +42,7 @@ from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.iam.credentials_v1.services.iam_credentials import IAMCredentialsAsyncClient

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
@@ -478,6 +478,8 @@ class EventarcAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1118,6 +1120,8 @@ class EventarcAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1736,6 +1740,8 @@ class EventarcAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1960,6 +1966,8 @@ class EventarcAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -900,6 +900,8 @@ class EventarcClient(metaclass=EventarcClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1535,6 +1537,8 @@ class EventarcClient(metaclass=EventarcClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2148,6 +2152,8 @@ class EventarcClient(metaclass=EventarcClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2370,6 +2376,8 @@ class EventarcClient(metaclass=EventarcClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/pagers.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/pagers.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+    OptionalAsyncRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+    OptionalAsyncRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
 from google.cloud.eventarc_v1.types import channel
 from google.cloud.eventarc_v1.types import channel_connection
@@ -44,6 +52,8 @@ class ListTriggersPager:
             request: eventarc.ListTriggersRequest,
             response: eventarc.ListTriggersResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -54,12 +64,17 @@ class ListTriggersPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListTriggersResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListTriggersRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -70,7 +85,7 @@ class ListTriggersPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[trigger.Trigger]:
@@ -103,6 +118,8 @@ class ListTriggersAsyncPager:
             request: eventarc.ListTriggersRequest,
             response: eventarc.ListTriggersResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -113,12 +130,17 @@ class ListTriggersAsyncPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListTriggersResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListTriggersRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -129,7 +151,7 @@ class ListTriggersAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[trigger.Trigger]:
         async def async_generator():
@@ -165,6 +187,8 @@ class ListChannelsPager:
             request: eventarc.ListChannelsRequest,
             response: eventarc.ListChannelsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -175,12 +199,17 @@ class ListChannelsPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListChannelsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListChannelsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -191,7 +220,7 @@ class ListChannelsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[channel.Channel]:
@@ -224,6 +253,8 @@ class ListChannelsAsyncPager:
             request: eventarc.ListChannelsRequest,
             response: eventarc.ListChannelsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -234,12 +265,17 @@ class ListChannelsAsyncPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListChannelsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListChannelsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -250,7 +286,7 @@ class ListChannelsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[channel.Channel]:
         async def async_generator():
@@ -286,6 +322,8 @@ class ListProvidersPager:
             request: eventarc.ListProvidersRequest,
             response: eventarc.ListProvidersResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -296,12 +334,17 @@ class ListProvidersPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListProvidersResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListProvidersRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -312,7 +355,7 @@ class ListProvidersPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[discovery.Provider]:
@@ -345,6 +388,8 @@ class ListProvidersAsyncPager:
             request: eventarc.ListProvidersRequest,
             response: eventarc.ListProvidersResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -355,12 +400,17 @@ class ListProvidersAsyncPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListProvidersResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListProvidersRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -371,7 +421,7 @@ class ListProvidersAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[discovery.Provider]:
         async def async_generator():
@@ -407,6 +457,8 @@ class ListChannelConnectionsPager:
             request: eventarc.ListChannelConnectionsRequest,
             response: eventarc.ListChannelConnectionsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -417,12 +469,17 @@ class ListChannelConnectionsPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListChannelConnectionsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListChannelConnectionsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -433,7 +490,7 @@ class ListChannelConnectionsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[channel_connection.ChannelConnection]:
@@ -466,6 +523,8 @@ class ListChannelConnectionsAsyncPager:
             request: eventarc.ListChannelConnectionsRequest,
             response: eventarc.ListChannelConnectionsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -476,12 +535,17 @@ class ListChannelConnectionsAsyncPager:
                 The initial request object.
             response (google.cloud.eventarc_v1.types.ListChannelConnectionsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = eventarc.ListChannelConnectionsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -492,7 +556,7 @@ class ListChannelConnectionsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[channel_connection.ChannelConnection]:
         async def async_generator():

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -187,7 +187,8 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        'mypy',
+        # Ignore release of mypy 1.11.0 which may have a regression
+        'mypy!=1.11.0',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -187,6 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
         # Ignore release of mypy 1.11.0 which may have a regression
         'mypy!=1.11.0',
         'types-requests',

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -46,6 +46,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.eventarc_v1.services.eventarc import EventarcAsyncClient
@@ -1550,14 +1551,18 @@ def test_list_triggers_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_triggers(request={})
+        pager = client.list_triggers(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -3597,14 +3602,18 @@ def test_list_channels_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_channels(request={})
+        pager = client.list_channels(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -5603,14 +5612,18 @@ def test_list_providers_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_providers(request={})
+        pager = client.list_providers(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -6517,14 +6530,18 @@ def test_list_channel_connections_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_channel_connections(request={})
+        pager = client.list_channel_connections(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -363,6 +363,8 @@ class ConfigServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1087,6 +1089,8 @@ class ConfigServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1533,6 +1537,8 @@ class ConfigServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2453,6 +2459,8 @@ class ConfigServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2681,6 +2689,8 @@ class ConfigServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -757,6 +757,8 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1480,6 +1482,8 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1925,6 +1929,8 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -2838,6 +2844,8 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -3064,6 +3072,8 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/pagers.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/pagers.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+    OptionalAsyncRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+    OptionalAsyncRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
 from google.cloud.logging_v2.types import logging_config
 
@@ -40,6 +48,8 @@ class ListBucketsPager:
             request: logging_config.ListBucketsRequest,
             response: logging_config.ListBucketsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -50,12 +60,17 @@ class ListBucketsPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListBucketsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListBucketsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -66,7 +81,7 @@ class ListBucketsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[logging_config.LogBucket]:
@@ -99,6 +114,8 @@ class ListBucketsAsyncPager:
             request: logging_config.ListBucketsRequest,
             response: logging_config.ListBucketsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -109,12 +126,17 @@ class ListBucketsAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListBucketsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListBucketsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -125,7 +147,7 @@ class ListBucketsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[logging_config.LogBucket]:
         async def async_generator():
@@ -161,6 +183,8 @@ class ListViewsPager:
             request: logging_config.ListViewsRequest,
             response: logging_config.ListViewsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -171,12 +195,17 @@ class ListViewsPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListViewsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListViewsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -187,7 +216,7 @@ class ListViewsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[logging_config.LogView]:
@@ -220,6 +249,8 @@ class ListViewsAsyncPager:
             request: logging_config.ListViewsRequest,
             response: logging_config.ListViewsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -230,12 +261,17 @@ class ListViewsAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListViewsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListViewsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -246,7 +282,7 @@ class ListViewsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[logging_config.LogView]:
         async def async_generator():
@@ -282,6 +318,8 @@ class ListSinksPager:
             request: logging_config.ListSinksRequest,
             response: logging_config.ListSinksResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -292,12 +330,17 @@ class ListSinksPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListSinksResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListSinksRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -308,7 +351,7 @@ class ListSinksPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[logging_config.LogSink]:
@@ -341,6 +384,8 @@ class ListSinksAsyncPager:
             request: logging_config.ListSinksRequest,
             response: logging_config.ListSinksResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -351,12 +396,17 @@ class ListSinksAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListSinksResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListSinksRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -367,7 +417,7 @@ class ListSinksAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[logging_config.LogSink]:
         async def async_generator():
@@ -403,6 +453,8 @@ class ListLinksPager:
             request: logging_config.ListLinksRequest,
             response: logging_config.ListLinksResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -413,12 +465,17 @@ class ListLinksPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLinksResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListLinksRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -429,7 +486,7 @@ class ListLinksPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[logging_config.Link]:
@@ -462,6 +519,8 @@ class ListLinksAsyncPager:
             request: logging_config.ListLinksRequest,
             response: logging_config.ListLinksResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -472,12 +531,17 @@ class ListLinksAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLinksResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListLinksRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -488,7 +552,7 @@ class ListLinksAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[logging_config.Link]:
         async def async_generator():
@@ -524,6 +588,8 @@ class ListExclusionsPager:
             request: logging_config.ListExclusionsRequest,
             response: logging_config.ListExclusionsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -534,12 +600,17 @@ class ListExclusionsPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListExclusionsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListExclusionsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -550,7 +621,7 @@ class ListExclusionsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[logging_config.LogExclusion]:
@@ -583,6 +654,8 @@ class ListExclusionsAsyncPager:
             request: logging_config.ListExclusionsRequest,
             response: logging_config.ListExclusionsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -593,12 +666,17 @@ class ListExclusionsAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListExclusionsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_config.ListExclusionsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -609,7 +687,7 @@ class ListExclusionsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[logging_config.LogExclusion]:
         async def async_generator():

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -672,6 +672,8 @@ class LoggingServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -760,6 +762,8 @@ class LoggingServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -881,6 +885,8 @@ class LoggingServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -1009,6 +1009,8 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1097,6 +1099,8 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 
@@ -1217,6 +1221,8 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/pagers.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/pagers.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+    OptionalAsyncRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+    OptionalAsyncRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
 from google.api import monitored_resource_pb2  # type: ignore
 from google.cloud.logging_v2.types import log_entry
@@ -42,6 +50,8 @@ class ListLogEntriesPager:
             request: logging.ListLogEntriesRequest,
             response: logging.ListLogEntriesResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -52,12 +62,17 @@ class ListLogEntriesPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLogEntriesResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging.ListLogEntriesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -68,7 +83,7 @@ class ListLogEntriesPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[log_entry.LogEntry]:
@@ -101,6 +116,8 @@ class ListLogEntriesAsyncPager:
             request: logging.ListLogEntriesRequest,
             response: logging.ListLogEntriesResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -111,12 +128,17 @@ class ListLogEntriesAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLogEntriesResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging.ListLogEntriesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -127,7 +149,7 @@ class ListLogEntriesAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[log_entry.LogEntry]:
         async def async_generator():
@@ -163,6 +185,8 @@ class ListMonitoredResourceDescriptorsPager:
             request: logging.ListMonitoredResourceDescriptorsRequest,
             response: logging.ListMonitoredResourceDescriptorsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -173,12 +197,17 @@ class ListMonitoredResourceDescriptorsPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListMonitoredResourceDescriptorsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging.ListMonitoredResourceDescriptorsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -189,7 +218,7 @@ class ListMonitoredResourceDescriptorsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[monitored_resource_pb2.MonitoredResourceDescriptor]:
@@ -222,6 +251,8 @@ class ListMonitoredResourceDescriptorsAsyncPager:
             request: logging.ListMonitoredResourceDescriptorsRequest,
             response: logging.ListMonitoredResourceDescriptorsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -232,12 +263,17 @@ class ListMonitoredResourceDescriptorsAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListMonitoredResourceDescriptorsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging.ListMonitoredResourceDescriptorsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -248,7 +284,7 @@ class ListMonitoredResourceDescriptorsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[monitored_resource_pb2.MonitoredResourceDescriptor]:
         async def async_generator():
@@ -284,6 +320,8 @@ class ListLogsPager:
             request: logging.ListLogsRequest,
             response: logging.ListLogsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -294,12 +332,17 @@ class ListLogsPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLogsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging.ListLogsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -310,7 +353,7 @@ class ListLogsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[str]:
@@ -343,6 +386,8 @@ class ListLogsAsyncPager:
             request: logging.ListLogsRequest,
             response: logging.ListLogsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -353,12 +398,17 @@ class ListLogsAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLogsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging.ListLogsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -369,7 +419,7 @@ class ListLogsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[str]:
         async def async_generator():

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -342,6 +342,8 @@ class MetricsServiceV2AsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -682,6 +682,8 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/pagers.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/pagers.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+    OptionalAsyncRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+    OptionalAsyncRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
 from google.cloud.logging_v2.types import logging_metrics
 
@@ -40,6 +48,8 @@ class ListLogMetricsPager:
             request: logging_metrics.ListLogMetricsRequest,
             response: logging_metrics.ListLogMetricsResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -50,12 +60,17 @@ class ListLogMetricsPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLogMetricsResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_metrics.ListLogMetricsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -66,7 +81,7 @@ class ListLogMetricsPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[logging_metrics.LogMetric]:
@@ -99,6 +114,8 @@ class ListLogMetricsAsyncPager:
             request: logging_metrics.ListLogMetricsRequest,
             response: logging_metrics.ListLogMetricsResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -109,12 +126,17 @@ class ListLogMetricsAsyncPager:
                 The initial request object.
             response (google.cloud.logging_v2.types.ListLogMetricsResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = logging_metrics.ListLogMetricsRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -125,7 +147,7 @@ class ListLogMetricsAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[logging_metrics.LogMetric]:
         async def async_generator():

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -187,7 +187,8 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        'mypy',
+        # Ignore release of mypy 1.11.0 which may have a regression
+        'mypy!=1.11.0',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -187,6 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
         # Ignore release of mypy 1.11.0 which may have a regression
         'mypy!=1.11.0',
         'types-requests',

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -39,6 +39,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.logging_v2.services.config_service_v2 import ConfigServiceV2AsyncClient
@@ -1138,14 +1139,18 @@ def test_list_buckets_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_buckets(request={})
+        pager = client.list_buckets(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -3644,14 +3649,18 @@ def test_list_views_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_views(request={})
+        pager = client.list_views(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -5284,14 +5293,18 @@ def test_list_sinks_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_sinks(request={})
+        pager = client.list_sinks(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -8089,14 +8102,18 @@ def test_list_links_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_links(request={})
+        pager = client.list_links(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -8993,14 +9010,18 @@ def test_list_exclusions_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_exclusions(request={})
+        pager = client.list_exclusions(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -36,6 +36,7 @@ from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2AsyncClient
@@ -1753,9 +1754,13 @@ def test_list_log_entries_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
-        pager = client.list_log_entries(request={})
+        retry = retries.Retry()
+        timeout = 5
+        pager = client.list_log_entries(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -2145,9 +2150,13 @@ def test_list_monitored_resource_descriptors_pager(transport_name: str = "grpc")
         )
 
         expected_metadata = ()
-        pager = client.list_monitored_resource_descriptors(request={})
+        retry = retries.Retry()
+        timeout = 5
+        pager = client.list_monitored_resource_descriptors(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6
@@ -2689,14 +2698,18 @@ def test_list_logs_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_logs(request={})
+        pager = client.list_logs(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -39,6 +39,7 @@ from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.logging_v2.services.metrics_service_v2 import MetricsServiceV2AsyncClient
@@ -1138,14 +1139,18 @@ def test_list_log_metrics_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_log_metrics(request={})
+        pager = client.list_log_metrics(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -377,6 +377,8 @@ class CloudRedisAsyncClient:
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -719,6 +719,8 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             method=rpc,
             request=request,
             response=response,
+            retry=retry,
+            timeout=timeout,
             metadata=metadata,
         )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/pagers.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/pagers.py
@@ -13,7 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator
+from google.api_core import gapic_v1
+from google.api_core import retry as retries
+from typing import Any, AsyncIterator, Awaitable, Callable, Sequence, Tuple, Optional, Iterator, Union
+try:
+    OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
+    OptionalAsyncRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
+except AttributeError:  # pragma: NO COVER
+    OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
+    OptionalAsyncRetry = Union[retries.AsyncRetry, object, None]  # type: ignore
 
 from google.cloud.redis_v1.types import cloud_redis
 
@@ -40,6 +48,8 @@ class ListInstancesPager:
             request: cloud_redis.ListInstancesRequest,
             response: cloud_redis.ListInstancesResponse,
             *,
+            retry: OptionalRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiate the pager.
 
@@ -50,12 +60,17 @@ class ListInstancesPager:
                 The initial request object.
             response (google.cloud.redis_v1.types.ListInstancesResponse):
                 The initial response object.
+            retry (google.api_core.retry.Retry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = cloud_redis.ListInstancesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -66,7 +81,7 @@ class ListInstancesPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = self._method(self._request, metadata=self._metadata)
+            self._response = self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
 
     def __iter__(self) -> Iterator[cloud_redis.Instance]:
@@ -99,6 +114,8 @@ class ListInstancesAsyncPager:
             request: cloud_redis.ListInstancesRequest,
             response: cloud_redis.ListInstancesResponse,
             *,
+            retry: OptionalAsyncRetry = gapic_v1.method.DEFAULT,
+            timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = ()):
         """Instantiates the pager.
 
@@ -109,12 +126,17 @@ class ListInstancesAsyncPager:
                 The initial request object.
             response (google.cloud.redis_v1.types.ListInstancesResponse):
                 The initial response object.
+            retry (google.api_core.retry.AsyncRetry): Designation of what errors,
+                if any, should be retried.
+            timeout (float): The timeout for this request.
             metadata (Sequence[Tuple[str, str]]): Strings which should be
                 sent along with the request as metadata.
         """
         self._method = method
         self._request = cloud_redis.ListInstancesRequest(request)
         self._response = response
+        self._retry = retry
+        self._timeout = timeout
         self._metadata = metadata
 
     def __getattr__(self, name: str) -> Any:
@@ -125,7 +147,7 @@ class ListInstancesAsyncPager:
         yield self._response
         while self._response.next_page_token:
             self._request.page_token = self._response.next_page_token
-            self._response = await self._method(self._request, metadata=self._metadata)
+            self._response = await self._method(self._request, retry=self._retry, timeout=self._timeout, metadata=self._metadata)
             yield self._response
     def __aiter__(self) -> AsyncIterator[cloud_redis.Instance]:
         async def async_generator():

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -187,7 +187,8 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        'mypy',
+        # Ignore release of mypy 1.11.0 which may have a regression
+        'mypy!=1.11.0',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -187,6 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
         # Ignore release of mypy 1.11.0 which may have a regression
         'mypy!=1.11.0',
         'types-requests',

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -46,6 +46,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
 from google.cloud.location import locations_pb2
@@ -1167,14 +1168,18 @@ def test_list_instances_pager(transport_name: str = "grpc"):
         )
 
         expected_metadata = ()
+        retry = retries.Retry()
+        timeout = 5
         expected_metadata = tuple(expected_metadata) + (
             gapic_v1.routing_header.to_grpc_metadata((
                 ('parent', ''),
             )),
         )
-        pager = client.list_instances(request={})
+        pager = client.list_instances(request={}, retry=retry, timeout=timeout)
 
         assert pager._metadata == expected_metadata
+        assert pager._retry == retry
+        assert pager._timeout == timeout
 
         results = list(pager)
         assert len(results) == 6


### PR DESCRIPTION
Fixes #1664  🦕
