### PR TITLE
chore: add failsafe check for gRPC

### DIFF
--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1959,10 +1959,12 @@ def test_unsupported_parameter_rest_asyncio():
 {% if is_rest_unsupported_method(method, is_async) == 'True' or not method.http_options %}
 {{ rest_method_not_implemented_error(service, method, transport, is_async) }}
 {% else %}
+{% if 'rest' in transport %}
 {{ bad_request_test(service, method, transport, is_async) }}
 {{ call_success_test(service, method, transport, is_async) }}
+{% endif %}{# if 'rest' in transport #}
 {% endif %}{# is_rest_unsupported_method(method, is_async) == 'False' and method.http_options #}
-{% endfor %}
+{% endfor %}{# for method in service.methods.values() #}
 {{ initialize_client_with_transport_test(service, transport, is_async) }}
 {% endmacro %}
 
@@ -2021,10 +2023,8 @@ def test_initialize_client_w_{{transport_name}}():
 
 {# bad_request_test generates tests for rest methods
  # which raise a google.api.core.exceptions.BadRequest error.
- # TODO(https://github.com/googleapis/gapic-generator-python/issues/2157): Refactor this macro to include `gRPC` coverage.
 #}
 {% macro bad_request_test(service, method, transport, is_async) %}
-{% if 'rest' in transport %}
 {% set await_prefix = get_await_prefix(is_async) %}
 {% set async_prefix = get_async_prefix(is_async) %}
 {% set async_decorator = get_async_decorator(is_async) %}
@@ -2033,6 +2033,10 @@ def test_initialize_client_w_{{transport_name}}():
 {% set mocked_session = "AsyncAuthorizedSession" if is_async else "Session" %}
 {{ async_decorator }}
 {{ async_prefix }}def test_{{ method_name }}_{{transport_name}}_bad_request(request_type={{ method.input.ident }}):
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2157): Refactor this macro to include `gRPC` coverage. #}
+{% if 'grpc' in transport %}
+    raise NotImplementedError("gRPC is currently not supported for this test case.")
+{% else %}{# 'rest' in transport #}
     {% if transport_name == 'rest_asyncio' %}
     if not HAS_GOOGLE_AUTH_AIO:
         {# TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged. #}
@@ -2062,7 +2066,7 @@ def test_initialize_client_w_{{transport_name}}():
         req.return_value = response_value
         {{ await_prefix }}client.{{ method_name }}(request)
 
-{% endif %}{# if 'rest' in transport #}
+{% endif %}{# if 'grpc' in transport #}
 {% endmacro %}
 
 {# call_success_test generates tests for rest methods
@@ -2073,7 +2077,6 @@ def test_initialize_client_w_{{transport_name}}():
  # TODO(https://github.com/googleapis/gapic-generator-python/issues/2142): Clean up `rest_required_tests` as we add support for each of the method types metioned above.
 #}
 {% macro call_success_test(service, method, transport, is_async) %}
-{% if 'rest' in transport %}
 {% set await_prefix = get_await_prefix(is_async) %}
 {% set async_prefix = get_async_prefix(is_async) %}
 {% set async_decorator = get_async_decorator(is_async) %}
@@ -2093,6 +2096,10 @@ def test_initialize_client_w_{{transport_name}}():
   dict,
 ])
 {{async_prefix}}def test_{{method_name}}_{{transport_name}}_call_success(request_type):
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2157): Refactor this macro to include `gRPC` coverage. #}
+{% if 'grpc' in transport %}
+    raise NotImplementedError("gRPC is currently not supported for this test case.")
+{% else %}{# 'rest' in transport #}
     {% if transport_name == 'rest_asyncio' %}
     if not HAS_GOOGLE_AUTH_AIO:
         {# TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged. #}
@@ -2265,5 +2272,5 @@ def test_initialize_client_w_{{transport_name}}():
     {% endif %}{# method.void #}
 
 {% endif %}{# if not (method.server_streaming or method.lro or method.extended_lro or method.paged_result_field) #}
-{% endif %}{# if 'rest' in transport #}
+{% endif %}{# if 'grpc' in transport #}
 {% endmacro %}


### PR DESCRIPTION
This PR adds a failsafe check to ensure that test macros aren't incorrectly called for a gRPC transport without making the necessary updates.
