### PR TITLE
fix: require google.shopping.type >= 0.1.6

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -16,6 +16,6 @@ Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has sup
     ("google", "cloud", "osconfig", "v1"): {"package_name": "google-cloud-os-config", "lower_bound": "1.0.0", "upper_bound": "2.0.0dev"},
     ("google", "iam", "v1"): {"package_name": "grpc-google-iam-v1", "lower_bound": "0.12.4", "upper_bound": "1.0.0dev"},
     ("google", "iam", "v2"): {"package_name": "google-cloud-iam", "lower_bound": "2.12.2", "upper_bound": "3.0.0dev"},
-    ("google", "shopping", "type"): {"package_name": "google-shopping-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"}
+    ("google", "shopping", "type"): {"package_name": "google-shopping-type", "lower_bound": "0.1.6", "upper_bound": "1.0.0dev"}
 }
 %}


### PR DESCRIPTION
Fixes #2035