### PR TITLE
chore: fix mock runtime warnings

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -230,8 +230,9 @@ def test_{{ method_name }}_use_cached_wrapped_rpc():
         assert mock_rpc.call_count == 1
 
         {% if method.lro or method.extended_lro %}
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
         {% endif %}
 
@@ -336,8 +337,9 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
         assert mock_object.call_count == 1
 
         {% if method.lro or method.extended_lro %}
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
         {% endif %}
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -324,7 +324,7 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.{{method.transport_safe_name|snake_case}}] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.{{method.transport_safe_name|snake_case}}] = mock_rpc
 
         {% if method.client_streaming %}
         request = [{}]

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -323,6 +323,7 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.{{method.transport_safe_name|snake_case}}] = mock_object
 
         {% if method.client_streaming %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -322,7 +322,7 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.{{method.transport_safe_name|snake_case}} in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
         client._client._transport._wrapped_methods[client._client._transport.{{method.transport_safe_name|snake_case}}] = mock_object
 
         {% if method.client_streaming %}
@@ -334,7 +334,7 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
         {% endif %}
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         {% if method.lro or method.extended_lro %}
         # Operation methods call wrapper_fn to build a cached
@@ -351,7 +351,7 @@ async def test_{{ method_name }}_async_use_cached_wrapped_rpc(transport: str = "
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_{{ method_name }}_async(transport: str = 'grpc_asyncio', request_type={{ method.input.ident }}):

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -874,8 +874,9 @@ def test_export_assets_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.export_assets(request)
@@ -924,24 +925,26 @@ async def test_export_assets_async_use_cached_wrapped_rpc(transport: str = "grpc
         assert client._client._transport.export_assets in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.export_assets] = mock_object
 
         request = {}
         await client.export_assets(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.export_assets(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_export_assets_async(transport: str = 'grpc_asyncio', request_type=asset_service.ExportAssetsRequest):
@@ -1197,20 +1200,21 @@ async def test_list_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.list_assets in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_assets] = mock_object
 
         request = {}
         await client.list_assets(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_assets(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_assets_async(transport: str = 'grpc_asyncio', request_type=asset_service.ListAssetsRequest):
@@ -1740,20 +1744,21 @@ async def test_batch_get_assets_history_async_use_cached_wrapped_rpc(transport: 
         assert client._client._transport.batch_get_assets_history in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.batch_get_assets_history] = mock_object
 
         request = {}
         await client.batch_get_assets_history(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.batch_get_assets_history(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_batch_get_assets_history_async(transport: str = 'grpc_asyncio', request_type=asset_service.BatchGetAssetsHistoryRequest):
@@ -2020,20 +2025,21 @@ async def test_create_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.create_feed in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_feed] = mock_object
 
         request = {}
         await client.create_feed(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.create_feed(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_feed_async(transport: str = 'grpc_asyncio', request_type=asset_service.CreateFeedRequest):
@@ -2390,20 +2396,21 @@ async def test_get_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         assert client._client._transport.get_feed in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_feed] = mock_object
 
         request = {}
         await client.get_feed(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_feed(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_feed_async(transport: str = 'grpc_asyncio', request_type=asset_service.GetFeedRequest):
@@ -2745,20 +2752,21 @@ async def test_list_feeds_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         assert client._client._transport.list_feeds in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_feeds] = mock_object
 
         request = {}
         await client.list_feeds(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_feeds(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_feeds_async(transport: str = 'grpc_asyncio', request_type=asset_service.ListFeedsRequest):
@@ -3103,20 +3111,21 @@ async def test_update_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.update_feed in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_feed] = mock_object
 
         request = {}
         await client.update_feed(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_feed(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_feed_async(transport: str = 'grpc_asyncio', request_type=asset_service.UpdateFeedRequest):
@@ -3456,20 +3465,21 @@ async def test_delete_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.delete_feed in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_feed] = mock_object
 
         request = {}
         await client.delete_feed(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_feed(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_feed_async(transport: str = 'grpc_asyncio', request_type=asset_service.DeleteFeedRequest):
@@ -3809,20 +3819,21 @@ async def test_search_all_resources_async_use_cached_wrapped_rpc(transport: str 
         assert client._client._transport.search_all_resources in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.search_all_resources] = mock_object
 
         request = {}
         await client.search_all_resources(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.search_all_resources(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_search_all_resources_async(transport: str = 'grpc_asyncio', request_type=asset_service.SearchAllResourcesRequest):
@@ -4381,20 +4392,21 @@ async def test_search_all_iam_policies_async_use_cached_wrapped_rpc(transport: s
         assert client._client._transport.search_all_iam_policies in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.search_all_iam_policies] = mock_object
 
         request = {}
         await client.search_all_iam_policies(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.search_all_iam_policies(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_search_all_iam_policies_async(transport: str = 'grpc_asyncio', request_type=asset_service.SearchAllIamPoliciesRequest):
@@ -4937,20 +4949,21 @@ async def test_analyze_iam_policy_async_use_cached_wrapped_rpc(transport: str = 
         assert client._client._transport.analyze_iam_policy in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.analyze_iam_policy] = mock_object
 
         request = {}
         await client.analyze_iam_policy(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.analyze_iam_policy(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_analyze_iam_policy_async(transport: str = 'grpc_asyncio', request_type=asset_service.AnalyzeIamPolicyRequest):
@@ -5156,8 +5169,9 @@ def test_analyze_iam_policy_longrunning_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.analyze_iam_policy_longrunning(request)
@@ -5206,24 +5220,26 @@ async def test_analyze_iam_policy_longrunning_async_use_cached_wrapped_rpc(trans
         assert client._client._transport.analyze_iam_policy_longrunning in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.analyze_iam_policy_longrunning] = mock_object
 
         request = {}
         await client.analyze_iam_policy_longrunning(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.analyze_iam_policy_longrunning(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_analyze_iam_policy_longrunning_async(transport: str = 'grpc_asyncio', request_type=asset_service.AnalyzeIamPolicyLongrunningRequest):
@@ -5476,20 +5492,21 @@ async def test_analyze_move_async_use_cached_wrapped_rpc(transport: str = "grpc_
         assert client._client._transport.analyze_move in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.analyze_move] = mock_object
 
         request = {}
         await client.analyze_move(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.analyze_move(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_analyze_move_async(transport: str = 'grpc_asyncio', request_type=asset_service.AnalyzeMoveRequest):
@@ -5751,20 +5768,21 @@ async def test_query_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_
         assert client._client._transport.query_assets in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.query_assets] = mock_object
 
         request = {}
         await client.query_assets(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.query_assets(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_query_assets_async(transport: str = 'grpc_asyncio', request_type=asset_service.QueryAssetsRequest):
@@ -6032,20 +6050,21 @@ async def test_create_saved_query_async_use_cached_wrapped_rpc(transport: str = 
         assert client._client._transport.create_saved_query in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_saved_query] = mock_object
 
         request = {}
         await client.create_saved_query(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.create_saved_query(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_saved_query_async(transport: str = 'grpc_asyncio', request_type=asset_service.CreateSavedQueryRequest):
@@ -6417,20 +6436,21 @@ async def test_get_saved_query_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.get_saved_query in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_saved_query] = mock_object
 
         request = {}
         await client.get_saved_query(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_saved_query(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_saved_query_async(transport: str = 'grpc_asyncio', request_type=asset_service.GetSavedQueryRequest):
@@ -6777,20 +6797,21 @@ async def test_list_saved_queries_async_use_cached_wrapped_rpc(transport: str = 
         assert client._client._transport.list_saved_queries in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_saved_queries] = mock_object
 
         request = {}
         await client.list_saved_queries(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_saved_queries(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_saved_queries_async(transport: str = 'grpc_asyncio', request_type=asset_service.ListSavedQueriesRequest):
@@ -7330,20 +7351,21 @@ async def test_update_saved_query_async_use_cached_wrapped_rpc(transport: str = 
         assert client._client._transport.update_saved_query in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_saved_query] = mock_object
 
         request = {}
         await client.update_saved_query(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_saved_query(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_saved_query_async(transport: str = 'grpc_asyncio', request_type=asset_service.UpdateSavedQueryRequest):
@@ -7691,20 +7713,21 @@ async def test_delete_saved_query_async_use_cached_wrapped_rpc(transport: str = 
         assert client._client._transport.delete_saved_query in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_saved_query] = mock_object
 
         request = {}
         await client.delete_saved_query(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_saved_query(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_saved_query_async(transport: str = 'grpc_asyncio', request_type=asset_service.DeleteSavedQueryRequest):
@@ -8035,20 +8058,21 @@ async def test_batch_get_effective_iam_policies_async_use_cached_wrapped_rpc(tra
         assert client._client._transport.batch_get_effective_iam_policies in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.batch_get_effective_iam_policies] = mock_object
 
         request = {}
         await client.batch_get_effective_iam_policies(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.batch_get_effective_iam_policies(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_batch_get_effective_iam_policies_async(transport: str = 'grpc_asyncio', request_type=asset_service.BatchGetEffectiveIamPoliciesRequest):
@@ -8307,20 +8331,21 @@ async def test_analyze_org_policies_async_use_cached_wrapped_rpc(transport: str 
         assert client._client._transport.analyze_org_policies in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.analyze_org_policies] = mock_object
 
         request = {}
         await client.analyze_org_policies(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.analyze_org_policies(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_analyze_org_policies_async(transport: str = 'grpc_asyncio', request_type=asset_service.AnalyzeOrgPoliciesRequest):
@@ -8879,20 +8904,21 @@ async def test_analyze_org_policy_governed_containers_async_use_cached_wrapped_r
         assert client._client._transport.analyze_org_policy_governed_containers in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.analyze_org_policy_governed_containers] = mock_object
 
         request = {}
         await client.analyze_org_policy_governed_containers(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.analyze_org_policy_governed_containers(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_analyze_org_policy_governed_containers_async(transport: str = 'grpc_asyncio', request_type=asset_service.AnalyzeOrgPolicyGovernedContainersRequest):
@@ -9451,20 +9477,21 @@ async def test_analyze_org_policy_governed_assets_async_use_cached_wrapped_rpc(t
         assert client._client._transport.analyze_org_policy_governed_assets in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.analyze_org_policy_governed_assets] = mock_object
 
         request = {}
         await client.analyze_org_policy_governed_assets(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.analyze_org_policy_governed_assets(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_analyze_org_policy_governed_assets_async(transport: str = 'grpc_asyncio', request_type=asset_service.AnalyzeOrgPolicyGovernedAssetsRequest):

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -927,7 +927,7 @@ async def test_export_assets_async_use_cached_wrapped_rpc(transport: str = "grpc
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.export_assets] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.export_assets] = mock_rpc
 
         request = {}
         await client.export_assets(request)
@@ -1202,7 +1202,7 @@ async def test_list_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_assets] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_assets] = mock_rpc
 
         request = {}
         await client.list_assets(request)
@@ -1746,7 +1746,7 @@ async def test_batch_get_assets_history_async_use_cached_wrapped_rpc(transport: 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.batch_get_assets_history] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.batch_get_assets_history] = mock_rpc
 
         request = {}
         await client.batch_get_assets_history(request)
@@ -2027,7 +2027,7 @@ async def test_create_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_feed] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_feed] = mock_rpc
 
         request = {}
         await client.create_feed(request)
@@ -2398,7 +2398,7 @@ async def test_get_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_feed] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_feed] = mock_rpc
 
         request = {}
         await client.get_feed(request)
@@ -2754,7 +2754,7 @@ async def test_list_feeds_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_feeds] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_feeds] = mock_rpc
 
         request = {}
         await client.list_feeds(request)
@@ -3113,7 +3113,7 @@ async def test_update_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_feed] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_feed] = mock_rpc
 
         request = {}
         await client.update_feed(request)
@@ -3467,7 +3467,7 @@ async def test_delete_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_feed] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_feed] = mock_rpc
 
         request = {}
         await client.delete_feed(request)
@@ -3821,7 +3821,7 @@ async def test_search_all_resources_async_use_cached_wrapped_rpc(transport: str 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.search_all_resources] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.search_all_resources] = mock_rpc
 
         request = {}
         await client.search_all_resources(request)
@@ -4394,7 +4394,7 @@ async def test_search_all_iam_policies_async_use_cached_wrapped_rpc(transport: s
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.search_all_iam_policies] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.search_all_iam_policies] = mock_rpc
 
         request = {}
         await client.search_all_iam_policies(request)
@@ -4951,7 +4951,7 @@ async def test_analyze_iam_policy_async_use_cached_wrapped_rpc(transport: str = 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.analyze_iam_policy] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.analyze_iam_policy] = mock_rpc
 
         request = {}
         await client.analyze_iam_policy(request)
@@ -5222,7 +5222,7 @@ async def test_analyze_iam_policy_longrunning_async_use_cached_wrapped_rpc(trans
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.analyze_iam_policy_longrunning] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.analyze_iam_policy_longrunning] = mock_rpc
 
         request = {}
         await client.analyze_iam_policy_longrunning(request)
@@ -5494,7 +5494,7 @@ async def test_analyze_move_async_use_cached_wrapped_rpc(transport: str = "grpc_
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.analyze_move] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.analyze_move] = mock_rpc
 
         request = {}
         await client.analyze_move(request)
@@ -5770,7 +5770,7 @@ async def test_query_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.query_assets] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.query_assets] = mock_rpc
 
         request = {}
         await client.query_assets(request)
@@ -6052,7 +6052,7 @@ async def test_create_saved_query_async_use_cached_wrapped_rpc(transport: str = 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_saved_query] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_saved_query] = mock_rpc
 
         request = {}
         await client.create_saved_query(request)
@@ -6438,7 +6438,7 @@ async def test_get_saved_query_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_saved_query] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_saved_query] = mock_rpc
 
         request = {}
         await client.get_saved_query(request)
@@ -6799,7 +6799,7 @@ async def test_list_saved_queries_async_use_cached_wrapped_rpc(transport: str = 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_saved_queries] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_saved_queries] = mock_rpc
 
         request = {}
         await client.list_saved_queries(request)
@@ -7353,7 +7353,7 @@ async def test_update_saved_query_async_use_cached_wrapped_rpc(transport: str = 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_saved_query] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_saved_query] = mock_rpc
 
         request = {}
         await client.update_saved_query(request)
@@ -7715,7 +7715,7 @@ async def test_delete_saved_query_async_use_cached_wrapped_rpc(transport: str = 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_saved_query] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_saved_query] = mock_rpc
 
         request = {}
         await client.delete_saved_query(request)
@@ -8060,7 +8060,7 @@ async def test_batch_get_effective_iam_policies_async_use_cached_wrapped_rpc(tra
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.batch_get_effective_iam_policies] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.batch_get_effective_iam_policies] = mock_rpc
 
         request = {}
         await client.batch_get_effective_iam_policies(request)
@@ -8333,7 +8333,7 @@ async def test_analyze_org_policies_async_use_cached_wrapped_rpc(transport: str 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.analyze_org_policies] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.analyze_org_policies] = mock_rpc
 
         request = {}
         await client.analyze_org_policies(request)
@@ -8906,7 +8906,7 @@ async def test_analyze_org_policy_governed_containers_async_use_cached_wrapped_r
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.analyze_org_policy_governed_containers] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.analyze_org_policy_governed_containers] = mock_rpc
 
         request = {}
         await client.analyze_org_policy_governed_containers(request)
@@ -9479,7 +9479,7 @@ async def test_analyze_org_policy_governed_assets_async_use_cached_wrapped_rpc(t
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.analyze_org_policy_governed_assets] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.analyze_org_policy_governed_assets] = mock_rpc
 
         request = {}
         await client.analyze_org_policy_governed_assets(request)

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -915,7 +915,7 @@ async def test_generate_access_token_async_use_cached_wrapped_rpc(transport: str
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.generate_access_token] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.generate_access_token] = mock_rpc
 
         request = {}
         await client.generate_access_token(request)
@@ -1294,7 +1294,7 @@ async def test_generate_id_token_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.generate_id_token] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.generate_id_token] = mock_rpc
 
         request = {}
         await client.generate_id_token(request)
@@ -1678,7 +1678,7 @@ async def test_sign_blob_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.sign_blob] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.sign_blob] = mock_rpc
 
         request = {}
         await client.sign_blob(request)
@@ -2056,7 +2056,7 @@ async def test_sign_jwt_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.sign_jwt] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.sign_jwt] = mock_rpc
 
         request = {}
         await client.sign_jwt(request)

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -913,20 +913,21 @@ async def test_generate_access_token_async_use_cached_wrapped_rpc(transport: str
         assert client._client._transport.generate_access_token in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.generate_access_token] = mock_object
 
         request = {}
         await client.generate_access_token(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.generate_access_token(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_generate_access_token_async(transport: str = 'grpc_asyncio', request_type=common.GenerateAccessTokenRequest):
@@ -1291,20 +1292,21 @@ async def test_generate_id_token_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.generate_id_token in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.generate_id_token] = mock_object
 
         request = {}
         await client.generate_id_token(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.generate_id_token(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_generate_id_token_async(transport: str = 'grpc_asyncio', request_type=common.GenerateIdTokenRequest):
@@ -1674,20 +1676,21 @@ async def test_sign_blob_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
         assert client._client._transport.sign_blob in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.sign_blob] = mock_object
 
         request = {}
         await client.sign_blob(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.sign_blob(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_sign_blob_async(transport: str = 'grpc_asyncio', request_type=common.SignBlobRequest):
@@ -2051,20 +2054,21 @@ async def test_sign_jwt_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         assert client._client._transport.sign_jwt in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.sign_jwt] = mock_object
 
         request = {}
         await client.sign_jwt(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.sign_jwt(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_sign_jwt_async(transport: str = 'grpc_asyncio', request_type=common.SignJwtRequest):

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -947,7 +947,7 @@ async def test_get_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_trigger] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_trigger] = mock_rpc
 
         request = {}
         await client.get_trigger(request)
@@ -1315,7 +1315,7 @@ async def test_list_triggers_async_use_cached_wrapped_rpc(transport: str = "grpc
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_triggers] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_triggers] = mock_rpc
 
         request = {}
         await client.list_triggers(request)
@@ -1868,7 +1868,7 @@ async def test_create_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_trigger] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_trigger] = mock_rpc
 
         request = {}
         await client.create_trigger(request)
