### PR TITLE
cleanup: refactor empty call test macro

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -123,37 +123,7 @@ def test_{{ method_name }}(request_type, transport: str = 'grpc'):
 
 
 {% if not method.client_streaming %}
-def test_{{ method_name }}_empty_call():
-    # This test is a coverage failsafe to make sure that totally empty calls,
-    # i.e. request == None and no flattened fields passed, work.
-    client = {{ service.client_name }}(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='grpc',
-    )
-
-    # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(
-            type(client.transport.{{ method.transport_safe_name|snake_case }}),
-            '__call__') as call:
-        call.return_value.name = "foo" # operation_request.operation in compute client(s) expect a string.
-        client.{{ method_name }}()
-        call.assert_called()
-        _, args, _ = call.mock_calls[0]
-        {% if method.client_streaming %}
-        assert next(args[0]) == request
-        {% else %}
-        {% with method_settings = api.all_method_settings.get(method.meta.address.proto) %}
-        {% if method_settings is not none %}
-        {% for auto_populated_field in method_settings.auto_populated_fields %}
-        # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(r"{{ uuid4_re }}", args[0].{{ auto_populated_field }})
-        # clear UUID field so that the check below succeeds
-        args[0].{{ auto_populated_field }} = None
-        {% endfor %}
-        {% endif %}{# if method_settings is not none #}
-        {% endwith %}{# method_settings #}
-        assert args[0] == {{ method.input.ident }}()
-        {% endif %}
+{{ empty_call_test(method, method_name, service, api, uuid4_re)}}
 
 
 def test_{{ method_name }}_non_empty_request_with_auto_populated_field():
@@ -249,59 +219,7 @@ def test_{{ method_name }}_use_cached_wrapped_rpc():
 
 {% if not full_extended_lro %}
 {% if not method.client_streaming %}
-@pytest.mark.asyncio
-async def test_{{ method_name }}_empty_call_async():
-    # This test is a coverage failsafe to make sure that totally empty calls,
-    # i.e. request == None and no flattened fields passed, work.
-    client = {{ service.async_client_name }}(
-        credentials=async_anonymous_credentials(),
-        transport='grpc_asyncio',
-    )
-
-    # Mock the actual call within the gRPC stub, and fake the request.
-    with mock.patch.object(
-            type(client.transport.{{ method.transport_safe_name|snake_case }}),
-            '__call__') as call:
-        # Designate an appropriate return value for the call.
-        {% if method.void %}
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        {% elif method.lro %}
-        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
-            operations_pb2.Operation(name='operations/spam')
-        )
-        {% elif not method.client_streaming and method.server_streaming %}
-        call.return_value = mock.Mock(aio.UnaryStreamCall, autospec=True)
-        call.return_value.read = mock.AsyncMock(side_effect=[{{ method.output.ident }}()])
-        {% elif method.client_streaming and method.server_streaming %}
-        call.return_value = mock.Mock(aio.StreamStreamCall, autospec=True)
-        call.return_value.read = mock.AsyncMock(side_effect=[{{ method.output.ident }}()])
-        {% else %}
-        call.return_value = {{ '' }}
-            {%- if not method.client_streaming and not method.server_streaming -%}
-                grpc_helpers_async.FakeUnaryUnaryCall
-            {%- else -%}
-                grpc_helpers_async.FakeStreamUnaryCall
-            {%- endif -%}({{ method.output.ident }}(
-            {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
-            {{ field.name }}={{ field.mock_value }},
-            {% endif %}
-            {% endfor %}
-        ))
-        {% endif %}
-        response = await client.{{ method_name }}()
-        call.assert_called()
-        _, args, _ = call.mock_calls[0]
-        {% with method_settings = api.all_method_settings.get(method.meta.address.proto) %}
-        {% if method_settings is not none %}
-        {% for auto_populated_field in method_settings.auto_populated_fields %}
-        # Ensure that the uuid4 field is set according to AIP 4235
-        assert re.match(r"{{ uuid4_re }}", args[0].{{ auto_populated_field }})
-        # clear UUID field so that the check below succeeds
-        args[0].{{ auto_populated_field }} = None
-        {% endfor %}
-        {% endif %}{# if method_settings is not none #}
-        {% endwith %}{# method_settings #}
-        assert args[0] == {{ method.input.ident }}()
+{{ empty_call_test(method, method_name, service, api, uuid4_re, is_async=True) }}
 {% endif %}
 
 @pytest.mark.asyncio
@@ -1887,4 +1805,74 @@ def test_{{ method_name }}_rest_no_http_options():
 
 {% endif %}{# not method.http_options #}
 {% endwith %}{# method_name #}
+{% endmacro %}
+
+
+{% macro empty_call_test(method, method_name, service, api, uuid4_re, is_async=False) %}
+{% if is_async %}
+@pytest.mark.asyncio
+async def test_{{ method_name }}_empty_call_async():
+{% else %}
+def test_{{ method_name }}_empty_call():
+{% endif %}{# if is_async #}
+    # This test is a coverage failsafe to make sure that totally empty calls,
+    # i.e. request == None and no flattened fields passed, work.
+    {% if is_async %}
+    client = {{ service.async_client_name }}(
+        credentials=async_anonymous_credentials(),
+        transport='grpc_asyncio',
+    )
+    {% else %}
+    client = {{ service.client_name }}(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport='grpc',
+    )
+    {% endif %}{# if is_async #}
+
+    # Mock the actual call within the gRPC stub, and fake the request.
+    with mock.patch.object(
+            type(client.transport.{{ method.transport_safe_name|snake_case }}),
+            '__call__') as call:
+        {% if is_async %}
+        # Designate an appropriate return value for the call.
+        {% if method.void %}
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
+        {% elif method.lro %}
+        call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
+            operations_pb2.Operation(name='operations/spam')
+        )
+        {% elif method.server_streaming %}
+        call.return_value = mock.Mock(aio.UnaryStreamCall, autospec=True)
+        call.return_value.read = mock.AsyncMock(side_effect=[{{ method.output.ident }}()])
+        {% else %}
+        call.return_value = {{ '' }}
+            {%- if not method.server_streaming -%}
+                grpc_helpers_async.FakeUnaryUnaryCall
+            {%- else -%}
+                grpc_helpers_async.FakeStreamUnaryCall
+            {%- endif -%}({{ method.output.ident }}(
+            {% for field in method.output.fields.values() | rejectattr('message') %}{% if not field.oneof or field.proto3_optional %}
+            {{ field.name }}={{ field.mock_value }},
+            {% endif %}
+            {% endfor %}
+        ))
+        {% endif %}{# method.void #}
+        await client.{{ method_name }}()
+        {% else %}{# if not is_async #}
+        call.return_value.name = "foo" # operation_request.operation in compute client(s) expect a string.
+        client.{{ method_name }}()
+        {% endif %}{# is_async #}
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        {% with method_settings = api.all_method_settings.get(method.meta.address.proto) %}
+        {% if method_settings is not none %}
+        {% for auto_populated_field in method_settings.auto_populated_fields %}
+        # Ensure that the uuid4 field is set according to AIP 4235
+        assert re.match(r"{{ uuid4_re }}", args[0].{{ auto_populated_field }})
+        # clear UUID field so that the check below succeeds
+        args[0].{{ auto_populated_field }} = None
+        {% endfor %}{# for auto_populated_field in method_settings.auto_populated_fields #}
+        {% endif %}{# if method_settings is not none #}
+        {% endwith %}{# method_settings #}
+        assert args[0] == {{ method.input.ident }}()
 {% endmacro %}

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -915,10 +915,11 @@ async def test_export_assets_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.export_assets()
+        await client.export_assets()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.ExportAssetsRequest()
+
 
 @pytest.mark.asyncio
 async def test_export_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1190,10 +1191,11 @@ async def test_list_assets_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListAssetsResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_assets()
+        await client.list_assets()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.ListAssetsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1734,10 +1736,11 @@ async def test_batch_get_assets_history_empty_call_async():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.BatchGetAssetsHistoryResponse(
         ))
-        response = await client.batch_get_assets_history()
+        await client.batch_get_assets_history()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.BatchGetAssetsHistoryRequest()
+
 
 @pytest.mark.asyncio
 async def test_batch_get_assets_history_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2015,10 +2018,11 @@ async def test_create_feed_empty_call_async():
             content_type=asset_service.ContentType.RESOURCE,
             relationship_types=['relationship_types_value'],
         ))
-        response = await client.create_feed()
+        await client.create_feed()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.CreateFeedRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2386,10 +2390,11 @@ async def test_get_feed_empty_call_async():
             content_type=asset_service.ContentType.RESOURCE,
             relationship_types=['relationship_types_value'],
         ))
-        response = await client.get_feed()
+        await client.get_feed()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.GetFeedRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2742,10 +2747,11 @@ async def test_list_feeds_empty_call_async():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListFeedsResponse(
         ))
-        response = await client.list_feeds()
+        await client.list_feeds()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.ListFeedsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_feeds_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3101,10 +3107,11 @@ async def test_update_feed_empty_call_async():
             content_type=asset_service.ContentType.RESOURCE,
             relationship_types=['relationship_types_value'],
         ))
-        response = await client.update_feed()
+        await client.update_feed()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.UpdateFeedRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3455,10 +3462,11 @@ async def test_delete_feed_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_feed()
+        await client.delete_feed()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.DeleteFeedRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_feed_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3809,10 +3817,11 @@ async def test_search_all_resources_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SearchAllResourcesResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.search_all_resources()
+        await client.search_all_resources()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.SearchAllResourcesRequest()
+
 
 @pytest.mark.asyncio
 async def test_search_all_resources_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4382,10 +4391,11 @@ async def test_search_all_iam_policies_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SearchAllIamPoliciesResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.search_all_iam_policies()
+        await client.search_all_iam_policies()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.SearchAllIamPoliciesRequest()
+
 
 @pytest.mark.asyncio
 async def test_search_all_iam_policies_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4939,10 +4949,11 @@ async def test_analyze_iam_policy_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeIamPolicyResponse(
             fully_explored=True,
         ))
-        response = await client.analyze_iam_policy()
+        await client.analyze_iam_policy()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.AnalyzeIamPolicyRequest()
+
 
 @pytest.mark.asyncio
 async def test_analyze_iam_policy_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5210,10 +5221,11 @@ async def test_analyze_iam_policy_longrunning_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.analyze_iam_policy_longrunning()
+        await client.analyze_iam_policy_longrunning()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.AnalyzeIamPolicyLongrunningRequest()
+
 
 @pytest.mark.asyncio
 async def test_analyze_iam_policy_longrunning_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5482,10 +5494,11 @@ async def test_analyze_move_empty_call_async():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeMoveResponse(
         ))
-        response = await client.analyze_move()
+        await client.analyze_move()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.AnalyzeMoveRequest()
+
 
 @pytest.mark.asyncio
 async def test_analyze_move_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5758,10 +5771,11 @@ async def test_query_assets_empty_call_async():
             job_reference='job_reference_value',
             done=True,
         ))
-        response = await client.query_assets()
+        await client.query_assets()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.QueryAssetsRequest()
+
 
 @pytest.mark.asyncio
 async def test_query_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6040,10 +6054,11 @@ async def test_create_saved_query_empty_call_async():
             creator='creator_value',
             last_updater='last_updater_value',
         ))
