### PR TITLE
chore: refactor unimplemented method test macro

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1057,7 +1057,7 @@ def test_transport_adc(transport_class):
 {% endfor %}
 {% for conf in configs %}
 {{ test_macros.transport_kind_test(**conf) }}
-{{ test_macros.rest_transport_specific_tests(**conf) }}
+{{ test_macros.transport_specific_tests(**conf) }}
 {% endfor %}
 {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2121): Remove the below macro when async rest is GA. #}
 {% if rest_async_io_enabled %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1057,6 +1057,7 @@ def test_transport_adc(transport_class):
 {% endfor %}
 {% for conf in configs %}
 {{ test_macros.transport_kind_test(**conf) }}
+{{ test_macros.rest_transport_specific_tests(**conf) }}
 {% endfor %}
 {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2121): Remove the below macro when async rest is GA. #}
 {% if rest_async_io_enabled %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1057,7 +1057,7 @@ def test_transport_adc(transport_class):
 {% endfor %}
 {% for conf in configs %}
 {{ test_macros.transport_kind_test(**conf) }}
-{{ test_macros.transport_specific_tests(**conf) }}
+{{ test_macros.run_transport_tests_for_config(**conf) }}
 {% endfor %}
 {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2121): Remove the below macro when async rest is GA. #}
 {% if rest_async_io_enabled %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1756,7 +1756,7 @@ def test_{{ method_name }}_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
-{%- endif %}
+{%- endif %}{# paged_result_field #}
 
 {% else %}{# this is an lro or streaming method #}
 def test_{{ method_name }}_rest_unimplemented():
@@ -1888,8 +1888,8 @@ def test_transport_kind_{{ transport_name }}():
 
 
 {% macro transport_close_test(service, transport, is_async) %}
-{% set async_prefix = "async " if is_async else "" %}
-{% set async_decorator = "@pytest.mark.asyncio " if is_async else "" %}
+{% set async_prefix = get_async_prefix(is_async) %}
+{% set async_decorator = get_async_decorator(is_async) %}
 {% set transport_name = get_transport_name(transport, is_async) %}
 {% set close_session = {
     'rest': "_session",
@@ -1930,12 +1930,35 @@ def test_unsupported_parameter_rest_asyncio():
 
 {% endmacro %}
 
+{# get_await_prefix sets an "await" keyword
+ # to a method call if is_async=True.
+#}
+{% macro get_await_prefix(is_async) %}
+{{- "await " if is_async else "" -}}
+{% endmacro %}
+
+{# get_async_prefix sets an "async" keyword
+ # to a method definition if is_async=True.
+#}
+{% macro get_async_prefix(is_async) %}
+{{- "async " if is_async else "" -}}
+{% endmacro %}
+
+{# get_async_decorator sets a "@pytest.mark.asyncio" decorator
+ # to an async test method if is_async=True.
+#}
+{% macro get_async_decorator(is_async) %}
+{{- "@pytest.mark.asyncio " if is_async else "" -}}
+{% endmacro %}
+
 {# is_rest_unsupported_method renders:
  # 'True' if transport is async REST.
  # 'True' if transport is sync REST and method is a client streaming method.
  # 'False' otherwise.
 #}
-{# NOTE: We will keep updating this method as we add support for methods in async REST. #}
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2152): Update this method as we add support for methods in async REST.
+ # There are no plans to add support for client streaming.
+#}
 {% macro is_rest_unsupported_method(method, is_async) %}
 {%- if method.client_streaming or is_async -%}
 {{'True'}}
@@ -1944,37 +1967,34 @@ def test_unsupported_parameter_rest_asyncio():
 {%- endif -%}
 {% endmacro %}
 
-{# rest_transport_specific_tests generates all the rest specific tests for both
-# sync and async transport. It refactors the test cases in macro::rest_required_tests
-# and should replace it once we cover all the test cases in it here.
+{# transport_specific_tests generates all the rest specific tests for both
+# sync and async transport.
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2142): Continue migrating the test cases
+# in macro::transport_specific_tests into here, and then delete that macro in favor of this one.
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2153): As a follow up, migrate gRPC test cases
+# into `transport_specific_tests` and make any of the rest specific specific macros which are called within more generic. 
 #}
-{% macro rest_transport_specific_tests(service, transport, is_async) %}
+{% macro transport_specific_tests(service, transport, is_async) %}
 {% if 'rest' in transport %}
-{### Test syntax configuration begins ###}
-{% set await_prefix = "await " if is_async else "" %}
-{% set async_prefix = "async " if is_async else "" %}
-{% set async_decorator = "@pytest.mark.asyncio " if is_async else "" %}
-{% set transport_name = get_transport_name(transport, is_async) %}
-{### Test syntax configuration ends ###}
-{### Test generation for all methods begins ###}
 {% for method in service.methods.values() %}
-{% set method_name = method.name|snake_case %}
-{### test cases section begin ###}
 {% if is_rest_unsupported_method(method, is_async) == 'True' or not method.http_options %}
-{{ rest_method_not_implemented_error(service, method, method_name, transport_name, async_prefix, await_prefix, async_decorator, is_async) }}
+{{ rest_method_not_implemented_error(service, method, transport, is_async) }}
 {% endif %}{# is_rest_unsupported_method(method, is_async) == 'False' and method.http_options #}
-{### test cases section ends ###}
 {% endfor %}
-{### Test generation for all methods ends ###}
-{{ rest_method_initialize_client_test(service, transport_name, is_async) }}
 {% endif %}{# if 'rest' in transport #}
+{{ initialize_client_with_transport_test(service, transport, is_async) }}
 {% endmacro %}
 
 {# rest_method_not_implemented_error generates tests for methods
  # which are not supported for rest transport.
 #}
-{% macro rest_method_not_implemented_error(service, method, method_name, transport_name, async_prefix, await_prefix, async_decorator, is_async) %}
-{% if not is_async %}{# TODO(b/362949446): Remove this guard once a not implemented __call__ method is added to async rest for all methods. #}
+{% macro rest_method_not_implemented_error(service, method, transport, is_async) %}
+{% if not is_async %}{# TODO(b/362949446): Remove this guard once a not implemented __call__ class method is added to async rest for every wrapper.Method. #}
+{% set await_prefix = get_await_prefix(is_async) %}
+{% set async_prefix = get_async_prefix(is_async) %}
+{% set async_decorator = get_async_decorator(is_async) %}
+{% set transport_name = get_transport_name(transport, is_async) %}
+{% set method_name = method.name|snake_case %}
 {{async_decorator}}
 {{async_prefix}}def test_{{ method_name }}_{{transport_name}}_error():
     {% if transport_name == 'rest_asyncio' %}
@@ -1988,8 +2008,6 @@ def test_unsupported_parameter_rest_asyncio():
         transport="{{transport_name}}"
     )
 
-    # Since a `google.api.http` annotation is required for using a rest transport
-    # method, this should error.
     with pytest.raises(NotImplementedError) as not_implemented_error:
         {{await_prefix}}client.{{ method_name }}({})
     assert (
@@ -2000,12 +2018,13 @@ def test_unsupported_parameter_rest_asyncio():
 {% endif %}{# if is_async #}
 {% endmacro %}
 
-{# rest_method_initialize_client_test adds coverage for rest transport clients.
- # Note: Unlike before, this test case is needed because we aren't unconditionally 
+{# initialize_client_with_transport_test adds coverage for transport clients.
+ # Note: This test case is needed because we aren't unconditionally 
  # generating the not implemented coverage test for every client.
 #}
-{% macro rest_method_initialize_client_test(service, transport_name, is_async) %}
-def test_{{transport_name}}_initialize_client():
+{% macro initialize_client_with_transport_test(service, transport, is_async) %}
+{% set transport_name = get_transport_name(transport, is_async) %}
+def test_initialize_client_w_{{transport_name}}():
     {% if transport_name == 'rest_asyncio' %}
     if not HAS_GOOGLE_AUTH_AIO:
         {# TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged. #}
@@ -2015,5 +2034,6 @@ def test_{{transport_name}}_initialize_client():
         credentials={{get_credentials(is_async)}},
         transport="{{transport_name}}"
     )
+    assert client is not None
 
 {% endmacro %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1967,14 +1967,14 @@ def test_unsupported_parameter_rest_asyncio():
 {%- endif -%}
 {% endmacro %}
 
-{# transport_specific_tests generates all the rest specific tests for both
+{# run_transport_tests_for_config generates all the rest specific tests for both
 # sync and async transport.
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2142): Continue migrating the test cases
-# in macro::transport_specific_tests into here, and then delete that macro in favor of this one.
+# in macro::run_transport_tests_for_config into here, and then delete that macro in favor of this one.
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2153): As a follow up, migrate gRPC test cases
-# into `transport_specific_tests` and make any of the rest specific specific macros which are called within more generic. 
+# into `run_transport_tests_for_config` and make any of the rest specific specific macros which are called within more generic. 
 #}
-{% macro transport_specific_tests(service, transport, is_async) %}
+{% macro run_transport_tests_for_config(service, transport, is_async) %}
 {% if 'rest' in transport %}
 {% for method in service.methods.values() %}
 {% if is_rest_unsupported_method(method, is_async) == 'True' or not method.http_options %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1756,25 +1756,7 @@ def test_{{ method_name }}_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
-{%- else %}{# paged_result_field #}
-
-def test_{{ method_name }}_rest_error():
-    client = {{ service.client_name }}(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-    {%- if not method.http_options %}
-    # Since a `google.api.http` annotation is required for using a rest transport
-    # method, this should error.
-    with pytest.raises(NotImplementedError) as not_implemented_error:
-        client.{{ method_name }}({})
-    assert (
-        "Method {{ method.name }} is not available over REST transport"
-        in str(not_implemented_error.value)
-    )
-
-    {%- endif %}{# not method.http_options #}
-{% endif %}{# flattened_fields #}
+{%- endif %}
 
 {% else %}{# this is an lro or streaming method #}
 def test_{{ method_name }}_rest_unimplemented():
@@ -1944,6 +1926,94 @@ def test_unsupported_parameter_rest_asyncio():
             credentials={{get_credentials(True)}},
             transport="rest_asyncio",
             client_options=options
+    )
+
+{% endmacro %}
+
+{# is_rest_unsupported_method renders:
+ # 'True' if transport is async REST.
+ # 'True' if transport is sync REST and method is a client streaming method.
+ # 'False' otherwise.
+#}
+{# NOTE: We will keep updating this method as we add support for methods in async REST. #}
+{% macro is_rest_unsupported_method(method, is_async) %}
+{%- if method.client_streaming or is_async -%}
+{{'True'}}
+{%- else -%}
+{{'False'}}
+{%- endif -%}
+{% endmacro %}
+
+{# rest_transport_specific_tests generates all the rest specific tests for both
+# sync and async transport. It refactors the test cases in macro::rest_required_tests
+# and should replace it once we cover all the test cases in it here.
+#}
+{% macro rest_transport_specific_tests(service, transport, is_async) %}
+{% if 'rest' in transport %}
+{### Test syntax configuration begins ###}
+{% set await_prefix = "await " if is_async else "" %}
+{% set async_prefix = "async " if is_async else "" %}
+{% set async_decorator = "@pytest.mark.asyncio " if is_async else "" %}
+{% set transport_name = get_transport_name(transport, is_async) %}
+{### Test syntax configuration ends ###}
+{### Test generation for all methods begins ###}
+{% for method in service.methods.values() %}
+{% set method_name = method.name|snake_case %}
+{### test cases section begin ###}
+{% if is_rest_unsupported_method(method, is_async) == 'True' or not method.http_options %}
+{{ rest_method_not_implemented_error(service, method, method_name, transport_name, async_prefix, await_prefix, async_decorator, is_async) }}
+{% endif %}{# is_rest_unsupported_method(method, is_async) == 'False' and method.http_options #}
+{### test cases section ends ###}
+{% endfor %}
+{### Test generation for all methods ends ###}
+{{ rest_method_initialize_client_test(service, transport_name, is_async) }}
+{% endif %}{# if 'rest' in transport #}
+{% endmacro %}
+
+{# rest_method_not_implemented_error generates tests for methods
+ # which are not supported for rest transport.
+#}
+{% macro rest_method_not_implemented_error(service, method, method_name, transport_name, async_prefix, await_prefix, async_decorator, is_async) %}
+{% if not is_async %}{# TODO(b/362949446): Remove this guard once a not implemented __call__ method is added to async rest for all methods. #}
+{{async_decorator}}
+{{async_prefix}}def test_{{ method_name }}_{{transport_name}}_error():
+    {% if transport_name == 'rest_asyncio' %}
+    if not HAS_GOOGLE_AUTH_AIO:
+        {# TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged. #}
+        pytest.skip("google-auth > 2.x.x is required for async rest transport.")
+    {% endif %}
+
+    client = {{ get_client(service, is_async) }}(
+        credentials={{get_credentials(is_async)}},
+        transport="{{transport_name}}"
+    )
+
+    # Since a `google.api.http` annotation is required for using a rest transport
+    # method, this should error.
+    with pytest.raises(NotImplementedError) as not_implemented_error:
+        {{await_prefix}}client.{{ method_name }}({})
+    assert (
+        "Method {{ method.name }} is not available over REST transport"
+        in str(not_implemented_error.value)
+    )
+
+{% endif %}{# if is_async #}
+{% endmacro %}
+
+{# rest_method_initialize_client_test adds coverage for rest transport clients.
+ # Note: Unlike before, this test case is needed because we aren't unconditionally 
+ # generating the not implemented coverage test for every client.
+#}
+{% macro rest_method_initialize_client_test(service, transport_name, is_async) %}
+def test_{{transport_name}}_initialize_client():
+    {% if transport_name == 'rest_asyncio' %}
+    if not HAS_GOOGLE_AUTH_AIO:
+        {# TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged. #}
+        pytest.skip("google-auth > 2.x.x is required for async rest transport.")
+    {% endif %}
+    client = {{ get_client(service, is_async) }}(
+        credentials={{get_credentials(is_async)}},
+        transport="{{transport_name}}"
     )
 
 {% endmacro %}

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -10133,13 +10133,6 @@ def test_export_assets_rest_bad_request(transport: str = 'rest', request_type=as
         client.export_assets(request)
 
 
-def test_export_assets_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.ListAssetsRequest,
     dict,
@@ -10671,13 +10664,6 @@ def test_batch_get_assets_history_rest_bad_request(transport: str = 'rest', requ
         client.batch_get_assets_history(request)
 
 
-def test_batch_get_assets_history_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.CreateFeedRequest,
     dict,
@@ -10951,13 +10937,6 @@ def test_create_feed_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_create_feed_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.GetFeedRequest,
     dict,
@@ -11226,13 +11205,6 @@ def test_get_feed_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_get_feed_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.ListFeedsRequest,
     dict,
@@ -11489,13 +11461,6 @@ def test_list_feeds_rest_flattened_error(transport: str = 'rest'):
             asset_service.ListFeedsRequest(),
             parent='parent_value',
         )
-
-
-def test_list_feeds_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -11762,13 +11727,6 @@ def test_update_feed_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_update_feed_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.DeleteFeedRequest,
     dict,
@@ -12012,13 +11970,6 @@ def test_delete_feed_rest_flattened_error(transport: str = 'rest'):
             asset_service.DeleteFeedRequest(),
             name='name_value',
         )
-
-
-def test_delete_feed_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -12879,13 +12830,6 @@ def test_analyze_iam_policy_rest_bad_request(transport: str = 'rest', request_ty
         client.analyze_iam_policy(request)
 
 
-def test_analyze_iam_policy_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.AnalyzeIamPolicyLongrunningRequest,
     dict,
@@ -13084,13 +13028,6 @@ def test_analyze_iam_policy_longrunning_rest_bad_request(transport: str = 'rest'
         response_value.request = Request()
         req.return_value = response_value
         client.analyze_iam_policy_longrunning(request)
-
-
-def test_analyze_iam_policy_longrunning_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -13311,13 +13248,6 @@ def test_analyze_move_rest_bad_request(transport: str = 'rest', request_type=ass
         client.analyze_move(request)
 
 
-def test_analyze_move_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.QueryAssetsRequest,
     dict,
@@ -13526,13 +13456,6 @@ def test_query_assets_rest_bad_request(transport: str = 'rest', request_type=ass
         response_value.request = Request()
         req.return_value = response_value
         client.query_assets(request)
-
-
-def test_query_assets_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -13883,13 +13806,6 @@ def test_create_saved_query_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_create_saved_query_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.GetSavedQueryRequest,
     dict,
@@ -14154,13 +14070,6 @@ def test_get_saved_query_rest_flattened_error(transport: str = 'rest'):
             asset_service.GetSavedQueryRequest(),
             name='name_value',
         )
-
-
-def test_get_saved_query_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -14817,13 +14726,6 @@ def test_update_saved_query_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_update_saved_query_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.DeleteSavedQueryRequest,
     dict,
@@ -15069,13 +14971,6 @@ def test_delete_saved_query_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_delete_saved_query_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     asset_service.BatchGetEffectiveIamPoliciesRequest,
     dict,
@@ -15292,13 +15187,6 @@ def test_batch_get_effective_iam_policies_rest_bad_request(transport: str = 'res
         response_value.request = Request()
         req.return_value = response_value
         client.batch_get_effective_iam_policies(request)
-
-
-def test_batch_get_effective_iam_policies_rest_error():
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -16424,6 +16312,13 @@ def test_transport_kind_rest():
         credentials=ga_credentials.AnonymousCredentials()
     )
     assert transport.kind == "rest"
+
+
+def test_rest_initialize_client():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -16300,11 +16300,27 @@ def test_transport_kind_grpc():
     assert transport.kind == "grpc"
 
 
+def test_initialize_client_w_grpc():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc"
+    )
+    assert client is not None
+
+
 def test_transport_kind_grpc_asyncio():
     transport = AssetServiceAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio"
+    )
+    assert client is not None
 
 
 def test_transport_kind_rest():
@@ -16314,11 +16330,12 @@ def test_transport_kind_rest():
     assert transport.kind == "rest"
 
 
-def test_rest_initialize_client():
+def test_initialize_client_w_rest():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
         transport="rest"
     )
+    assert client is not None
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3469,11 +3469,27 @@ def test_transport_kind_grpc():
     assert transport.kind == "grpc"
 
 
+def test_initialize_client_w_grpc():
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc"
+    )
+    assert client is not None
+
+
 def test_transport_kind_grpc_asyncio():
     transport = IAMCredentialsAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio"
+    )
+    assert client is not None
 
 
 def test_transport_kind_rest():
@@ -3483,11 +3499,12 @@ def test_transport_kind_rest():
     assert transport.kind == "rest"
 
 
-def test_rest_initialize_client():
+def test_initialize_client_w_rest():
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
         transport="rest"
     )
+    assert client is not None
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -2562,13 +2562,6 @@ def test_generate_access_token_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_generate_access_token_rest_error():
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     common.GenerateIdTokenRequest,
     dict,
@@ -2838,13 +2831,6 @@ def test_generate_id_token_rest_flattened_error(transport: str = 'rest'):
             audience='audience_value',
             include_email=True,
         )
-
-
-def test_generate_id_token_rest_error():
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -3118,13 +3104,6 @@ def test_sign_blob_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_sign_blob_rest_error():
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     common.SignJwtRequest,
     dict,
@@ -3396,13 +3375,6 @@ def test_sign_jwt_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_sign_jwt_rest_error():
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.IAMCredentialsGrpcTransport(
@@ -3509,6 +3481,13 @@ def test_transport_kind_rest():
         credentials=ga_credentials.AnonymousCredentials()
     )
     assert transport.kind == "rest"
+
+
+def test_rest_initialize_client():
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -13746,11 +13746,27 @@ def test_transport_kind_grpc():
     assert transport.kind == "grpc"
 
 
+def test_initialize_client_w_grpc():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc"
+    )
+    assert client is not None
+
+
 def test_transport_kind_grpc_asyncio():
     transport = EventarcAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio"
+    )
+    assert client is not None
 
 
 def test_transport_kind_rest():
@@ -13760,11 +13776,12 @@ def test_transport_kind_rest():
     assert transport.kind == "rest"
 
 
-def test_rest_initialize_client():
+def test_initialize_client_w_rest():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
         transport="rest"
     )
+    assert client is not None
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -8471,13 +8471,6 @@ def test_get_trigger_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_get_trigger_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     eventarc.ListTriggersRequest,
     dict,
@@ -9152,13 +9145,6 @@ def test_create_trigger_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_create_trigger_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     eventarc.UpdateTriggerRequest,
     dict,
@@ -9492,13 +9478,6 @@ def test_update_trigger_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_update_trigger_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     eventarc.DeleteTriggerRequest,
     dict,
@@ -9767,13 +9746,6 @@ def test_delete_trigger_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
             allow_missing=True,
         )
-
-
-def test_delete_trigger_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -10045,13 +10017,6 @@ def test_get_channel_rest_flattened_error(transport: str = 'rest'):
             eventarc.GetChannelRequest(),
             name='name_value',
         )
-
-
-def test_get_channel_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -10728,13 +10693,6 @@ def test_create_channel_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_create_channel_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     eventarc.UpdateChannelRequest,
     dict,
@@ -11066,13 +11024,6 @@ def test_update_channel_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_update_channel_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     eventarc.DeleteChannelRequest,
     dict,
@@ -11341,13 +11292,6 @@ def test_delete_channel_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_delete_channel_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     eventarc.GetProviderRequest,
     dict,
@@ -11608,13 +11552,6 @@ def test_get_provider_rest_flattened_error(transport: str = 'rest'):
             eventarc.GetProviderRequest(),
             name='name_value',
         )
-
-
-def test_get_provider_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -12207,13 +12144,6 @@ def test_get_channel_connection_rest_flattened_error(transport: str = 'rest'):
             eventarc.GetChannelConnectionRequest(),
             name='name_value',
         )
-
-
-def test_get_channel_connection_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -12879,13 +12809,6 @@ def test_create_channel_connection_rest_flattened_error(transport: str = 'rest')
         )
 
 
-def test_create_channel_connection_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     eventarc.DeleteChannelConnectionRequest,
     dict,
@@ -13139,13 +13062,6 @@ def test_delete_channel_connection_rest_flattened_error(transport: str = 'rest')
             eventarc.DeleteChannelConnectionRequest(),
             name='name_value',
         )
-
-
-def test_delete_channel_connection_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -13408,13 +13324,6 @@ def test_get_google_channel_config_rest_flattened_error(transport: str = 'rest')
             eventarc.GetGoogleChannelConfigRequest(),
             name='name_value',
         )
-
-
-def test_get_google_channel_config_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -13743,13 +13652,6 @@ def test_update_google_channel_config_rest_flattened_error(transport: str = 'res
         )
 
 
-def test_update_google_channel_config_rest_error():
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.EventarcGrpcTransport(
@@ -13856,6 +13758,13 @@ def test_transport_kind_rest():
         credentials=ga_credentials.AnonymousCredentials()
     )
     assert transport.kind == "rest"
+
+
+def test_rest_initialize_client():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12342,11 +12342,27 @@ def test_transport_kind_grpc():
     assert transport.kind == "grpc"
 
 
+def test_initialize_client_w_grpc():
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc"
+    )
+    assert client is not None
+
+
 def test_transport_kind_grpc_asyncio():
     transport = ConfigServiceV2AsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio"
+    )
+    assert client is not None
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3106,11 +3106,27 @@ def test_transport_kind_grpc():
     assert transport.kind == "grpc"
 
 
+def test_initialize_client_w_grpc():
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc"
+    )
+    assert client is not None
+
+
 def test_transport_kind_grpc_asyncio():
     transport = LoggingServiceV2AsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio"
+    )
+    assert client is not None
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2913,11 +2913,27 @@ def test_transport_kind_grpc():
     assert transport.kind == "grpc"
 
 
+def test_initialize_client_w_grpc():
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc"
+    )
+    assert client is not None
+
+
 def test_transport_kind_grpc_asyncio():
     transport = MetricsServiceV2AsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio"
+    )
+    assert client is not None
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -8341,11 +8341,27 @@ def test_transport_kind_grpc():
     assert transport.kind == "grpc"
 
 
+def test_initialize_client_w_grpc():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc"
+    )
+    assert client is not None
+
+
 def test_transport_kind_grpc_asyncio():
     transport = CloudRedisAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "grpc_asyncio"
+
+
+def test_initialize_client_w_grpc_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio"
+    )
+    assert client is not None
 
 
 def test_transport_kind_rest():
@@ -8355,11 +8371,12 @@ def test_transport_kind_rest():
     assert transport.kind == "rest"
 
 
-def test_rest_initialize_client():
+def test_initialize_client_w_rest():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
         transport="rest"
     )
+    assert client is not None
 
 
 def test_transport_kind_rest_asyncio():
@@ -8371,13 +8388,14 @@ def test_transport_kind_rest_asyncio():
     assert transport.kind == "rest_asyncio"
 
 
-def test_rest_asyncio_initialize_client():
+def test_initialize_client_w_rest_asyncio():
     if not HAS_GOOGLE_AUTH_AIO:
         pytest.skip("google-auth > 2.x.x is required for async rest transport.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio"
     )
+    assert client is not None
 
 
 def test_unsupported_parameter_rest_asyncio():

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -5780,13 +5780,6 @@ def test_get_instance_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_get_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     cloud_redis.GetInstanceAuthStringRequest,
     dict,
@@ -6045,13 +6038,6 @@ def test_get_instance_auth_string_rest_flattened_error(transport: str = 'rest'):
             cloud_redis.GetInstanceAuthStringRequest(),
             name='name_value',
         )
-
-
-def test_get_instance_auth_string_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -6391,13 +6377,6 @@ def test_create_instance_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_create_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     cloud_redis.UpdateInstanceRequest,
     dict,
@@ -6717,13 +6696,6 @@ def test_update_instance_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_update_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     cloud_redis.UpgradeInstanceRequest,
     dict,
@@ -6986,13 +6958,6 @@ def test_upgrade_instance_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_upgrade_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     cloud_redis.ImportInstanceRequest,
     dict,
@@ -7249,13 +7214,6 @@ def test_import_instance_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
             input_config=cloud_redis.InputConfig(gcs_source=cloud_redis.GcsSource(uri='uri_value')),
         )
-
-
-def test_import_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -7516,13 +7474,6 @@ def test_export_instance_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_export_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     cloud_redis.FailoverInstanceRequest,
     dict,
@@ -7781,13 +7732,6 @@ def test_failover_instance_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_failover_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 @pytest.mark.parametrize("request_type", [
     cloud_redis.DeleteInstanceRequest,
     dict,
@@ -8041,13 +7985,6 @@ def test_delete_instance_rest_flattened_error(transport: str = 'rest'):
             cloud_redis.DeleteInstanceRequest(),
             name='name_value',
         )
-
-
-def test_delete_instance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
 
 
 @pytest.mark.parametrize("request_type", [
@@ -8310,13 +8247,6 @@ def test_reschedule_maintenance_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-def test_reschedule_maintenance_rest_error():
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport='rest'
-    )
-
-
 def test_credentials_transport_error():
     # It is an error to provide credentials and a transport instance.
     transport = transports.CloudRedisGrpcTransport(
@@ -8425,6 +8355,13 @@ def test_transport_kind_rest():
     assert transport.kind == "rest"
 
 
+def test_rest_initialize_client():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+
 def test_transport_kind_rest_asyncio():
     if not HAS_GOOGLE_AUTH_AIO:
         pytest.skip("google-auth > 2.x.x is required for async rest transport.")
@@ -8432,6 +8369,15 @@ def test_transport_kind_rest_asyncio():
         credentials=async_anonymous_credentials()
     )
     assert transport.kind == "rest_asyncio"
+
+
+def test_rest_asyncio_initialize_client():
+    if not HAS_GOOGLE_AUTH_AIO:
+        pytest.skip("google-auth > 2.x.x is required for async rest transport.")
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio"
+    )
 
 
 def test_unsupported_parameter_rest_asyncio():


### PR DESCRIPTION
This PR refactors the macro for testing not implemented methods of rest transport. 

For now, the macro is guarded and only generates tests for sync REST not implemented methods. Once we implement the relevant logic in async rest, the guard can be removed. (This will be addressed in a follow up PR).