### PR TITLE
chore: add default library settings

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -698,13 +698,23 @@ class API:
             self.service_yaml_config.publishing.library_settings
         )
 
-        return {
+        result = {
             library_setting.version: client_pb2.ClientLibrarySettings(
                 version=library_setting.version,
                 python_settings=library_setting.python_settings,
             )
             for library_setting in self.service_yaml_config.publishing.library_settings
         }
+
+        # Add default settings for the current proto package
+        if not result:
+            result = {
+                self.naming.proto_package: client_pb2.ClientLibrarySettings(
+                    version=self.naming.proto_package
+                )
+            }
+
+        return result
 
     def enforce_valid_library_settings(
         self, client_library_settings: Sequence[client_pb2.ClientLibrarySettings]

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -2737,6 +2737,10 @@ def test_read_empty_python_settings_from_service_yaml():
     api_schema = api.API.build(fd, "google.example.v1beta1", opts=cli_options)
     assert api_schema.all_library_settings["google.example.v1beta1"].python_settings \
         == client_pb2.PythonSettings()
+    assert api_schema.all_library_settings["google.example.v1beta1"].python_settings.experimental_features \
+        == client_pb2.PythonSettings.ExperimentalFeatures()
+    assert api_schema.all_library_settings["google.example.v1beta1"].python_settings.experimental_features.rest_async_io_enabled \
+        == False
 
 
 def test_python_settings_duplicate_version_raises_error():

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -2726,6 +2726,19 @@ def test_read_python_settings_from_service_yaml():
     }
 
 
+def test_read_empty_python_settings_from_service_yaml():
+    service_yaml_config = {
+        "apis": [
+            {"name": "google.example.v1beta1.ServiceOne.Example1"},
+        ],
+    }
+    cli_options = Options(service_yaml_config=service_yaml_config)
+    fd = get_file_descriptor_proto_for_tests(fields=[])
+    api_schema = api.API.build(fd, "google.example.v1beta1", opts=cli_options)
+    assert api_schema.all_library_settings["google.example.v1beta1"].python_settings \
+        == client_pb2.PythonSettings()
+
+
 def test_python_settings_duplicate_version_raises_error():
     """
     Test that `ClientLibrarySettingsError` is raised when there are duplicate versions in


### PR DESCRIPTION
This PR adds default library settings for the proto package being generated to avoid `KeyError` when looking up the python specific settings.

Without this fix test `test_read_empty_python_settings_from_service_yaml` fails with the error below:
```
________________________________________________________________________________________ test_read_empty_python_settings_from_service_yaml ________________________________________________________________________________________

    def test_read_empty_python_settings_from_service_yaml():
        service_yaml_config = {
            "apis": [
                {"name": "google.example.v1beta1.ServiceOne.Example1"},
            ],
        }
        cli_options = Options(service_yaml_config=service_yaml_config)
        fd = get_file_descriptor_proto_for_tests(fields=[])
        api_schema = api.API.build(fd, "google.example.v1beta1", opts=cli_options)
>       assert api_schema.all_library_settings["google.example.v1beta1"].python_settings \
            == client_pb2.PythonSettings()
E       KeyError: 'google.example.v1beta1'

tests/unit/schema/test_api.py:2738: KeyError
```