-        response = await client.create_saved_query()
+        await client.create_saved_query()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.CreateSavedQueryRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_saved_query_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6426,10 +6441,11 @@ async def test_get_saved_query_empty_call_async():
             creator='creator_value',
             last_updater='last_updater_value',
         ))
-        response = await client.get_saved_query()
+        await client.get_saved_query()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.GetSavedQueryRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_saved_query_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6787,10 +6803,11 @@ async def test_list_saved_queries_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListSavedQueriesResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_saved_queries()
+        await client.list_saved_queries()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.ListSavedQueriesRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_saved_queries_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7341,10 +7358,11 @@ async def test_update_saved_query_empty_call_async():
             creator='creator_value',
             last_updater='last_updater_value',
         ))
-        response = await client.update_saved_query()
+        await client.update_saved_query()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.UpdateSavedQueryRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_saved_query_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7703,10 +7721,11 @@ async def test_delete_saved_query_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_saved_query()
+        await client.delete_saved_query()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.DeleteSavedQueryRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_saved_query_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -8048,10 +8067,11 @@ async def test_batch_get_effective_iam_policies_empty_call_async():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.BatchGetEffectiveIamPoliciesResponse(
         ))
-        response = await client.batch_get_effective_iam_policies()
+        await client.batch_get_effective_iam_policies()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.BatchGetEffectiveIamPoliciesRequest()
+
 
 @pytest.mark.asyncio
 async def test_batch_get_effective_iam_policies_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -8321,10 +8341,11 @@ async def test_analyze_org_policies_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeOrgPoliciesResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.analyze_org_policies()
