### PR TITLE
chore: refactor rest call success test macro

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1051,7 +1051,8 @@ def test_{{ method_name }}_raw_page_lro():
 {% with method_name = method.safe_name|snake_case + "_unary" if method.extended_lro and not full_extended_lro else method.name|snake_case, method_output = method.extended_lro.operation_type if method.extended_lro and not full_extended_lro else method.output %}{% if method.http_options %}
 {# TODO(kbandes): remove this if condition when lro and client streaming are supported. #}
 {% if not method.client_streaming %}
-{# NOTE: This guard is added to avoid generating duplicate tests for methods which are tested elsewhere.
+{# NOTE: This guard is added to avoid generating duplicate tests for methods which are tested elsewhere. As we implement each of the api methods
+ # in the `macro::call_success_test`, the case will be removed from this condition below.
  # TODO(https://github.com/googleapis/gapic-generator-python/issues/2143): Remove the test `test_{{ method_name }}_rest` from here once the linked issue is resolved.
 #}
 {% if method.server_streaming or method.lro or method.extended_lro or method.paged_result_field %}
@@ -1189,6 +1190,7 @@ def test_{{ method_name }}_rest(request_type):
         json_return_value = json_format.MessageToJson(return_value)
         {% else %}
         {% if method.output.ident.is_proto_plus_type %}
+
         # Convert return value to protobuf type
         return_value = {{ method.output.ident }}.pb(return_value)
         {% endif %}
@@ -2063,12 +2065,12 @@ def test_initialize_client_w_{{transport_name}}():
 {% endif %}{# if 'rest' in transport #}
 {% endmacro %}
 
-{# rest_method_call_success_test generates tests for rest methods
+{# call_success_test generates tests for rest methods
  # when they make a successful request.
  # NOTE: Currently, this macro does not support the following method
  # types: [method.server_streaming, method.lro, method.extended_lro, method.paged_result_field].
  # As support is added for the above methods, the relevant guard can be removed from within the macro
- # TODO(https://github.com/googleapis/gapic-generator-python/issues/2142): Clean up `rest_required_tests` once support for all the methods metioned above is added here.
+ # TODO(https://github.com/googleapis/gapic-generator-python/issues/2142): Clean up `rest_required_tests` as we add support for each of the method types metioned above.
 #}
 {% macro call_success_test(service, method, transport, is_async) %}
 {% if 'rest' in transport %}
@@ -2085,11 +2087,11 @@ def test_initialize_client_w_{{transport_name}}():
  # all the methods supported in async rest transport that are supported in sync rest transport.
  #}
 {% if not (method.server_streaming or method.lro or method.extended_lro or method.paged_result_field)%}
+{{async_decorator}}
 @pytest.mark.parametrize("request_type", [
   {{ method.input.ident }},
   dict,
 ])
-{{async_decorator}}
 {{async_prefix}}def test_{{method_name}}_{{transport_name}}_call_success(request_type):
     {% if transport_name == 'rest_asyncio' %}
     if not HAS_GOOGLE_AUTH_AIO:
@@ -2104,6 +2106,75 @@ def test_initialize_client_w_{{transport_name}}():
 
     # send a request that will satisfy transcoding
     request_init = {{ method.http_options[0].sample_request(method) }}
+    {% for field in method.body_fields.values() %}
+    {% if not field.oneof or field.proto3_optional %}
+    {# ignore oneof fields that might conflict with sample_request #}
+    request_init["{{ field.name }}"] = {{ field.merged_mock_value(method.http_options[0].sample_request(method).get(field.name)) }}
+    # The version of a generated dependency at test runtime may differ from the version used during generation.
+    # Delete any fields which are not present in the current runtime dependency
+    # See https://github.com/googleapis/gapic-generator-python/issues/1748
+
+    # Determine if the message type is proto-plus or protobuf
+    test_field = {{ method.input.ident }}.meta.fields["{{ field.name }}"]
+
+    def get_message_fields(field):
+        # Given a field which is a message (composite type), return a list with
+        # all the fields of the message.
+        # If the field is not a composite type, return an empty list.
+        message_fields = []
+
+        if hasattr(field, "message") and field.message:
+            is_field_type_proto_plus_type = not hasattr(field.message, "DESCRIPTOR")
+
+            if is_field_type_proto_plus_type:
+                message_fields = field.message.meta.fields.values()
+            # Add `# pragma: NO COVER` because there may not be any `*_pb2` field types
+            else: # pragma: NO COVER
+                message_fields = field.message.DESCRIPTOR.fields
+        return message_fields
+
+    runtime_nested_fields = [
+        (field.name, nested_field.name)
+        for field in get_message_fields(test_field)
+        for nested_field in get_message_fields(field)
+    ]
+
+    subfields_not_in_runtime = []
+
+    # For each item in the sample request, create a list of sub fields which are not present at runtime
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for field, value in request_init["{{ field.name }}"].items(): # pragma: NO COVER
+        result = None
+        is_repeated = False
+        # For repeated fields
+        if isinstance(value, list) and len(value):
+            is_repeated = True
+            result = value[0]
+        # For fields where the type is another message
+        if isinstance(value, dict):
+            result = value
+
+        if result and hasattr(result, "keys"):
+            for subfield in result.keys():
+                if (field, subfield) not in runtime_nested_fields:
+                    subfields_not_in_runtime.append(
+                        {"field": field, "subfield": subfield, "is_repeated": is_repeated}
+                    )
+
+    # Remove fields from the sample request which are not present in the runtime version of the dependency
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for subfield_to_delete in subfields_not_in_runtime: # pragma: NO COVER
+        field = subfield_to_delete.get("field")
+        field_repeated = subfield_to_delete.get("is_repeated")
+        subfield = subfield_to_delete.get("subfield")
+        if subfield:
+            if field_repeated:
+                for i in range(0, len(request_init["{{ field.name }}"][field])):
+                    del request_init["{{ field.name }}"][field][i][subfield]
+            else:
+                del request_init["{{ field.name }}"][field][subfield]
+    {% endif %}
+    {% endfor %}
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -2111,7 +2182,24 @@ def test_initialize_client_w_{{transport_name}}():
         # Designate an appropriate value for the returned response.
         {% if method.void %}
         return_value = None
-        {% else %}{# method.void #}
+        {% elif method.lro %}
+        return_value = operations_pb2.Operation(name='operations/spam')
+        {% elif method.extended_lro %}
+        return_value = {{ method.extended_lro.operation_type.ident }}(
+            {% for field in method.extended_lro.operation_type.fields.values() | rejectattr('message')%}
+            {% if not field.oneof or field.proto3_optional %}
+              {{ field.name }}={{ field.mock_value }},
+            {% endif %}{% endfor %}
+            {# This is a hack to only pick one field #}
+            {% for oneof_fields in method.output.oneof_fields().values() %}
+            {% if (oneof_fields | rejectattr('message') | list) %}
+            {% with field = (oneof_fields | rejectattr('message') | first) %}
+            {{ field.name }}={{ field.mock_value }},
+            {% endwith %}
+            {% endif %}
+            {% endfor %}
+        )
+        {% else %}
         return_value = {{ method.output.ident }}(
             {% for field in method.output.fields.values() | rejectattr('message')%}
             {% if not field.oneof or field.proto3_optional %}
@@ -2135,6 +2223,7 @@ def test_initialize_client_w_{{transport_name}}():
         json_return_value = ''
         {% else %}{# method.void #}
         {% if method.output.ident.is_proto_plus_type %}
+
         # Convert return value to protobuf type
         return_value = {{ method.output.ident }}.pb(return_value)
         {% endif %}{# method.output.ident.is_proto_plus_type #}
@@ -2147,6 +2236,7 @@ def test_initialize_client_w_{{transport_name}}():
         {% endif %}
         req.return_value = response_value
         response = {{ await_prefix }}client.{{ method_name }}(request)
+
     # Establish that the response is the type that we expect.
     {% if method.void %}
     assert response is None
@@ -2171,7 +2261,6 @@ def test_initialize_client_w_{{transport_name}}():
     assert response.{{ field.name }} == {{ field.mock_value }}
     {% endif %}{# field.field_pb.type in [1, 2] #}
     {% endif %}{# not field.oneof or field.proto3_optional #}
-
     {% endfor %}{# field in method_output.fields.values() | rejectattr('message') #}
     {% endif %}{# method.void #}
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1051,6 +1051,10 @@ def test_{{ method_name }}_raw_page_lro():
 {% with method_name = method.safe_name|snake_case + "_unary" if method.extended_lro and not full_extended_lro else method.name|snake_case, method_output = method.extended_lro.operation_type if method.extended_lro and not full_extended_lro else method.output %}{% if method.http_options %}
 {# TODO(kbandes): remove this if condition when lro and client streaming are supported. #}
 {% if not method.client_streaming %}
+{# NOTE: This guard is added to avoid generating duplicate tests for methods which are tested elsewhere.
+ # TODO(https://github.com/googleapis/gapic-generator-python/issues/2143): Remove the test `test_{{ method_name }}_rest` from here once the linked issue is resolved.
+#}
+{% if method.server_streaming or method.lro or method.extended_lro or method.paged_result_field %}
 @pytest.mark.parametrize("request_type", [
     {{ method.input.ident }},
     dict,
@@ -1249,6 +1253,7 @@ def test_{{ method_name }}_rest(request_type):
     {% endfor %}
     {% endif %}
 
+{% endif %}{# if method.server_streaming or method.lro or method.extended_lro or method.paged_result_field #}
 def test_{{ method_name }}_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -1953,6 +1958,7 @@ def test_unsupported_parameter_rest_asyncio():
 {{ rest_method_not_implemented_error(service, method, transport, is_async) }}
 {% else %}
 {{ bad_request_test(service, method, transport, is_async) }}
+{{ call_success_test(service, method, transport, is_async) }}
 {% endif %}{# is_rest_unsupported_method(method, is_async) == 'False' and method.http_options #}
 {% endfor %}
 {{ initialize_client_with_transport_test(service, transport, is_async) }}
@@ -2054,5 +2060,121 @@ def test_initialize_client_w_{{transport_name}}():
         req.return_value = response_value
         {{ await_prefix }}client.{{ method_name }}(request)
 
+{% endif %}{# if 'rest' in transport #}
+{% endmacro %}
+
+{# rest_method_call_success_test generates tests for rest methods
+ # when they make a successful request.
+ # NOTE: Currently, this macro does not support the following method
+ # types: [method.server_streaming, method.lro, method.extended_lro, method.paged_result_field].
+ # As support is added for the above methods, the relevant guard can be removed from within the macro
+ # TODO(https://github.com/googleapis/gapic-generator-python/issues/2142): Clean up `rest_required_tests` once support for all the methods metioned above is added here.
+#}
+{% macro call_success_test(service, method, transport, is_async) %}
+{% if 'rest' in transport %}
+{% set await_prefix = get_await_prefix(is_async) %}
+{% set async_prefix = get_async_prefix(is_async) %}
+{% set async_decorator = get_async_decorator(is_async) %}
+{% set transport_name = get_transport_name(transport, is_async) %}
+{% set method_name = method.name|snake_case %}
+{# NOTE: set method_output to method.extended_lro.operation_type for the following method types:
+ # (method.extended_lro and not full_extended_lro)
+#}
+{% set method_output = method.output %}
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2143): Update the guard below as support we add for each method. Remove it once we have
+ # all the methods supported in async rest transport that are supported in sync rest transport.
+ #}
+{% if not (method.server_streaming or method.lro or method.extended_lro or method.paged_result_field)%}
+@pytest.mark.parametrize("request_type", [
+  {{ method.input.ident }},
+  dict,
+])
+{{async_decorator}}
+{{async_prefix}}def test_{{method_name}}_{{transport_name}}_call_success(request_type):
+    {% if transport_name == 'rest_asyncio' %}
+    if not HAS_GOOGLE_AUTH_AIO:
+        {# TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged. #}
+        pytest.skip("google-auth > 2.x.x is required for async rest transport.")
+
+    {% endif %}
+    client = {{ get_client(service, is_async) }}(
+        credentials={{get_credentials(is_async)}},
+        transport="{{transport_name}}"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {{ method.http_options[0].sample_request(method) }}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        {% if method.void %}
+        return_value = None
+        {% else %}{# method.void #}
+        return_value = {{ method.output.ident }}(
+            {% for field in method.output.fields.values() | rejectattr('message')%}
+            {% if not field.oneof or field.proto3_optional %}
+              {{ field.name }}={{ field.mock_value }},
+              {% endif %}{% endfor %}
+            {# This is a hack to only pick one field #}
+            {% for oneof_fields in method.output.oneof_fields().values() %}
+            {% if (oneof_fields | rejectattr('message') | list) %}
+            {% with field = (oneof_fields | rejectattr('message') | first) %}
+            {{ field.name }}={{ field.mock_value }},
+            {% endwith %}
+            {% endif %}
+            {% endfor %}
+        )
+        {% endif %}{# method.void #}
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        {% if method.void %}
+        json_return_value = ''
+        {% else %}{# method.void #}
+        {% if method.output.ident.is_proto_plus_type %}
+        # Convert return value to protobuf type
+        return_value = {{ method.output.ident }}.pb(return_value)
+        {% endif %}{# method.output.ident.is_proto_plus_type #}
+        json_return_value = json_format.MessageToJson(return_value)
+        {% endif %}{# method.void #}
+        {% if is_async %}
+        response_value.read = mock.AsyncMock(return_value=b'{}')
+        {% else %}{# is_async #}
+        response_value.content = json_return_value.encode('UTF-8')
+        {% endif %}
+        req.return_value = response_value
+        response = {{ await_prefix }}client.{{ method_name }}(request)
+    # Establish that the response is the type that we expect.
+    {% if method.void %}
+    assert response is None
+    {% else %}
+    assert isinstance(response, {{ method.client_output.ident }})
+    {% for field in method_output.fields.values() | rejectattr('message') %}
+    {% if not field.oneof or field.proto3_optional %}
+    {% if field.field_pb.type in [1, 2] %}{# Use approx eq for floats #}
+    {% if field.repeated %}
+    for index in range(len(response.{{ field.name }})):
+        assert math.isclose(
+            response.{{ field.name }}[index],
+            {{ field.mock_value }}[index],
+            rel_tol=1e-6,
+        )
+    {% else %}{# field.repeated #}
+    assert math.isclose(response.{{ field.name }}, {{ field.mock_value }}, rel_tol=1e-6)
+    {% endif %}{# field.repeated #}
+    {% elif field.field_pb.type == 8 %}{# Use 'is' for bools #}
+    assert response.{{ field.name }} is {{ field.mock_value }}
+    {% else %}
+    assert response.{{ field.name }} == {{ field.mock_value }}
+    {% endif %}{# field.field_pb.type in [1, 2] #}
+    {% endif %}{# not field.oneof or field.proto3_optional #}
+
+    {% endfor %}{# field in method_output.fields.values() | rejectattr('message') #}
+    {% endif %}{# method.void #}
+
+{% endif %}{# if not (method.server_streaming or method.lro or method.extended_lro or method.paged_result_field) #}
 {% endif %}{# if 'rest' in transport #}
 {% endmacro %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -2083,8 +2083,8 @@ def test_initialize_client_w_{{transport_name}}():
  # (method.extended_lro and not full_extended_lro)
 #}
 {% set method_output = method.output %}
-{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2143): Update the guard below as support we add for each method. Remove it once we have
- # all the methods supported in async rest transport that are supported in sync rest transport.
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2143): Update the guard below as we add support for each method, and keep it in sync with the guard in
+ # `rest_required_tests`, which should be the exact opposite. Remove it once we have all the methods supported in async rest transport that are supported in sync rest transport.
  #}
 {% if not (method.server_streaming or method.lro or method.extended_lro or method.paged_result_field)%}
 {{async_decorator}}

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -10137,6 +10137,7 @@ def test_list_assets_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.ListAssetsResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -11605,6 +11606,7 @@ def test_search_all_resources_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.SearchAllResourcesResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -11913,6 +11915,7 @@ def test_search_all_iam_policies_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.SearchAllIamPoliciesResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -13289,6 +13292,7 @@ def test_list_saved_queries_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.ListSavedQueriesResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -14155,6 +14159,7 @@ def test_analyze_org_policies_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.AnalyzeOrgPoliciesResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -14474,6 +14479,7 @@ def test_analyze_org_policy_governed_containers_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -14793,6 +14799,7 @@ def test_analyze_org_policy_governed_assets_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -15279,7 +15286,6 @@ def test_batch_get_assets_history_rest_bad_request(request_type=asset_service.Ba
   asset_service.BatchGetAssetsHistoryRequest,
   dict,
 ])
-
 def test_batch_get_assets_history_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15299,12 +15305,14 @@ def test_batch_get_assets_history_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.BatchGetAssetsHistoryResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.batch_get_assets_history(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
 
@@ -15334,7 +15342,6 @@ def test_create_feed_rest_bad_request(request_type=asset_service.CreateFeedReque
   asset_service.CreateFeedRequest,
   dict,
 ])
-
 def test_create_feed_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15359,22 +15366,20 @@ def test_create_feed_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.Feed.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.create_feed(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.Feed)
     assert response.name == 'name_value'
-
     assert response.asset_names == ['asset_names_value']
-
     assert response.asset_types == ['asset_types_value']
-
     assert response.content_type == asset_service.ContentType.RESOURCE
-
     assert response.relationship_types == ['relationship_types_value']
 
 
@@ -15403,7 +15408,6 @@ def test_get_feed_rest_bad_request(request_type=asset_service.GetFeedRequest):
   asset_service.GetFeedRequest,
   dict,
 ])
-
 def test_get_feed_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15428,22 +15432,20 @@ def test_get_feed_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.Feed.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_feed(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.Feed)
     assert response.name == 'name_value'
-
     assert response.asset_names == ['asset_names_value']
-
     assert response.asset_types == ['asset_types_value']
-
     assert response.content_type == asset_service.ContentType.RESOURCE
-
     assert response.relationship_types == ['relationship_types_value']
 
 
@@ -15472,7 +15474,6 @@ def test_list_feeds_rest_bad_request(request_type=asset_service.ListFeedsRequest
   asset_service.ListFeedsRequest,
   dict,
 ])
-
 def test_list_feeds_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15492,12 +15493,14 @@ def test_list_feeds_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.ListFeedsResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.list_feeds(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.ListFeedsResponse)
 
@@ -15527,7 +15530,6 @@ def test_update_feed_rest_bad_request(request_type=asset_service.UpdateFeedReque
   asset_service.UpdateFeedRequest,
   dict,
 ])
-
 def test_update_feed_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15552,22 +15554,20 @@ def test_update_feed_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.Feed.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.update_feed(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.Feed)
     assert response.name == 'name_value'
-
     assert response.asset_names == ['asset_names_value']
-
     assert response.asset_types == ['asset_types_value']
-
     assert response.content_type == asset_service.ContentType.RESOURCE
-
     assert response.relationship_types == ['relationship_types_value']
 
 
@@ -15596,7 +15596,6 @@ def test_delete_feed_rest_bad_request(request_type=asset_service.DeleteFeedReque
   asset_service.DeleteFeedRequest,
   dict,
 ])
-
 def test_delete_feed_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15619,6 +15618,7 @@ def test_delete_feed_rest_call_success(request_type):
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.delete_feed(request)
+
     # Establish that the response is the type that we expect.
     assert response is None
 
@@ -15690,7 +15690,6 @@ def test_analyze_iam_policy_rest_bad_request(request_type=asset_service.AnalyzeI
   asset_service.AnalyzeIamPolicyRequest,
   dict,
 ])
-
 def test_analyze_iam_policy_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15711,12 +15710,14 @@ def test_analyze_iam_policy_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.AnalyzeIamPolicyResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.analyze_iam_policy(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
     assert response.fully_explored is True
@@ -15768,7 +15769,6 @@ def test_analyze_move_rest_bad_request(request_type=asset_service.AnalyzeMoveReq
   asset_service.AnalyzeMoveRequest,
   dict,
 ])
-
 def test_analyze_move_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15788,12 +15788,14 @@ def test_analyze_move_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.AnalyzeMoveResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.analyze_move(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.AnalyzeMoveResponse)
 
@@ -15823,7 +15825,6 @@ def test_query_assets_rest_bad_request(request_type=asset_service.QueryAssetsReq
   asset_service.QueryAssetsRequest,
   dict,
 ])
-
 def test_query_assets_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15845,16 +15846,17 @@ def test_query_assets_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.QueryAssetsResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.query_assets(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.QueryAssetsResponse)
     assert response.job_reference == 'job_reference_value'
-
     assert response.done is True
 
 
@@ -15883,7 +15885,6 @@ def test_create_saved_query_rest_bad_request(request_type=asset_service.CreateSa
   asset_service.CreateSavedQueryRequest,
   dict,
 ])
-
 def test_create_saved_query_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15892,6 +15893,70 @@ def test_create_saved_query_rest_call_success(request_type):
 
     # send a request that will satisfy transcoding
     request_init = {'parent': 'sample1/sample2'}
+    request_init["saved_query"] = {'name': 'name_value', 'description': 'description_value', 'create_time': {'seconds': 751, 'nanos': 543}, 'creator': 'creator_value', 'last_update_time': {}, 'last_updater': 'last_updater_value', 'labels': {}, 'content': {'iam_policy_analysis_query': {'scope': 'scope_value', 'resource_selector': {'full_resource_name': 'full_resource_name_value'}, 'identity_selector': {'identity': 'identity_value'}, 'access_selector': {'roles': ['roles_value1', 'roles_value2'], 'permissions': ['permissions_value1', 'permissions_value2']}, 'options': {'expand_groups': True, 'expand_roles': True, 'expand_resources': True, 'output_resource_edges': True, 'output_group_edges': True, 'analyze_service_account_impersonation': True}, 'condition_context': {'access_time': {}}}}}
+    # The version of a generated dependency at test runtime may differ from the version used during generation.
+    # Delete any fields which are not present in the current runtime dependency
+    # See https://github.com/googleapis/gapic-generator-python/issues/1748
+
+    # Determine if the message type is proto-plus or protobuf
+    test_field = asset_service.CreateSavedQueryRequest.meta.fields["saved_query"]
+
+    def get_message_fields(field):
+        # Given a field which is a message (composite type), return a list with
+        # all the fields of the message.
+        # If the field is not a composite type, return an empty list.
+        message_fields = []
+
+        if hasattr(field, "message") and field.message:
+            is_field_type_proto_plus_type = not hasattr(field.message, "DESCRIPTOR")
+
+            if is_field_type_proto_plus_type:
+                message_fields = field.message.meta.fields.values()
+            # Add `# pragma: NO COVER` because there may not be any `*_pb2` field types
+            else: # pragma: NO COVER
+                message_fields = field.message.DESCRIPTOR.fields
+        return message_fields
+
+    runtime_nested_fields = [
+        (field.name, nested_field.name)
+        for field in get_message_fields(test_field)
+        for nested_field in get_message_fields(field)
+    ]
+
+    subfields_not_in_runtime = []
+
+    # For each item in the sample request, create a list of sub fields which are not present at runtime
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for field, value in request_init["saved_query"].items(): # pragma: NO COVER
+        result = None
+        is_repeated = False
+        # For repeated fields
+        if isinstance(value, list) and len(value):
+            is_repeated = True
+            result = value[0]
+        # For fields where the type is another message
+        if isinstance(value, dict):
+            result = value
+
+        if result and hasattr(result, "keys"):
+            for subfield in result.keys():
+                if (field, subfield) not in runtime_nested_fields:
+                    subfields_not_in_runtime.append(
+                        {"field": field, "subfield": subfield, "is_repeated": is_repeated}
+                    )
+
+    # Remove fields from the sample request which are not present in the runtime version of the dependency
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for subfield_to_delete in subfields_not_in_runtime: # pragma: NO COVER
+        field = subfield_to_delete.get("field")
+        field_repeated = subfield_to_delete.get("is_repeated")
+        subfield = subfield_to_delete.get("subfield")
+        if subfield:
+            if field_repeated:
+                for i in range(0, len(request_init["saved_query"][field])):
+                    del request_init["saved_query"][field][i][subfield]
+            else:
+                del request_init["saved_query"][field][subfield]
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -15907,20 +15972,19 @@ def test_create_saved_query_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.SavedQuery.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.create_saved_query(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.SavedQuery)
     assert response.name == 'name_value'
-
     assert response.description == 'description_value'
-
     assert response.creator == 'creator_value'
-
     assert response.last_updater == 'last_updater_value'
 
 
@@ -15949,7 +16013,6 @@ def test_get_saved_query_rest_bad_request(request_type=asset_service.GetSavedQue
   asset_service.GetSavedQueryRequest,
   dict,
 ])
-
 def test_get_saved_query_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15973,20 +16036,19 @@ def test_get_saved_query_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.SavedQuery.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_saved_query(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.SavedQuery)
     assert response.name == 'name_value'
-
     assert response.description == 'description_value'
-
     assert response.creator == 'creator_value'
-
     assert response.last_updater == 'last_updater_value'
 
 
@@ -16036,7 +16098,6 @@ def test_update_saved_query_rest_bad_request(request_type=asset_service.UpdateSa
   asset_service.UpdateSavedQueryRequest,
   dict,
 ])
-
 def test_update_saved_query_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16045,6 +16106,70 @@ def test_update_saved_query_rest_call_success(request_type):
 
     # send a request that will satisfy transcoding
     request_init = {'saved_query': {'name': 'sample1/sample2/savedQueries/sample3'}}
+    request_init["saved_query"] = {'name': 'sample1/sample2/savedQueries/sample3', 'description': 'description_value', 'create_time': {'seconds': 751, 'nanos': 543}, 'creator': 'creator_value', 'last_update_time': {}, 'last_updater': 'last_updater_value', 'labels': {}, 'content': {'iam_policy_analysis_query': {'scope': 'scope_value', 'resource_selector': {'full_resource_name': 'full_resource_name_value'}, 'identity_selector': {'identity': 'identity_value'}, 'access_selector': {'roles': ['roles_value1', 'roles_value2'], 'permissions': ['permissions_value1', 'permissions_value2']}, 'options': {'expand_groups': True, 'expand_roles': True, 'expand_resources': True, 'output_resource_edges': True, 'output_group_edges': True, 'analyze_service_account_impersonation': True}, 'condition_context': {'access_time': {}}}}}
+    # The version of a generated dependency at test runtime may differ from the version used during generation.
+    # Delete any fields which are not present in the current runtime dependency
+    # See https://github.com/googleapis/gapic-generator-python/issues/1748
+
+    # Determine if the message type is proto-plus or protobuf
+    test_field = asset_service.UpdateSavedQueryRequest.meta.fields["saved_query"]
+
+    def get_message_fields(field):
+        # Given a field which is a message (composite type), return a list with
+        # all the fields of the message.
+        # If the field is not a composite type, return an empty list.
+        message_fields = []
+
+        if hasattr(field, "message") and field.message:
+            is_field_type_proto_plus_type = not hasattr(field.message, "DESCRIPTOR")
+
+            if is_field_type_proto_plus_type:
+                message_fields = field.message.meta.fields.values()
+            # Add `# pragma: NO COVER` because there may not be any `*_pb2` field types
+            else: # pragma: NO COVER
+                message_fields = field.message.DESCRIPTOR.fields
+        return message_fields
+
+    runtime_nested_fields = [
+        (field.name, nested_field.name)
+        for field in get_message_fields(test_field)
+        for nested_field in get_message_fields(field)
+    ]
+
+    subfields_not_in_runtime = []
+
+    # For each item in the sample request, create a list of sub fields which are not present at runtime
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for field, value in request_init["saved_query"].items(): # pragma: NO COVER
+        result = None
+        is_repeated = False
+        # For repeated fields
+        if isinstance(value, list) and len(value):
+            is_repeated = True
+            result = value[0]
+        # For fields where the type is another message
+        if isinstance(value, dict):
+            result = value
+
+        if result and hasattr(result, "keys"):
+            for subfield in result.keys():
+                if (field, subfield) not in runtime_nested_fields:
+                    subfields_not_in_runtime.append(
+                        {"field": field, "subfield": subfield, "is_repeated": is_repeated}
+                    )
+
+    # Remove fields from the sample request which are not present in the runtime version of the dependency
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for subfield_to_delete in subfields_not_in_runtime: # pragma: NO COVER
+        field = subfield_to_delete.get("field")
+        field_repeated = subfield_to_delete.get("is_repeated")
+        subfield = subfield_to_delete.get("subfield")
+        if subfield:
+            if field_repeated:
+                for i in range(0, len(request_init["saved_query"][field])):
+                    del request_init["saved_query"][field][i][subfield]
+            else:
+                del request_init["saved_query"][field][subfield]
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -16060,20 +16185,19 @@ def test_update_saved_query_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.SavedQuery.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.update_saved_query(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.SavedQuery)
     assert response.name == 'name_value'
-
     assert response.description == 'description_value'
-
     assert response.creator == 'creator_value'
-
     assert response.last_updater == 'last_updater_value'
 
 
@@ -16102,7 +16226,6 @@ def test_delete_saved_query_rest_bad_request(request_type=asset_service.DeleteSa
   asset_service.DeleteSavedQueryRequest,
   dict,
 ])
-
 def test_delete_saved_query_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16125,6 +16248,7 @@ def test_delete_saved_query_rest_call_success(request_type):
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.delete_saved_query(request)
+
     # Establish that the response is the type that we expect.
     assert response is None
 
@@ -16154,7 +16278,6 @@ def test_batch_get_effective_iam_policies_rest_bad_request(request_type=asset_se
   asset_service.BatchGetEffectiveIamPoliciesRequest,
   dict,
 ])
-
 def test_batch_get_effective_iam_policies_rest_call_success(request_type):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16174,12 +16297,14 @@ def test_batch_get_effective_iam_policies_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = asset_service.BatchGetEffectiveIamPoliciesResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.batch_get_effective_iam_policies(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
 

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -10417,40 +10417,6 @@ def test_list_assets_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.BatchGetAssetsHistoryRequest,
-    dict,
-])
-def test_batch_get_assets_history_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'parent': 'sample1/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.BatchGetAssetsHistoryResponse(
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.BatchGetAssetsHistoryResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.batch_get_assets_history(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
-
 def test_batch_get_assets_history_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -10603,50 +10569,6 @@ def test_batch_get_assets_history_rest_interceptors(null_interceptor):
         pre.assert_called_once()
         post.assert_called_once()
 
-
-@pytest.mark.parametrize("request_type", [
-    asset_service.CreateFeedRequest,
-    dict,
-])
-def test_create_feed_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'parent': 'sample1/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.Feed(
-              name='name_value',
-              asset_names=['asset_names_value'],
-              asset_types=['asset_types_value'],
-              content_type=asset_service.ContentType.RESOURCE,
-              relationship_types=['relationship_types_value'],
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.Feed.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.create_feed(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.Feed)
-    assert response.name == 'name_value'
-    assert response.asset_names == ['asset_names_value']
-    assert response.asset_types == ['asset_types_value']
-    assert response.content_type == asset_service.ContentType.RESOURCE
-    assert response.relationship_types == ['relationship_types_value']
 
 def test_create_feed_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -10857,50 +10779,6 @@ def test_create_feed_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.GetFeedRequest,
-    dict,
-])
-def test_get_feed_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'sample1/sample2/feeds/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.Feed(
-              name='name_value',
-              asset_names=['asset_names_value'],
-              asset_types=['asset_types_value'],
-              content_type=asset_service.ContentType.RESOURCE,
-              relationship_types=['relationship_types_value'],
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.Feed.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_feed(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.Feed)
-    assert response.name == 'name_value'
-    assert response.asset_names == ['asset_names_value']
-    assert response.asset_types == ['asset_types_value']
-    assert response.content_type == asset_service.ContentType.RESOURCE
-    assert response.relationship_types == ['relationship_types_value']
-
 def test_get_feed_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -11104,40 +10982,6 @@ def test_get_feed_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    asset_service.ListFeedsRequest,
-    dict,
-])
-def test_list_feeds_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'parent': 'sample1/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.ListFeedsResponse(
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.ListFeedsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.list_feeds(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.ListFeedsResponse)
 
 def test_list_feeds_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -11343,50 +11187,6 @@ def test_list_feeds_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.UpdateFeedRequest,
-    dict,
-])
-def test_update_feed_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'feed': {'name': 'sample1/sample2/feeds/sample3'}}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.Feed(
-              name='name_value',
-              asset_names=['asset_names_value'],
-              asset_types=['asset_types_value'],
-              content_type=asset_service.ContentType.RESOURCE,
-              relationship_types=['relationship_types_value'],
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.Feed.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.update_feed(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.Feed)
-    assert response.name == 'name_value'
-    assert response.asset_names == ['asset_names_value']
-    assert response.asset_types == ['asset_types_value']
-    assert response.content_type == asset_service.ContentType.RESOURCE
-    assert response.relationship_types == ['relationship_types_value']
-
 def test_update_feed_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -11586,37 +11386,6 @@ def test_update_feed_rest_flattened_error(transport: str = 'rest'):
             feed=asset_service.Feed(name='name_value'),
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    asset_service.DeleteFeedRequest,
-    dict,
-])
-def test_delete_feed_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'sample1/sample2/feeds/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = None
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        json_return_value = ''
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.delete_feed(request)
-
-    # Establish that the response is the type that we expect.
-    assert response is None
 
 def test_delete_feed_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -12426,42 +12195,6 @@ def test_search_all_iam_policies_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.AnalyzeIamPolicyRequest,
-    dict,
-])
-def test_analyze_iam_policy_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'analysis_query': {'scope': 'sample1/sample2'}}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.AnalyzeIamPolicyResponse(
-              fully_explored=True,
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.AnalyzeIamPolicyResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.analyze_iam_policy(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
-    assert response.fully_explored is True
-
 def test_analyze_iam_policy_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -12790,40 +12523,6 @@ def test_analyze_iam_policy_longrunning_rest_interceptors(null_interceptor):
         post.assert_called_once()
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.AnalyzeMoveRequest,
-    dict,
-])
-def test_analyze_move_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'resource': 'sample1/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.AnalyzeMoveResponse(
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.AnalyzeMoveResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.analyze_move(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.AnalyzeMoveResponse)
-
 def test_analyze_move_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -12988,44 +12687,6 @@ def test_analyze_move_rest_interceptors(null_interceptor):
         post.assert_called_once()
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.QueryAssetsRequest,
-    dict,
-])
-def test_query_assets_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'parent': 'sample1/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.QueryAssetsResponse(
-              job_reference='job_reference_value',
-              done=True,
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.QueryAssetsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.query_assets(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.QueryAssetsResponse)
-    assert response.job_reference == 'job_reference_value'
-    assert response.done is True
-
 def test_query_assets_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -13177,112 +12838,6 @@ def test_query_assets_rest_interceptors(null_interceptor):
         pre.assert_called_once()
         post.assert_called_once()
 
-
-@pytest.mark.parametrize("request_type", [
-    asset_service.CreateSavedQueryRequest,
-    dict,
-])
-def test_create_saved_query_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'parent': 'sample1/sample2'}
-    request_init["saved_query"] = {'name': 'name_value', 'description': 'description_value', 'create_time': {'seconds': 751, 'nanos': 543}, 'creator': 'creator_value', 'last_update_time': {}, 'last_updater': 'last_updater_value', 'labels': {}, 'content': {'iam_policy_analysis_query': {'scope': 'scope_value', 'resource_selector': {'full_resource_name': 'full_resource_name_value'}, 'identity_selector': {'identity': 'identity_value'}, 'access_selector': {'roles': ['roles_value1', 'roles_value2'], 'permissions': ['permissions_value1', 'permissions_value2']}, 'options': {'expand_groups': True, 'expand_roles': True, 'expand_resources': True, 'output_resource_edges': True, 'output_group_edges': True, 'analyze_service_account_impersonation': True}, 'condition_context': {'access_time': {}}}}}
-    # The version of a generated dependency at test runtime may differ from the version used during generation.
-    # Delete any fields which are not present in the current runtime dependency
-    # See https://github.com/googleapis/gapic-generator-python/issues/1748
-
-    # Determine if the message type is proto-plus or protobuf
-    test_field = asset_service.CreateSavedQueryRequest.meta.fields["saved_query"]
-
-    def get_message_fields(field):
-        # Given a field which is a message (composite type), return a list with
-        # all the fields of the message.
-        # If the field is not a composite type, return an empty list.
-        message_fields = []
-
-        if hasattr(field, "message") and field.message:
-            is_field_type_proto_plus_type = not hasattr(field.message, "DESCRIPTOR")
-
-            if is_field_type_proto_plus_type:
-                message_fields = field.message.meta.fields.values()
-            # Add `# pragma: NO COVER` because there may not be any `*_pb2` field types
-            else: # pragma: NO COVER
-                message_fields = field.message.DESCRIPTOR.fields
-        return message_fields
-
-    runtime_nested_fields = [
-        (field.name, nested_field.name)
-        for field in get_message_fields(test_field)
-        for nested_field in get_message_fields(field)
-    ]
-
-    subfields_not_in_runtime = []
-
-    # For each item in the sample request, create a list of sub fields which are not present at runtime
-    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
-    for field, value in request_init["saved_query"].items(): # pragma: NO COVER
-        result = None
-        is_repeated = False
-        # For repeated fields
-        if isinstance(value, list) and len(value):
-            is_repeated = True
-            result = value[0]
-        # For fields where the type is another message
-        if isinstance(value, dict):
-            result = value
-
-        if result and hasattr(result, "keys"):
-            for subfield in result.keys():
-                if (field, subfield) not in runtime_nested_fields:
-                    subfields_not_in_runtime.append(
-                        {"field": field, "subfield": subfield, "is_repeated": is_repeated}
-                    )
-
-    # Remove fields from the sample request which are not present in the runtime version of the dependency
-    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
-    for subfield_to_delete in subfields_not_in_runtime: # pragma: NO COVER
-        field = subfield_to_delete.get("field")
-        field_repeated = subfield_to_delete.get("is_repeated")
-        subfield = subfield_to_delete.get("subfield")
-        if subfield:
-            if field_repeated:
-                for i in range(0, len(request_init["saved_query"][field])):
-                    del request_init["saved_query"][field][i][subfield]
-            else:
-                del request_init["saved_query"][field][subfield]
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.SavedQuery(
-              name='name_value',
-              description='description_value',
-              creator='creator_value',
-              last_updater='last_updater_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.SavedQuery.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.create_saved_query(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.SavedQuery)
-    assert response.name == 'name_value'
-    assert response.description == 'description_value'
-    assert response.creator == 'creator_value'
-    assert response.last_updater == 'last_updater_value'
 
 def test_create_saved_query_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -13505,48 +13060,6 @@ def test_create_saved_query_rest_flattened_error(transport: str = 'rest'):
             saved_query_id='saved_query_id_value',
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    asset_service.GetSavedQueryRequest,
-    dict,
-])
-def test_get_saved_query_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'sample1/sample2/savedQueries/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.SavedQuery(
-              name='name_value',
-              description='description_value',
-              creator='creator_value',
-              last_updater='last_updater_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.SavedQuery.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_saved_query(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.SavedQuery)
-    assert response.name == 'name_value'
-    assert response.description == 'description_value'
-    assert response.creator == 'creator_value'
-    assert response.last_updater == 'last_updater_value'
 
 def test_get_saved_query_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -14056,112 +13569,6 @@ def test_list_saved_queries_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.UpdateSavedQueryRequest,
-    dict,
-])
-def test_update_saved_query_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'saved_query': {'name': 'sample1/sample2/savedQueries/sample3'}}
-    request_init["saved_query"] = {'name': 'sample1/sample2/savedQueries/sample3', 'description': 'description_value', 'create_time': {'seconds': 751, 'nanos': 543}, 'creator': 'creator_value', 'last_update_time': {}, 'last_updater': 'last_updater_value', 'labels': {}, 'content': {'iam_policy_analysis_query': {'scope': 'scope_value', 'resource_selector': {'full_resource_name': 'full_resource_name_value'}, 'identity_selector': {'identity': 'identity_value'}, 'access_selector': {'roles': ['roles_value1', 'roles_value2'], 'permissions': ['permissions_value1', 'permissions_value2']}, 'options': {'expand_groups': True, 'expand_roles': True, 'expand_resources': True, 'output_resource_edges': True, 'output_group_edges': True, 'analyze_service_account_impersonation': True}, 'condition_context': {'access_time': {}}}}}
-    # The version of a generated dependency at test runtime may differ from the version used during generation.
-    # Delete any fields which are not present in the current runtime dependency
-    # See https://github.com/googleapis/gapic-generator-python/issues/1748
-
-    # Determine if the message type is proto-plus or protobuf
-    test_field = asset_service.UpdateSavedQueryRequest.meta.fields["saved_query"]
-
-    def get_message_fields(field):
-        # Given a field which is a message (composite type), return a list with
-        # all the fields of the message.
-        # If the field is not a composite type, return an empty list.
-        message_fields = []
-
-        if hasattr(field, "message") and field.message:
-            is_field_type_proto_plus_type = not hasattr(field.message, "DESCRIPTOR")
-
-            if is_field_type_proto_plus_type:
-                message_fields = field.message.meta.fields.values()
-            # Add `# pragma: NO COVER` because there may not be any `*_pb2` field types
-            else: # pragma: NO COVER
-                message_fields = field.message.DESCRIPTOR.fields
-        return message_fields
-
-    runtime_nested_fields = [
-        (field.name, nested_field.name)
-        for field in get_message_fields(test_field)
-        for nested_field in get_message_fields(field)
-    ]
-
-    subfields_not_in_runtime = []
-
-    # For each item in the sample request, create a list of sub fields which are not present at runtime
-    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
-    for field, value in request_init["saved_query"].items(): # pragma: NO COVER
-        result = None
-        is_repeated = False
-        # For repeated fields
-        if isinstance(value, list) and len(value):
-            is_repeated = True
-            result = value[0]
-        # For fields where the type is another message
-        if isinstance(value, dict):
-            result = value
-
-        if result and hasattr(result, "keys"):
-            for subfield in result.keys():
-                if (field, subfield) not in runtime_nested_fields:
-                    subfields_not_in_runtime.append(
-                        {"field": field, "subfield": subfield, "is_repeated": is_repeated}
-                    )
-
-    # Remove fields from the sample request which are not present in the runtime version of the dependency
-    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
-    for subfield_to_delete in subfields_not_in_runtime: # pragma: NO COVER
-        field = subfield_to_delete.get("field")
-        field_repeated = subfield_to_delete.get("is_repeated")
-        subfield = subfield_to_delete.get("subfield")
-        if subfield:
-            if field_repeated:
-                for i in range(0, len(request_init["saved_query"][field])):
-                    del request_init["saved_query"][field][i][subfield]
-            else:
-                del request_init["saved_query"][field][subfield]
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.SavedQuery(
-              name='name_value',
-              description='description_value',
-              creator='creator_value',
-              last_updater='last_updater_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.SavedQuery.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.update_saved_query(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.SavedQuery)
-    assert response.name == 'name_value'
-    assert response.description == 'description_value'
-    assert response.creator == 'creator_value'
-    assert response.last_updater == 'last_updater_value'
-
 def test_update_saved_query_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -14366,37 +13773,6 @@ def test_update_saved_query_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    asset_service.DeleteSavedQueryRequest,
-    dict,
-])
-def test_delete_saved_query_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'sample1/sample2/savedQueries/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = None
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        json_return_value = ''
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.delete_saved_query(request)
-
-    # Establish that the response is the type that we expect.
-    assert response is None
-
 def test_delete_saved_query_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -14590,40 +13966,6 @@ def test_delete_saved_query_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    asset_service.BatchGetEffectiveIamPoliciesRequest,
-    dict,
-])
-def test_batch_get_effective_iam_policies_rest(request_type):
-    client = AssetServiceClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'scope': 'sample1/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse(
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.batch_get_effective_iam_policies(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
 
 def test_batch_get_effective_iam_policies_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -15933,6 +15275,40 @@ def test_batch_get_assets_history_rest_bad_request(request_type=asset_service.Ba
         client.batch_get_assets_history(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.BatchGetAssetsHistoryRequest,
+  dict,
+])
+
+def test_batch_get_assets_history_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'parent': 'sample1/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.BatchGetAssetsHistoryResponse(
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.BatchGetAssetsHistoryResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.batch_get_assets_history(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
+
+
 def test_create_feed_rest_bad_request(request_type=asset_service.CreateFeedRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15952,6 +15328,54 @@ def test_create_feed_rest_bad_request(request_type=asset_service.CreateFeedReque
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.create_feed(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  asset_service.CreateFeedRequest,
+  dict,
+])
+
+def test_create_feed_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'parent': 'sample1/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.Feed(
+              name='name_value',
+              asset_names=['asset_names_value'],
+              asset_types=['asset_types_value'],
+              content_type=asset_service.ContentType.RESOURCE,
+              relationship_types=['relationship_types_value'],
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.Feed.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.create_feed(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.Feed)
+    assert response.name == 'name_value'
+
+    assert response.asset_names == ['asset_names_value']
+
+    assert response.asset_types == ['asset_types_value']
+
+    assert response.content_type == asset_service.ContentType.RESOURCE
+
+    assert response.relationship_types == ['relationship_types_value']
 
 
 def test_get_feed_rest_bad_request(request_type=asset_service.GetFeedRequest):
@@ -15975,6 +15399,54 @@ def test_get_feed_rest_bad_request(request_type=asset_service.GetFeedRequest):
         client.get_feed(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.GetFeedRequest,
+  dict,
+])
+
+def test_get_feed_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'sample1/sample2/feeds/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.Feed(
+              name='name_value',
+              asset_names=['asset_names_value'],
+              asset_types=['asset_types_value'],
+              content_type=asset_service.ContentType.RESOURCE,
+              relationship_types=['relationship_types_value'],
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.Feed.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_feed(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.Feed)
+    assert response.name == 'name_value'
+
+    assert response.asset_names == ['asset_names_value']
+
+    assert response.asset_types == ['asset_types_value']
+
+    assert response.content_type == asset_service.ContentType.RESOURCE
+
+    assert response.relationship_types == ['relationship_types_value']
+
+
 def test_list_feeds_rest_bad_request(request_type=asset_service.ListFeedsRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -15994,6 +15466,40 @@ def test_list_feeds_rest_bad_request(request_type=asset_service.ListFeedsRequest
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.list_feeds(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  asset_service.ListFeedsRequest,
+  dict,
+])
+
+def test_list_feeds_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'parent': 'sample1/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.ListFeedsResponse(
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.ListFeedsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.list_feeds(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.ListFeedsResponse)
 
 
 def test_update_feed_rest_bad_request(request_type=asset_service.UpdateFeedRequest):
@@ -16017,6 +15523,54 @@ def test_update_feed_rest_bad_request(request_type=asset_service.UpdateFeedReque
         client.update_feed(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.UpdateFeedRequest,
+  dict,
+])
+
+def test_update_feed_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'feed': {'name': 'sample1/sample2/feeds/sample3'}}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.Feed(
+              name='name_value',
+              asset_names=['asset_names_value'],
+              asset_types=['asset_types_value'],
+              content_type=asset_service.ContentType.RESOURCE,
+              relationship_types=['relationship_types_value'],
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.Feed.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.update_feed(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.Feed)
+    assert response.name == 'name_value'
+
+    assert response.asset_names == ['asset_names_value']
+
+    assert response.asset_types == ['asset_types_value']
+
+    assert response.content_type == asset_service.ContentType.RESOURCE
+
+    assert response.relationship_types == ['relationship_types_value']
+
+
 def test_delete_feed_rest_bad_request(request_type=asset_service.DeleteFeedRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16036,6 +15590,37 @@ def test_delete_feed_rest_bad_request(request_type=asset_service.DeleteFeedReque
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.delete_feed(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  asset_service.DeleteFeedRequest,
+  dict,
+])
+
+def test_delete_feed_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'sample1/sample2/feeds/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = None
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        json_return_value = ''
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.delete_feed(request)
+    # Establish that the response is the type that we expect.
+    assert response is None
 
 
 def test_search_all_resources_rest_bad_request(request_type=asset_service.SearchAllResourcesRequest):
@@ -16101,6 +15686,42 @@ def test_analyze_iam_policy_rest_bad_request(request_type=asset_service.AnalyzeI
         client.analyze_iam_policy(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.AnalyzeIamPolicyRequest,
+  dict,
+])
+
+def test_analyze_iam_policy_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'analysis_query': {'scope': 'sample1/sample2'}}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.AnalyzeIamPolicyResponse(
+              fully_explored=True,
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.AnalyzeIamPolicyResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.analyze_iam_policy(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
+    assert response.fully_explored is True
+
+
 def test_analyze_iam_policy_longrunning_rest_bad_request(request_type=asset_service.AnalyzeIamPolicyLongrunningRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16143,6 +15764,40 @@ def test_analyze_move_rest_bad_request(request_type=asset_service.AnalyzeMoveReq
         client.analyze_move(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.AnalyzeMoveRequest,
+  dict,
+])
+
+def test_analyze_move_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'resource': 'sample1/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.AnalyzeMoveResponse(
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.AnalyzeMoveResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.analyze_move(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.AnalyzeMoveResponse)
+
+
 def test_query_assets_rest_bad_request(request_type=asset_service.QueryAssetsRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16162,6 +15817,45 @@ def test_query_assets_rest_bad_request(request_type=asset_service.QueryAssetsReq
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.query_assets(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  asset_service.QueryAssetsRequest,
+  dict,
+])
+
+def test_query_assets_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'parent': 'sample1/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.QueryAssetsResponse(
+              job_reference='job_reference_value',
+              done=True,
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.QueryAssetsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.query_assets(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.QueryAssetsResponse)
+    assert response.job_reference == 'job_reference_value'
+
+    assert response.done is True
 
 
 def test_create_saved_query_rest_bad_request(request_type=asset_service.CreateSavedQueryRequest):
@@ -16185,6 +15879,51 @@ def test_create_saved_query_rest_bad_request(request_type=asset_service.CreateSa
         client.create_saved_query(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.CreateSavedQueryRequest,
+  dict,
+])
+
+def test_create_saved_query_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'parent': 'sample1/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.SavedQuery(
+              name='name_value',
+              description='description_value',
+              creator='creator_value',
+              last_updater='last_updater_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.SavedQuery.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.create_saved_query(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.SavedQuery)
+    assert response.name == 'name_value'
+
+    assert response.description == 'description_value'
+
+    assert response.creator == 'creator_value'
+
+    assert response.last_updater == 'last_updater_value'
+
+
 def test_get_saved_query_rest_bad_request(request_type=asset_service.GetSavedQueryRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16204,6 +15943,51 @@ def test_get_saved_query_rest_bad_request(request_type=asset_service.GetSavedQue
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.get_saved_query(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  asset_service.GetSavedQueryRequest,
+  dict,
+])
+
+def test_get_saved_query_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'sample1/sample2/savedQueries/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.SavedQuery(
+              name='name_value',
+              description='description_value',
+              creator='creator_value',
+              last_updater='last_updater_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.SavedQuery.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_saved_query(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.SavedQuery)
+    assert response.name == 'name_value'
+
+    assert response.description == 'description_value'
+
+    assert response.creator == 'creator_value'
+
+    assert response.last_updater == 'last_updater_value'
 
 
 def test_list_saved_queries_rest_bad_request(request_type=asset_service.ListSavedQueriesRequest):
@@ -16248,6 +16032,51 @@ def test_update_saved_query_rest_bad_request(request_type=asset_service.UpdateSa
         client.update_saved_query(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.UpdateSavedQueryRequest,
+  dict,
+])
+
+def test_update_saved_query_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'saved_query': {'name': 'sample1/sample2/savedQueries/sample3'}}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.SavedQuery(
+              name='name_value',
+              description='description_value',
+              creator='creator_value',
+              last_updater='last_updater_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.SavedQuery.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.update_saved_query(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.SavedQuery)
+    assert response.name == 'name_value'
+
+    assert response.description == 'description_value'
+
+    assert response.creator == 'creator_value'
+
+    assert response.last_updater == 'last_updater_value'
+
+
 def test_delete_saved_query_rest_bad_request(request_type=asset_service.DeleteSavedQueryRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16269,6 +16098,37 @@ def test_delete_saved_query_rest_bad_request(request_type=asset_service.DeleteSa
         client.delete_saved_query(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  asset_service.DeleteSavedQueryRequest,
+  dict,
+])
+
+def test_delete_saved_query_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'sample1/sample2/savedQueries/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = None
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        json_return_value = ''
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.delete_saved_query(request)
+    # Establish that the response is the type that we expect.
+    assert response is None
+
+
 def test_batch_get_effective_iam_policies_rest_bad_request(request_type=asset_service.BatchGetEffectiveIamPoliciesRequest):
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -16288,6 +16148,40 @@ def test_batch_get_effective_iam_policies_rest_bad_request(request_type=asset_se
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.batch_get_effective_iam_policies(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  asset_service.BatchGetEffectiveIamPoliciesRequest,
+  dict,
+])
+
+def test_batch_get_effective_iam_policies_rest_call_success(request_type):
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'scope': 'sample1/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse(
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.batch_get_effective_iam_policies(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
 
 
 def test_analyze_org_policies_rest_bad_request(request_type=asset_service.AnalyzeOrgPoliciesRequest):

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3316,6 +3316,7 @@ def test_generate_access_token_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = common.GenerateAccessTokenResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -3373,6 +3374,7 @@ def test_generate_id_token_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = common.GenerateIdTokenResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -3431,6 +3433,7 @@ def test_sign_blob_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = common.SignBlobResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -3441,7 +3444,6 @@ def test_sign_blob_rest_call_success(request_type):
     # Establish that the response is the type that we expect.
     assert isinstance(response, common.SignBlobResponse)
     assert response.key_id == 'key_id_value'
-
     assert response.signed_blob == b'signed_blob_blob'
 
 
@@ -3491,6 +3493,7 @@ def test_sign_jwt_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = common.SignJwtResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -3501,7 +3504,6 @@ def test_sign_jwt_rest_call_success(request_type):
     # Establish that the response is the type that we expect.
     assert isinstance(response, common.SignJwtResponse)
     assert response.key_id == 'key_id_value'
-
     assert response.signed_jwt == 'signed_jwt_value'
 
 

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -2291,42 +2291,6 @@ async def test_sign_jwt_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    common.GenerateAccessTokenRequest,
-    dict,
-])
-def test_generate_access_token_rest(request_type):
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = common.GenerateAccessTokenResponse(
-              access_token='access_token_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = common.GenerateAccessTokenResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.generate_access_token(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, common.GenerateAccessTokenResponse)
-    assert response.access_token == 'access_token_value'
-
 def test_generate_access_token_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -2541,42 +2505,6 @@ def test_generate_access_token_rest_flattened_error(transport: str = 'rest'):
             lifetime=duration_pb2.Duration(seconds=751),
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    common.GenerateIdTokenRequest,
-    dict,
-])
-def test_generate_id_token_rest(request_type):
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = common.GenerateIdTokenResponse(
-              token='token_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = common.GenerateIdTokenResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.generate_id_token(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, common.GenerateIdTokenResponse)
-    assert response.token == 'token_value'
 
 def test_generate_id_token_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -2793,44 +2721,6 @@ def test_generate_id_token_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    common.SignBlobRequest,
-    dict,
-])
-def test_sign_blob_rest(request_type):
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = common.SignBlobResponse(
-              key_id='key_id_value',
-              signed_blob=b'signed_blob_blob',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = common.SignBlobResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.sign_blob(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, common.SignBlobResponse)
-    assert response.key_id == 'key_id_value'
-    assert response.signed_blob == b'signed_blob_blob'
-
 def test_sign_blob_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -3043,44 +2933,6 @@ def test_sign_blob_rest_flattened_error(transport: str = 'rest'):
             payload=b'payload_blob',
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    common.SignJwtRequest,
-    dict,
-])
-def test_sign_jwt_rest(request_type):
-    client = IAMCredentialsClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = common.SignJwtResponse(
-              key_id='key_id_value',
-              signed_jwt='signed_jwt_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = common.SignJwtResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.sign_jwt(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, common.SignJwtResponse)
-    assert response.key_id == 'key_id_value'
-    assert response.signed_jwt == 'signed_jwt_value'
 
 def test_sign_jwt_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -3440,6 +3292,42 @@ def test_generate_access_token_rest_bad_request(request_type=common.GenerateAcce
         client.generate_access_token(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  common.GenerateAccessTokenRequest,
+  dict,
+])
+
+def test_generate_access_token_rest_call_success(request_type):
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = common.GenerateAccessTokenResponse(
+              access_token='access_token_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = common.GenerateAccessTokenResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.generate_access_token(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, common.GenerateAccessTokenResponse)
+    assert response.access_token == 'access_token_value'
+
+
 def test_generate_id_token_rest_bad_request(request_type=common.GenerateIdTokenRequest):
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -3459,6 +3347,42 @@ def test_generate_id_token_rest_bad_request(request_type=common.GenerateIdTokenR
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.generate_id_token(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  common.GenerateIdTokenRequest,
+  dict,
+])
+
+def test_generate_id_token_rest_call_success(request_type):
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = common.GenerateIdTokenResponse(
+              token='token_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = common.GenerateIdTokenResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.generate_id_token(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, common.GenerateIdTokenResponse)
+    assert response.token == 'token_value'
 
 
 def test_sign_blob_rest_bad_request(request_type=common.SignBlobRequest):
@@ -3482,6 +3406,45 @@ def test_sign_blob_rest_bad_request(request_type=common.SignBlobRequest):
         client.sign_blob(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  common.SignBlobRequest,
+  dict,
+])
+
+def test_sign_blob_rest_call_success(request_type):
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = common.SignBlobResponse(
+              key_id='key_id_value',
+              signed_blob=b'signed_blob_blob',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = common.SignBlobResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.sign_blob(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, common.SignBlobResponse)
+    assert response.key_id == 'key_id_value'
+
+    assert response.signed_blob == b'signed_blob_blob'
+
+
 def test_sign_jwt_rest_bad_request(request_type=common.SignJwtRequest):
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -3501,6 +3464,45 @@ def test_sign_jwt_rest_bad_request(request_type=common.SignJwtRequest):
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.sign_jwt(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  common.SignJwtRequest,
+  dict,
+])
+
+def test_sign_jwt_rest_call_success(request_type):
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/serviceAccounts/sample2'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = common.SignJwtResponse(
+              key_id='key_id_value',
+              signed_jwt='signed_jwt_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = common.SignJwtResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.sign_jwt(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, common.SignJwtResponse)
+    assert response.key_id == 'key_id_value'
+
+    assert response.signed_jwt == 'signed_jwt_value'
 
 
 def test_initialize_client_w_rest():

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3296,7 +3296,6 @@ def test_generate_access_token_rest_bad_request(request_type=common.GenerateAcce
   common.GenerateAccessTokenRequest,
   dict,
 ])
-
 def test_generate_access_token_rest_call_success(request_type):
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -3323,6 +3322,7 @@ def test_generate_access_token_rest_call_success(request_type):
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.generate_access_token(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, common.GenerateAccessTokenResponse)
     assert response.access_token == 'access_token_value'
@@ -3353,7 +3353,6 @@ def test_generate_id_token_rest_bad_request(request_type=common.GenerateIdTokenR
   common.GenerateIdTokenRequest,
   dict,
 ])
-
 def test_generate_id_token_rest_call_success(request_type):
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -3380,6 +3379,7 @@ def test_generate_id_token_rest_call_success(request_type):
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.generate_id_token(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, common.GenerateIdTokenResponse)
     assert response.token == 'token_value'
@@ -3410,7 +3410,6 @@ def test_sign_blob_rest_bad_request(request_type=common.SignBlobRequest):
   common.SignBlobRequest,
   dict,
 ])
-
 def test_sign_blob_rest_call_success(request_type):
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -3438,6 +3437,7 @@ def test_sign_blob_rest_call_success(request_type):
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.sign_blob(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, common.SignBlobResponse)
     assert response.key_id == 'key_id_value'
@@ -3470,7 +3470,6 @@ def test_sign_jwt_rest_bad_request(request_type=common.SignJwtRequest):
   common.SignJwtRequest,
   dict,
 ])
-
 def test_sign_jwt_rest_call_success(request_type):
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -3498,6 +3497,7 @@ def test_sign_jwt_rest_call_success(request_type):
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.sign_jwt(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, common.SignJwtResponse)
     assert response.key_id == 'key_id_value'

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -8432,6 +8432,7 @@ def test_list_triggers_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = eventarc.ListTriggersResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -9833,6 +9834,7 @@ def test_list_channels_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = eventarc.ListChannelsResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -11230,6 +11232,7 @@ def test_list_providers_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = eventarc.ListProvidersResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -11740,6 +11743,7 @@ def test_list_channel_connections_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = eventarc.ListChannelConnectionsResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -13130,7 +13134,6 @@ def test_get_trigger_rest_bad_request(request_type=eventarc.GetTriggerRequest):
   eventarc.GetTriggerRequest,
   dict,
 ])
-
 def test_get_trigger_rest_call_success(request_type):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13155,22 +13158,20 @@ def test_get_trigger_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = trigger.Trigger.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_trigger(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, trigger.Trigger)
     assert response.name == 'name_value'
-
     assert response.uid == 'uid_value'
-
     assert response.service_account == 'service_account_value'
-
     assert response.channel == 'channel_value'
-
     assert response.etag == 'etag_value'
 
 
@@ -13283,7 +13284,6 @@ def test_get_channel_rest_bad_request(request_type=eventarc.GetChannelRequest):
   eventarc.GetChannelRequest,
   dict,
 ])
-
 def test_get_channel_rest_call_success(request_type):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13310,24 +13310,21 @@ def test_get_channel_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = channel.Channel.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_channel(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, channel.Channel)
     assert response.name == 'name_value'
-
     assert response.uid == 'uid_value'
-
     assert response.provider == 'provider_value'
-
     assert response.state == channel.Channel.State.PENDING
-
     assert response.activation_token == 'activation_token_value'
-
     assert response.crypto_key_name == 'crypto_key_name_value'
 
 
@@ -13440,7 +13437,6 @@ def test_get_provider_rest_bad_request(request_type=eventarc.GetProviderRequest)
   eventarc.GetProviderRequest,
   dict,
 ])
-
 def test_get_provider_rest_call_success(request_type):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13462,16 +13458,17 @@ def test_get_provider_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = discovery.Provider.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_provider(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, discovery.Provider)
     assert response.name == 'name_value'
-
     assert response.display_name == 'display_name_value'
 
 
@@ -13521,7 +13518,6 @@ def test_get_channel_connection_rest_bad_request(request_type=eventarc.GetChanne
   eventarc.GetChannelConnectionRequest,
   dict,
 ])
-
 def test_get_channel_connection_rest_call_success(request_type):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13545,20 +13541,19 @@ def test_get_channel_connection_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = channel_connection.ChannelConnection.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_channel_connection(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, channel_connection.ChannelConnection)
     assert response.name == 'name_value'
-
     assert response.uid == 'uid_value'
-
     assert response.channel == 'channel_value'
-
     assert response.activation_token == 'activation_token_value'
 
 
@@ -13650,7 +13645,6 @@ def test_get_google_channel_config_rest_bad_request(request_type=eventarc.GetGoo
   eventarc.GetGoogleChannelConfigRequest,
   dict,
 ])
-
 def test_get_google_channel_config_rest_call_success(request_type):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13672,16 +13666,17 @@ def test_get_google_channel_config_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = google_channel_config.GoogleChannelConfig.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_google_channel_config(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, google_channel_config.GoogleChannelConfig)
     assert response.name == 'name_value'
-
     assert response.crypto_key_name == 'crypto_key_name_value'
 
 
@@ -13710,7 +13705,6 @@ def test_update_google_channel_config_rest_bad_request(request_type=eventarc.Upd
   eventarc.UpdateGoogleChannelConfigRequest,
   dict,
 ])
-
 def test_update_google_channel_config_rest_call_success(request_type):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13719,6 +13713,70 @@ def test_update_google_channel_config_rest_call_success(request_type):
 
     # send a request that will satisfy transcoding
     request_init = {'google_channel_config': {'name': 'projects/sample1/locations/sample2/googleChannelConfig'}}
+    request_init["google_channel_config"] = {'name': 'projects/sample1/locations/sample2/googleChannelConfig', 'update_time': {'seconds': 751, 'nanos': 543}, 'crypto_key_name': 'crypto_key_name_value'}
+    # The version of a generated dependency at test runtime may differ from the version used during generation.
+    # Delete any fields which are not present in the current runtime dependency
+    # See https://github.com/googleapis/gapic-generator-python/issues/1748
+
+    # Determine if the message type is proto-plus or protobuf
+    test_field = eventarc.UpdateGoogleChannelConfigRequest.meta.fields["google_channel_config"]
+
+    def get_message_fields(field):
+        # Given a field which is a message (composite type), return a list with
+        # all the fields of the message.
+        # If the field is not a composite type, return an empty list.
+        message_fields = []
+
+        if hasattr(field, "message") and field.message:
+            is_field_type_proto_plus_type = not hasattr(field.message, "DESCRIPTOR")
+
+            if is_field_type_proto_plus_type:
+                message_fields = field.message.meta.fields.values()
+            # Add `# pragma: NO COVER` because there may not be any `*_pb2` field types
+            else: # pragma: NO COVER
+                message_fields = field.message.DESCRIPTOR.fields
+        return message_fields
+
+    runtime_nested_fields = [
+        (field.name, nested_field.name)
+        for field in get_message_fields(test_field)
+        for nested_field in get_message_fields(field)
+    ]
+
+    subfields_not_in_runtime = []
+
+    # For each item in the sample request, create a list of sub fields which are not present at runtime
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for field, value in request_init["google_channel_config"].items(): # pragma: NO COVER
+        result = None
+        is_repeated = False
+        # For repeated fields
+        if isinstance(value, list) and len(value):
+            is_repeated = True
+            result = value[0]
+        # For fields where the type is another message
+        if isinstance(value, dict):
+            result = value
+
+        if result and hasattr(result, "keys"):
+            for subfield in result.keys():
+                if (field, subfield) not in runtime_nested_fields:
+                    subfields_not_in_runtime.append(
+                        {"field": field, "subfield": subfield, "is_repeated": is_repeated}
+                    )
+
+    # Remove fields from the sample request which are not present in the runtime version of the dependency
+    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
+    for subfield_to_delete in subfields_not_in_runtime: # pragma: NO COVER
+        field = subfield_to_delete.get("field")
+        field_repeated = subfield_to_delete.get("is_repeated")
+        subfield = subfield_to_delete.get("subfield")
+        if subfield:
+            if field_repeated:
+                for i in range(0, len(request_init["google_channel_config"][field])):
+                    del request_init["google_channel_config"][field][i][subfield]
+            else:
+                del request_init["google_channel_config"][field][subfield]
     request = request_type(**request_init)
 
     # Mock the http request call within the method and fake a response.
@@ -13732,16 +13790,17 @@ def test_update_google_channel_config_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = gce_google_channel_config.GoogleChannelConfig.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.update_google_channel_config(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
     assert response.name == 'name_value'
-
     assert response.crypto_key_name == 'crypto_key_name_value'
 
 

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -8203,50 +8203,6 @@ async def test_update_google_channel_config_flattened_error_async():
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    eventarc.GetTriggerRequest,
-    dict,
-])
-def test_get_trigger_rest(request_type):
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/locations/sample2/triggers/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = trigger.Trigger(
-              name='name_value',
-              uid='uid_value',
-              service_account='service_account_value',
-              channel='channel_value',
-              etag='etag_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = trigger.Trigger.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_trigger(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, trigger.Trigger)
-    assert response.name == 'name_value'
-    assert response.uid == 'uid_value'
-    assert response.service_account == 'service_account_value'
-    assert response.channel == 'channel_value'
-    assert response.etag == 'etag_value'
-
 def test_get_trigger_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -9648,53 +9604,6 @@ def test_delete_trigger_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    eventarc.GetChannelRequest,
-    dict,
-])
-def test_get_channel_rest(request_type):
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/locations/sample2/channels/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = channel.Channel(
-              name='name_value',
-              uid='uid_value',
-              provider='provider_value',
-              state=channel.Channel.State.PENDING,
-              activation_token='activation_token_value',
-              crypto_key_name='crypto_key_name_value',
-            pubsub_topic='pubsub_topic_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = channel.Channel.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_channel(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, channel.Channel)
-    assert response.name == 'name_value'
-    assert response.uid == 'uid_value'
-    assert response.provider == 'provider_value'
-    assert response.state == channel.Channel.State.PENDING
-    assert response.activation_token == 'activation_token_value'
-    assert response.crypto_key_name == 'crypto_key_name_value'
-
 def test_get_channel_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -11092,44 +11001,6 @@ def test_delete_channel_rest_flattened_error(transport: str = 'rest'):
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    eventarc.GetProviderRequest,
-    dict,
-])
-def test_get_provider_rest(request_type):
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/locations/sample2/providers/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = discovery.Provider(
-              name='name_value',
-              display_name='display_name_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = discovery.Provider.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_provider(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, discovery.Provider)
-    assert response.name == 'name_value'
-    assert response.display_name == 'display_name_value'
-
 def test_get_provider_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -11639,48 +11510,6 @@ def test_list_providers_rest_pager(transport: str = 'rest'):
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
 
-
-@pytest.mark.parametrize("request_type", [
-    eventarc.GetChannelConnectionRequest,
-    dict,
-])
-def test_get_channel_connection_rest(request_type):
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/locations/sample2/channelConnections/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = channel_connection.ChannelConnection(
-              name='name_value',
-              uid='uid_value',
-              channel='channel_value',
-              activation_token='activation_token_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = channel_connection.ChannelConnection.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_channel_connection(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, channel_connection.ChannelConnection)
-    assert response.name == 'name_value'
-    assert response.uid == 'uid_value'
-    assert response.channel == 'channel_value'
-    assert response.activation_token == 'activation_token_value'
 
 def test_get_channel_connection_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -12744,44 +12573,6 @@ def test_delete_channel_connection_rest_flattened_error(transport: str = 'rest')
         )
 
 
-@pytest.mark.parametrize("request_type", [
-    eventarc.GetGoogleChannelConfigRequest,
-    dict,
-])
-def test_get_google_channel_config_rest(request_type):
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/locations/sample2/googleChannelConfig'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = google_channel_config.GoogleChannelConfig(
-              name='name_value',
-              crypto_key_name='crypto_key_name_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = google_channel_config.GoogleChannelConfig.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_google_channel_config(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, google_channel_config.GoogleChannelConfig)
-    assert response.name == 'name_value'
-    assert response.crypto_key_name == 'crypto_key_name_value'
-
 def test_get_google_channel_config_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -12985,108 +12776,6 @@ def test_get_google_channel_config_rest_flattened_error(transport: str = 'rest')
             name='name_value',
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    eventarc.UpdateGoogleChannelConfigRequest,
-    dict,
-])
-def test_update_google_channel_config_rest(request_type):
-    client = EventarcClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'google_channel_config': {'name': 'projects/sample1/locations/sample2/googleChannelConfig'}}
-    request_init["google_channel_config"] = {'name': 'projects/sample1/locations/sample2/googleChannelConfig', 'update_time': {'seconds': 751, 'nanos': 543}, 'crypto_key_name': 'crypto_key_name_value'}
-    # The version of a generated dependency at test runtime may differ from the version used during generation.
-    # Delete any fields which are not present in the current runtime dependency
-    # See https://github.com/googleapis/gapic-generator-python/issues/1748
-
-    # Determine if the message type is proto-plus or protobuf
-    test_field = eventarc.UpdateGoogleChannelConfigRequest.meta.fields["google_channel_config"]
-
-    def get_message_fields(field):
-        # Given a field which is a message (composite type), return a list with
-        # all the fields of the message.
-        # If the field is not a composite type, return an empty list.
-        message_fields = []
-
-        if hasattr(field, "message") and field.message:
-            is_field_type_proto_plus_type = not hasattr(field.message, "DESCRIPTOR")
-
-            if is_field_type_proto_plus_type:
-                message_fields = field.message.meta.fields.values()
-            # Add `# pragma: NO COVER` because there may not be any `*_pb2` field types
-            else: # pragma: NO COVER
-                message_fields = field.message.DESCRIPTOR.fields
-        return message_fields
-
-    runtime_nested_fields = [
-        (field.name, nested_field.name)
-        for field in get_message_fields(test_field)
-        for nested_field in get_message_fields(field)
-    ]
-
-    subfields_not_in_runtime = []
-
-    # For each item in the sample request, create a list of sub fields which are not present at runtime
-    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
-    for field, value in request_init["google_channel_config"].items(): # pragma: NO COVER
-        result = None
-        is_repeated = False
-        # For repeated fields
-        if isinstance(value, list) and len(value):
-            is_repeated = True
-            result = value[0]
-        # For fields where the type is another message
-        if isinstance(value, dict):
-            result = value
-
-        if result and hasattr(result, "keys"):
-            for subfield in result.keys():
-                if (field, subfield) not in runtime_nested_fields:
-                    subfields_not_in_runtime.append(
-                        {"field": field, "subfield": subfield, "is_repeated": is_repeated}
-                    )
-
-    # Remove fields from the sample request which are not present in the runtime version of the dependency
-    # Add `# pragma: NO COVER` because this test code will not run if all subfields are present at runtime
-    for subfield_to_delete in subfields_not_in_runtime: # pragma: NO COVER
-        field = subfield_to_delete.get("field")
-        field_repeated = subfield_to_delete.get("is_repeated")
-        subfield = subfield_to_delete.get("subfield")
-        if subfield:
-            if field_repeated:
-                for i in range(0, len(request_init["google_channel_config"][field])):
-                    del request_init["google_channel_config"][field][i][subfield]
-            else:
-                del request_init["google_channel_config"][field][subfield]
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = gce_google_channel_config.GoogleChannelConfig(
-              name='name_value',
-              crypto_key_name='crypto_key_name_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = gce_google_channel_config.GoogleChannelConfig.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.update_google_channel_config(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
-    assert response.name == 'name_value'
-    assert response.crypto_key_name == 'crypto_key_name_value'
 
 def test_update_google_channel_config_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -13437,6 +13126,54 @@ def test_get_trigger_rest_bad_request(request_type=eventarc.GetTriggerRequest):
         client.get_trigger(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  eventarc.GetTriggerRequest,
+  dict,
+])
+
+def test_get_trigger_rest_call_success(request_type):
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/locations/sample2/triggers/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = trigger.Trigger(
+              name='name_value',
+              uid='uid_value',
+              service_account='service_account_value',
+              channel='channel_value',
+              etag='etag_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = trigger.Trigger.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_trigger(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, trigger.Trigger)
+    assert response.name == 'name_value'
+
+    assert response.uid == 'uid_value'
+
+    assert response.service_account == 'service_account_value'
+
+    assert response.channel == 'channel_value'
+
+    assert response.etag == 'etag_value'
+
+
 def test_list_triggers_rest_bad_request(request_type=eventarc.ListTriggersRequest):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13540,6 +13277,58 @@ def test_get_channel_rest_bad_request(request_type=eventarc.GetChannelRequest):
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.get_channel(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  eventarc.GetChannelRequest,
+  dict,
+])
+
+def test_get_channel_rest_call_success(request_type):
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/locations/sample2/channels/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = channel.Channel(
+              name='name_value',
+              uid='uid_value',
+              provider='provider_value',
+              state=channel.Channel.State.PENDING,
+              activation_token='activation_token_value',
+              crypto_key_name='crypto_key_name_value',
+            pubsub_topic='pubsub_topic_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = channel.Channel.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_channel(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, channel.Channel)
+    assert response.name == 'name_value'
+
+    assert response.uid == 'uid_value'
+
+    assert response.provider == 'provider_value'
+
+    assert response.state == channel.Channel.State.PENDING
+
+    assert response.activation_token == 'activation_token_value'
+
+    assert response.crypto_key_name == 'crypto_key_name_value'
 
 
 def test_list_channels_rest_bad_request(request_type=eventarc.ListChannelsRequest):
@@ -13647,6 +13436,45 @@ def test_get_provider_rest_bad_request(request_type=eventarc.GetProviderRequest)
         client.get_provider(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  eventarc.GetProviderRequest,
+  dict,
+])
+
+def test_get_provider_rest_call_success(request_type):
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/locations/sample2/providers/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = discovery.Provider(
+              name='name_value',
+              display_name='display_name_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = discovery.Provider.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_provider(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, discovery.Provider)
+    assert response.name == 'name_value'
+
+    assert response.display_name == 'display_name_value'
+
+
 def test_list_providers_rest_bad_request(request_type=eventarc.ListProvidersRequest):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13687,6 +13515,51 @@ def test_get_channel_connection_rest_bad_request(request_type=eventarc.GetChanne
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.get_channel_connection(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  eventarc.GetChannelConnectionRequest,
+  dict,
+])
+
+def test_get_channel_connection_rest_call_success(request_type):
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/locations/sample2/channelConnections/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = channel_connection.ChannelConnection(
+              name='name_value',
+              uid='uid_value',
+              channel='channel_value',
+              activation_token='activation_token_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = channel_connection.ChannelConnection.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_channel_connection(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, channel_connection.ChannelConnection)
+    assert response.name == 'name_value'
+
+    assert response.uid == 'uid_value'
+
+    assert response.channel == 'channel_value'
+
+    assert response.activation_token == 'activation_token_value'
 
 
 def test_list_channel_connections_rest_bad_request(request_type=eventarc.ListChannelConnectionsRequest):
@@ -13773,6 +13646,45 @@ def test_get_google_channel_config_rest_bad_request(request_type=eventarc.GetGoo
         client.get_google_channel_config(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  eventarc.GetGoogleChannelConfigRequest,
+  dict,
+])
+
+def test_get_google_channel_config_rest_call_success(request_type):
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/locations/sample2/googleChannelConfig'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = google_channel_config.GoogleChannelConfig(
+              name='name_value',
+              crypto_key_name='crypto_key_name_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = google_channel_config.GoogleChannelConfig.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_google_channel_config(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, google_channel_config.GoogleChannelConfig)
+    assert response.name == 'name_value'
+
+    assert response.crypto_key_name == 'crypto_key_name_value'
+
+
 def test_update_google_channel_config_rest_bad_request(request_type=eventarc.UpdateGoogleChannelConfigRequest):
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -13792,6 +13704,45 @@ def test_update_google_channel_config_rest_bad_request(request_type=eventarc.Upd
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.update_google_channel_config(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  eventarc.UpdateGoogleChannelConfigRequest,
+  dict,
+])
+
+def test_update_google_channel_config_rest_call_success(request_type):
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'google_channel_config': {'name': 'projects/sample1/locations/sample2/googleChannelConfig'}}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = gce_google_channel_config.GoogleChannelConfig(
+              name='name_value',
+              crypto_key_name='crypto_key_name_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = gce_google_channel_config.GoogleChannelConfig.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.update_google_channel_config(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
+    assert response.name == 'name_value'
+
+    assert response.crypto_key_name == 'crypto_key_name_value'
 
 
 def test_initialize_client_w_rest():

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -5167,6 +5167,7 @@ def test_list_instances_rest(request_type):
         # Wrap the value into a proper Response obj
         response_value = Response()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = cloud_redis.ListInstancesResponse.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
@@ -8073,7 +8074,6 @@ def test_get_instance_rest_bad_request(request_type=cloud_redis.GetInstanceReque
   cloud_redis.GetInstanceRequest,
   dict,
 ])
-
 def test_get_instance_rest_call_success(request_type):
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -8120,66 +8120,42 @@ def test_get_instance_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = cloud_redis.Instance.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_instance(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, cloud_redis.Instance)
     assert response.name == 'name_value'
-
     assert response.display_name == 'display_name_value'
-
     assert response.location_id == 'location_id_value'
-
     assert response.alternative_location_id == 'alternative_location_id_value'
-
     assert response.redis_version == 'redis_version_value'
-
     assert response.reserved_ip_range == 'reserved_ip_range_value'
-
     assert response.secondary_ip_range == 'secondary_ip_range_value'
-
     assert response.host == 'host_value'
-
     assert response.port == 453
-
     assert response.current_location_id == 'current_location_id_value'
-
     assert response.state == cloud_redis.Instance.State.CREATING
-
     assert response.status_message == 'status_message_value'
-
     assert response.tier == cloud_redis.Instance.Tier.BASIC
-
     assert response.memory_size_gb == 1499
-
     assert response.authorized_network == 'authorized_network_value'
-
     assert response.persistence_iam_identity == 'persistence_iam_identity_value'
-
     assert response.connect_mode == cloud_redis.Instance.ConnectMode.DIRECT_PEERING
-
     assert response.auth_enabled is True
-
     assert response.transit_encryption_mode == cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION
-
     assert response.replica_count == 1384
-
     assert response.read_endpoint == 'read_endpoint_value'
-
     assert response.read_endpoint_port == 1920
-
     assert response.read_replicas_mode == cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED
-
     assert response.customer_managed_key == 'customer_managed_key_value'
-
     assert response.suspension_reasons == [cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE]
-
     assert response.maintenance_version == 'maintenance_version_value'
-
     assert response.available_maintenance_versions == ['available_maintenance_versions_value']
 
 
@@ -8208,7 +8184,6 @@ def test_get_instance_auth_string_rest_bad_request(request_type=cloud_redis.GetI
   cloud_redis.GetInstanceAuthStringRequest,
   dict,
 ])
