### PR TITLE
fix: mypy types in get_transport

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -5,7 +5,6 @@
 {% import "%namespace/%name_%version/%sub/services/%service/_shared_macros.j2" as shared_macros %}
 
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, {% if service.any_server_streaming %}AsyncIterable, Awaitable, {% endif %}{% if service.any_client_streaming %}AsyncIterator, {% endif %}Sequence, Tuple, Type, Union
 {% if api.all_method_settings.values()|map(attribute="auto_populated_fields", default=[])|list %}
@@ -172,7 +171,7 @@ class {{ service.async_client_name }}:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type({{ service.client_name }}).get_transport_class, type({{ service.client_name }}))
+    get_transport_class = {{ service.client_name }}).get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -171,7 +171,7 @@ class {{ service.async_client_name }}:
         """
         return self._client._universe_domain
 
-    get_transport_class = {{ service.client_name }}).get_transport_class
+    get_transport_class = {{ service.client_name }}.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -548,7 +548,7 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[{{ service.name  }}Transport], Callable[..., {{ service.name }}Transport]] = (
-                type(self).get_transport_class(transport)
+                {{ service.client_name  }}.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., {{ service.name }}Transport], transport)
             )

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
 
@@ -180,7 +179,7 @@ class AssetServiceAsyncClient:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type(AssetServiceClient).get_transport_class, type(AssetServiceClient))
+    get_transport_class = AssetServiceClient.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -628,7 +628,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[AssetServiceTransport], Callable[..., AssetServiceTransport]] = (
-                type(self).get_transport_class(transport)
+                AssetServiceClient.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., AssetServiceTransport], transport)
             )

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
 
@@ -171,7 +170,7 @@ class IAMCredentialsAsyncClient:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type(IAMCredentialsClient).get_transport_class, type(IAMCredentialsClient))
+    get_transport_class = IAMCredentialsClient.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -565,7 +565,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[IAMCredentialsTransport], Callable[..., IAMCredentialsTransport]] = (
-                type(self).get_transport_class(transport)
+                IAMCredentialsClient.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., IAMCredentialsTransport], transport)
             )

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
 
@@ -198,7 +197,7 @@ class EventarcAsyncClient:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type(EventarcClient).get_transport_class, type(EventarcClient))
+    get_transport_class = EventarcClient.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -673,7 +673,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[EventarcTransport], Callable[..., EventarcTransport]] = (
-                type(self).get_transport_class(transport)
+                EventarcClient.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., EventarcTransport], transport)
             )

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
 
@@ -178,7 +177,7 @@ class ConfigServiceV2AsyncClient:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type(ConfigServiceV2Client).get_transport_class, type(ConfigServiceV2Client))
+    get_transport_class = ConfigServiceV2Client.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -621,7 +621,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[ConfigServiceV2Transport], Callable[..., ConfigServiceV2Transport]] = (
-                type(self).get_transport_class(transport)
+                ConfigServiceV2Client.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., ConfigServiceV2Transport], transport)
             )

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, AsyncIterable, Awaitable, AsyncIterator, Sequence, Tuple, Type, Union
 
@@ -163,7 +162,7 @@ class LoggingServiceV2AsyncClient:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type(LoggingServiceV2Client).get_transport_class, type(LoggingServiceV2Client))
+    get_transport_class = LoggingServiceV2Client.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -552,7 +552,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[LoggingServiceV2Transport], Callable[..., LoggingServiceV2Transport]] = (
-                type(self).get_transport_class(transport)
+                LoggingServiceV2Client.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., LoggingServiceV2Transport], transport)
             )

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
 
@@ -164,7 +163,7 @@ class MetricsServiceV2AsyncClient:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type(MetricsServiceV2Client).get_transport_class, type(MetricsServiceV2Client))
+    get_transport_class = MetricsServiceV2Client.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -553,7 +553,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[MetricsServiceV2Transport], Callable[..., MetricsServiceV2Transport]] = (
-                type(self).get_transport_class(transport)
+                MetricsServiceV2Client.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., MetricsServiceV2Transport], transport)
             )

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from collections import OrderedDict
-import functools
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
 
@@ -188,7 +187,7 @@ class CloudRedisAsyncClient:
         """
         return self._client._universe_domain
 
-    get_transport_class = functools.partial(type(CloudRedisClient).get_transport_class, type(CloudRedisClient))
+    get_transport_class = CloudRedisClient.get_transport_class
 
     def __init__(self, *,
             credentials: Optional[ga_credentials.Credentials] = None,

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -582,7 +582,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 credentials = google.auth._default.get_api_key_credentials(api_key_value)
 
             transport_init: Union[Type[CloudRedisTransport], Callable[..., CloudRedisTransport]] = (
-                type(self).get_transport_class(transport)
+                CloudRedisClient.get_transport_class(transport)
                 if isinstance(transport, str) or transport is None
                 else cast(Callable[..., CloudRedisTransport], transport)
             )


### PR DESCRIPTION
We were getting some mypy test failures in the generated outputs, which is currently blocking https://github.com/googleapis/gapic-generator-python/pull/2085

Fixes https://github.com/googleapis/gapic-generator-python/issues/2087