+        await client.analyze_org_policies()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.AnalyzeOrgPoliciesRequest()
+
 
 @pytest.mark.asyncio
 async def test_analyze_org_policies_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -8894,10 +8915,11 @@ async def test_analyze_org_policy_governed_containers_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeOrgPolicyGovernedContainersResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.analyze_org_policy_governed_containers()
+        await client.analyze_org_policy_governed_containers()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.AnalyzeOrgPolicyGovernedContainersRequest()
+
 
 @pytest.mark.asyncio
 async def test_analyze_org_policy_governed_containers_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -9467,10 +9489,11 @@ async def test_analyze_org_policy_governed_assets_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeOrgPolicyGovernedAssetsResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.analyze_org_policy_governed_assets()
+        await client.analyze_org_policy_governed_assets()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == asset_service.AnalyzeOrgPolicyGovernedAssetsRequest()
+
 
 @pytest.mark.asyncio
 async def test_analyze_org_policy_governed_assets_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -903,10 +903,11 @@ async def test_generate_access_token_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(common.GenerateAccessTokenResponse(
             access_token='access_token_value',
         ))
-        response = await client.generate_access_token()
+        await client.generate_access_token()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == common.GenerateAccessTokenRequest()
+
 
 @pytest.mark.asyncio
 async def test_generate_access_token_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1282,10 +1283,11 @@ async def test_generate_id_token_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(common.GenerateIdTokenResponse(
             token='token_value',
         ))