@@ -2245,7 +2245,7 @@ async def test_update_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_trigger] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_trigger] = mock_rpc
 
         request = {}
         await client.update_trigger(request)
@@ -2626,7 +2626,7 @@ async def test_delete_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_trigger] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_trigger] = mock_rpc
 
         request = {}
         await client.delete_trigger(request)
@@ -3009,7 +3009,7 @@ async def test_get_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_channel] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_channel] = mock_rpc
 
         request = {}
         await client.get_channel(request)
@@ -3377,7 +3377,7 @@ async def test_list_channels_async_use_cached_wrapped_rpc(transport: str = "grpc
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_channels] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_channels] = mock_rpc
 
         request = {}
         await client.list_channels(request)
@@ -3930,7 +3930,7 @@ async def test_create_channel_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_channel_] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_channel_] = mock_rpc
 
         request = {}
         await client.create_channel(request)
@@ -4307,7 +4307,7 @@ async def test_update_channel_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_channel] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_channel] = mock_rpc
 
         request = {}
         await client.update_channel(request)
@@ -4676,7 +4676,7 @@ async def test_delete_channel_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_channel] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_channel] = mock_rpc
 
         request = {}
         await client.delete_channel(request)
@@ -5036,7 +5036,7 @@ async def test_get_provider_async_use_cached_wrapped_rpc(transport: str = "grpc_
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_provider] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_provider] = mock_rpc
 
         request = {}
         await client.get_provider(request)