-
 def test_get_instance_auth_string_rest_call_success(request_type):
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -8229,12 +8204,14 @@ def test_get_instance_auth_string_rest_call_success(request_type):
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+
         # Convert return value to protobuf type
         return_value = cloud_redis.InstanceAuthString.pb(return_value)
         json_return_value = json_format.MessageToJson(return_value)
         response_value.content = json_return_value.encode('UTF-8')
         req.return_value = response_value
         response = client.get_instance_auth_string(request)
+
     # Establish that the response is the type that we expect.
     assert isinstance(response, cloud_redis.InstanceAuthString)
     assert response.auth_string == 'auth_string_value'

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -5448,94 +5448,6 @@ def test_list_instances_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
-@pytest.mark.parametrize("request_type", [
-    cloud_redis.GetInstanceRequest,
-    dict,
-])
-def test_get_instance_rest(request_type):
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/locations/sample2/instances/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = cloud_redis.Instance(
-              name='name_value',
-              display_name='display_name_value',
-              location_id='location_id_value',
-              alternative_location_id='alternative_location_id_value',
-              redis_version='redis_version_value',
-              reserved_ip_range='reserved_ip_range_value',
-              secondary_ip_range='secondary_ip_range_value',
-              host='host_value',
-              port=453,
-              current_location_id='current_location_id_value',
-              state=cloud_redis.Instance.State.CREATING,
-              status_message='status_message_value',
-              tier=cloud_redis.Instance.Tier.BASIC,
-              memory_size_gb=1499,
-              authorized_network='authorized_network_value',
-              persistence_iam_identity='persistence_iam_identity_value',
-              connect_mode=cloud_redis.Instance.ConnectMode.DIRECT_PEERING,
-              auth_enabled=True,
-              transit_encryption_mode=cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION,
-              replica_count=1384,
-              read_endpoint='read_endpoint_value',
-              read_endpoint_port=1920,
-              read_replicas_mode=cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED,
-              customer_managed_key='customer_managed_key_value',
-              suspension_reasons=[cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE],
-              maintenance_version='maintenance_version_value',
-              available_maintenance_versions=['available_maintenance_versions_value'],
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = cloud_redis.Instance.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_instance(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, cloud_redis.Instance)
-    assert response.name == 'name_value'
-    assert response.display_name == 'display_name_value'
-    assert response.location_id == 'location_id_value'
-    assert response.alternative_location_id == 'alternative_location_id_value'
-    assert response.redis_version == 'redis_version_value'
-    assert response.reserved_ip_range == 'reserved_ip_range_value'
-    assert response.secondary_ip_range == 'secondary_ip_range_value'
-    assert response.host == 'host_value'
-    assert response.port == 453
-    assert response.current_location_id == 'current_location_id_value'
-    assert response.state == cloud_redis.Instance.State.CREATING
-    assert response.status_message == 'status_message_value'
-    assert response.tier == cloud_redis.Instance.Tier.BASIC
-    assert response.memory_size_gb == 1499
-    assert response.authorized_network == 'authorized_network_value'
-    assert response.persistence_iam_identity == 'persistence_iam_identity_value'
-    assert response.connect_mode == cloud_redis.Instance.ConnectMode.DIRECT_PEERING
-    assert response.auth_enabled is True
-    assert response.transit_encryption_mode == cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION
-    assert response.replica_count == 1384
-    assert response.read_endpoint == 'read_endpoint_value'
-    assert response.read_endpoint_port == 1920
-    assert response.read_replicas_mode == cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED
-    assert response.customer_managed_key == 'customer_managed_key_value'
-    assert response.suspension_reasons == [cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE]
-    assert response.maintenance_version == 'maintenance_version_value'
-    assert response.available_maintenance_versions == ['available_maintenance_versions_value']
-
 def test_get_instance_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -5739,42 +5651,6 @@ def test_get_instance_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
         )
 