-        response = await client.generate_id_token()
+        await client.generate_id_token()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == common.GenerateIdTokenRequest()
+
 
 @pytest.mark.asyncio
 async def test_generate_id_token_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1666,10 +1668,11 @@ async def test_sign_blob_empty_call_async():
             key_id='key_id_value',
             signed_blob=b'signed_blob_blob',
         ))
-        response = await client.sign_blob()
+        await client.sign_blob()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == common.SignBlobRequest()
+
 
 @pytest.mark.asyncio
 async def test_sign_blob_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2044,10 +2047,11 @@ async def test_sign_jwt_empty_call_async():
             key_id='key_id_value',
             signed_jwt='signed_jwt_value',
         ))
-        response = await client.sign_jwt()
+        await client.sign_jwt()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == common.SignJwtRequest()
+
 
 @pytest.mark.asyncio
 async def test_sign_jwt_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -935,10 +935,11 @@ async def test_get_trigger_empty_call_async():
             channel='channel_value',
             etag='etag_value',
         ))
-        response = await client.get_trigger()
+        await client.get_trigger()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.GetTriggerRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1303,10 +1304,11 @@ async def test_list_triggers_empty_call_async():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        response = await client.list_triggers()
+        await client.list_triggers()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.ListTriggersRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_triggers_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1856,10 +1858,11 @@ async def test_create_trigger_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.create_trigger()
+        await client.create_trigger()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.CreateTriggerRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2233,10 +2236,11 @@ async def test_update_trigger_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.update_trigger()
+        await client.update_trigger()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.UpdateTriggerRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2614,10 +2618,11 @@ async def test_delete_trigger_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.delete_trigger()
+        await client.delete_trigger()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.DeleteTriggerRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_trigger_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2997,10 +3002,11 @@ async def test_get_channel_empty_call_async():
             activation_token='activation_token_value',
             crypto_key_name='crypto_key_name_value',
         ))
-        response = await client.get_channel()
+        await client.get_channel()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.GetChannelRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3365,10 +3371,11 @@ async def test_list_channels_empty_call_async():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        response = await client.list_channels()
+        await client.list_channels()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.ListChannelsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_channels_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3918,10 +3925,11 @@ async def test_create_channel_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.create_channel()
+        await client.create_channel()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.CreateChannelRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4295,10 +4303,11 @@ async def test_update_channel_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.update_channel()
+        await client.update_channel()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.UpdateChannelRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4664,10 +4673,11 @@ async def test_delete_channel_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.delete_channel()
+        await client.delete_channel()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.DeleteChannelRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_channel_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5024,10 +5034,11 @@ async def test_get_provider_empty_call_async():
             name='name_value',
             display_name='display_name_value',
         ))
-        response = await client.get_provider()
+        await client.get_provider()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.GetProviderRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_provider_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5386,10 +5397,11 @@ async def test_list_providers_empty_call_async():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        response = await client.list_providers()
+        await client.list_providers()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.ListProvidersRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_providers_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5944,10 +5956,11 @@ async def test_get_channel_connection_empty_call_async():
             channel='channel_value',
             activation_token='activation_token_value',
         ))
