### PR TITLE
test: improve routing parameter assert

### DIFF
--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -55,12 +55,6 @@ from gapic.schema import metadata
 from gapic.utils import uri_sample
 
 
-# This is the value for the `maxsize` argument of @functools.lru_cache
-# https://docs.python.org/3/library/functools.html#functools.lru_cache
-# This represents the number of recent function calls to store.
-ROUTING_PARAM_REGEX_CACHE_SIZE = 32
-
-
 @dataclasses.dataclass(frozen=True)
 class Field:
     """Description of a field."""
@@ -1043,7 +1037,8 @@ class RoutingParameter:
         return re.compile(f"^{self._convert_to_regex(path_template)}$")
 
     # Use caching to avoid repeated computation
-    @functools.lru_cache(maxsize=ROUTING_PARAM_REGEX_CACHE_SIZE)
+    # https://docs.python.org/3/library/functools.html#functools.cache
+    @functools.cache
     def to_regex(self) -> Pattern:
         return self._to_regex(self.path_template)
 

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1037,15 +1037,19 @@ class RoutingParameter:
         return re.compile(f"^{self._convert_to_regex(path_template)}$")
 
     # Use caching to avoid repeated computation
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2161):
+    # Use `@functools.cache` instead of `@functools.lru_cache` once python 3.8 is dropped.
     # https://docs.python.org/3/library/functools.html#functools.cache
-    @functools.cache
+    @functools.lru_cache(max_size=None)
     def to_regex(self) -> Pattern:
         return self._to_regex(self.path_template)
 
     @property
     # Use caching to avoid repeated computation
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2161):
+    # Use `@functools.cache` instead of `@functools.lru_cache` once python 3.8 is dropped.
     # https://docs.python.org/3/library/functools.html#functools.cache
-    @functools.cache
+    @functools.lru_cache(max_size=None)
     def key(self) -> Union[str, None]:
         if self.path_template == "":
             return self.field

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1067,6 +1067,66 @@ class RoutingRule:
         params = [RoutingParameter(x.field, x.path_template) for x in params]
         return cls(params)
 