@@ -5398,7 +5398,7 @@ async def test_list_providers_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_providers] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_providers] = mock_rpc
 
         request = {}
         await client.list_providers(request)
@@ -5956,7 +5956,7 @@ async def test_get_channel_connection_async_use_cached_wrapped_rpc(transport: st
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_channel_connection] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_channel_connection] = mock_rpc
 
         request = {}
         await client.get_channel_connection(request)
@@ -6318,7 +6318,7 @@ async def test_list_channel_connections_async_use_cached_wrapped_rpc(transport: 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_channel_connections] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_channel_connections] = mock_rpc
 
         request = {}
         await client.list_channel_connections(request)
@@ -6871,7 +6871,7 @@ async def test_create_channel_connection_async_use_cached_wrapped_rpc(transport:
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_channel_connection] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_channel_connection] = mock_rpc
 
         request = {}
         await client.create_channel_connection(request)
@@ -7250,7 +7250,7 @@ async def test_delete_channel_connection_async_use_cached_wrapped_rpc(transport:
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_channel_connection] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_channel_connection] = mock_rpc
 
         request = {}
         await client.delete_channel_connection(request)
@@ -7610,7 +7610,7 @@ async def test_get_google_channel_config_async_use_cached_wrapped_rpc(transport:
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_google_channel_config] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_google_channel_config] = mock_rpc
 
         request = {}
         await client.get_google_channel_config(request)