-        response = await client.get_channel_connection()
+        await client.get_channel_connection()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.GetChannelConnectionRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_channel_connection_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6306,10 +6319,11 @@ async def test_list_channel_connections_empty_call_async():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        response = await client.list_channel_connections()
+        await client.list_channel_connections()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.ListChannelConnectionsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_channel_connections_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6859,10 +6873,11 @@ async def test_create_channel_connection_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.create_channel_connection()
+        await client.create_channel_connection()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.CreateChannelConnectionRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_channel_connection_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7238,10 +7253,11 @@ async def test_delete_channel_connection_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.delete_channel_connection()
+        await client.delete_channel_connection()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.DeleteChannelConnectionRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_channel_connection_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7598,10 +7614,11 @@ async def test_get_google_channel_config_empty_call_async():
             name='name_value',
             crypto_key_name='crypto_key_name_value',
         ))
-        response = await client.get_google_channel_config()
+        await client.get_google_channel_config()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.GetGoogleChannelConfigRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_google_channel_config_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7952,10 +7969,11 @@ async def test_update_google_channel_config_empty_call_async():
             name='name_value',
             crypto_key_name='crypto_key_name_value',
         ))
-        response = await client.update_google_channel_config()
+        await client.update_google_channel_config()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == eventarc.UpdateGoogleChannelConfigRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_google_channel_config_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -892,10 +892,11 @@ async def test_list_buckets_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListBucketsResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_buckets()
+        await client.list_buckets()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.ListBucketsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_buckets_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1457,10 +1458,11 @@ async def test_get_bucket_empty_call_async():
             analytics_enabled=True,
             restricted_fields=['restricted_fields_value'],
         ))
-        response = await client.get_bucket()
+        await client.get_bucket()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.GetBucketRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1742,10 +1744,11 @@ async def test_create_bucket_async_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.create_bucket_async()
+        await client.create_bucket_async()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.CreateBucketRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_bucket_async_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2017,10 +2020,11 @@ async def test_update_bucket_async_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.update_bucket_async()
+        await client.update_bucket_async()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UpdateBucketRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_bucket_async_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2310,10 +2314,11 @@ async def test_create_bucket_empty_call_async():
             analytics_enabled=True,
             restricted_fields=['restricted_fields_value'],
         ))
-        response = await client.create_bucket()
+        await client.create_bucket()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.CreateBucketRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2609,10 +2614,11 @@ async def test_update_bucket_empty_call_async():
             analytics_enabled=True,
             restricted_fields=['restricted_fields_value'],
         ))
-        response = await client.update_bucket()
+        await client.update_bucket()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UpdateBucketRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2885,10 +2891,11 @@ async def test_delete_bucket_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_bucket()
+        await client.delete_bucket()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.DeleteBucketRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3146,10 +3153,11 @@ async def test_undelete_bucket_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.undelete_bucket()
+        await client.undelete_bucket()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UndeleteBucketRequest()
+
 
 @pytest.mark.asyncio
 async def test_undelete_bucket_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3414,10 +3422,11 @@ async def test_list_views_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListViewsResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_views()
+        await client.list_views()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.ListViewsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_views_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3967,10 +3976,11 @@ async def test_get_view_empty_call_async():
             description='description_value',
             filter='filter_value',
         ))
-        response = await client.get_view()
+        await client.get_view()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.GetViewRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4248,10 +4258,11 @@ async def test_create_view_empty_call_async():
             description='description_value',
             filter='filter_value',
         ))
-        response = await client.create_view()
+        await client.create_view()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.CreateViewRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4527,10 +4538,11 @@ async def test_update_view_empty_call_async():
             description='description_value',
             filter='filter_value',
         ))
-        response = await client.update_view()
+        await client.update_view()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UpdateViewRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4795,10 +4807,11 @@ async def test_delete_view_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_view()
+        await client.delete_view()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.DeleteViewRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_view_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5063,10 +5076,11 @@ async def test_list_sinks_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListSinksResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_sinks()
+        await client.list_sinks()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.ListSinksRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_sinks_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -5631,10 +5645,11 @@ async def test_get_sink_empty_call_async():
             writer_identity='writer_identity_value',
             include_children=True,
         ))