+    @classmethod
+    def resolve(cls, routing_rule: routing_pb2.RoutingRule, request: Union[dict, str]) -> dict:
+        """Resolves the routing header which should be sent along with the request.
+        This function performs dynamic header resolution, identical to what's in `client.py.j2`.
+        The routing header is determined based on the given routing rule and request.
+        See the following link for more information on explicit routing headers:
+        https://google.aip.dev/client-libraries/4222#explicit-routing-headers-googleapirouting
+
+        Args:
+            routing_rule(routing_pb2.RoutingRule): A collection of Routing Parameter specifications
+                defined by `routing_pb2.RoutingRule`.
+                See https://github.com/googleapis/googleapis/blob/cb39bdd75da491466f6c92bc73cd46b0fbd6ba9a/google/api/routing.proto#L391
+            request(Union[dict, str]): The request for which the routine rule should be resolved.
+                The format can be either a dictionary or json string representing the request.
+
+        Returns(dict):
+            A dictionary containing the resolved routing header to the sent along with the given request.
+        """
+
+        def _get_field(request, field_path: str):
+            segments = field_path.split(".")
+
+            # Either json string or dictionary is supported
+            if isinstance(request, str):
+                current = json.loads(request)
+            else:
+                current = request
+
+            # This is to cater for the case where the `field_path` contains a
+            # dot-separated path of field names leading to a field in a sub-message.
+            for x in segments:
+                current = current.get(x, None)
+                # Break if the sub-message does not exist
+                if current is None:
+                    break
+            return current
+
+        header_params = {}
+        for routing_param in routing_rule.routing_parameters:
+            request_field_value = _get_field(request, routing_param.field)
+            # Only resolve the header for routing parameter fields which are populated in the request
+            if request_field_value is not None:
+                # If there is a path_template for a given routing parameter field, the value of the field must match
+                # If multiple Routing Parameters describe the same key
+                # (via the `path_template` field or via the `field` field when
+                # `path_template` is not provided), "last one wins" rule
+                # determines which Parameter gets used.
+                if routing_param.path_template:
+                    routing_param_regex = routing_param.to_regex()
+                    regex_match = routing_param_regex.match(
+                        request_field_value
+                    )
+                    if regex_match:
+                        header_params[routing_param.key] = regex_match.group(
+                            routing_param.key
+                        )
+                else:  # No need to match
+                    header_params[routing_param.key] = request_field_value
+        return header_params
+
 
 @dataclasses.dataclass(frozen=True)
 class HttpRule:

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1081,8 +1081,6 @@ class RoutingRule:
     @classmethod
     def resolve(cls, routing_rule: routing_pb2.RoutingRule, request: Union[dict, str]) -> dict:
         """Resolves the routing header which should be sent along with the request.
-        This function performs dynamic header resolution, identical to what's in `_client_macros.j2`.
-        https://github.com/googleapis/gapic-generator-python/blob/4c5de8791795f8101f6ec66f80b8a8e5e9a21822/gapic/templates/%25namespace/%25name_%25version/%25sub/services/%25service/_client_macros.j2#L150-L164
         The routing header is determined based on the given routing rule and request.
         See the following link for more information on explicit routing headers:
         https://google.aip.dev/client-libraries/4222#explicit-routing-headers-googleapirouting
@@ -1117,6 +1115,9 @@ class RoutingRule:
             return current
 
         header_params = {}
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2160): Move this logic to
+        # `google-api-core` so that the shared code can be used in both `wrappers.py` and GAPIC clients
+        # via Jinja templates.
         for routing_param in routing_rule.routing_parameters:
             request_field_value = _get_field(request, routing_param.field)
             # Only resolve the header for routing parameter fields which are populated in the request

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1043,6 +1043,9 @@ class RoutingParameter:
         return self._to_regex(self.path_template)
 
     @property
+    # Use caching to avoid repeated computation
+    # https://docs.python.org/3/library/functools.html#functools.cache
+    @functools.cache
     def key(self) -> Union[str, None]:
         if self.path_template == "":
             return self.field

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1040,7 +1040,7 @@ class RoutingParameter:
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2161):
     # Use `@functools.cache` instead of `@functools.lru_cache` once python 3.8 is dropped.
     # https://docs.python.org/3/library/functools.html#functools.cache
-    @functools.lru_cache(max_size=None)
+    @functools.lru_cache(maxsize=None)
     def to_regex(self) -> Pattern:
         return self._to_regex(self.path_template)
 
@@ -1049,7 +1049,7 @@ class RoutingParameter:
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2161):
     # Use `@functools.cache` instead of `@functools.lru_cache` once python 3.8 is dropped.
     # https://docs.python.org/3/library/functools.html#functools.cache
-    @functools.lru_cache(max_size=None)
+    @functools.lru_cache(maxsize=None)
     def key(self) -> Union[str, None]:
         if self.path_template == "":
             return self.field

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1110,10 +1110,10 @@ class RoutingRule:
             # Only resolve the header for routing parameter fields which are populated in the request
             if request_field_value is not None:
                 # If there is a path_template for a given routing parameter field, the value of the field must match
-                # If multiple Routing Parameters describe the same key
+                # If multiple `routing_param`s describe the same key
                 # (via the `path_template` field or via the `field` field when
-                # `path_template` is not provided), "last one wins" rule
-                # determines which Parameter gets used.
+                # `path_template` is not provided), the "last one wins" rule
+                # determines which parameter gets used. See https://google.aip.dev/client-libraries/4222.
                 if routing_param.path_template:
                     routing_param_regex = routing_param.to_regex()
                     regex_match = routing_param_regex.match(

--- a/gapic/schema/wrappers.py
+++ b/gapic/schema/wrappers.py
@@ -1077,7 +1077,8 @@ class RoutingRule:
     @classmethod
     def resolve(cls, routing_rule: routing_pb2.RoutingRule, request: Union[dict, str]) -> dict:
         """Resolves the routing header which should be sent along with the request.
-        This function performs dynamic header resolution, identical to what's in `client.py.j2`.
+        This function performs dynamic header resolution, identical to what's in `_client_macros.j2`.
+        https://github.com/googleapis/gapic-generator-python/blob/4c5de8791795f8101f6ec66f80b8a8e5e9a21822/gapic/templates/%25namespace/%25name_%25version/%25sub/services/%25service/_client_macros.j2#L150-L164
         The routing header is determined based on the given routing rule and request.
         See the following link for more information on explicit routing headers:
         https://google.aip.dev/client-libraries/4222#explicit-routing-headers-googleapirouting

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -422,12 +422,11 @@ def test_{{ method.name|snake_case }}_routing_parameters():
 
         # Establish that the underlying gRPC stub method was called.
         assert len(call.mock_calls) == 1
-        _, args, _ = call.mock_calls[0]
+        _, args, kw = call.mock_calls[0]
         assert args[0] == request
 
-    _, _, kw = call.mock_calls[0]
-    # This test doesn't assert anything useful.
-    assert kw['metadata']
+        expected_headers = {{ method.routing_rule.resolve(method.routing_rule, routing_param.sample_request) }}
+        assert gapic_v1.routing_header.to_grpc_metadata(expected_headers) in kw['metadata']
     {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
This PR fixes the assert in `test_*_routing_parameters` to verify the routing headers in `kw['metadata']`. 

The `resolve` function in `tests/unit/schema/wrappers/test_routing.py` was moved to `gapic/schema/wrappers.py` so that it can be used in `gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2`

```
    # This test doesn't assert anything useful.
    assert kw['metadata']
```

Towards https://github.com/googleapis/gapic-generator-python/issues/2091