@@ -7964,7 +7964,7 @@ async def test_update_google_channel_config_async_use_cached_wrapped_rpc(transpo
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_google_channel_config] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_google_channel_config] = mock_rpc
 
         request = {}
         await client.update_google_channel_config(request)

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -945,20 +945,21 @@ async def test_get_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.get_trigger in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_trigger] = mock_object
 
         request = {}
         await client.get_trigger(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_trigger(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_trigger_async(transport: str = 'grpc_asyncio', request_type=eventarc.GetTriggerRequest):
@@ -1312,20 +1313,21 @@ async def test_list_triggers_async_use_cached_wrapped_rpc(transport: str = "grpc
         assert client._client._transport.list_triggers in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_triggers] = mock_object
 
         request = {}
         await client.list_triggers(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_triggers(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_triggers_async(transport: str = 'grpc_asyncio', request_type=eventarc.ListTriggersRequest):
@@ -1813,8 +1815,9 @@ def test_create_trigger_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.create_trigger(request)
@@ -1863,24 +1866,26 @@ async def test_create_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.create_trigger in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_trigger] = mock_object
 
         request = {}
         await client.create_trigger(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.create_trigger(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_trigger_async(transport: str = 'grpc_asyncio', request_type=eventarc.CreateTriggerRequest):
@@ -2187,8 +2192,9 @@ def test_update_trigger_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.update_trigger(request)
@@ -2237,24 +2243,26 @@ async def test_update_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.update_trigger in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_trigger] = mock_object
 
         request = {}
         await client.update_trigger(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.update_trigger(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_trigger_async(transport: str = 'grpc_asyncio', request_type=eventarc.UpdateTriggerRequest):
@@ -2565,8 +2573,9 @@ def test_delete_trigger_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.delete_trigger(request)
@@ -2615,24 +2624,26 @@ async def test_delete_trigger_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.delete_trigger in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_trigger] = mock_object
 
         request = {}
         await client.delete_trigger(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.delete_trigger(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_trigger_async(transport: str = 'grpc_asyncio', request_type=eventarc.DeleteTriggerRequest):
@@ -2996,20 +3007,21 @@ async def test_get_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.get_channel in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_channel] = mock_object
 
         request = {}
         await client.get_channel(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_channel(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_channel_async(transport: str = 'grpc_asyncio', request_type=eventarc.GetChannelRequest):
@@ -3363,20 +3375,21 @@ async def test_list_channels_async_use_cached_wrapped_rpc(transport: str = "grpc
         assert client._client._transport.list_channels in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_channels] = mock_object
 
         request = {}
         await client.list_channels(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_channels(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_channels_async(transport: str = 'grpc_asyncio', request_type=eventarc.ListChannelsRequest):
@@ -3864,8 +3877,9 @@ def test_create_channel_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.create_channel(request)
@@ -3914,24 +3928,26 @@ async def test_create_channel_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.create_channel_ in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_channel_] = mock_object
 
         request = {}
         await client.create_channel(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.create_channel(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_channel_async(transport: str = 'grpc_asyncio', request_type=eventarc.CreateChannelRequest):
@@ -4238,8 +4254,9 @@ def test_update_channel_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.update_channel(request)
@@ -4288,24 +4305,26 @@ async def test_update_channel_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.update_channel in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_channel] = mock_object
 
         request = {}
         await client.update_channel(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.update_channel(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_channel_async(transport: str = 'grpc_asyncio', request_type=eventarc.UpdateChannelRequest):
@@ -4604,8 +4623,9 @@ def test_delete_channel_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.delete_channel(request)
@@ -4654,24 +4674,26 @@ async def test_delete_channel_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.delete_channel in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_channel] = mock_object
 
         request = {}
         await client.delete_channel(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.delete_channel(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_channel_async(transport: str = 'grpc_asyncio', request_type=eventarc.DeleteChannelRequest):
@@ -5012,20 +5034,21 @@ async def test_get_provider_async_use_cached_wrapped_rpc(transport: str = "grpc_
         assert client._client._transport.get_provider in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_provider] = mock_object
 
         request = {}
         await client.get_provider(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_provider(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_provider_async(transport: str = 'grpc_asyncio', request_type=eventarc.GetProviderRequest):
@@ -5373,20 +5396,21 @@ async def test_list_providers_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.list_providers in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_providers] = mock_object
 
         request = {}
         await client.list_providers(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_providers(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_providers_async(transport: str = 'grpc_asyncio', request_type=eventarc.ListProvidersRequest):
@@ -5930,20 +5954,21 @@ async def test_get_channel_connection_async_use_cached_wrapped_rpc(transport: st
         assert client._client._transport.get_channel_connection in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_channel_connection] = mock_object
 
         request = {}
         await client.get_channel_connection(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_channel_connection(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_channel_connection_async(transport: str = 'grpc_asyncio', request_type=eventarc.GetChannelConnectionRequest):
@@ -6291,20 +6316,21 @@ async def test_list_channel_connections_async_use_cached_wrapped_rpc(transport: 
         assert client._client._transport.list_channel_connections in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_channel_connections] = mock_object
 
         request = {}
         await client.list_channel_connections(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_channel_connections(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_channel_connections_async(transport: str = 'grpc_asyncio', request_type=eventarc.ListChannelConnectionsRequest):
@@ -6792,8 +6818,9 @@ def test_create_channel_connection_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.create_channel_connection(request)
@@ -6842,24 +6869,26 @@ async def test_create_channel_connection_async_use_cached_wrapped_rpc(transport:
         assert client._client._transport.create_channel_connection in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_channel_connection] = mock_object
 
         request = {}
         await client.create_channel_connection(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.create_channel_connection(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_channel_connection_async(transport: str = 'grpc_asyncio', request_type=eventarc.CreateChannelConnectionRequest):
@@ -7168,8 +7197,9 @@ def test_delete_channel_connection_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.delete_channel_connection(request)
@@ -7218,24 +7248,26 @@ async def test_delete_channel_connection_async_use_cached_wrapped_rpc(transport:
         assert client._client._transport.delete_channel_connection in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_channel_connection] = mock_object
 
         request = {}
         await client.delete_channel_connection(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.delete_channel_connection(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_channel_connection_async(transport: str = 'grpc_asyncio', request_type=eventarc.DeleteChannelConnectionRequest):
@@ -7576,20 +7608,21 @@ async def test_get_google_channel_config_async_use_cached_wrapped_rpc(transport:
         assert client._client._transport.get_google_channel_config in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_google_channel_config] = mock_object
 
         request = {}
         await client.get_google_channel_config(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_google_channel_config(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_google_channel_config_async(transport: str = 'grpc_asyncio', request_type=eventarc.GetGoogleChannelConfigRequest):
@@ -7929,20 +7962,21 @@ async def test_update_google_channel_config_async_use_cached_wrapped_rpc(transpo
         assert client._client._transport.update_google_channel_config in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_google_channel_config] = mock_object
 
         request = {}
         await client.update_google_channel_config(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_google_channel_config(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_google_channel_config_async(transport: str = 'grpc_asyncio', request_type=eventarc.UpdateGoogleChannelConfigRequest):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -904,7 +904,7 @@ async def test_list_buckets_async_use_cached_wrapped_rpc(transport: str = "grpc_
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_buckets] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_buckets] = mock_rpc
 
         request = {}
         await client.list_buckets(request)
@@ -1469,7 +1469,7 @@ async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_bucket] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_bucket] = mock_rpc
 
         request = {}
         await client.get_bucket(request)
@@ -1754,7 +1754,7 @@ async def test_create_bucket_async_async_use_cached_wrapped_rpc(transport: str =
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_bucket_async] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_bucket_async] = mock_rpc
 
         request = {}
         await client.create_bucket_async(request)
@@ -2029,7 +2029,7 @@ async def test_update_bucket_async_async_use_cached_wrapped_rpc(transport: str =
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_bucket_async] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_bucket_async] = mock_rpc
 
         request = {}
         await client.update_bucket_async(request)
@@ -2322,7 +2322,7 @@ async def test_create_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_bucket] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_bucket] = mock_rpc
 
         request = {}
         await client.create_bucket(request)
@@ -2621,7 +2621,7 @@ async def test_update_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_bucket] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_bucket] = mock_rpc
 
         request = {}
         await client.update_bucket(request)
@@ -2897,7 +2897,7 @@ async def test_delete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_bucket] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_bucket] = mock_rpc
 
         request = {}
         await client.delete_bucket(request)
@@ -3158,7 +3158,7 @@ async def test_undelete_bucket_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.undelete_bucket] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.undelete_bucket] = mock_rpc
 
         request = {}
         await client.undelete_bucket(request)
@@ -3426,7 +3426,7 @@ async def test_list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_views] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_views] = mock_rpc
 
         request = {}
         await client.list_views(request)
@@ -3979,7 +3979,7 @@ async def test_get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_view] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_view] = mock_rpc
 
         request = {}
         await client.get_view(request)
@@ -4260,7 +4260,7 @@ async def test_create_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_view] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_view] = mock_rpc
 
         request = {}
         await client.create_view(request)
@@ -4539,7 +4539,7 @@ async def test_update_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_view] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_view] = mock_rpc
 
         request = {}
         await client.update_view(request)
@@ -4807,7 +4807,7 @@ async def test_delete_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_view] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_view] = mock_rpc
 
         request = {}
         await client.delete_view(request)
@@ -5075,7 +5075,7 @@ async def test_list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_sinks] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_sinks] = mock_rpc
 
         request = {}
         await client.list_sinks(request)
@@ -5643,7 +5643,7 @@ async def test_get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_sink] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_sink] = mock_rpc
 
         request = {}
         await client.get_sink(request)
@@ -6029,7 +6029,7 @@ async def test_create_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_sink] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_sink] = mock_rpc
 
         request = {}
         await client.create_sink(request)
