### PR TITLE
build: fix mypy

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -176,9 +176,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
-        # Ignore release of mypy 1.11.0 which may have a regression
-        'mypy!=1.11.0',
+        'mypy',
         'types-requests',
         'types-protobuf'
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -431,10 +431,7 @@ def showcase_mypy(
 ):
     """Perform typecheck analysis on the generated Showcase library."""
 
-    # Install pytest and gapic-generator-python
-    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
-    # Ignore release of mypy 1.11.0 which may have a regression
-    session.install("mypy!=1.11.0", "types-pkg-resources", "types-protobuf", "types-requests", "types-dataclasses")
+    session.install("mypy", "types-setuptools", "types-protobuf", "types-requests", "types-dataclasses")
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
         session.chdir(lib)

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -187,9 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
-        # Ignore release of mypy 1.11.0 which may have a regression
-        'mypy!=1.11.0',
+        'mypy',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -187,9 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
-        # Ignore release of mypy 1.11.0 which may have a regression
-        'mypy!=1.11.0',
+        'mypy',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -187,9 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
-        # Ignore release of mypy 1.11.0 which may have a regression
-        'mypy!=1.11.0',
+        'mypy',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -187,9 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
-        # Ignore release of mypy 1.11.0 which may have a regression
-        'mypy!=1.11.0',
+        'mypy',
         'types-requests',
         'types-protobuf'
     )

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -187,9 +187,7 @@ def cover(session):
 def mypy(session):
     """Run the type checker."""
     session.install(
-        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2066):
-        # Ignore release of mypy 1.11.0 which may have a regression
-        'mypy!=1.11.0',
+        'mypy',
         'types-requests',
         'types-protobuf'
     )


### PR DESCRIPTION
- [types-pkg-resources](https://pypi.org/project/types-pkg-resources/) is no longer available on PyPI. Use [types-setuptools](https://pypi.org/project/types-setuptools) instead.
- Remove obsolete pin for mypy