-        response = await client.get_sink()
+        await client.get_sink()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.GetSinkRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6017,10 +6032,11 @@ async def test_create_sink_empty_call_async():
             writer_identity='writer_identity_value',
             include_children=True,
         ))
-        response = await client.create_sink()
+        await client.create_sink()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.CreateSinkRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6413,10 +6429,11 @@ async def test_update_sink_empty_call_async():
             writer_identity='writer_identity_value',
             include_children=True,
         ))
-        response = await client.update_sink()
+        await client.update_sink()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UpdateSinkRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -6793,10 +6810,11 @@ async def test_delete_sink_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_sink()
+        await client.delete_sink()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.DeleteSinkRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_sink_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7145,10 +7163,11 @@ async def test_create_link_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.create_link()
+        await client.create_link()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.CreateLinkRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7524,10 +7543,11 @@ async def test_delete_link_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.delete_link()
+        await client.delete_link()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.DeleteLinkRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -7883,10 +7903,11 @@ async def test_list_links_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListLinksResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_links()
+        await client.list_links()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.ListLinksRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_links_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -8436,10 +8457,11 @@ async def test_get_link_empty_call_async():
             description='description_value',
             lifecycle_state=logging_config.LifecycleState.ACTIVE,
         ))
-        response = await client.get_link()
+        await client.get_link()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.GetLinkRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_link_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -8793,10 +8815,11 @@ async def test_list_exclusions_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListExclusionsResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_exclusions()
+        await client.list_exclusions()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.ListExclusionsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_exclusions_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -9349,10 +9372,11 @@ async def test_get_exclusion_empty_call_async():
             filter='filter_value',
             disabled=True,
         ))
-        response = await client.get_exclusion()
+        await client.get_exclusion()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.GetExclusionRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -9715,10 +9739,11 @@ async def test_create_exclusion_empty_call_async():
             filter='filter_value',
             disabled=True,
         ))
-        response = await client.create_exclusion()
+        await client.create_exclusion()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.CreateExclusionRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -10091,10 +10116,11 @@ async def test_update_exclusion_empty_call_async():
             filter='filter_value',
             disabled=True,
         ))
-        response = await client.update_exclusion()
+        await client.update_exclusion()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UpdateExclusionRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -10463,10 +10489,11 @@ async def test_delete_exclusion_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_exclusion()
+        await client.delete_exclusion()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.DeleteExclusionRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_exclusion_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -10820,10 +10847,11 @@ async def test_get_cmek_settings_empty_call_async():
             kms_key_version_name='kms_key_version_name_value',
             service_account_id='service_account_id_value',
         ))
-        response = await client.get_cmek_settings()
+        await client.get_cmek_settings()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.GetCmekSettingsRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_cmek_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -11104,10 +11132,11 @@ async def test_update_cmek_settings_empty_call_async():
             kms_key_version_name='kms_key_version_name_value',
             service_account_id='service_account_id_value',
         ))
-        response = await client.update_cmek_settings()
+        await client.update_cmek_settings()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UpdateCmekSettingsRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_cmek_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -11391,10 +11420,11 @@ async def test_get_settings_empty_call_async():
             storage_location='storage_location_value',
             disable_default_sink=True,
         ))
-        response = await client.get_settings()
+        await client.get_settings()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.GetSettingsRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -11762,10 +11792,11 @@ async def test_update_settings_empty_call_async():
             storage_location='storage_location_value',
             disable_default_sink=True,
         ))
-        response = await client.update_settings()
+        await client.update_settings()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.UpdateSettingsRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_settings_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -12137,10 +12168,11 @@ async def test_copy_log_entries_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.copy_log_entries()
+        await client.copy_log_entries()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_config.CopyLogEntriesRequest()
+
 
 @pytest.mark.asyncio
 async def test_copy_log_entries_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -887,10 +887,11 @@ async def test_delete_log_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_log()
+        await client.delete_log()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging.DeleteLogRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_log_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1232,10 +1233,11 @@ async def test_write_log_entries_empty_call_async():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging.WriteLogEntriesResponse(
         ))
-        response = await client.write_log_entries()
+        await client.write_log_entries()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging.WriteLogEntriesRequest()
+
 
 @pytest.mark.asyncio
 async def test_write_log_entries_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1552,10 +1554,11 @@ async def test_list_log_entries_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging.ListLogEntriesResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_log_entries()