@@ -6425,7 +6425,7 @@ async def test_update_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_sink] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_sink] = mock_rpc
 
         request = {}
         await client.update_sink(request)
@@ -6805,7 +6805,7 @@ async def test_delete_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_sink] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_sink] = mock_rpc
 
         request = {}
         await client.delete_sink(request)
@@ -7157,7 +7157,7 @@ async def test_create_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_link] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_link] = mock_rpc
 
         request = {}
         await client.create_link(request)
@@ -7536,7 +7536,7 @@ async def test_delete_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_link] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_link] = mock_rpc
 
         request = {}
         await client.delete_link(request)
@@ -7895,7 +7895,7 @@ async def test_list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_links] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_links] = mock_rpc
 
         request = {}
         await client.list_links(request)
@@ -8448,7 +8448,7 @@ async def test_get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_link] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_link] = mock_rpc
 
         request = {}
         await client.get_link(request)
@@ -8805,7 +8805,7 @@ async def test_list_exclusions_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_exclusions] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_exclusions] = mock_rpc
 
         request = {}
         await client.list_exclusions(request)
@@ -9361,7 +9361,7 @@ async def test_get_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_exclusion] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_exclusion] = mock_rpc
 
         request = {}
         await client.get_exclusion(request)
@@ -9727,7 +9727,7 @@ async def test_create_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_exclusion] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_exclusion] = mock_rpc
 
         request = {}
         await client.create_exclusion(request)
@@ -10103,7 +10103,7 @@ async def test_update_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_exclusion] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_exclusion] = mock_rpc
 
         request = {}
         await client.update_exclusion(request)
@@ -10475,7 +10475,7 @@ async def test_delete_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_exclusion] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_exclusion] = mock_rpc
 
         request = {}
         await client.delete_exclusion(request)
@@ -10832,7 +10832,7 @@ async def test_get_cmek_settings_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_cmek_settings] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_cmek_settings] = mock_rpc
 
         request = {}
         await client.get_cmek_settings(request)
@@ -11116,7 +11116,7 @@ async def test_update_cmek_settings_async_use_cached_wrapped_rpc(transport: str 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_cmek_settings] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_cmek_settings] = mock_rpc
 
         request = {}
         await client.update_cmek_settings(request)
@@ -11403,7 +11403,7 @@ async def test_get_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_settings] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_settings] = mock_rpc
 
         request = {}
         await client.get_settings(request)
@@ -11774,7 +11774,7 @@ async def test_update_settings_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_settings] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_settings] = mock_rpc
 
         request = {}
         await client.update_settings(request)