-
-@pytest.mark.parametrize("request_type", [
-    cloud_redis.GetInstanceAuthStringRequest,
-    dict,
-])
-def test_get_instance_auth_string_rest(request_type):
-    client = CloudRedisClient(
-        credentials=ga_credentials.AnonymousCredentials(),
-        transport="rest",
-    )
-
-    # send a request that will satisfy transcoding
-    request_init = {'name': 'projects/sample1/locations/sample2/instances/sample3'}
-    request = request_type(**request_init)
-
-    # Mock the http request call within the method and fake a response.
-    with mock.patch.object(type(client.transport._session), 'request') as req:
-        # Designate an appropriate value for the returned response.
-        return_value = cloud_redis.InstanceAuthString(
-              auth_string='auth_string_value',
-        )
-
-        # Wrap the value into a proper Response obj
-        response_value = Response()
-        response_value.status_code = 200
-        # Convert return value to protobuf type
-        return_value = cloud_redis.InstanceAuthString.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        response_value._content = json_return_value.encode('UTF-8')
-        req.return_value = response_value
-        response = client.get_instance_auth_string(request)
-
-    # Establish that the response is the type that we expect.
-    assert isinstance(response, cloud_redis.InstanceAuthString)
-    assert response.auth_string == 'auth_string_value'
 
 def test_get_instance_auth_string_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
