### PR TITLE
chore: refactor wrap method helper into a macro

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -161,7 +161,7 @@ def _get_response(
 {% endmacro %}
 
 
-{% macro prep_wrapped_messages_method(service, is_async=True) %}
+{% macro prep_wrapped_messages_method(service) %}
 def _prep_wrapped_messages(self, client_info):
     """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
     self._wrapped_methods = {

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -159,3 +159,45 @@ def _get_response(
         raise core_exceptions.from_http_response(response)
 
 {% endmacro %}
+
+
+{% macro prep_wrapped_messages_method(service, is_async=True) %}
+def _prep_wrapped_messages(self, client_info):
+    """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+    self._wrapped_methods = {
+        {% for method in service.methods.values() %}
+        self.{{ method.transport_safe_name|snake_case }}: self._wrap_method_with_kind(
+            self.{{ method.transport_safe_name|snake_case }},
+            {% if method.retry %}
+            default_retry=retries.AsyncRetry(
+                {% if method.retry.initial_backoff %}
+                initial={{ method.retry.initial_backoff }},
+                {% endif %}
+                {% if method.retry.max_backoff %}
+                maximum={{ method.retry.max_backoff }},
+                {% endif %}
+                {% if method.retry.backoff_multiplier %}
+                multiplier={{ method.retry.backoff_multiplier }},
+                {% endif %}
+                predicate=retries.if_exception_type(
+                    {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
+                    core_exceptions.{{ ex.__name__ }},
+                    {% endfor %}
+                ),
+                deadline={{ method.timeout }},
+            ),
+            {% endif %}
+            default_timeout={{ method.timeout }},
+            client_info=client_info,
+        ),
+        {% endfor %}{# service.methods.values() #}
+    }
+{% endmacro %}
+
+{% macro wrap_method_macro() %}
+def _wrap_method_with_kind(self, func, *args, **kwargs):
+    {# TODO: Remove `pragma: NO COVER` once https://github.com/googleapis/python-api-core/pull/688 is merged. #}
+    if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+        kwargs["kind"] = self.kind
+    return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
+{% endmacro %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -161,7 +161,7 @@ def _get_response(
 {% endmacro %}
 
 
-{% macro prep_wrapped_messages_method(service) %}
+{% macro prep_wrapped_messages_async_method(service) %}
 def _prep_wrapped_messages(self, client_info):
     """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
     self._wrapped_methods = {
@@ -194,9 +194,15 @@ def _prep_wrapped_messages(self, client_info):
     }
 {% endmacro %}
 
-{# TODO: This helper logic to check if `kind` needs to be configured in wrap_method
-can be removed once we required the correct version of the google-api-core dependency. #}
-{% macro wrap_method_macro() %}
+{# TODO: This helper logic to check whether `kind` needs to be configured in wrap_method
+can be removed once we require the correct version of the google-api-core dependency to
+avoid having a gRPC code path in an async REST call.
+See related issue: https://github.com/googleapis/python-api-core/issues/661.
+In the meantime, if an older version of the dependency is installed (which has a wrap_method with
+no kind parameter), then an async gRPC call will work correctly and async REST transport
+will not be available as a transport.
+See related issue: https://github.com/googleapis/gapic-generator-python/issues/2119. #}
+{% macro wrap_async_method_macro() %}
 def _wrap_method(self, func, *args, **kwargs):
     {# TODO: Remove `pragma: NO COVER` once https://github.com/googleapis/python-api-core/pull/688 is merged. #}
     if self._wrap_with_kind:  # pragma: NO COVER

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -166,7 +166,7 @@ def _prep_wrapped_messages(self, client_info):
     """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
     self._wrapped_methods = {
         {% for method in service.methods.values() %}
-        self.{{ method.transport_safe_name|snake_case }}: self._wrap_method_with_kind(
+        self.{{ method.transport_safe_name|snake_case }}: self._wrap_method(
             self.{{ method.transport_safe_name|snake_case }},
             {% if method.retry %}
             default_retry=retries.AsyncRetry(
@@ -194,10 +194,12 @@ def _prep_wrapped_messages(self, client_info):
     }
 {% endmacro %}
 
+{# TODO: This helper logic to check if `kind` needs to be configured in wrap_method
+can be removed once we required the correct version of the google-api-core dependency. #}
 {% macro wrap_method_macro() %}
-def _wrap_method_with_kind(self, func, *args, **kwargs):
+def _wrap_method(self, func, *args, **kwargs):
     {# TODO: Remove `pragma: NO COVER` once https://github.com/googleapis/python-api-core/pull/688 is merged. #}
-    if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    if self._wrap_with_kind:  # pragma: NO COVER
         kwargs["kind"] = self.kind
     return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 {% endmacro %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -243,6 +243,7 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
         self._prep_wrapped_messages(client_info)
 
     @property

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -1,7 +1,9 @@
 {% extends '_base.py.j2' %}
 
 {% block content %}
+{% import "%namespace/%name_%version/%sub/services/%service/_shared_macros.j2" as shared_macros %}
 
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -385,39 +387,16 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         return self._stubs["test_iam_permissions"]
     {% endif %}
 
-    def _prep_wrapped_messages(self, client_info):
-        """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
-        self._wrapped_methods = {
-            {% for method in service.methods.values() %}
-            self.{{ method.transport_safe_name|snake_case }}: gapic_v1.method_async.wrap_method(
-                self.{{ method.transport_safe_name|snake_case }},
-                {% if method.retry %}
-                default_retry=retries.AsyncRetry(
-                    {% if method.retry.initial_backoff %}
-                    initial={{ method.retry.initial_backoff }},
-                    {% endif %}
-                    {% if method.retry.max_backoff %}
-                    maximum={{ method.retry.max_backoff }},
-                    {% endif %}
-                    {% if method.retry.backoff_multiplier %}
-                    multiplier={{ method.retry.backoff_multiplier }},
-                    {% endif %}
-                    predicate=retries.if_exception_type(
-                        {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
-                        core_exceptions.{{ ex.__name__ }},
-                        {% endfor %}
-                    ),
-                    deadline={{ method.timeout }},
-                ),
-                {% endif %}
-                default_timeout={{ method.timeout }},
-                client_info=client_info,
-            ),
-            {% endfor %} {# service.methods.values() #}
-        }
+    {{ shared_macros.prep_wrapped_messages_method(service)|indent(4) }}
+
+    {{ shared_macros.wrap_method_macro()|indent(4) }}
 
     def close(self):
         return self.grpc_channel.close()
+    
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
     {% include '%namespace/%name_%version/%sub/services/%service/transports/_mixins.py.j2' %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/grpc_asyncio.py.j2
@@ -388,9 +388,9 @@ class {{ service.grpc_asyncio_transport_name }}({{ service.name }}Transport):
         return self._stubs["test_iam_permissions"]
     {% endif %}
 
-    {{ shared_macros.prep_wrapped_messages_method(service)|indent(4) }}
+    {{ shared_macros.prep_wrapped_messages_async_method(service)|indent(4) }}
 
-    {{ shared_macros.wrap_method_macro()|indent(4) }}
+    {{ shared_macros.wrap_async_method_macro()|indent(4) }}
 
     def close(self):
         return self.grpc_channel.close()

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1041,19 +1041,9 @@ def test_transport_adc(transport_class):
         transport_class()
         adc.assert_called_once()
 
-@pytest.mark.parametrize("transport_name", [
-    {% if "grpc" in opts.transport %}
-    "grpc",
-    {% endif %}
-    {% if "rest" in opts.transport %}
-    "rest",
-    {% endif %}
-])
-def test_transport_kind(transport_name):
-    transport = {{ service.client_name }}.get_transport_class(transport_name)(
-        credentials=ga_credentials.AnonymousCredentials(),
-    )
-    assert transport.kind == transport_name
+{{ test_macros.transport_kind_test(service, opts) }}
+
+{{ test_macros.transport_kind_test(service, opts, is_async=True) }}
 
 {% if 'grpc' in opts.transport %}
 def test_transport_grpc_default():

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1876,3 +1876,34 @@ def test_{{ method_name }}_empty_call():
         {% endwith %}{# method_settings #}
         assert args[0] == {{ method.input.ident }}()
 {% endmacro %}
+
+
+{% macro transport_kind_test(service, opts, is_async=False) %}
+@pytest.mark.parametrize("transport_name", [
+    {% if is_async %}
+    {% if "grpc" in opts.transport %}
+    "grpc_asyncio",
+    {% endif %}
+    {% else %}{# if not is_async #}
+    {% if "grpc" in opts.transport%}
+    "grpc",
+    {% endif %}
+    {% if "rest" in opts.transport %}
+    "rest",
+    {% endif %}
+    {% endif %}{# is_async #}
+])
+{% if is_async %}
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = {{ service.async_client_name }}.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+{% else %}
+def test_transport_kind(transport_name):
+    transport = {{ service.client_name }}.get_transport_class(transport_name)(
+        credentials=ga_credentials.AnonymousCredentials(),
+    )
+{% endif %}
+    assert transport.kind == transport_name
+{% endmacro %}

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -228,8 +228,8 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
-        self._prep_wrapped_messages(client_info)
         self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
+        self._prep_wrapped_messages(client_info)
 
     @property
     def grpc_channel(self) -> aio.Channel:

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -229,6 +229,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
 
         # Wrap messages. This must be done after self._grpc_channel exists
         self._prep_wrapped_messages(client_info)
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
 
     @property
     def grpc_channel(self) -> aio.Channel:
@@ -942,17 +943,17 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.export_assets: self._wrap_method_with_kind(
+            self.export_assets: self._wrap_method(
                 self.export_assets,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_assets: self._wrap_method_with_kind(
+            self.list_assets: self._wrap_method(
                 self.list_assets,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.batch_get_assets_history: self._wrap_method_with_kind(
+            self.batch_get_assets_history: self._wrap_method(
                 self.batch_get_assets_history,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -967,12 +968,12 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_feed: self._wrap_method_with_kind(
+            self.create_feed: self._wrap_method(
                 self.create_feed,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_feed: self._wrap_method_with_kind(
+            self.get_feed: self._wrap_method(
                 self.get_feed,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -987,7 +988,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_feeds: self._wrap_method_with_kind(
+            self.list_feeds: self._wrap_method(
                 self.list_feeds,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1002,12 +1003,12 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.update_feed: self._wrap_method_with_kind(
+            self.update_feed: self._wrap_method(
                 self.update_feed,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.delete_feed: self._wrap_method_with_kind(
+            self.delete_feed: self._wrap_method(
                 self.delete_feed,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1022,7 +1023,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.search_all_resources: self._wrap_method_with_kind(
+            self.search_all_resources: self._wrap_method(
                 self.search_all_resources,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1037,7 +1038,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=15.0,
                 client_info=client_info,
             ),
-            self.search_all_iam_policies: self._wrap_method_with_kind(
+            self.search_all_iam_policies: self._wrap_method(
                 self.search_all_iam_policies,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1052,7 +1053,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=15.0,
                 client_info=client_info,
             ),
-            self.analyze_iam_policy: self._wrap_method_with_kind(
+            self.analyze_iam_policy: self._wrap_method(
                 self.analyze_iam_policy,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1066,70 +1067,70 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=300.0,
                 client_info=client_info,
             ),
-            self.analyze_iam_policy_longrunning: self._wrap_method_with_kind(
+            self.analyze_iam_policy_longrunning: self._wrap_method(
                 self.analyze_iam_policy_longrunning,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.analyze_move: self._wrap_method_with_kind(
+            self.analyze_move: self._wrap_method(
                 self.analyze_move,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.query_assets: self._wrap_method_with_kind(
+            self.query_assets: self._wrap_method(
                 self.query_assets,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_saved_query: self._wrap_method_with_kind(
+            self.create_saved_query: self._wrap_method(
                 self.create_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_saved_query: self._wrap_method_with_kind(
+            self.get_saved_query: self._wrap_method(
                 self.get_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_saved_queries: self._wrap_method_with_kind(
+            self.list_saved_queries: self._wrap_method(
                 self.list_saved_queries,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_saved_query: self._wrap_method_with_kind(
+            self.update_saved_query: self._wrap_method(
                 self.update_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_saved_query: self._wrap_method_with_kind(
+            self.delete_saved_query: self._wrap_method(
                 self.delete_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.batch_get_effective_iam_policies: self._wrap_method_with_kind(
+            self.batch_get_effective_iam_policies: self._wrap_method(
                 self.batch_get_effective_iam_policies,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.analyze_org_policies: self._wrap_method_with_kind(
+            self.analyze_org_policies: self._wrap_method(
                 self.analyze_org_policies,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.analyze_org_policy_governed_containers: self._wrap_method_with_kind(
+            self.analyze_org_policy_governed_containers: self._wrap_method(
                 self.analyze_org_policy_governed_containers,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.analyze_org_policy_governed_assets: self._wrap_method_with_kind(
+            self.analyze_org_policy_governed_assets: self._wrap_method(
                 self.analyze_org_policy_governed_assets,
                 default_timeout=None,
                 client_info=client_info,
             ),
         }
 
-    def _wrap_method_with_kind(self, func, *args, **kwargs):
-        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -941,17 +942,17 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.export_assets: gapic_v1.method_async.wrap_method(
+            self.export_assets: self._wrap_method_with_kind(
                 self.export_assets,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_assets: gapic_v1.method_async.wrap_method(
+            self.list_assets: self._wrap_method_with_kind(
                 self.list_assets,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.batch_get_assets_history: gapic_v1.method_async.wrap_method(
+            self.batch_get_assets_history: self._wrap_method_with_kind(
                 self.batch_get_assets_history,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -966,12 +967,12 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_feed: gapic_v1.method_async.wrap_method(
+            self.create_feed: self._wrap_method_with_kind(
                 self.create_feed,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_feed: gapic_v1.method_async.wrap_method(
+            self.get_feed: self._wrap_method_with_kind(
                 self.get_feed,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -986,7 +987,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_feeds: gapic_v1.method_async.wrap_method(
+            self.list_feeds: self._wrap_method_with_kind(
                 self.list_feeds,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1001,12 +1002,12 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.update_feed: gapic_v1.method_async.wrap_method(
+            self.update_feed: self._wrap_method_with_kind(
                 self.update_feed,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.delete_feed: gapic_v1.method_async.wrap_method(
+            self.delete_feed: self._wrap_method_with_kind(
                 self.delete_feed,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1021,7 +1022,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.search_all_resources: gapic_v1.method_async.wrap_method(
+            self.search_all_resources: self._wrap_method_with_kind(
                 self.search_all_resources,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1036,7 +1037,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=15.0,
                 client_info=client_info,
             ),
-            self.search_all_iam_policies: gapic_v1.method_async.wrap_method(
+            self.search_all_iam_policies: self._wrap_method_with_kind(
                 self.search_all_iam_policies,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1051,7 +1052,7 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=15.0,
                 client_info=client_info,
             ),
-            self.analyze_iam_policy: gapic_v1.method_async.wrap_method(
+            self.analyze_iam_policy: self._wrap_method_with_kind(
                 self.analyze_iam_policy,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1065,70 +1066,79 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
                 default_timeout=300.0,
                 client_info=client_info,
             ),
-            self.analyze_iam_policy_longrunning: gapic_v1.method_async.wrap_method(
+            self.analyze_iam_policy_longrunning: self._wrap_method_with_kind(
                 self.analyze_iam_policy_longrunning,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.analyze_move: gapic_v1.method_async.wrap_method(
+            self.analyze_move: self._wrap_method_with_kind(
                 self.analyze_move,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.query_assets: gapic_v1.method_async.wrap_method(
+            self.query_assets: self._wrap_method_with_kind(
                 self.query_assets,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_saved_query: gapic_v1.method_async.wrap_method(
+            self.create_saved_query: self._wrap_method_with_kind(
                 self.create_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_saved_query: gapic_v1.method_async.wrap_method(
+            self.get_saved_query: self._wrap_method_with_kind(
                 self.get_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_saved_queries: gapic_v1.method_async.wrap_method(
+            self.list_saved_queries: self._wrap_method_with_kind(
                 self.list_saved_queries,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_saved_query: gapic_v1.method_async.wrap_method(
+            self.update_saved_query: self._wrap_method_with_kind(
                 self.update_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_saved_query: gapic_v1.method_async.wrap_method(
+            self.delete_saved_query: self._wrap_method_with_kind(
                 self.delete_saved_query,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.batch_get_effective_iam_policies: gapic_v1.method_async.wrap_method(
+            self.batch_get_effective_iam_policies: self._wrap_method_with_kind(
                 self.batch_get_effective_iam_policies,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.analyze_org_policies: gapic_v1.method_async.wrap_method(
+            self.analyze_org_policies: self._wrap_method_with_kind(
                 self.analyze_org_policies,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.analyze_org_policy_governed_containers: gapic_v1.method_async.wrap_method(
+            self.analyze_org_policy_governed_containers: self._wrap_method_with_kind(
                 self.analyze_org_policy_governed_containers,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.analyze_org_policy_governed_assets: gapic_v1.method_async.wrap_method(
+            self.analyze_org_policy_governed_assets: self._wrap_method_with_kind(
                 self.analyze_org_policy_governed_assets,
                 default_timeout=None,
                 client_info=client_info,
             ),
-         }
+        }
+
+    def _wrap_method_with_kind(self, func, *args, **kwargs):
+        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):
         return self.grpc_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
     @property
     def get_operation(

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -16415,6 +16415,18 @@ def test_transport_kind(transport_name):
     )
     assert transport.kind == transport_name
 
+
+@pytest.mark.parametrize("transport_name", [
+    "grpc_asyncio",
+])
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = AssetServiceAsyncClient.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = AssetServiceClient(

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
@@ -233,6 +233,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
         self._prep_wrapped_messages(client_info)
 
     @property
@@ -356,7 +357,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.generate_access_token: self._wrap_method_with_kind(
+            self.generate_access_token: self._wrap_method(
                 self.generate_access_token,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -371,7 +372,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.generate_id_token: self._wrap_method_with_kind(
+            self.generate_id_token: self._wrap_method(
                 self.generate_id_token,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -386,7 +387,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.sign_blob: self._wrap_method_with_kind(
+            self.sign_blob: self._wrap_method(
                 self.sign_blob,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -401,7 +402,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.sign_jwt: self._wrap_method_with_kind(
+            self.sign_jwt: self._wrap_method(
                 self.sign_jwt,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -418,8 +419,8 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
             ),
         }
 
-    def _wrap_method_with_kind(self, func, *args, **kwargs):
-        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -355,7 +356,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.generate_access_token: gapic_v1.method_async.wrap_method(
+            self.generate_access_token: self._wrap_method_with_kind(
                 self.generate_access_token,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -370,7 +371,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.generate_id_token: gapic_v1.method_async.wrap_method(
+            self.generate_id_token: self._wrap_method_with_kind(
                 self.generate_id_token,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -385,7 +386,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.sign_blob: gapic_v1.method_async.wrap_method(
+            self.sign_blob: self._wrap_method_with_kind(
                 self.sign_blob,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -400,7 +401,7 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.sign_jwt: gapic_v1.method_async.wrap_method(
+            self.sign_jwt: self._wrap_method_with_kind(
                 self.sign_jwt,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -415,10 +416,19 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-         }
+        }
+
+    def _wrap_method_with_kind(self, func, *args, **kwargs):
+        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):
         return self.grpc_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
 
 __all__ = (

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3500,6 +3500,18 @@ def test_transport_kind(transport_name):
     )
     assert transport.kind == transport_name
 
+
+@pytest.mark.parametrize("transport_name", [
+    "grpc_asyncio",
+])
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = IAMCredentialsAsyncClient.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = IAMCredentialsClient(

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -739,100 +740,109 @@ class EventarcGrpcAsyncIOTransport(EventarcTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.get_trigger: gapic_v1.method_async.wrap_method(
+            self.get_trigger: self._wrap_method_with_kind(
                 self.get_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_triggers: gapic_v1.method_async.wrap_method(
+            self.list_triggers: self._wrap_method_with_kind(
                 self.list_triggers,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_trigger: gapic_v1.method_async.wrap_method(
+            self.create_trigger: self._wrap_method_with_kind(
                 self.create_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_trigger: gapic_v1.method_async.wrap_method(
+            self.update_trigger: self._wrap_method_with_kind(
                 self.update_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_trigger: gapic_v1.method_async.wrap_method(
+            self.delete_trigger: self._wrap_method_with_kind(
                 self.delete_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_channel: gapic_v1.method_async.wrap_method(
+            self.get_channel: self._wrap_method_with_kind(
                 self.get_channel,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_channels: gapic_v1.method_async.wrap_method(
+            self.list_channels: self._wrap_method_with_kind(
                 self.list_channels,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_channel_: gapic_v1.method_async.wrap_method(
+            self.create_channel_: self._wrap_method_with_kind(
                 self.create_channel_,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_channel: gapic_v1.method_async.wrap_method(
+            self.update_channel: self._wrap_method_with_kind(
                 self.update_channel,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_channel: gapic_v1.method_async.wrap_method(
+            self.delete_channel: self._wrap_method_with_kind(
                 self.delete_channel,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_provider: gapic_v1.method_async.wrap_method(
+            self.get_provider: self._wrap_method_with_kind(
                 self.get_provider,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_providers: gapic_v1.method_async.wrap_method(
+            self.list_providers: self._wrap_method_with_kind(
                 self.list_providers,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_channel_connection: gapic_v1.method_async.wrap_method(
+            self.get_channel_connection: self._wrap_method_with_kind(
                 self.get_channel_connection,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_channel_connections: gapic_v1.method_async.wrap_method(
+            self.list_channel_connections: self._wrap_method_with_kind(
                 self.list_channel_connections,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_channel_connection: gapic_v1.method_async.wrap_method(
+            self.create_channel_connection: self._wrap_method_with_kind(
                 self.create_channel_connection,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_channel_connection: gapic_v1.method_async.wrap_method(
+            self.delete_channel_connection: self._wrap_method_with_kind(
                 self.delete_channel_connection,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_google_channel_config: gapic_v1.method_async.wrap_method(
+            self.get_google_channel_config: self._wrap_method_with_kind(
                 self.get_google_channel_config,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_google_channel_config: gapic_v1.method_async.wrap_method(
+            self.update_google_channel_config: self._wrap_method_with_kind(
                 self.update_google_channel_config,
                 default_timeout=None,
                 client_info=client_info,
             ),
-         }
+        }
+
+    def _wrap_method_with_kind(self, func, *args, **kwargs):
+        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):
         return self.grpc_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
     @property
     def delete_operation(

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
@@ -238,6 +238,7 @@ class EventarcGrpcAsyncIOTransport(EventarcTransport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
         self._prep_wrapped_messages(client_info)
 
     @property
@@ -740,100 +741,100 @@ class EventarcGrpcAsyncIOTransport(EventarcTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.get_trigger: self._wrap_method_with_kind(
+            self.get_trigger: self._wrap_method(
                 self.get_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_triggers: self._wrap_method_with_kind(
+            self.list_triggers: self._wrap_method(
                 self.list_triggers,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_trigger: self._wrap_method_with_kind(
+            self.create_trigger: self._wrap_method(
                 self.create_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_trigger: self._wrap_method_with_kind(
+            self.update_trigger: self._wrap_method(
                 self.update_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_trigger: self._wrap_method_with_kind(
+            self.delete_trigger: self._wrap_method(
                 self.delete_trigger,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_channel: self._wrap_method_with_kind(
+            self.get_channel: self._wrap_method(
                 self.get_channel,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_channels: self._wrap_method_with_kind(
+            self.list_channels: self._wrap_method(
                 self.list_channels,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_channel_: self._wrap_method_with_kind(
+            self.create_channel_: self._wrap_method(
                 self.create_channel_,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_channel: self._wrap_method_with_kind(
+            self.update_channel: self._wrap_method(
                 self.update_channel,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_channel: self._wrap_method_with_kind(
+            self.delete_channel: self._wrap_method(
                 self.delete_channel,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_provider: self._wrap_method_with_kind(
+            self.get_provider: self._wrap_method(
                 self.get_provider,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_providers: self._wrap_method_with_kind(
+            self.list_providers: self._wrap_method(
                 self.list_providers,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_channel_connection: self._wrap_method_with_kind(
+            self.get_channel_connection: self._wrap_method(
                 self.get_channel_connection,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_channel_connections: self._wrap_method_with_kind(
+            self.list_channel_connections: self._wrap_method(
                 self.list_channel_connections,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_channel_connection: self._wrap_method_with_kind(
+            self.create_channel_connection: self._wrap_method(
                 self.create_channel_connection,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_channel_connection: self._wrap_method_with_kind(
+            self.delete_channel_connection: self._wrap_method(
                 self.delete_channel_connection,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_google_channel_config: self._wrap_method_with_kind(
+            self.get_google_channel_config: self._wrap_method(
                 self.get_google_channel_config,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_google_channel_config: self._wrap_method_with_kind(
+            self.update_google_channel_config: self._wrap_method(
                 self.update_google_channel_config,
                 default_timeout=None,
                 client_info=client_info,
             ),
         }
 
-    def _wrap_method_with_kind(self, func, *args, **kwargs):
-        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -13847,6 +13847,18 @@ def test_transport_kind(transport_name):
     )
     assert transport.kind == transport_name
 
+
+@pytest.mark.parametrize("transport_name", [
+    "grpc_asyncio",
+])
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = EventarcAsyncClient.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = EventarcClient(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -1191,72 +1192,72 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.list_buckets: gapic_v1.method_async.wrap_method(
+            self.list_buckets: self._wrap_method_with_kind(
                 self.list_buckets,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_bucket: gapic_v1.method_async.wrap_method(
+            self.get_bucket: self._wrap_method_with_kind(
                 self.get_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_bucket_async: gapic_v1.method_async.wrap_method(
+            self.create_bucket_async: self._wrap_method_with_kind(
                 self.create_bucket_async,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_bucket_async: gapic_v1.method_async.wrap_method(
+            self.update_bucket_async: self._wrap_method_with_kind(
                 self.update_bucket_async,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_bucket: gapic_v1.method_async.wrap_method(
+            self.create_bucket: self._wrap_method_with_kind(
                 self.create_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_bucket: gapic_v1.method_async.wrap_method(
+            self.update_bucket: self._wrap_method_with_kind(
                 self.update_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_bucket: gapic_v1.method_async.wrap_method(
+            self.delete_bucket: self._wrap_method_with_kind(
                 self.delete_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.undelete_bucket: gapic_v1.method_async.wrap_method(
+            self.undelete_bucket: self._wrap_method_with_kind(
                 self.undelete_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_views: gapic_v1.method_async.wrap_method(
+            self.list_views: self._wrap_method_with_kind(
                 self.list_views,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_view: gapic_v1.method_async.wrap_method(
+            self.get_view: self._wrap_method_with_kind(
                 self.get_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_view: gapic_v1.method_async.wrap_method(
+            self.create_view: self._wrap_method_with_kind(
                 self.create_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_view: gapic_v1.method_async.wrap_method(
+            self.update_view: self._wrap_method_with_kind(
                 self.update_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_view: gapic_v1.method_async.wrap_method(
+            self.delete_view: self._wrap_method_with_kind(
                 self.delete_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_sinks: gapic_v1.method_async.wrap_method(
+            self.list_sinks: self._wrap_method_with_kind(
                 self.list_sinks,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1272,7 +1273,7 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_sink: gapic_v1.method_async.wrap_method(
+            self.get_sink: self._wrap_method_with_kind(
                 self.get_sink,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1288,12 +1289,12 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_sink: gapic_v1.method_async.wrap_method(
+            self.create_sink: self._wrap_method_with_kind(
                 self.create_sink,
                 default_timeout=120.0,
                 client_info=client_info,
             ),
-            self.update_sink: gapic_v1.method_async.wrap_method(
+            self.update_sink: self._wrap_method_with_kind(
                 self.update_sink,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1309,7 +1310,7 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.delete_sink: gapic_v1.method_async.wrap_method(
+            self.delete_sink: self._wrap_method_with_kind(
                 self.delete_sink,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1325,27 +1326,27 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_link: gapic_v1.method_async.wrap_method(
+            self.create_link: self._wrap_method_with_kind(
                 self.create_link,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_link: gapic_v1.method_async.wrap_method(
+            self.delete_link: self._wrap_method_with_kind(
                 self.delete_link,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_links: gapic_v1.method_async.wrap_method(
+            self.list_links: self._wrap_method_with_kind(
                 self.list_links,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_link: gapic_v1.method_async.wrap_method(
+            self.get_link: self._wrap_method_with_kind(
                 self.get_link,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_exclusions: gapic_v1.method_async.wrap_method(
+            self.list_exclusions: self._wrap_method_with_kind(
                 self.list_exclusions,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1361,7 +1362,7 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_exclusion: gapic_v1.method_async.wrap_method(
+            self.get_exclusion: self._wrap_method_with_kind(
                 self.get_exclusion,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1377,17 +1378,17 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_exclusion: gapic_v1.method_async.wrap_method(
+            self.create_exclusion: self._wrap_method_with_kind(
                 self.create_exclusion,
                 default_timeout=120.0,
                 client_info=client_info,
             ),
-            self.update_exclusion: gapic_v1.method_async.wrap_method(
+            self.update_exclusion: self._wrap_method_with_kind(
                 self.update_exclusion,
                 default_timeout=120.0,
                 client_info=client_info,
             ),
-            self.delete_exclusion: gapic_v1.method_async.wrap_method(
+            self.delete_exclusion: self._wrap_method_with_kind(
                 self.delete_exclusion,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1403,35 +1404,44 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_cmek_settings: gapic_v1.method_async.wrap_method(
+            self.get_cmek_settings: self._wrap_method_with_kind(
                 self.get_cmek_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_cmek_settings: gapic_v1.method_async.wrap_method(
+            self.update_cmek_settings: self._wrap_method_with_kind(
                 self.update_cmek_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_settings: gapic_v1.method_async.wrap_method(
+            self.get_settings: self._wrap_method_with_kind(
                 self.get_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_settings: gapic_v1.method_async.wrap_method(
+            self.update_settings: self._wrap_method_with_kind(
                 self.update_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.copy_log_entries: gapic_v1.method_async.wrap_method(
+            self.copy_log_entries: self._wrap_method_with_kind(
                 self.copy_log_entries,
                 default_timeout=None,
                 client_info=client_info,
             ),
-         }
+        }
+
+    def _wrap_method_with_kind(self, func, *args, **kwargs):
+        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):
         return self.grpc_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
     @property
     def cancel_operation(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
@@ -228,6 +228,7 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
         self._prep_wrapped_messages(client_info)
 
     @property
@@ -1192,72 +1193,72 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.list_buckets: self._wrap_method_with_kind(
+            self.list_buckets: self._wrap_method(
                 self.list_buckets,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_bucket: self._wrap_method_with_kind(
+            self.get_bucket: self._wrap_method(
                 self.get_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_bucket_async: self._wrap_method_with_kind(
+            self.create_bucket_async: self._wrap_method(
                 self.create_bucket_async,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_bucket_async: self._wrap_method_with_kind(
+            self.update_bucket_async: self._wrap_method(
                 self.update_bucket_async,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_bucket: self._wrap_method_with_kind(
+            self.create_bucket: self._wrap_method(
                 self.create_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_bucket: self._wrap_method_with_kind(
+            self.update_bucket: self._wrap_method(
                 self.update_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_bucket: self._wrap_method_with_kind(
+            self.delete_bucket: self._wrap_method(
                 self.delete_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.undelete_bucket: self._wrap_method_with_kind(
+            self.undelete_bucket: self._wrap_method(
                 self.undelete_bucket,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_views: self._wrap_method_with_kind(
+            self.list_views: self._wrap_method(
                 self.list_views,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_view: self._wrap_method_with_kind(
+            self.get_view: self._wrap_method(
                 self.get_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.create_view: self._wrap_method_with_kind(
+            self.create_view: self._wrap_method(
                 self.create_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_view: self._wrap_method_with_kind(
+            self.update_view: self._wrap_method(
                 self.update_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_view: self._wrap_method_with_kind(
+            self.delete_view: self._wrap_method(
                 self.delete_view,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_sinks: self._wrap_method_with_kind(
+            self.list_sinks: self._wrap_method(
                 self.list_sinks,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1273,7 +1274,7 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_sink: self._wrap_method_with_kind(
+            self.get_sink: self._wrap_method(
                 self.get_sink,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1289,12 +1290,12 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_sink: self._wrap_method_with_kind(
+            self.create_sink: self._wrap_method(
                 self.create_sink,
                 default_timeout=120.0,
                 client_info=client_info,
             ),
-            self.update_sink: self._wrap_method_with_kind(
+            self.update_sink: self._wrap_method(
                 self.update_sink,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1310,7 +1311,7 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.delete_sink: self._wrap_method_with_kind(
+            self.delete_sink: self._wrap_method(
                 self.delete_sink,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1326,27 +1327,27 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_link: self._wrap_method_with_kind(
+            self.create_link: self._wrap_method(
                 self.create_link,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.delete_link: self._wrap_method_with_kind(
+            self.delete_link: self._wrap_method(
                 self.delete_link,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_links: self._wrap_method_with_kind(
+            self.list_links: self._wrap_method(
                 self.list_links,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_link: self._wrap_method_with_kind(
+            self.get_link: self._wrap_method(
                 self.get_link,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.list_exclusions: self._wrap_method_with_kind(
+            self.list_exclusions: self._wrap_method(
                 self.list_exclusions,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1362,7 +1363,7 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_exclusion: self._wrap_method_with_kind(
+            self.get_exclusion: self._wrap_method(
                 self.get_exclusion,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1378,17 +1379,17 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_exclusion: self._wrap_method_with_kind(
+            self.create_exclusion: self._wrap_method(
                 self.create_exclusion,
                 default_timeout=120.0,
                 client_info=client_info,
             ),
-            self.update_exclusion: self._wrap_method_with_kind(
+            self.update_exclusion: self._wrap_method(
                 self.update_exclusion,
                 default_timeout=120.0,
                 client_info=client_info,
             ),
-            self.delete_exclusion: self._wrap_method_with_kind(
+            self.delete_exclusion: self._wrap_method(
                 self.delete_exclusion,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -1404,35 +1405,35 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_cmek_settings: self._wrap_method_with_kind(
+            self.get_cmek_settings: self._wrap_method(
                 self.get_cmek_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_cmek_settings: self._wrap_method_with_kind(
+            self.update_cmek_settings: self._wrap_method(
                 self.update_cmek_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.get_settings: self._wrap_method_with_kind(
+            self.get_settings: self._wrap_method(
                 self.get_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.update_settings: self._wrap_method_with_kind(
+            self.update_settings: self._wrap_method(
                 self.update_settings,
                 default_timeout=None,
                 client_info=client_info,
             ),
-            self.copy_log_entries: self._wrap_method_with_kind(
+            self.copy_log_entries: self._wrap_method(
                 self.copy_log_entries,
                 default_timeout=None,
                 client_info=client_info,
             ),
         }
 
-    def _wrap_method_with_kind(self, func, *args, **kwargs):
-        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -415,7 +416,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.delete_log: gapic_v1.method_async.wrap_method(
+            self.delete_log: self._wrap_method_with_kind(
                 self.delete_log,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -431,7 +432,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.write_log_entries: gapic_v1.method_async.wrap_method(
+            self.write_log_entries: self._wrap_method_with_kind(
                 self.write_log_entries,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -447,7 +448,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_log_entries: gapic_v1.method_async.wrap_method(
+            self.list_log_entries: self._wrap_method_with_kind(
                 self.list_log_entries,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -463,7 +464,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_monitored_resource_descriptors: gapic_v1.method_async.wrap_method(
+            self.list_monitored_resource_descriptors: self._wrap_method_with_kind(
                 self.list_monitored_resource_descriptors,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -479,7 +480,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_logs: gapic_v1.method_async.wrap_method(
+            self.list_logs: self._wrap_method_with_kind(
                 self.list_logs,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -495,7 +496,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.tail_log_entries: gapic_v1.method_async.wrap_method(
+            self.tail_log_entries: self._wrap_method_with_kind(
                 self.tail_log_entries,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -511,10 +512,19 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=3600.0,
                 client_info=client_info,
             ),
-         }
+        }
+
+    def _wrap_method_with_kind(self, func, *args, **kwargs):
+        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):
         return self.grpc_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
     @property
     def cancel_operation(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
@@ -226,6 +226,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
         self._prep_wrapped_messages(client_info)
 
     @property
@@ -416,7 +417,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.delete_log: self._wrap_method_with_kind(
+            self.delete_log: self._wrap_method(
                 self.delete_log,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -432,7 +433,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.write_log_entries: self._wrap_method_with_kind(
+            self.write_log_entries: self._wrap_method(
                 self.write_log_entries,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -448,7 +449,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_log_entries: self._wrap_method_with_kind(
+            self.list_log_entries: self._wrap_method(
                 self.list_log_entries,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -464,7 +465,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_monitored_resource_descriptors: self._wrap_method_with_kind(
+            self.list_monitored_resource_descriptors: self._wrap_method(
                 self.list_monitored_resource_descriptors,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -480,7 +481,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.list_logs: self._wrap_method_with_kind(
+            self.list_logs: self._wrap_method(
                 self.list_logs,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -496,7 +497,7 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.tail_log_entries: self._wrap_method_with_kind(
+            self.tail_log_entries: self._wrap_method(
                 self.tail_log_entries,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -514,8 +515,8 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
             ),
         }
 
-    def _wrap_method_with_kind(self, func, *args, **kwargs):
-        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
@@ -226,6 +226,7 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
         self._prep_wrapped_messages(client_info)
 
     @property
@@ -371,7 +372,7 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.list_log_metrics: self._wrap_method_with_kind(
+            self.list_log_metrics: self._wrap_method(
                 self.list_log_metrics,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -387,7 +388,7 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_log_metric: self._wrap_method_with_kind(
+            self.get_log_metric: self._wrap_method(
                 self.get_log_metric,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -403,12 +404,12 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_log_metric: self._wrap_method_with_kind(
+            self.create_log_metric: self._wrap_method(
                 self.create_log_metric,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.update_log_metric: self._wrap_method_with_kind(
+            self.update_log_metric: self._wrap_method(
                 self.update_log_metric,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -424,7 +425,7 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.delete_log_metric: self._wrap_method_with_kind(
+            self.delete_log_metric: self._wrap_method(
                 self.delete_log_metric,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -442,8 +443,8 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
             ),
         }
 
-    def _wrap_method_with_kind(self, func, *args, **kwargs):
-        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -370,7 +371,7 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.list_log_metrics: gapic_v1.method_async.wrap_method(
+            self.list_log_metrics: self._wrap_method_with_kind(
                 self.list_log_metrics,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -386,7 +387,7 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.get_log_metric: gapic_v1.method_async.wrap_method(
+            self.get_log_metric: self._wrap_method_with_kind(
                 self.get_log_metric,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -402,12 +403,12 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.create_log_metric: gapic_v1.method_async.wrap_method(
+            self.create_log_metric: self._wrap_method_with_kind(
                 self.create_log_metric,
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.update_log_metric: gapic_v1.method_async.wrap_method(
+            self.update_log_metric: self._wrap_method_with_kind(
                 self.update_log_metric,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -423,7 +424,7 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-            self.delete_log_metric: gapic_v1.method_async.wrap_method(
+            self.delete_log_metric: self._wrap_method_with_kind(
                 self.delete_log_metric,
                 default_retry=retries.AsyncRetry(
                     initial=0.1,
@@ -439,10 +440,19 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
                 default_timeout=60.0,
                 client_info=client_info,
             ),
-         }
+        }
+
+    def _wrap_method_with_kind(self, func, *args, **kwargs):
+        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):
         return self.grpc_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
     @property
     def cancel_operation(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12344,6 +12344,18 @@ def test_transport_kind(transport_name):
     )
     assert transport.kind == transport_name
 
+
+@pytest.mark.parametrize("transport_name", [
+    "grpc_asyncio",
+])
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = ConfigServiceV2AsyncClient.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = ConfigServiceV2Client(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3108,6 +3108,18 @@ def test_transport_kind(transport_name):
     )
     assert transport.kind == transport_name
 
+
+@pytest.mark.parametrize("transport_name", [
+    "grpc_asyncio",
+])
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = LoggingServiceV2AsyncClient.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = LoggingServiceV2Client(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2915,6 +2915,18 @@ def test_transport_kind(transport_name):
     )
     assert transport.kind == transport_name
 
+
+@pytest.mark.parametrize("transport_name", [
+    "grpc_asyncio",
+])
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = MetricsServiceV2AsyncClient.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = MetricsServiceV2Client(

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
@@ -248,6 +248,7 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
             )
 
         # Wrap messages. This must be done after self._grpc_channel exists
+        self._wrap_with_kind = "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters
         self._prep_wrapped_messages(client_info)
 
     @property
@@ -613,65 +614,65 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.list_instances: self._wrap_method_with_kind(
+            self.list_instances: self._wrap_method(
                 self.list_instances,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.get_instance: self._wrap_method_with_kind(
+            self.get_instance: self._wrap_method(
                 self.get_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.get_instance_auth_string: self._wrap_method_with_kind(
+            self.get_instance_auth_string: self._wrap_method(
                 self.get_instance_auth_string,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.create_instance: self._wrap_method_with_kind(
+            self.create_instance: self._wrap_method(
                 self.create_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.update_instance: self._wrap_method_with_kind(
+            self.update_instance: self._wrap_method(
                 self.update_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.upgrade_instance: self._wrap_method_with_kind(
+            self.upgrade_instance: self._wrap_method(
                 self.upgrade_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.import_instance: self._wrap_method_with_kind(
+            self.import_instance: self._wrap_method(
                 self.import_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.export_instance: self._wrap_method_with_kind(
+            self.export_instance: self._wrap_method(
                 self.export_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.failover_instance: self._wrap_method_with_kind(
+            self.failover_instance: self._wrap_method(
                 self.failover_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.delete_instance: self._wrap_method_with_kind(
+            self.delete_instance: self._wrap_method(
                 self.delete_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.reschedule_maintenance: self._wrap_method_with_kind(
+            self.reschedule_maintenance: self._wrap_method(
                 self.reschedule_maintenance,
                 default_timeout=None,
                 client_info=client_info,
             ),
         }
 
-    def _wrap_method_with_kind(self, func, *args, **kwargs):
-        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+    def _wrap_method(self, func, *args, **kwargs):
+        if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 import warnings
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
@@ -612,65 +613,74 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
         self._wrapped_methods = {
-            self.list_instances: gapic_v1.method_async.wrap_method(
+            self.list_instances: self._wrap_method_with_kind(
                 self.list_instances,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.get_instance: gapic_v1.method_async.wrap_method(
+            self.get_instance: self._wrap_method_with_kind(
                 self.get_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.get_instance_auth_string: gapic_v1.method_async.wrap_method(
+            self.get_instance_auth_string: self._wrap_method_with_kind(
                 self.get_instance_auth_string,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.create_instance: gapic_v1.method_async.wrap_method(
+            self.create_instance: self._wrap_method_with_kind(
                 self.create_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.update_instance: gapic_v1.method_async.wrap_method(
+            self.update_instance: self._wrap_method_with_kind(
                 self.update_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.upgrade_instance: gapic_v1.method_async.wrap_method(
+            self.upgrade_instance: self._wrap_method_with_kind(
                 self.upgrade_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.import_instance: gapic_v1.method_async.wrap_method(
+            self.import_instance: self._wrap_method_with_kind(
                 self.import_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.export_instance: gapic_v1.method_async.wrap_method(
+            self.export_instance: self._wrap_method_with_kind(
                 self.export_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.failover_instance: gapic_v1.method_async.wrap_method(
+            self.failover_instance: self._wrap_method_with_kind(
                 self.failover_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.delete_instance: gapic_v1.method_async.wrap_method(
+            self.delete_instance: self._wrap_method_with_kind(
                 self.delete_instance,
                 default_timeout=600.0,
                 client_info=client_info,
             ),
-            self.reschedule_maintenance: gapic_v1.method_async.wrap_method(
+            self.reschedule_maintenance: self._wrap_method_with_kind(
                 self.reschedule_maintenance,
                 default_timeout=None,
                 client_info=client_info,
             ),
-         }
+        }
+
+    def _wrap_method_with_kind(self, func, *args, **kwargs):
+        if "kind" in inspect.signature(gapic_v1.method_async.wrap_method).parameters:  # pragma: NO COVER
+            kwargs["kind"] = self.kind
+        return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):
         return self.grpc_channel.close()
+
+    @property
+    def kind(self) -> str:
+        return "grpc_asyncio"
 
     @property
     def delete_operation(

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -8413,6 +8413,18 @@ def test_transport_kind(transport_name):
     )
     assert transport.kind == transport_name
 
+
+@pytest.mark.parametrize("transport_name", [
+    "grpc_asyncio",
+])
+@pytest.mark.asyncio
+async def test_transport_kind_async(transport_name):
+    transport = CloudRedisAsyncClient.get_transport_class(transport_name)(
+        credentials=async_anonymous_credentials(),
+    )
+    assert transport.kind == transport_name
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = CloudRedisClient(


### PR DESCRIPTION
This PR does the following:
- adds a kind property to async gRPC transport similar to sync gRPC.
- implements a macro to call _prep_wrapped_messages; can be re-used for async REST.
- implements a macro to add a helper for conditionally calling `wrap_method` with the kind property configured.