@@ -12149,7 +12149,7 @@ async def test_copy_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.copy_log_entries] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.copy_log_entries] = mock_rpc
 
         request = {}
         await client.copy_log_entries(request)

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -902,20 +902,21 @@ async def test_list_buckets_async_use_cached_wrapped_rpc(transport: str = "grpc_
         assert client._client._transport.list_buckets in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_buckets] = mock_object
 
         request = {}
         await client.list_buckets(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_buckets(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_buckets_async(transport: str = 'grpc_asyncio', request_type=logging_config.ListBucketsRequest):
@@ -1466,20 +1467,21 @@ async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         assert client._client._transport.get_bucket in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_bucket] = mock_object
 
         request = {}
         await client.get_bucket(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_bucket(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_bucket_async(transport: str = 'grpc_asyncio', request_type=logging_config.GetBucketRequest):
@@ -1699,8 +1701,9 @@ def test_create_bucket_async_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.create_bucket_async(request)
@@ -1749,24 +1752,26 @@ async def test_create_bucket_async_async_use_cached_wrapped_rpc(transport: str =
         assert client._client._transport.create_bucket_async in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_bucket_async] = mock_object
 
         request = {}
         await client.create_bucket_async(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.create_bucket_async(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_bucket_async_async(transport: str = 'grpc_asyncio', request_type=logging_config.CreateBucketRequest):
@@ -1971,8 +1976,9 @@ def test_update_bucket_async_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.update_bucket_async(request)
@@ -2021,24 +2027,26 @@ async def test_update_bucket_async_async_use_cached_wrapped_rpc(transport: str =
         assert client._client._transport.update_bucket_async in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_bucket_async] = mock_object
 
         request = {}
         await client.update_bucket_async(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.update_bucket_async(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_bucket_async_async(transport: str = 'grpc_asyncio', request_type=logging_config.UpdateBucketRequest):
@@ -2312,20 +2320,21 @@ async def test_create_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
         assert client._client._transport.create_bucket in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_bucket] = mock_object
 
         request = {}
         await client.create_bucket(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.create_bucket(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_bucket_async(transport: str = 'grpc_asyncio', request_type=logging_config.CreateBucketRequest):
@@ -2610,20 +2619,21 @@ async def test_update_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
         assert client._client._transport.update_bucket in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_bucket] = mock_object
 
         request = {}
         await client.update_bucket(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_bucket(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_bucket_async(transport: str = 'grpc_asyncio', request_type=logging_config.UpdateBucketRequest):
@@ -2885,20 +2895,21 @@ async def test_delete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc
         assert client._client._transport.delete_bucket in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_bucket] = mock_object
 
         request = {}
         await client.delete_bucket(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_bucket(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_bucket_async(transport: str = 'grpc_asyncio', request_type=logging_config.DeleteBucketRequest):
@@ -3145,20 +3156,21 @@ async def test_undelete_bucket_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.undelete_bucket in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.undelete_bucket] = mock_object
 
         request = {}
         await client.undelete_bucket(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.undelete_bucket(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_undelete_bucket_async(transport: str = 'grpc_asyncio', request_type=logging_config.UndeleteBucketRequest):
@@ -3412,20 +3424,21 @@ async def test_list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         assert client._client._transport.list_views in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_views] = mock_object
 
         request = {}
         await client.list_views(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_views(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_views_async(transport: str = 'grpc_asyncio', request_type=logging_config.ListViewsRequest):
@@ -3964,20 +3977,21 @@ async def test_get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         assert client._client._transport.get_view in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_view] = mock_object
 
         request = {}
         await client.get_view(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_view(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_view_async(transport: str = 'grpc_asyncio', request_type=logging_config.GetViewRequest):
@@ -4244,20 +4258,21 @@ async def test_create_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.create_view in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_view] = mock_object
 
         request = {}
         await client.create_view(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.create_view(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_view_async(transport: str = 'grpc_asyncio', request_type=logging_config.CreateViewRequest):
@@ -4522,20 +4537,21 @@ async def test_update_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.update_view in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_view] = mock_object
 
         request = {}
         await client.update_view(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_view(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_view_async(transport: str = 'grpc_asyncio', request_type=logging_config.UpdateViewRequest):
@@ -4789,20 +4805,21 @@ async def test_delete_view_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.delete_view in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_view] = mock_object
 
         request = {}
         await client.delete_view(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_view(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_view_async(transport: str = 'grpc_asyncio', request_type=logging_config.DeleteViewRequest):
@@ -5056,20 +5073,21 @@ async def test_list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         assert client._client._transport.list_sinks in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_sinks] = mock_object
 
         request = {}
         await client.list_sinks(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_sinks(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_sinks_async(transport: str = 'grpc_asyncio', request_type=logging_config.ListSinksRequest):
@@ -5623,20 +5641,21 @@ async def test_get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         assert client._client._transport.get_sink in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_sink] = mock_object
 
         request = {}
         await client.get_sink(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_sink(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_sink_async(transport: str = 'grpc_asyncio', request_type=logging_config.GetSinkRequest):
@@ -6008,20 +6027,21 @@ async def test_create_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.create_sink in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_sink] = mock_object
 
         request = {}
         await client.create_sink(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.create_sink(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_sink_async(transport: str = 'grpc_asyncio', request_type=logging_config.CreateSinkRequest):
@@ -6403,20 +6423,21 @@ async def test_update_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.update_sink in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_sink] = mock_object
 
         request = {}
         await client.update_sink(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_sink(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_sink_async(transport: str = 'grpc_asyncio', request_type=logging_config.UpdateSinkRequest):
@@ -6782,20 +6803,21 @@ async def test_delete_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.delete_sink in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_sink] = mock_object
 
         request = {}
         await client.delete_sink(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_sink(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_sink_async(transport: str = 'grpc_asyncio', request_type=logging_config.DeleteSinkRequest):
@@ -7082,8 +7104,9 @@ def test_create_link_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.create_link(request)
@@ -7132,24 +7155,26 @@ async def test_create_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.create_link in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_link] = mock_object
 
         request = {}
         await client.create_link(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.create_link(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_link_async(transport: str = 'grpc_asyncio', request_type=logging_config.CreateLinkRequest):
@@ -7458,8 +7483,9 @@ def test_delete_link_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.delete_link(request)
@@ -7508,24 +7534,26 @@ async def test_delete_link_async_use_cached_wrapped_rpc(transport: str = "grpc_a
         assert client._client._transport.delete_link in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_link] = mock_object
 
         request = {}
         await client.delete_link(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.delete_link(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_link_async(transport: str = 'grpc_asyncio', request_type=logging_config.DeleteLinkRequest):
@@ -7865,20 +7893,21 @@ async def test_list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         assert client._client._transport.list_links in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_links] = mock_object
 
         request = {}
         await client.list_links(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_links(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_links_async(transport: str = 'grpc_asyncio', request_type=logging_config.ListLinksRequest):
@@ -8417,20 +8446,21 @@ async def test_get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyn
         assert client._client._transport.get_link in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_link] = mock_object
 
         request = {}
         await client.get_link(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_link(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_link_async(transport: str = 'grpc_asyncio', request_type=logging_config.GetLinkRequest):
@@ -8773,20 +8803,21 @@ async def test_list_exclusions_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.list_exclusions in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_exclusions] = mock_object
 
         request = {}
         await client.list_exclusions(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_exclusions(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_exclusions_async(transport: str = 'grpc_asyncio', request_type=logging_config.ListExclusionsRequest):
@@ -9328,20 +9359,21 @@ async def test_get_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc
         assert client._client._transport.get_exclusion in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_exclusion] = mock_object
 
         request = {}
         await client.get_exclusion(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_exclusion(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_exclusion_async(transport: str = 'grpc_asyncio', request_type=logging_config.GetExclusionRequest):
@@ -9693,20 +9725,21 @@ async def test_create_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.create_exclusion in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_exclusion] = mock_object
 
         request = {}
         await client.create_exclusion(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.create_exclusion(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_exclusion_async(transport: str = 'grpc_asyncio', request_type=logging_config.CreateExclusionRequest):
@@ -10068,20 +10101,21 @@ async def test_update_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.update_exclusion in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_exclusion] = mock_object
 
         request = {}
         await client.update_exclusion(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_exclusion(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_exclusion_async(transport: str = 'grpc_asyncio', request_type=logging_config.UpdateExclusionRequest):
@@ -10439,20 +10473,21 @@ async def test_delete_exclusion_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.delete_exclusion in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_exclusion] = mock_object
 
         request = {}
         await client.delete_exclusion(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_exclusion(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_exclusion_async(transport: str = 'grpc_asyncio', request_type=logging_config.DeleteExclusionRequest):
@@ -10795,20 +10830,21 @@ async def test_get_cmek_settings_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.get_cmek_settings in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_cmek_settings] = mock_object
 
         request = {}
         await client.get_cmek_settings(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_cmek_settings(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_cmek_settings_async(transport: str = 'grpc_asyncio', request_type=logging_config.GetCmekSettingsRequest):
@@ -11078,20 +11114,21 @@ async def test_update_cmek_settings_async_use_cached_wrapped_rpc(transport: str 
         assert client._client._transport.update_cmek_settings in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_cmek_settings] = mock_object
 
         request = {}
         await client.update_cmek_settings(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_cmek_settings(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_cmek_settings_async(transport: str = 'grpc_asyncio', request_type=logging_config.UpdateCmekSettingsRequest):
@@ -11364,20 +11401,21 @@ async def test_get_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_
         assert client._client._transport.get_settings in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_settings] = mock_object
 
         request = {}
         await client.get_settings(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_settings(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_settings_async(transport: str = 'grpc_asyncio', request_type=logging_config.GetSettingsRequest):
@@ -11734,20 +11772,21 @@ async def test_update_settings_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.update_settings in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_settings] = mock_object
 
         request = {}
         await client.update_settings(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_settings(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_settings_async(transport: str = 'grpc_asyncio', request_type=logging_config.UpdateSettingsRequest):
@@ -12057,8 +12096,9 @@ def test_copy_log_entries_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.copy_log_entries(request)
@@ -12107,24 +12147,26 @@ async def test_copy_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.copy_log_entries in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.copy_log_entries] = mock_object
 
         request = {}
         await client.copy_log_entries(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.copy_log_entries(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_copy_log_entries_async(transport: str = 'grpc_asyncio', request_type=logging_config.CopyLogEntriesRequest):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -899,7 +899,7 @@ async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_log] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_log] = mock_rpc
 
         request = {}
         await client.delete_log(request)
@@ -1244,7 +1244,7 @@ async def test_write_log_entries_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.write_log_entries] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.write_log_entries] = mock_rpc
 
         request = {}
         await client.write_log_entries(request)
@@ -1564,7 +1564,7 @@ async def test_list_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_log_entries] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_log_entries] = mock_rpc
 
         request = {}
         await client.list_log_entries(request)
@@ -2063,7 +2063,7 @@ async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_monitored_resource_descriptors] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_monitored_resource_descriptors] = mock_rpc
 
         request = {}
         await client.list_monitored_resource_descriptors(request)
@@ -2465,7 +2465,7 @@ async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_logs] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_logs] = mock_rpc
 
         request = {}
         await client.list_logs(request)
@@ -2945,7 +2945,7 @@ async def test_tail_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.tail_log_entries] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.tail_log_entries] = mock_rpc
 
         request = [{}]
         await client.tail_log_entries(request)

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -897,20 +897,21 @@ async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_as
         assert client._client._transport.delete_log in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_log] = mock_object
 
         request = {}
         await client.delete_log(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_log(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_log_async(transport: str = 'grpc_asyncio', request_type=logging.DeleteLogRequest):
@@ -1241,20 +1242,21 @@ async def test_write_log_entries_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.write_log_entries in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.write_log_entries] = mock_object
 
         request = {}
         await client.write_log_entries(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.write_log_entries(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_write_log_entries_async(transport: str = 'grpc_asyncio', request_type=logging.WriteLogEntriesRequest):
@@ -1560,20 +1562,21 @@ async def test_list_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.list_log_entries in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_log_entries] = mock_object
 
         request = {}
         await client.list_log_entries(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_log_entries(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_log_entries_async(transport: str = 'grpc_asyncio', request_type=logging.ListLogEntriesRequest):
@@ -2058,20 +2061,21 @@ async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(
         assert client._client._transport.list_monitored_resource_descriptors in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_monitored_resource_descriptors] = mock_object
 
         request = {}
         await client.list_monitored_resource_descriptors(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_monitored_resource_descriptors(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_monitored_resource_descriptors_async(transport: str = 'grpc_asyncio', request_type=logging.ListMonitoredResourceDescriptorsRequest):
@@ -2459,20 +2463,21 @@ async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asy
         assert client._client._transport.list_logs in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_logs] = mock_object
 
         request = {}
         await client.list_logs(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_logs(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_logs_async(transport: str = 'grpc_asyncio', request_type=logging.ListLogsRequest):
@@ -2938,20 +2943,21 @@ async def test_tail_log_entries_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.tail_log_entries in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.tail_log_entries] = mock_object
 
         request = [{}]
         await client.tail_log_entries(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.tail_log_entries(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_tail_log_entries_async(transport: str = 'grpc_asyncio', request_type=logging.TailLogEntriesRequest):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -904,7 +904,7 @@ async def test_list_log_metrics_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_log_metrics] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_log_metrics] = mock_rpc
 
         request = {}
         await client.list_log_metrics(request)
@@ -1469,7 +1469,7 @@ async def test_get_log_metric_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_log_metric] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_log_metric] = mock_rpc
 
         request = {}
         await client.get_log_metric(request)
@@ -1850,7 +1850,7 @@ async def test_create_log_metric_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_log_metric] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_log_metric] = mock_rpc
 
         request = {}
         await client.create_log_metric(request)
@@ -2241,7 +2241,7 @@ async def test_update_log_metric_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_log_metric] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_log_metric] = mock_rpc
 
         request = {}
         await client.update_log_metric(request)
@@ -2609,7 +2609,7 @@ async def test_delete_log_metric_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_log_metric] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_log_metric] = mock_rpc
 
         request = {}
         await client.delete_log_metric(request)

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -902,20 +902,21 @@ async def test_list_log_metrics_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.list_log_metrics in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_log_metrics] = mock_object
 
         request = {}
         await client.list_log_metrics(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_log_metrics(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_log_metrics_async(transport: str = 'grpc_asyncio', request_type=logging_metrics.ListLogMetricsRequest):
@@ -1466,20 +1467,21 @@ async def test_get_log_metric_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.get_log_metric in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_log_metric] = mock_object
 
         request = {}
         await client.get_log_metric(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_log_metric(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_log_metric_async(transport: str = 'grpc_asyncio', request_type=logging_metrics.GetLogMetricRequest):
@@ -1846,20 +1848,21 @@ async def test_create_log_metric_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.create_log_metric in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_log_metric] = mock_object
 
         request = {}
         await client.create_log_metric(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.create_log_metric(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_log_metric_async(transport: str = 'grpc_asyncio', request_type=logging_metrics.CreateLogMetricRequest):
@@ -2236,20 +2239,21 @@ async def test_update_log_metric_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.update_log_metric in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_log_metric] = mock_object
 
         request = {}
         await client.update_log_metric(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.update_log_metric(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_log_metric_async(transport: str = 'grpc_asyncio', request_type=logging_metrics.UpdateLogMetricRequest):
@@ -2603,20 +2607,21 @@ async def test_delete_log_metric_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.delete_log_metric in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_log_metric] = mock_object
 
         request = {}
         await client.delete_log_metric(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.delete_log_metric(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_log_metric_async(transport: str = 'grpc_asyncio', request_type=logging_metrics.DeleteLogMetricRequest):

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -929,20 +929,21 @@ async def test_list_instances_async_use_cached_wrapped_rpc(transport: str = "grp
         assert client._client._transport.list_instances in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.list_instances] = mock_object
 
         request = {}
         await client.list_instances(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.list_instances(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_list_instances_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.ListInstancesRequest):
@@ -1555,20 +1556,21 @@ async def test_get_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_
         assert client._client._transport.get_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_instance] = mock_object
 
         request = {}
         await client.get_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.GetInstanceRequest):
@@ -1957,20 +1959,21 @@ async def test_get_instance_auth_string_async_use_cached_wrapped_rpc(transport: 
         assert client._client._transport.get_instance_auth_string in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.get_instance_auth_string] = mock_object
 
         request = {}
         await client.get_instance_auth_string(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
         await client.get_instance_auth_string(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_get_instance_auth_string_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.GetInstanceAuthStringRequest):
@@ -2260,8 +2263,9 @@ def test_create_instance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.create_instance(request)
@@ -2310,24 +2314,26 @@ async def test_create_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.create_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.create_instance] = mock_object
 
         request = {}
         await client.create_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.create_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_create_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.CreateInstanceRequest):
@@ -2634,8 +2640,9 @@ def test_update_instance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.update_instance(request)
@@ -2684,24 +2691,26 @@ async def test_update_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.update_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.update_instance] = mock_object
 
         request = {}
         await client.update_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.update_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_update_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.UpdateInstanceRequest):
@@ -3002,8 +3011,9 @@ def test_upgrade_instance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.upgrade_instance(request)
@@ -3052,24 +3062,26 @@ async def test_upgrade_instance_async_use_cached_wrapped_rpc(transport: str = "g
         assert client._client._transport.upgrade_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.upgrade_instance] = mock_object
 
         request = {}
         await client.upgrade_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.upgrade_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_upgrade_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.UpgradeInstanceRequest):
@@ -3368,8 +3380,9 @@ def test_import_instance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.import_instance(request)
@@ -3418,24 +3431,26 @@ async def test_import_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.import_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.import_instance] = mock_object
 
         request = {}
         await client.import_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.import_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_import_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.ImportInstanceRequest):
@@ -3734,8 +3749,9 @@ def test_export_instance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.export_instance(request)
@@ -3784,24 +3800,26 @@ async def test_export_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.export_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.export_instance] = mock_object
 
         request = {}
         await client.export_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.export_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_export_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.ExportInstanceRequest):
@@ -4100,8 +4118,9 @@ def test_failover_instance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.failover_instance(request)
@@ -4150,24 +4169,26 @@ async def test_failover_instance_async_use_cached_wrapped_rpc(transport: str = "
         assert client._client._transport.failover_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.failover_instance] = mock_object
 
         request = {}
         await client.failover_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.failover_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_failover_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.FailoverInstanceRequest):
@@ -4466,8 +4487,9 @@ def test_delete_instance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.delete_instance(request)
@@ -4516,24 +4538,26 @@ async def test_delete_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         assert client._client._transport.delete_instance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.delete_instance] = mock_object
 
         request = {}
         await client.delete_instance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.delete_instance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_delete_instance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.DeleteInstanceRequest):
@@ -4822,8 +4846,9 @@ def test_reschedule_maintenance_use_cached_wrapped_rpc():
         # Establish that the underlying gRPC stub method was called.
         assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         client.reschedule_maintenance(request)
@@ -4872,24 +4897,26 @@ async def test_reschedule_maintenance_async_use_cached_wrapped_rpc(transport: st
         assert client._client._transport.reschedule_maintenance in client._client._transport._wrapped_methods
 
         # Replace cached wrapped function with mock
-        mock_object = mock.AsyncMock()
+        mock_rpc = mock.AsyncMock()
+        mock_rpc.return_value = mock.Mock()
         client._client._transport._wrapped_methods[client._client._transport.reschedule_maintenance] = mock_object
 
         request = {}
         await client.reschedule_maintenance(request)
 
         # Establish that the underlying gRPC stub method was called.
-        assert mock_object.call_count == 1
+        assert mock_rpc.call_count == 1
 
-        # Operation methods build a cached wrapper on first rpc call
-        # subsequent calls should use the cached wrapper
+        # Operation methods call wrapper_fn to build a cached
+        # client._transport.operations_client instance on first rpc call.
+        # Subsequent calls should use the cached wrapper
         wrapper_fn.reset_mock()
 
         await client.reschedule_maintenance(request)
 
         # Establish that a new wrapper was not created for this call
         assert wrapper_fn.call_count == 0
-        assert mock_object.call_count == 2
+        assert mock_rpc.call_count == 2
 
 @pytest.mark.asyncio
 async def test_reschedule_maintenance_async(transport: str = 'grpc_asyncio', request_type=cloud_redis.RescheduleMaintenanceRequest):

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -931,7 +931,7 @@ async def test_list_instances_async_use_cached_wrapped_rpc(transport: str = "grp
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.list_instances] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.list_instances] = mock_rpc
 
         request = {}
         await client.list_instances(request)
@@ -1558,7 +1558,7 @@ async def test_get_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_instance] = mock_rpc
 
         request = {}
         await client.get_instance(request)
@@ -1961,7 +1961,7 @@ async def test_get_instance_auth_string_async_use_cached_wrapped_rpc(transport: 
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.get_instance_auth_string] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.get_instance_auth_string] = mock_rpc
 
         request = {}
         await client.get_instance_auth_string(request)
@@ -2316,7 +2316,7 @@ async def test_create_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.create_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.create_instance] = mock_rpc
 
         request = {}
         await client.create_instance(request)
@@ -2693,7 +2693,7 @@ async def test_update_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.update_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.update_instance] = mock_rpc
 
         request = {}
         await client.update_instance(request)
@@ -3064,7 +3064,7 @@ async def test_upgrade_instance_async_use_cached_wrapped_rpc(transport: str = "g
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.upgrade_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.upgrade_instance] = mock_rpc
 
         request = {}
         await client.upgrade_instance(request)
@@ -3433,7 +3433,7 @@ async def test_import_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.import_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.import_instance] = mock_rpc
 
         request = {}
         await client.import_instance(request)
@@ -3802,7 +3802,7 @@ async def test_export_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.export_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.export_instance] = mock_rpc
 
         request = {}
         await client.export_instance(request)
@@ -4171,7 +4171,7 @@ async def test_failover_instance_async_use_cached_wrapped_rpc(transport: str = "
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.failover_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.failover_instance] = mock_rpc
 
         request = {}
         await client.failover_instance(request)
@@ -4540,7 +4540,7 @@ async def test_delete_instance_async_use_cached_wrapped_rpc(transport: str = "gr
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.delete_instance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.delete_instance] = mock_rpc
 
         request = {}
         await client.delete_instance(request)
@@ -4899,7 +4899,7 @@ async def test_reschedule_maintenance_async_use_cached_wrapped_rpc(transport: st
         # Replace cached wrapped function with mock
         mock_rpc = mock.AsyncMock()
         mock_rpc.return_value = mock.Mock()
-        client._client._transport._wrapped_methods[client._client._transport.reschedule_maintenance] = mock_object
+        client._client._transport._wrapped_methods[client._client._transport.reschedule_maintenance] = mock_rpc
 
         request = {}
         await client.reschedule_maintenance(request)


### PR DESCRIPTION
Fixes https://github.com/googleapis/gapic-generator-python/issues/2046

The issue came down to using AsyncMock with streaming Operation rpcs. To resolve it, I had to make the AsyncMock return a standard mock.Mock

I also improved the comments and variable names to make future work in this area more clear