@@ -8193,6 +8069,120 @@ def test_get_instance_rest_bad_request(request_type=cloud_redis.GetInstanceReque
         client.get_instance(request)
 
 
+@pytest.mark.parametrize("request_type", [
+  cloud_redis.GetInstanceRequest,
+  dict,
+])
+
+def test_get_instance_rest_call_success(request_type):
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/locations/sample2/instances/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = cloud_redis.Instance(
+              name='name_value',
+              display_name='display_name_value',
+              location_id='location_id_value',
+              alternative_location_id='alternative_location_id_value',
+              redis_version='redis_version_value',
+              reserved_ip_range='reserved_ip_range_value',
+              secondary_ip_range='secondary_ip_range_value',
+              host='host_value',
+              port=453,
+              current_location_id='current_location_id_value',
+              state=cloud_redis.Instance.State.CREATING,
+              status_message='status_message_value',
+              tier=cloud_redis.Instance.Tier.BASIC,
+              memory_size_gb=1499,
+              authorized_network='authorized_network_value',
+              persistence_iam_identity='persistence_iam_identity_value',
+              connect_mode=cloud_redis.Instance.ConnectMode.DIRECT_PEERING,
+              auth_enabled=True,
+              transit_encryption_mode=cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION,
+              replica_count=1384,
+              read_endpoint='read_endpoint_value',
+              read_endpoint_port=1920,
+              read_replicas_mode=cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED,
+              customer_managed_key='customer_managed_key_value',
+              suspension_reasons=[cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE],
+              maintenance_version='maintenance_version_value',
+              available_maintenance_versions=['available_maintenance_versions_value'],
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = cloud_redis.Instance.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_instance(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, cloud_redis.Instance)
+    assert response.name == 'name_value'
+
+    assert response.display_name == 'display_name_value'
+
+    assert response.location_id == 'location_id_value'
+
+    assert response.alternative_location_id == 'alternative_location_id_value'
+
+    assert response.redis_version == 'redis_version_value'
+
+    assert response.reserved_ip_range == 'reserved_ip_range_value'
+
+    assert response.secondary_ip_range == 'secondary_ip_range_value'
+
+    assert response.host == 'host_value'
+
+    assert response.port == 453
+
+    assert response.current_location_id == 'current_location_id_value'
+
+    assert response.state == cloud_redis.Instance.State.CREATING
+
+    assert response.status_message == 'status_message_value'
+
+    assert response.tier == cloud_redis.Instance.Tier.BASIC
+
+    assert response.memory_size_gb == 1499
+
+    assert response.authorized_network == 'authorized_network_value'
+
+    assert response.persistence_iam_identity == 'persistence_iam_identity_value'
+
+    assert response.connect_mode == cloud_redis.Instance.ConnectMode.DIRECT_PEERING
+
+    assert response.auth_enabled is True
+
+    assert response.transit_encryption_mode == cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION
+
+    assert response.replica_count == 1384
+
+    assert response.read_endpoint == 'read_endpoint_value'
+
+    assert response.read_endpoint_port == 1920
+
+    assert response.read_replicas_mode == cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED
+
+    assert response.customer_managed_key == 'customer_managed_key_value'
+
+    assert response.suspension_reasons == [cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE]
+
+    assert response.maintenance_version == 'maintenance_version_value'
+
+    assert response.available_maintenance_versions == ['available_maintenance_versions_value']
+
+
 def test_get_instance_auth_string_rest_bad_request(request_type=cloud_redis.GetInstanceAuthStringRequest):
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -8212,6 +8202,42 @@ def test_get_instance_auth_string_rest_bad_request(request_type=cloud_redis.GetI
         response_value.request = mock.Mock()
         req.return_value = response_value
         client.get_instance_auth_string(request)
+
+
+@pytest.mark.parametrize("request_type", [
+  cloud_redis.GetInstanceAuthStringRequest,
+  dict,
+])
+
+def test_get_instance_auth_string_rest_call_success(request_type):
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest"
+    )
+
+    # send a request that will satisfy transcoding
+    request_init = {'name': 'projects/sample1/locations/sample2/instances/sample3'}
+    request = request_type(**request_init)
+
+    # Mock the http request call within the method and fake a response.
+    with mock.patch.object(type(client.transport._session), 'request') as req:
+        # Designate an appropriate value for the returned response.
+        return_value = cloud_redis.InstanceAuthString(
+              auth_string='auth_string_value',
+        )
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        # Convert return value to protobuf type
+        return_value = cloud_redis.InstanceAuthString.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+        response_value.content = json_return_value.encode('UTF-8')
+        req.return_value = response_value
+        response = client.get_instance_auth_string(request)
+    # Establish that the response is the type that we expect.
+    assert isinstance(response, cloud_redis.InstanceAuthString)
+    assert response.auth_string == 'auth_string_value'
 
 
 def test_create_instance_rest_bad_request(request_type=cloud_redis.CreateInstanceRequest):


### PR DESCRIPTION
This PR refactors the macro for testing a rest method success call.

For now, the macro is guarded and only generates tests for sync REST methods. Once we implement the relevant logic in async rest, the guard can be removed. (This will be addressed in a follow up PR.)

This PR should be reviewed and merged after: https://github.com/googleapis/gapic-generator-python/pull/2141.