+        await client.list_log_entries()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging.ListLogEntriesRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_log_entries_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2051,10 +2054,11 @@ async def test_list_monitored_resource_descriptors_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging.ListMonitoredResourceDescriptorsResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_monitored_resource_descriptors()
+        await client.list_monitored_resource_descriptors()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging.ListMonitoredResourceDescriptorsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_monitored_resource_descriptors_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2453,10 +2457,11 @@ async def test_list_logs_empty_call_async():
             log_names=['log_names_value'],
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_logs()
+        await client.list_logs()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging.ListLogsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_logs_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -892,10 +892,11 @@ async def test_list_log_metrics_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_metrics.ListLogMetricsResponse(
             next_page_token='next_page_token_value',
         ))
-        response = await client.list_log_metrics()
+        await client.list_log_metrics()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_metrics.ListLogMetricsRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_log_metrics_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1457,10 +1458,11 @@ async def test_get_log_metric_empty_call_async():
             value_extractor='value_extractor_value',
             version=logging_metrics.LogMetric.ApiVersion.V1,
         ))
-        response = await client.get_log_metric()
+        await client.get_log_metric()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_metrics.GetLogMetricRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_log_metric_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1838,10 +1840,11 @@ async def test_create_log_metric_empty_call_async():
             value_extractor='value_extractor_value',
             version=logging_metrics.LogMetric.ApiVersion.V1,
         ))
-        response = await client.create_log_metric()
+        await client.create_log_metric()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_metrics.CreateLogMetricRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_log_metric_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2229,10 +2232,11 @@ async def test_update_log_metric_empty_call_async():
             value_extractor='value_extractor_value',
             version=logging_metrics.LogMetric.ApiVersion.V1,
         ))
-        response = await client.update_log_metric()
+        await client.update_log_metric()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_metrics.UpdateLogMetricRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_log_metric_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2597,10 +2601,11 @@ async def test_delete_log_metric_empty_call_async():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        response = await client.delete_log_metric()
+        await client.delete_log_metric()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == logging_metrics.DeleteLogMetricRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_log_metric_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -919,10 +919,11 @@ async def test_list_instances_empty_call_async():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        response = await client.list_instances()
+        await client.list_instances()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.ListInstancesRequest()
+
 
 @pytest.mark.asyncio
 async def test_list_instances_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1546,10 +1547,11 @@ async def test_get_instance_empty_call_async():
             maintenance_version='maintenance_version_value',
             available_maintenance_versions=['available_maintenance_versions_value'],
         ))
-        response = await client.get_instance()
+        await client.get_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.GetInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -1949,10 +1951,11 @@ async def test_get_instance_auth_string_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.InstanceAuthString(
             auth_string='auth_string_value',
         ))
-        response = await client.get_instance_auth_string()
+        await client.get_instance_auth_string()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.GetInstanceAuthStringRequest()
+
 
 @pytest.mark.asyncio
 async def test_get_instance_auth_string_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2304,10 +2307,11 @@ async def test_create_instance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.create_instance()
+        await client.create_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.CreateInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_create_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -2681,10 +2685,11 @@ async def test_update_instance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.update_instance()
+        await client.update_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.UpdateInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_update_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3052,10 +3057,11 @@ async def test_upgrade_instance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.upgrade_instance()
+        await client.upgrade_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.UpgradeInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_upgrade_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3421,10 +3427,11 @@ async def test_import_instance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.import_instance()
+        await client.import_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.ImportInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_import_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -3790,10 +3797,11 @@ async def test_export_instance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.export_instance()
+        await client.export_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.ExportInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_export_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4159,10 +4167,11 @@ async def test_failover_instance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.failover_instance()
+        await client.failover_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.FailoverInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_failover_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4528,10 +4537,11 @@ async def test_delete_instance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.delete_instance()
+        await client.delete_instance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.DeleteInstanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_delete_instance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):
@@ -4887,10 +4897,11 @@ async def test_reschedule_maintenance_empty_call_async():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        response = await client.reschedule_maintenance()
+        await client.reschedule_maintenance()
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         assert args[0] == cloud_redis.RescheduleMaintenanceRequest()
+
 
 @pytest.mark.asyncio
 async def test_reschedule_maintenance_async_use_cached_wrapped_rpc(transport: str = "grpc_asyncio"):


### PR DESCRIPTION
This PR introduces a macro to refactor the empty call test template for sync and async code.

As a follow up, this macro can parameterize the transport to support `rest` and `rest_asyncio`.