### PR TITLE
test: add routing parameter and empty call test for REST

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,8 +105,3 @@ switched_rules_by_language(
     gapic = True,
     grpc = True,
 )
-load("@rules_python//python:repositories.bzl", "python_register_toolchains")
-python_register_toolchains(
-    name = "python39",
-    python_version = "3.9",
-)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -105,3 +105,8 @@ switched_rules_by_language(
     gapic = True,
     grpc = True,
 )
+load("@rules_python//python:repositories.bzl", "python_register_toolchains")
+python_register_toolchains(
+    name = "python39",
+    python_version = "3.9",
+)

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1478,27 +1478,7 @@ def test_{{ method_name }}_rest_no_http_options():
     # Mock the actual call, and fake the request.
     {% if 'rest' in transport %}
     with mock.patch.object(
-            type(client.transport.{{ method.transport_safe_name|snake_case }}),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        {% if method.void %}
-        return_value = None
-        json_return_value = ''
-        {% elif method.lro %}
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-        {% else %}
-        return_value = {{ method.output.ident }}()
-        {% if method.output.ident.is_proto_plus_type %}
-        # Convert return value to protobuf type
-        return_value = {{ method.output.ident }}.pb(return_value)
-        {% endif %}
-        json_return_value = json_format.MessageToJson(return_value)
-        {% endif %}
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.{{ method.transport_safe_name|snake_case }}), '__call__') as call:
     {% else %}{# gRPC #}
     with mock.patch.object(
             type(client.transport.{{ method.transport_safe_name|snake_case }}),

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1466,6 +1466,10 @@ def test_{{ method_name }}_rest_no_http_options():
 @pytest.mark.asyncio
 {% endif %}{# is_async #}
 {{ async_method_prefix }}def test_{{ method_name }}_{{ test_name }}_{{transport_name}}():
+    {% if transport_name == 'rest_asyncio' %}
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    {% endif %}
     client = {{ get_client(service=service, is_async=is_async) }}(
         credentials={{ get_credentials(is_async=is_async) }},
         transport="{{ transport_name }}",

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -2193,7 +2193,7 @@ def test_initialize_client_w_{{transport_name}}():
 {# Any value that is part of the HTTP/1.1 URI should be sent as #}
 {# a field header. Set these to a non-empty value. #}
 {% for routing_param in method.routing_rule.routing_parameters %}
-{{ method_call_test_generic("routing_parameters_request_" + loop.index|string, method, service, api, transport, request_dict=routing_param.sample_request,is_async=is_async, routing_param=routing_param) }}
+{{ method_call_test_generic("routing_parameters_request_" + loop.index|string, method, service, api, transport, request_dict=routing_param.sample_request, is_async=is_async, routing_param=routing_param) }}
 {% endfor %}{# routing_param in method.routing_rule.routing_parameters #}
 {% endif %}{# method.explicit_routing #}
 {% endfor %}{# method in service.methods.values() #}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1504,7 +1504,6 @@ def test_{{ method_name }}_rest_no_http_options():
             {% endfor %}
         ))
         {% endif %}{# method.void #}
-        await client.{{ method_name }}(request={{ request_dict }})
         {% else %}{# if not is_async #}
         {% if method.void %}
         call.return_value = None
@@ -1515,10 +1514,8 @@ def test_{{ method_name }}_rest_no_http_options():
         {% else %}
         call.return_value = {{ method.output.ident }}()
         {% endif %}
-        client.{{ method_name }}(request={{ request_dict }})
         {% endif %}{# is_async #}
     {% endif %}{# if 'rest' not in transport #}
-
         {% if is_async %}
         await client.{{ method_name }}(request={{ request_dict }})
         {% else %}{# is_async #}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1479,7 +1479,7 @@ def test_{{ method_name }}_rest_no_http_options():
     with mock.patch.object(
             type(client.transport.{{ method.transport_safe_name|snake_case }}),
             '__call__') as call:
-    {% else %}{# gRPC #}
+    {% if 'rest' not in transport %}
         {% if is_async %}
         # Designate an appropriate return value for the call.
         {% if method.void %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1476,13 +1476,10 @@ def test_{{ method_name }}_rest_no_http_options():
     )
 
     # Mock the actual call, and fake the request.
-    {% if 'rest' in transport %}
-    with mock.patch.object(
-            type(client.transport.{{ method.transport_safe_name|snake_case }}), '__call__') as call:
-    {% else %}{# gRPC #}
     with mock.patch.object(
             type(client.transport.{{ method.transport_safe_name|snake_case }}),
             '__call__') as call:
+    {% else %}{# gRPC #}
         {% if is_async %}
         # Designate an appropriate return value for the call.
         {% if method.void %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1517,7 +1517,7 @@ def test_{{ method_name }}_rest_no_http_options():
         {% endif %}
         client.{{ method_name }}(request={{ request_dict }})
         {% endif %}{# is_async #}
-    {% endif %}{# if 'rest' in transport #}
+    {% endif %}{# if 'rest' not in transport #}
 
         {% if is_async %}
         await client.{{ method_name }}(request={{ request_dict }})

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1468,9 +1468,34 @@ def test_{{ method_name }}_rest_no_http_options():
 {{ async_method_prefix }}def test_{{ method_name }}_{{ test_name }}_{{transport_name}}():
     client = {{ get_client(service=service, is_async=is_async) }}(
         credentials={{ get_credentials(is_async=is_async) }},
+        transport="{{ transport_name }}",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
+    {% if 'rest' in transport %}
+    with mock.patch.object(
+            type(client.transport.{{ method.transport_safe_name|snake_case }}),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        {% if method.void %}
+        return_value = None
+        json_return_value = ''
+        {% elif method.lro %}
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+        {% else %}
+        return_value = {{ method.output.ident }}()
+        {% if method.output.ident.is_proto_plus_type %}
+        # Convert return value to protobuf type
+        return_value = {{ method.output.ident }}.pb(return_value)
+        {% endif %}
+        json_return_value = json_format.MessageToJson(return_value)
+        {% endif %}
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+    {% else %}{# gRPC #}
     with mock.patch.object(
             type(client.transport.{{ method.transport_safe_name|snake_case }}),
             '__call__') as call:
@@ -1511,8 +1536,15 @@ def test_{{ method_name }}_rest_no_http_options():
         {% endif %}
         client.{{ method_name }}(request={{ request_dict }})
         {% endif %}{# is_async #}
+    {% endif %}{# if 'rest' in transport #}
 
-        # Establish that the underlying gRPC stub method was called.
+        {% if is_async %}
+        await client.{{ method_name }}(request={{ request_dict }})
+        {% else %}{# is_async #}
+        client.{{ method_name }}(request={{ request_dict }})
+        {% endif %}{# is_async #}
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, {% if routing_param %}kw{% else %}_{% endif %} = call.mock_calls[0]
         {% with method_settings = api.all_method_settings.get(method.meta.address.proto) %}
@@ -2142,11 +2174,6 @@ def test_initialize_client_w_{{transport_name}}():
 {% endmacro %}{# call_success_mixins_test #}
 
 {% macro empty_call_test(service, api, transport, is_async) %}
-{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2159): 
-  Currently this macro only supports gRPC. It should be updated to support REST
-  transport as well.
-#}
-{% if 'rest' not in transport %}
 {% for method in service.methods.values() %}{# method #}
 {% if not method.client_streaming %}
 # This test is a coverage failsafe to make sure that totally empty calls,
@@ -2154,7 +2181,6 @@ def test_initialize_client_w_{{transport_name}}():
 {{ method_call_test_generic("empty_call", method, service, api, transport, request_dict=None, is_async=is_async) }}
 {% endif %}{# not method.client_streaming #}
 {% endfor %}{# method in service.methods.values() #}
-{% endif %}{# 'rest' not in transport #}
 {% endmacro %}{# empty_call_test #}
 
 {% macro get_uuid4_re() -%}
@@ -2162,21 +2188,15 @@ def test_initialize_client_w_{{transport_name}}():
 {%- endmacro %}{# uuid_re #}
 
 {% macro routing_parameter_test(service, api, transport, is_async) %}
-{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2159):
-  Currently this macro only supports gRPC. It should be updated to support REST
-  transport as well.
-#}
-{% if 'rest' not in transport %}
 {% for method in service.methods.values() %}{# method #}
 {% if method.explicit_routing %}
 {# Any value that is part of the HTTP/1.1 URI should be sent as #}
 {# a field header. Set these to a non-empty value. #}
 {% for routing_param in method.routing_rule.routing_parameters %}
-{{ method_call_test_generic("routing_parameters_request_" + loop.index|string, method, service, api, transport, request_dict=routing_param.sample_request, is_async=is_async, routing_param=routing_param) }}
+{{ method_call_test_generic("routing_parameters_request_" + loop.index|string, method, service, api, transport, request_dict=routing_param.sample_request,is_async=is_async, routing_param=routing_param) }}
 {% endfor %}{# routing_param in method.routing_rule.routing_parameters #}
 {% endif %}{# method.explicit_routing #}
 {% endfor %}{# method in service.methods.values() #}
-{% endif %}
 {% endmacro %}{# routing_parameter_test #}
 
 {# inteceptor_class_test generates tests for rest interceptors. #}
@@ -2269,4 +2289,4 @@ def test_initialize_client_w_{{transport_name}}():
         post.assert_called_once()
         {% endif %}
 {% endif %}{# end 'grpc' in transport #}
-{% endmacro%}
+{% endmacro%}{# inteceptor_class_test #}

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -12981,8 +12981,6 @@ def test_export_assets_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.export_assets(request=None)
 
-        client.export_assets(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13004,8 +13002,6 @@ def test_list_assets_empty_call_grpc():
             type(client.transport.list_assets),
             '__call__') as call:
         call.return_value = asset_service.ListAssetsResponse()
-        client.list_assets(request=None)
-
         client.list_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13031,8 +13027,6 @@ def test_batch_get_assets_history_empty_call_grpc():
         call.return_value = asset_service.BatchGetAssetsHistoryResponse()
         client.batch_get_assets_history(request=None)
 
-        client.batch_get_assets_history(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13054,8 +13048,6 @@ def test_create_feed_empty_call_grpc():
             type(client.transport.create_feed),
             '__call__') as call:
         call.return_value = asset_service.Feed()
-        client.create_feed(request=None)
-
         client.create_feed(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13081,8 +13073,6 @@ def test_get_feed_empty_call_grpc():
         call.return_value = asset_service.Feed()
         client.get_feed(request=None)
 
-        client.get_feed(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13104,8 +13094,6 @@ def test_list_feeds_empty_call_grpc():
             type(client.transport.list_feeds),
             '__call__') as call:
         call.return_value = asset_service.ListFeedsResponse()
-        client.list_feeds(request=None)
-
         client.list_feeds(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13131,8 +13119,6 @@ def test_update_feed_empty_call_grpc():
         call.return_value = asset_service.Feed()
         client.update_feed(request=None)
 
-        client.update_feed(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13154,8 +13140,6 @@ def test_delete_feed_empty_call_grpc():
             type(client.transport.delete_feed),
             '__call__') as call:
         call.return_value = None
-        client.delete_feed(request=None)
-
         client.delete_feed(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13181,8 +13165,6 @@ def test_search_all_resources_empty_call_grpc():
         call.return_value = asset_service.SearchAllResourcesResponse()
         client.search_all_resources(request=None)
 
-        client.search_all_resources(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13204,8 +13186,6 @@ def test_search_all_iam_policies_empty_call_grpc():
             type(client.transport.search_all_iam_policies),
             '__call__') as call:
         call.return_value = asset_service.SearchAllIamPoliciesResponse()
-        client.search_all_iam_policies(request=None)
-
         client.search_all_iam_policies(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13231,8 +13211,6 @@ def test_analyze_iam_policy_empty_call_grpc():
         call.return_value = asset_service.AnalyzeIamPolicyResponse()
         client.analyze_iam_policy(request=None)
 
-        client.analyze_iam_policy(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13254,8 +13232,6 @@ def test_analyze_iam_policy_longrunning_empty_call_grpc():
             type(client.transport.analyze_iam_policy_longrunning),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.analyze_iam_policy_longrunning(request=None)
-
         client.analyze_iam_policy_longrunning(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13281,8 +13257,6 @@ def test_analyze_move_empty_call_grpc():
         call.return_value = asset_service.AnalyzeMoveResponse()
         client.analyze_move(request=None)
 
-        client.analyze_move(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13304,8 +13278,6 @@ def test_query_assets_empty_call_grpc():
             type(client.transport.query_assets),
             '__call__') as call:
         call.return_value = asset_service.QueryAssetsResponse()
-        client.query_assets(request=None)
-
         client.query_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13331,8 +13303,6 @@ def test_create_saved_query_empty_call_grpc():
         call.return_value = asset_service.SavedQuery()
         client.create_saved_query(request=None)
 
-        client.create_saved_query(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13354,8 +13324,6 @@ def test_get_saved_query_empty_call_grpc():
             type(client.transport.get_saved_query),
             '__call__') as call:
         call.return_value = asset_service.SavedQuery()
-        client.get_saved_query(request=None)
-
         client.get_saved_query(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13381,8 +13349,6 @@ def test_list_saved_queries_empty_call_grpc():
         call.return_value = asset_service.ListSavedQueriesResponse()
         client.list_saved_queries(request=None)
 
-        client.list_saved_queries(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13404,8 +13370,6 @@ def test_update_saved_query_empty_call_grpc():
             type(client.transport.update_saved_query),
             '__call__') as call:
         call.return_value = asset_service.SavedQuery()
-        client.update_saved_query(request=None)
-
         client.update_saved_query(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13431,8 +13395,6 @@ def test_delete_saved_query_empty_call_grpc():
         call.return_value = None
         client.delete_saved_query(request=None)
 
-        client.delete_saved_query(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13454,8 +13416,6 @@ def test_batch_get_effective_iam_policies_empty_call_grpc():
             type(client.transport.batch_get_effective_iam_policies),
             '__call__') as call:
         call.return_value = asset_service.BatchGetEffectiveIamPoliciesResponse()
-        client.batch_get_effective_iam_policies(request=None)
-
         client.batch_get_effective_iam_policies(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13481,8 +13441,6 @@ def test_analyze_org_policies_empty_call_grpc():
         call.return_value = asset_service.AnalyzeOrgPoliciesResponse()
         client.analyze_org_policies(request=None)
 
-        client.analyze_org_policies(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13506,8 +13464,6 @@ def test_analyze_org_policy_governed_containers_empty_call_grpc():
         call.return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse()
         client.analyze_org_policy_governed_containers(request=None)
 
-        client.analyze_org_policy_governed_containers(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13529,8 +13485,6 @@ def test_analyze_org_policy_governed_assets_empty_call_grpc():
             type(client.transport.analyze_org_policy_governed_assets),
             '__call__') as call:
         call.return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse()
-        client.analyze_org_policy_governed_assets(request=None)
-
         client.analyze_org_policy_governed_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13575,8 +13529,6 @@ async def test_export_assets_empty_call_grpc_asyncio():
         )
         await client.export_assets(request=None)
 
-        await client.export_assets(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13604,8 +13556,6 @@ async def test_list_assets_empty_call_grpc_asyncio():
         ))
         await client.list_assets(request=None)
 
-        await client.list_assets(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13630,8 +13580,6 @@ async def test_batch_get_assets_history_empty_call_grpc_asyncio():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.BatchGetAssetsHistoryResponse(
         ))
-        await client.batch_get_assets_history(request=None)
-
         await client.batch_get_assets_history(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13665,8 +13613,6 @@ async def test_create_feed_empty_call_grpc_asyncio():
         ))
         await client.create_feed(request=None)
 
-        await client.create_feed(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13698,8 +13644,6 @@ async def test_get_feed_empty_call_grpc_asyncio():
         ))
         await client.get_feed(request=None)
 
-        await client.get_feed(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13724,8 +13668,6 @@ async def test_list_feeds_empty_call_grpc_asyncio():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListFeedsResponse(
         ))
-        await client.list_feeds(request=None)
-
         await client.list_feeds(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13759,8 +13701,6 @@ async def test_update_feed_empty_call_grpc_asyncio():
         ))
         await client.update_feed(request=None)
 
-        await client.update_feed(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13784,8 +13724,6 @@ async def test_delete_feed_empty_call_grpc_asyncio():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        await client.delete_feed(request=None)
-
         await client.delete_feed(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13815,8 +13753,6 @@ async def test_search_all_resources_empty_call_grpc_asyncio():
         ))
         await client.search_all_resources(request=None)
 
-        await client.search_all_resources(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13842,8 +13778,6 @@ async def test_search_all_iam_policies_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SearchAllIamPoliciesResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.search_all_iam_policies(request=None)
-
         await client.search_all_iam_policies(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13873,8 +13807,6 @@ async def test_analyze_iam_policy_empty_call_grpc_asyncio():
         ))
         await client.analyze_iam_policy(request=None)
 
-        await client.analyze_iam_policy(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13900,8 +13832,6 @@ async def test_analyze_iam_policy_longrunning_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.analyze_iam_policy_longrunning(request=None)
-
         await client.analyze_iam_policy_longrunning(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13930,8 +13860,6 @@ async def test_analyze_move_empty_call_grpc_asyncio():
         ))
         await client.analyze_move(request=None)
 
-        await client.analyze_move(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -13958,8 +13886,6 @@ async def test_query_assets_empty_call_grpc_asyncio():
             job_reference='job_reference_value',
             done=True,
         ))
-        await client.query_assets(request=None)
-
         await client.query_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -13992,8 +13918,6 @@ async def test_create_saved_query_empty_call_grpc_asyncio():
         ))
         await client.create_saved_query(request=None)
 
-        await client.create_saved_query(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -14024,8 +13948,6 @@ async def test_get_saved_query_empty_call_grpc_asyncio():
         ))
         await client.get_saved_query(request=None)
 
-        await client.get_saved_query(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -14051,8 +13973,6 @@ async def test_list_saved_queries_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListSavedQueriesResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.list_saved_queries(request=None)
-
         await client.list_saved_queries(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14085,8 +14005,6 @@ async def test_update_saved_query_empty_call_grpc_asyncio():
         ))
         await client.update_saved_query(request=None)
 
-        await client.update_saved_query(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -14110,8 +14028,6 @@ async def test_delete_saved_query_empty_call_grpc_asyncio():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        await client.delete_saved_query(request=None)
-
         await client.delete_saved_query(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14138,8 +14054,6 @@ async def test_batch_get_effective_iam_policies_empty_call_grpc_asyncio():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.BatchGetEffectiveIamPoliciesResponse(
         ))
-        await client.batch_get_effective_iam_policies(request=None)
-
         await client.batch_get_effective_iam_policies(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14169,8 +14083,6 @@ async def test_analyze_org_policies_empty_call_grpc_asyncio():
         ))
         await client.analyze_org_policies(request=None)
 
-        await client.analyze_org_policies(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -14198,8 +14110,6 @@ async def test_analyze_org_policy_governed_containers_empty_call_grpc_asyncio():
         ))
         await client.analyze_org_policy_governed_containers(request=None)
 
-        await client.analyze_org_policy_governed_containers(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -14225,8 +14135,6 @@ async def test_analyze_org_policy_governed_assets_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeOrgPolicyGovernedAssetsResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.analyze_org_policy_governed_assets(request=None)
-
         await client.analyze_org_policy_governed_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16719,8 +16627,8 @@ def test_export_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.export_assets), '__call__') as call:
-
+            type(client.transport.export_assets),
+            '__call__') as call:
         client.export_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16741,8 +16649,8 @@ def test_list_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_assets), '__call__') as call:
-
+            type(client.transport.list_assets),
+            '__call__') as call:
         client.list_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16763,8 +16671,8 @@ def test_batch_get_assets_history_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.batch_get_assets_history), '__call__') as call:
-
+            type(client.transport.batch_get_assets_history),
+            '__call__') as call:
         client.batch_get_assets_history(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16785,8 +16693,8 @@ def test_create_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_feed), '__call__') as call:
-
+            type(client.transport.create_feed),
+            '__call__') as call:
         client.create_feed(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16807,8 +16715,8 @@ def test_get_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_feed), '__call__') as call:
-
+            type(client.transport.get_feed),
+            '__call__') as call:
         client.get_feed(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16829,8 +16737,8 @@ def test_list_feeds_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_feeds), '__call__') as call:
-
+            type(client.transport.list_feeds),
+            '__call__') as call:
         client.list_feeds(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16851,8 +16759,8 @@ def test_update_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_feed), '__call__') as call:
-
+            type(client.transport.update_feed),
+            '__call__') as call:
         client.update_feed(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16873,8 +16781,8 @@ def test_delete_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_feed), '__call__') as call:
-
+            type(client.transport.delete_feed),
+            '__call__') as call:
         client.delete_feed(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16895,8 +16803,8 @@ def test_search_all_resources_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.search_all_resources), '__call__') as call:
-
+            type(client.transport.search_all_resources),
+            '__call__') as call:
         client.search_all_resources(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16917,8 +16825,8 @@ def test_search_all_iam_policies_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.search_all_iam_policies), '__call__') as call:
-
+            type(client.transport.search_all_iam_policies),
+            '__call__') as call:
         client.search_all_iam_policies(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16939,8 +16847,8 @@ def test_analyze_iam_policy_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_iam_policy), '__call__') as call:
-
+            type(client.transport.analyze_iam_policy),
+            '__call__') as call:
         client.analyze_iam_policy(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16961,8 +16869,8 @@ def test_analyze_iam_policy_longrunning_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_iam_policy_longrunning), '__call__') as call:
-
+            type(client.transport.analyze_iam_policy_longrunning),
+            '__call__') as call:
         client.analyze_iam_policy_longrunning(request=None)
 
         # Establish that the underlying stub method was called.
@@ -16983,8 +16891,8 @@ def test_analyze_move_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_move), '__call__') as call:
-
+            type(client.transport.analyze_move),
+            '__call__') as call:
         client.analyze_move(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17005,8 +16913,8 @@ def test_query_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.query_assets), '__call__') as call:
-
+            type(client.transport.query_assets),
+            '__call__') as call:
         client.query_assets(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17027,8 +16935,8 @@ def test_create_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_saved_query), '__call__') as call:
-
+            type(client.transport.create_saved_query),
+            '__call__') as call:
         client.create_saved_query(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17049,8 +16957,8 @@ def test_get_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_saved_query), '__call__') as call:
-
+            type(client.transport.get_saved_query),
+            '__call__') as call:
         client.get_saved_query(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17071,8 +16979,8 @@ def test_list_saved_queries_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_saved_queries), '__call__') as call:
-
+            type(client.transport.list_saved_queries),
+            '__call__') as call:
         client.list_saved_queries(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17093,8 +17001,8 @@ def test_update_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_saved_query), '__call__') as call:
-
+            type(client.transport.update_saved_query),
+            '__call__') as call:
         client.update_saved_query(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17115,8 +17023,8 @@ def test_delete_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_saved_query), '__call__') as call:
-
+            type(client.transport.delete_saved_query),
+            '__call__') as call:
         client.delete_saved_query(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17137,8 +17045,8 @@ def test_batch_get_effective_iam_policies_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.batch_get_effective_iam_policies), '__call__') as call:
-
+            type(client.transport.batch_get_effective_iam_policies),
+            '__call__') as call:
         client.batch_get_effective_iam_policies(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17159,8 +17067,8 @@ def test_analyze_org_policies_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_org_policies), '__call__') as call:
-
+            type(client.transport.analyze_org_policies),
+            '__call__') as call:
         client.analyze_org_policies(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17181,8 +17089,8 @@ def test_analyze_org_policy_governed_containers_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_org_policy_governed_containers), '__call__') as call:
-
+            type(client.transport.analyze_org_policy_governed_containers),
+            '__call__') as call:
         client.analyze_org_policy_governed_containers(request=None)
 
         # Establish that the underlying stub method was called.
@@ -17203,8 +17111,8 @@ def test_analyze_org_policy_governed_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_org_policy_governed_assets), '__call__') as call:
-
+            type(client.transport.analyze_org_policy_governed_assets),
+            '__call__') as call:
         client.analyze_org_policy_governed_assets(request=None)
 
         # Establish that the underlying stub method was called.

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -16719,15 +16719,7 @@ def test_export_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.export_assets),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.export_assets), '__call__') as call:
 
         client.export_assets(request=None)
 
@@ -16749,17 +16741,7 @@ def test_list_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_assets),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.ListAssetsResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.ListAssetsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_assets), '__call__') as call:
 
         client.list_assets(request=None)
 
@@ -16781,17 +16763,7 @@ def test_batch_get_assets_history_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.batch_get_assets_history),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.BatchGetAssetsHistoryResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.BatchGetAssetsHistoryResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.batch_get_assets_history), '__call__') as call:
 
         client.batch_get_assets_history(request=None)
 
@@ -16813,17 +16785,7 @@ def test_create_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_feed),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.Feed()
-        # Convert return value to protobuf type
-        return_value = asset_service.Feed.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.create_feed), '__call__') as call:
 
         client.create_feed(request=None)
 
@@ -16845,17 +16807,7 @@ def test_get_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_feed),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.Feed()
-        # Convert return value to protobuf type
-        return_value = asset_service.Feed.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_feed), '__call__') as call:
 
         client.get_feed(request=None)
 
@@ -16877,17 +16829,7 @@ def test_list_feeds_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_feeds),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.ListFeedsResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.ListFeedsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_feeds), '__call__') as call:
 
         client.list_feeds(request=None)
 
@@ -16909,17 +16851,7 @@ def test_update_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_feed),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.Feed()
-        # Convert return value to protobuf type
-        return_value = asset_service.Feed.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.update_feed), '__call__') as call:
 
         client.update_feed(request=None)
 
@@ -16941,15 +16873,7 @@ def test_delete_feed_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_feed),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = None
-        json_return_value = ''
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.delete_feed), '__call__') as call:
 
         client.delete_feed(request=None)
 
@@ -16971,17 +16895,7 @@ def test_search_all_resources_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.search_all_resources),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.SearchAllResourcesResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.SearchAllResourcesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.search_all_resources), '__call__') as call:
 
         client.search_all_resources(request=None)
 
@@ -17003,17 +16917,7 @@ def test_search_all_iam_policies_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.search_all_iam_policies),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.SearchAllIamPoliciesResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.SearchAllIamPoliciesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.search_all_iam_policies), '__call__') as call:
 
         client.search_all_iam_policies(request=None)
 
@@ -17035,17 +16939,7 @@ def test_analyze_iam_policy_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_iam_policy),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.AnalyzeIamPolicyResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.AnalyzeIamPolicyResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.analyze_iam_policy), '__call__') as call:
 
         client.analyze_iam_policy(request=None)
 
@@ -17067,15 +16961,7 @@ def test_analyze_iam_policy_longrunning_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_iam_policy_longrunning),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.analyze_iam_policy_longrunning), '__call__') as call:
 
         client.analyze_iam_policy_longrunning(request=None)
 
@@ -17097,17 +16983,7 @@ def test_analyze_move_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_move),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.AnalyzeMoveResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.AnalyzeMoveResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.analyze_move), '__call__') as call:
 
         client.analyze_move(request=None)
 
@@ -17129,17 +17005,7 @@ def test_query_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.query_assets),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.QueryAssetsResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.QueryAssetsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.query_assets), '__call__') as call:
 
         client.query_assets(request=None)
 
@@ -17161,17 +17027,7 @@ def test_create_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_saved_query),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.SavedQuery()
-        # Convert return value to protobuf type
-        return_value = asset_service.SavedQuery.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.create_saved_query), '__call__') as call:
 
         client.create_saved_query(request=None)
 
@@ -17193,17 +17049,7 @@ def test_get_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_saved_query),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.SavedQuery()
-        # Convert return value to protobuf type
-        return_value = asset_service.SavedQuery.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_saved_query), '__call__') as call:
 
         client.get_saved_query(request=None)
 
@@ -17225,17 +17071,7 @@ def test_list_saved_queries_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_saved_queries),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.ListSavedQueriesResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.ListSavedQueriesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_saved_queries), '__call__') as call:
 
         client.list_saved_queries(request=None)
 
@@ -17257,17 +17093,7 @@ def test_update_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_saved_query),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.SavedQuery()
-        # Convert return value to protobuf type
-        return_value = asset_service.SavedQuery.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.update_saved_query), '__call__') as call:
 
         client.update_saved_query(request=None)
 
@@ -17289,15 +17115,7 @@ def test_delete_saved_query_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_saved_query),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = None
-        json_return_value = ''
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.delete_saved_query), '__call__') as call:
 
         client.delete_saved_query(request=None)
 
@@ -17319,17 +17137,7 @@ def test_batch_get_effective_iam_policies_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.batch_get_effective_iam_policies),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.batch_get_effective_iam_policies), '__call__') as call:
 
         client.batch_get_effective_iam_policies(request=None)
 
@@ -17351,17 +17159,7 @@ def test_analyze_org_policies_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_org_policies),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.AnalyzeOrgPoliciesResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.AnalyzeOrgPoliciesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.analyze_org_policies), '__call__') as call:
 
         client.analyze_org_policies(request=None)
 
@@ -17383,17 +17181,7 @@ def test_analyze_org_policy_governed_containers_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_org_policy_governed_containers),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.analyze_org_policy_governed_containers), '__call__') as call:
 
         client.analyze_org_policy_governed_containers(request=None)
 
@@ -17415,17 +17203,7 @@ def test_analyze_org_policy_governed_assets_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.analyze_org_policy_governed_assets),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse()
-        # Convert return value to protobuf type
-        return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.analyze_org_policy_governed_assets), '__call__') as call:
 
         client.analyze_org_policy_governed_assets(request=None)
 

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -12971,16 +12971,19 @@ def test_initialize_client_w_grpc():
 def test_export_assets_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.export_assets),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.export_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.export_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ExportAssetsRequest()
@@ -12993,16 +12996,19 @@ def test_export_assets_empty_call_grpc():
 def test_list_assets_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_assets),
             '__call__') as call:
         call.return_value = asset_service.ListAssetsResponse()
         client.list_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ListAssetsRequest()
@@ -13015,16 +13021,19 @@ def test_list_assets_empty_call_grpc():
 def test_batch_get_assets_history_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.batch_get_assets_history),
             '__call__') as call:
         call.return_value = asset_service.BatchGetAssetsHistoryResponse()
         client.batch_get_assets_history(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.batch_get_assets_history(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.BatchGetAssetsHistoryRequest()
@@ -13037,16 +13046,19 @@ def test_batch_get_assets_history_empty_call_grpc():
 def test_create_feed_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_feed),
             '__call__') as call:
         call.return_value = asset_service.Feed()
         client.create_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.CreateFeedRequest()
@@ -13059,16 +13071,19 @@ def test_create_feed_empty_call_grpc():
 def test_get_feed_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_feed),
             '__call__') as call:
         call.return_value = asset_service.Feed()
         client.get_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.GetFeedRequest()
@@ -13081,16 +13096,19 @@ def test_get_feed_empty_call_grpc():
 def test_list_feeds_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_feeds),
             '__call__') as call:
         call.return_value = asset_service.ListFeedsResponse()
         client.list_feeds(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_feeds(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ListFeedsRequest()
@@ -13103,16 +13121,19 @@ def test_list_feeds_empty_call_grpc():
 def test_update_feed_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_feed),
             '__call__') as call:
         call.return_value = asset_service.Feed()
         client.update_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.UpdateFeedRequest()
@@ -13125,16 +13146,19 @@ def test_update_feed_empty_call_grpc():
 def test_delete_feed_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_feed),
             '__call__') as call:
         call.return_value = None
         client.delete_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.DeleteFeedRequest()
@@ -13147,16 +13171,19 @@ def test_delete_feed_empty_call_grpc():
 def test_search_all_resources_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.search_all_resources),
             '__call__') as call:
         call.return_value = asset_service.SearchAllResourcesResponse()
         client.search_all_resources(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.search_all_resources(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.SearchAllResourcesRequest()
@@ -13169,16 +13196,19 @@ def test_search_all_resources_empty_call_grpc():
 def test_search_all_iam_policies_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.search_all_iam_policies),
             '__call__') as call:
         call.return_value = asset_service.SearchAllIamPoliciesResponse()
         client.search_all_iam_policies(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.search_all_iam_policies(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.SearchAllIamPoliciesRequest()
@@ -13191,16 +13221,19 @@ def test_search_all_iam_policies_empty_call_grpc():
 def test_analyze_iam_policy_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_iam_policy),
             '__call__') as call:
         call.return_value = asset_service.AnalyzeIamPolicyResponse()
         client.analyze_iam_policy(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.analyze_iam_policy(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeIamPolicyRequest()
@@ -13213,16 +13246,19 @@ def test_analyze_iam_policy_empty_call_grpc():
 def test_analyze_iam_policy_longrunning_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_iam_policy_longrunning),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.analyze_iam_policy_longrunning(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.analyze_iam_policy_longrunning(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeIamPolicyLongrunningRequest()
@@ -13235,16 +13271,19 @@ def test_analyze_iam_policy_longrunning_empty_call_grpc():
 def test_analyze_move_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_move),
             '__call__') as call:
         call.return_value = asset_service.AnalyzeMoveResponse()
         client.analyze_move(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.analyze_move(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeMoveRequest()
@@ -13257,16 +13296,19 @@ def test_analyze_move_empty_call_grpc():
 def test_query_assets_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.query_assets),
             '__call__') as call:
         call.return_value = asset_service.QueryAssetsResponse()
         client.query_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.query_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.QueryAssetsRequest()
@@ -13279,16 +13321,19 @@ def test_query_assets_empty_call_grpc():
 def test_create_saved_query_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_saved_query),
             '__call__') as call:
         call.return_value = asset_service.SavedQuery()
         client.create_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.CreateSavedQueryRequest()
@@ -13301,16 +13346,19 @@ def test_create_saved_query_empty_call_grpc():
 def test_get_saved_query_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_saved_query),
             '__call__') as call:
         call.return_value = asset_service.SavedQuery()
         client.get_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.GetSavedQueryRequest()
@@ -13323,16 +13371,19 @@ def test_get_saved_query_empty_call_grpc():
 def test_list_saved_queries_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_saved_queries),
             '__call__') as call:
         call.return_value = asset_service.ListSavedQueriesResponse()
         client.list_saved_queries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_saved_queries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ListSavedQueriesRequest()
@@ -13345,16 +13396,19 @@ def test_list_saved_queries_empty_call_grpc():
 def test_update_saved_query_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_saved_query),
             '__call__') as call:
         call.return_value = asset_service.SavedQuery()
         client.update_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.UpdateSavedQueryRequest()
@@ -13367,16 +13421,19 @@ def test_update_saved_query_empty_call_grpc():
 def test_delete_saved_query_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_saved_query),
             '__call__') as call:
         call.return_value = None
         client.delete_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.DeleteSavedQueryRequest()
@@ -13389,16 +13446,19 @@ def test_delete_saved_query_empty_call_grpc():
 def test_batch_get_effective_iam_policies_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.batch_get_effective_iam_policies),
             '__call__') as call:
         call.return_value = asset_service.BatchGetEffectiveIamPoliciesResponse()
         client.batch_get_effective_iam_policies(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.batch_get_effective_iam_policies(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.BatchGetEffectiveIamPoliciesRequest()
@@ -13411,16 +13471,19 @@ def test_batch_get_effective_iam_policies_empty_call_grpc():
 def test_analyze_org_policies_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_org_policies),
             '__call__') as call:
         call.return_value = asset_service.AnalyzeOrgPoliciesResponse()
         client.analyze_org_policies(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.analyze_org_policies(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeOrgPoliciesRequest()
@@ -13433,16 +13496,19 @@ def test_analyze_org_policies_empty_call_grpc():
 def test_analyze_org_policy_governed_containers_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_org_policy_governed_containers),
             '__call__') as call:
         call.return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse()
         client.analyze_org_policy_governed_containers(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.analyze_org_policy_governed_containers(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeOrgPolicyGovernedContainersRequest()
@@ -13455,16 +13521,19 @@ def test_analyze_org_policy_governed_containers_empty_call_grpc():
 def test_analyze_org_policy_governed_assets_empty_call_grpc():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_org_policy_governed_assets),
             '__call__') as call:
         call.return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse()
         client.analyze_org_policy_governed_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.analyze_org_policy_governed_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeOrgPolicyGovernedAssetsRequest()
@@ -13493,9 +13562,10 @@ def test_initialize_client_w_grpc_asyncio():
 async def test_export_assets_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.export_assets),
             '__call__') as call:
@@ -13505,7 +13575,9 @@ async def test_export_assets_empty_call_grpc_asyncio():
         )
         await client.export_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.export_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ExportAssetsRequest()
@@ -13519,9 +13591,10 @@ async def test_export_assets_empty_call_grpc_asyncio():
 async def test_list_assets_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_assets),
             '__call__') as call:
@@ -13531,7 +13604,9 @@ async def test_list_assets_empty_call_grpc_asyncio():
         ))
         await client.list_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ListAssetsRequest()
@@ -13545,9 +13620,10 @@ async def test_list_assets_empty_call_grpc_asyncio():
 async def test_batch_get_assets_history_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.batch_get_assets_history),
             '__call__') as call:
@@ -13556,7 +13632,9 @@ async def test_batch_get_assets_history_empty_call_grpc_asyncio():
         ))
         await client.batch_get_assets_history(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.batch_get_assets_history(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.BatchGetAssetsHistoryRequest()
@@ -13570,9 +13648,10 @@ async def test_batch_get_assets_history_empty_call_grpc_asyncio():
 async def test_create_feed_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_feed),
             '__call__') as call:
@@ -13586,7 +13665,9 @@ async def test_create_feed_empty_call_grpc_asyncio():
         ))
         await client.create_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.CreateFeedRequest()
@@ -13600,9 +13681,10 @@ async def test_create_feed_empty_call_grpc_asyncio():
 async def test_get_feed_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_feed),
             '__call__') as call:
@@ -13616,7 +13698,9 @@ async def test_get_feed_empty_call_grpc_asyncio():
         ))
         await client.get_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.GetFeedRequest()
@@ -13630,9 +13714,10 @@ async def test_get_feed_empty_call_grpc_asyncio():
 async def test_list_feeds_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_feeds),
             '__call__') as call:
@@ -13641,7 +13726,9 @@ async def test_list_feeds_empty_call_grpc_asyncio():
         ))
         await client.list_feeds(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_feeds(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ListFeedsRequest()
@@ -13655,9 +13742,10 @@ async def test_list_feeds_empty_call_grpc_asyncio():
 async def test_update_feed_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_feed),
             '__call__') as call:
@@ -13671,7 +13759,9 @@ async def test_update_feed_empty_call_grpc_asyncio():
         ))
         await client.update_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.UpdateFeedRequest()
@@ -13685,9 +13775,10 @@ async def test_update_feed_empty_call_grpc_asyncio():
 async def test_delete_feed_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_feed),
             '__call__') as call:
@@ -13695,7 +13786,9 @@ async def test_delete_feed_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_feed(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_feed(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.DeleteFeedRequest()
@@ -13709,9 +13802,10 @@ async def test_delete_feed_empty_call_grpc_asyncio():
 async def test_search_all_resources_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.search_all_resources),
             '__call__') as call:
@@ -13721,7 +13815,9 @@ async def test_search_all_resources_empty_call_grpc_asyncio():
         ))
         await client.search_all_resources(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.search_all_resources(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.SearchAllResourcesRequest()
@@ -13735,9 +13831,10 @@ async def test_search_all_resources_empty_call_grpc_asyncio():
 async def test_search_all_iam_policies_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.search_all_iam_policies),
             '__call__') as call:
@@ -13747,7 +13844,9 @@ async def test_search_all_iam_policies_empty_call_grpc_asyncio():
         ))
         await client.search_all_iam_policies(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.search_all_iam_policies(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.SearchAllIamPoliciesRequest()
@@ -13761,9 +13860,10 @@ async def test_search_all_iam_policies_empty_call_grpc_asyncio():
 async def test_analyze_iam_policy_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_iam_policy),
             '__call__') as call:
@@ -13773,7 +13873,9 @@ async def test_analyze_iam_policy_empty_call_grpc_asyncio():
         ))
         await client.analyze_iam_policy(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.analyze_iam_policy(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeIamPolicyRequest()
@@ -13787,9 +13889,10 @@ async def test_analyze_iam_policy_empty_call_grpc_asyncio():
 async def test_analyze_iam_policy_longrunning_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_iam_policy_longrunning),
             '__call__') as call:
@@ -13799,7 +13902,9 @@ async def test_analyze_iam_policy_longrunning_empty_call_grpc_asyncio():
         )
         await client.analyze_iam_policy_longrunning(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.analyze_iam_policy_longrunning(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeIamPolicyLongrunningRequest()
@@ -13813,9 +13918,10 @@ async def test_analyze_iam_policy_longrunning_empty_call_grpc_asyncio():
 async def test_analyze_move_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_move),
             '__call__') as call:
@@ -13824,7 +13930,9 @@ async def test_analyze_move_empty_call_grpc_asyncio():
         ))
         await client.analyze_move(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.analyze_move(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeMoveRequest()
@@ -13838,9 +13946,10 @@ async def test_analyze_move_empty_call_grpc_asyncio():
 async def test_query_assets_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.query_assets),
             '__call__') as call:
@@ -13851,7 +13960,9 @@ async def test_query_assets_empty_call_grpc_asyncio():
         ))
         await client.query_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.query_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.QueryAssetsRequest()
@@ -13865,9 +13976,10 @@ async def test_query_assets_empty_call_grpc_asyncio():
 async def test_create_saved_query_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_saved_query),
             '__call__') as call:
@@ -13880,7 +13992,9 @@ async def test_create_saved_query_empty_call_grpc_asyncio():
         ))
         await client.create_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.CreateSavedQueryRequest()
@@ -13894,9 +14008,10 @@ async def test_create_saved_query_empty_call_grpc_asyncio():
 async def test_get_saved_query_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_saved_query),
             '__call__') as call:
@@ -13909,7 +14024,9 @@ async def test_get_saved_query_empty_call_grpc_asyncio():
         ))
         await client.get_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.GetSavedQueryRequest()
@@ -13923,9 +14040,10 @@ async def test_get_saved_query_empty_call_grpc_asyncio():
 async def test_list_saved_queries_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_saved_queries),
             '__call__') as call:
@@ -13935,7 +14053,9 @@ async def test_list_saved_queries_empty_call_grpc_asyncio():
         ))
         await client.list_saved_queries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_saved_queries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.ListSavedQueriesRequest()
@@ -13949,9 +14069,10 @@ async def test_list_saved_queries_empty_call_grpc_asyncio():
 async def test_update_saved_query_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_saved_query),
             '__call__') as call:
@@ -13964,7 +14085,9 @@ async def test_update_saved_query_empty_call_grpc_asyncio():
         ))
         await client.update_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.UpdateSavedQueryRequest()
@@ -13978,9 +14101,10 @@ async def test_update_saved_query_empty_call_grpc_asyncio():
 async def test_delete_saved_query_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_saved_query),
             '__call__') as call:
@@ -13988,7 +14112,9 @@ async def test_delete_saved_query_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_saved_query(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.DeleteSavedQueryRequest()
@@ -14002,9 +14128,10 @@ async def test_delete_saved_query_empty_call_grpc_asyncio():
 async def test_batch_get_effective_iam_policies_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.batch_get_effective_iam_policies),
             '__call__') as call:
@@ -14013,7 +14140,9 @@ async def test_batch_get_effective_iam_policies_empty_call_grpc_asyncio():
         ))
         await client.batch_get_effective_iam_policies(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.batch_get_effective_iam_policies(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.BatchGetEffectiveIamPoliciesRequest()
@@ -14027,9 +14156,10 @@ async def test_batch_get_effective_iam_policies_empty_call_grpc_asyncio():
 async def test_analyze_org_policies_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_org_policies),
             '__call__') as call:
@@ -14039,7 +14169,9 @@ async def test_analyze_org_policies_empty_call_grpc_asyncio():
         ))
         await client.analyze_org_policies(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.analyze_org_policies(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeOrgPoliciesRequest()
@@ -14053,9 +14185,10 @@ async def test_analyze_org_policies_empty_call_grpc_asyncio():
 async def test_analyze_org_policy_governed_containers_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_org_policy_governed_containers),
             '__call__') as call:
@@ -14065,7 +14198,9 @@ async def test_analyze_org_policy_governed_containers_empty_call_grpc_asyncio():
         ))
         await client.analyze_org_policy_governed_containers(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.analyze_org_policy_governed_containers(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeOrgPolicyGovernedContainersRequest()
@@ -14079,9 +14214,10 @@ async def test_analyze_org_policy_governed_containers_empty_call_grpc_asyncio():
 async def test_analyze_org_policy_governed_assets_empty_call_grpc_asyncio():
     client = AssetServiceAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.analyze_org_policy_governed_assets),
             '__call__') as call:
@@ -14091,7 +14227,9 @@ async def test_analyze_org_policy_governed_assets_empty_call_grpc_asyncio():
         ))
         await client.analyze_org_policy_governed_assets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.analyze_org_policy_governed_assets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = asset_service.AnalyzeOrgPolicyGovernedAssetsRequest()
@@ -16569,6 +16707,734 @@ def test_initialize_client_w_rest():
         transport="rest"
     )
     assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_export_assets_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.export_assets),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.export_assets(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.ExportAssetsRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_assets_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_assets),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.ListAssetsResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.ListAssetsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_assets(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.ListAssetsRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_batch_get_assets_history_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.batch_get_assets_history),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.BatchGetAssetsHistoryResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.BatchGetAssetsHistoryResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.batch_get_assets_history(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.BatchGetAssetsHistoryRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_create_feed_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.create_feed),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.Feed()
+        # Convert return value to protobuf type
+        return_value = asset_service.Feed.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.create_feed(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.CreateFeedRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_feed_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_feed),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.Feed()
+        # Convert return value to protobuf type
+        return_value = asset_service.Feed.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_feed(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.GetFeedRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_feeds_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_feeds),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.ListFeedsResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.ListFeedsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_feeds(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.ListFeedsRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_update_feed_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.update_feed),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.Feed()
+        # Convert return value to protobuf type
+        return_value = asset_service.Feed.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.update_feed(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.UpdateFeedRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_delete_feed_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.delete_feed),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = None
+        json_return_value = ''
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.delete_feed(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.DeleteFeedRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_search_all_resources_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.search_all_resources),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.SearchAllResourcesResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.SearchAllResourcesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.search_all_resources(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.SearchAllResourcesRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_search_all_iam_policies_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.search_all_iam_policies),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.SearchAllIamPoliciesResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.SearchAllIamPoliciesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.search_all_iam_policies(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.SearchAllIamPoliciesRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_analyze_iam_policy_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.analyze_iam_policy),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.AnalyzeIamPolicyResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.AnalyzeIamPolicyResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.analyze_iam_policy(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.AnalyzeIamPolicyRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_analyze_iam_policy_longrunning_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.analyze_iam_policy_longrunning),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.analyze_iam_policy_longrunning(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.AnalyzeIamPolicyLongrunningRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_analyze_move_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.analyze_move),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.AnalyzeMoveResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.AnalyzeMoveResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.analyze_move(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.AnalyzeMoveRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_query_assets_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.query_assets),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.QueryAssetsResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.QueryAssetsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.query_assets(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.QueryAssetsRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_create_saved_query_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.create_saved_query),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.SavedQuery()
+        # Convert return value to protobuf type
+        return_value = asset_service.SavedQuery.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.create_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.CreateSavedQueryRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_saved_query_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_saved_query),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.SavedQuery()
+        # Convert return value to protobuf type
+        return_value = asset_service.SavedQuery.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.GetSavedQueryRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_saved_queries_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_saved_queries),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.ListSavedQueriesResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.ListSavedQueriesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_saved_queries(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.ListSavedQueriesRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_update_saved_query_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.update_saved_query),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.SavedQuery()
+        # Convert return value to protobuf type
+        return_value = asset_service.SavedQuery.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.update_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.UpdateSavedQueryRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_delete_saved_query_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.delete_saved_query),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = None
+        json_return_value = ''
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.delete_saved_query(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.DeleteSavedQueryRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_batch_get_effective_iam_policies_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.batch_get_effective_iam_policies),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.BatchGetEffectiveIamPoliciesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.batch_get_effective_iam_policies(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.BatchGetEffectiveIamPoliciesRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_analyze_org_policies_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.analyze_org_policies),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.AnalyzeOrgPoliciesResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.AnalyzeOrgPoliciesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.analyze_org_policies(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.AnalyzeOrgPoliciesRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_analyze_org_policy_governed_containers_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.analyze_org_policy_governed_containers),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.analyze_org_policy_governed_containers(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.AnalyzeOrgPolicyGovernedContainersRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_analyze_org_policy_governed_assets_empty_call_rest():
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.analyze_org_policy_governed_assets),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse()
+        # Convert return value to protobuf type
+        return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.analyze_org_policy_governed_assets(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = asset_service.AnalyzeOrgPolicyGovernedAssetsRequest()
+
+        assert args[0] == request_msg
 
 
 def test_asset_service_rest_lro_client():

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -2925,16 +2925,19 @@ def test_initialize_client_w_grpc():
 def test_generate_access_token_empty_call_grpc():
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.generate_access_token),
             '__call__') as call:
         call.return_value = common.GenerateAccessTokenResponse()
         client.generate_access_token(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.generate_access_token(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.GenerateAccessTokenRequest()
@@ -2947,16 +2950,19 @@ def test_generate_access_token_empty_call_grpc():
 def test_generate_id_token_empty_call_grpc():
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.generate_id_token),
             '__call__') as call:
         call.return_value = common.GenerateIdTokenResponse()
         client.generate_id_token(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.generate_id_token(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.GenerateIdTokenRequest()
@@ -2969,16 +2975,19 @@ def test_generate_id_token_empty_call_grpc():
 def test_sign_blob_empty_call_grpc():
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.sign_blob),
             '__call__') as call:
         call.return_value = common.SignBlobResponse()
         client.sign_blob(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.sign_blob(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.SignBlobRequest()
@@ -2991,16 +3000,19 @@ def test_sign_blob_empty_call_grpc():
 def test_sign_jwt_empty_call_grpc():
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.sign_jwt),
             '__call__') as call:
         call.return_value = common.SignJwtResponse()
         client.sign_jwt(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.sign_jwt(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.SignJwtRequest()
@@ -3029,9 +3041,10 @@ def test_initialize_client_w_grpc_asyncio():
 async def test_generate_access_token_empty_call_grpc_asyncio():
     client = IAMCredentialsAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.generate_access_token),
             '__call__') as call:
@@ -3041,7 +3054,9 @@ async def test_generate_access_token_empty_call_grpc_asyncio():
         ))
         await client.generate_access_token(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.generate_access_token(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.GenerateAccessTokenRequest()
@@ -3055,9 +3070,10 @@ async def test_generate_access_token_empty_call_grpc_asyncio():
 async def test_generate_id_token_empty_call_grpc_asyncio():
     client = IAMCredentialsAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.generate_id_token),
             '__call__') as call:
@@ -3067,7 +3083,9 @@ async def test_generate_id_token_empty_call_grpc_asyncio():
         ))
         await client.generate_id_token(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.generate_id_token(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.GenerateIdTokenRequest()
@@ -3081,9 +3099,10 @@ async def test_generate_id_token_empty_call_grpc_asyncio():
 async def test_sign_blob_empty_call_grpc_asyncio():
     client = IAMCredentialsAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.sign_blob),
             '__call__') as call:
@@ -3094,7 +3113,9 @@ async def test_sign_blob_empty_call_grpc_asyncio():
         ))
         await client.sign_blob(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.sign_blob(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.SignBlobRequest()
@@ -3108,9 +3129,10 @@ async def test_sign_blob_empty_call_grpc_asyncio():
 async def test_sign_jwt_empty_call_grpc_asyncio():
     client = IAMCredentialsAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.sign_jwt),
             '__call__') as call:
@@ -3121,7 +3143,9 @@ async def test_sign_jwt_empty_call_grpc_asyncio():
         ))
         await client.sign_jwt(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.sign_jwt(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = common.SignJwtRequest()
@@ -3541,6 +3565,134 @@ def test_initialize_client_w_rest():
         transport="rest"
     )
     assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_generate_access_token_empty_call_rest():
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.generate_access_token),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = common.GenerateAccessTokenResponse()
+        # Convert return value to protobuf type
+        return_value = common.GenerateAccessTokenResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.generate_access_token(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = common.GenerateAccessTokenRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_generate_id_token_empty_call_rest():
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.generate_id_token),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = common.GenerateIdTokenResponse()
+        # Convert return value to protobuf type
+        return_value = common.GenerateIdTokenResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.generate_id_token(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = common.GenerateIdTokenRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_sign_blob_empty_call_rest():
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.sign_blob),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = common.SignBlobResponse()
+        # Convert return value to protobuf type
+        return_value = common.SignBlobResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.sign_blob(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = common.SignBlobRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_sign_jwt_empty_call_rest():
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.sign_jwt),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = common.SignJwtResponse()
+        # Convert return value to protobuf type
+        return_value = common.SignJwtResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.sign_jwt(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = common.SignJwtRequest()
+
+        assert args[0] == request_msg
 
 
 def test_transport_grpc_default():

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3577,17 +3577,7 @@ def test_generate_access_token_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.generate_access_token),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = common.GenerateAccessTokenResponse()
-        # Convert return value to protobuf type
-        return_value = common.GenerateAccessTokenResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.generate_access_token), '__call__') as call:
 
         client.generate_access_token(request=None)
 
@@ -3609,17 +3599,7 @@ def test_generate_id_token_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.generate_id_token),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = common.GenerateIdTokenResponse()
-        # Convert return value to protobuf type
-        return_value = common.GenerateIdTokenResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.generate_id_token), '__call__') as call:
 
         client.generate_id_token(request=None)
 
@@ -3641,17 +3621,7 @@ def test_sign_blob_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.sign_blob),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = common.SignBlobResponse()
-        # Convert return value to protobuf type
-        return_value = common.SignBlobResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.sign_blob), '__call__') as call:
 
         client.sign_blob(request=None)
 
@@ -3673,17 +3643,7 @@ def test_sign_jwt_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.sign_jwt),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = common.SignJwtResponse()
-        # Convert return value to protobuf type
-        return_value = common.SignJwtResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.sign_jwt), '__call__') as call:
 
         client.sign_jwt(request=None)
 

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -2935,8 +2935,6 @@ def test_generate_access_token_empty_call_grpc():
         call.return_value = common.GenerateAccessTokenResponse()
         client.generate_access_token(request=None)
 
-        client.generate_access_token(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2958,8 +2956,6 @@ def test_generate_id_token_empty_call_grpc():
             type(client.transport.generate_id_token),
             '__call__') as call:
         call.return_value = common.GenerateIdTokenResponse()
-        client.generate_id_token(request=None)
-
         client.generate_id_token(request=None)
 
         # Establish that the underlying stub method was called.
@@ -2985,8 +2981,6 @@ def test_sign_blob_empty_call_grpc():
         call.return_value = common.SignBlobResponse()
         client.sign_blob(request=None)
 
-        client.sign_blob(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -3008,8 +3002,6 @@ def test_sign_jwt_empty_call_grpc():
             type(client.transport.sign_jwt),
             '__call__') as call:
         call.return_value = common.SignJwtResponse()
-        client.sign_jwt(request=None)
-
         client.sign_jwt(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3054,8 +3046,6 @@ async def test_generate_access_token_empty_call_grpc_asyncio():
         ))
         await client.generate_access_token(request=None)
 
-        await client.generate_access_token(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -3081,8 +3071,6 @@ async def test_generate_id_token_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(common.GenerateIdTokenResponse(
             token='token_value',
         ))
-        await client.generate_id_token(request=None)
-
         await client.generate_id_token(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3113,8 +3101,6 @@ async def test_sign_blob_empty_call_grpc_asyncio():
         ))
         await client.sign_blob(request=None)
 
-        await client.sign_blob(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -3141,8 +3127,6 @@ async def test_sign_jwt_empty_call_grpc_asyncio():
             key_id='key_id_value',
             signed_jwt='signed_jwt_value',
         ))
-        await client.sign_jwt(request=None)
-
         await client.sign_jwt(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3577,8 +3561,8 @@ def test_generate_access_token_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.generate_access_token), '__call__') as call:
-
+            type(client.transport.generate_access_token),
+            '__call__') as call:
         client.generate_access_token(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3599,8 +3583,8 @@ def test_generate_id_token_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.generate_id_token), '__call__') as call:
-
+            type(client.transport.generate_id_token),
+            '__call__') as call:
         client.generate_id_token(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3621,8 +3605,8 @@ def test_sign_blob_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.sign_blob), '__call__') as call:
-
+            type(client.transport.sign_blob),
+            '__call__') as call:
         client.sign_blob(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3643,8 +3627,8 @@ def test_sign_jwt_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.sign_jwt), '__call__') as call:
-
+            type(client.transport.sign_jwt),
+            '__call__') as call:
         client.sign_jwt(request=None)
 
         # Establish that the underlying stub method was called.

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -10862,8 +10862,6 @@ def test_get_trigger_empty_call_grpc():
         call.return_value = trigger.Trigger()
         client.get_trigger(request=None)
 
-        client.get_trigger(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -10885,8 +10883,6 @@ def test_list_triggers_empty_call_grpc():
             type(client.transport.list_triggers),
             '__call__') as call:
         call.return_value = eventarc.ListTriggersResponse()
-        client.list_triggers(request=None)
-
         client.list_triggers(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10912,8 +10908,6 @@ def test_create_trigger_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_trigger(request=None)
 
-        client.create_trigger(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -10935,8 +10929,6 @@ def test_update_trigger_empty_call_grpc():
             type(client.transport.update_trigger),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.update_trigger(request=None)
-
         client.update_trigger(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10962,8 +10954,6 @@ def test_delete_trigger_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.delete_trigger(request=None)
 
-        client.delete_trigger(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -10985,8 +10975,6 @@ def test_get_channel_empty_call_grpc():
             type(client.transport.get_channel),
             '__call__') as call:
         call.return_value = channel.Channel()
-        client.get_channel(request=None)
-
         client.get_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11012,8 +11000,6 @@ def test_list_channels_empty_call_grpc():
         call.return_value = eventarc.ListChannelsResponse()
         client.list_channels(request=None)
 
-        client.list_channels(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11035,8 +11021,6 @@ def test_create_channel_empty_call_grpc():
             type(client.transport.create_channel_),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.create_channel(request=None)
-
         client.create_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11062,8 +11046,6 @@ def test_update_channel_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.update_channel(request=None)
 
-        client.update_channel(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11085,8 +11067,6 @@ def test_delete_channel_empty_call_grpc():
             type(client.transport.delete_channel),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.delete_channel(request=None)
-
         client.delete_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11112,8 +11092,6 @@ def test_get_provider_empty_call_grpc():
         call.return_value = discovery.Provider()
         client.get_provider(request=None)
 
-        client.get_provider(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11135,8 +11113,6 @@ def test_list_providers_empty_call_grpc():
             type(client.transport.list_providers),
             '__call__') as call:
         call.return_value = eventarc.ListProvidersResponse()
-        client.list_providers(request=None)
-
         client.list_providers(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11162,8 +11138,6 @@ def test_get_channel_connection_empty_call_grpc():
         call.return_value = channel_connection.ChannelConnection()
         client.get_channel_connection(request=None)
 
-        client.get_channel_connection(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11185,8 +11159,6 @@ def test_list_channel_connections_empty_call_grpc():
             type(client.transport.list_channel_connections),
             '__call__') as call:
         call.return_value = eventarc.ListChannelConnectionsResponse()
-        client.list_channel_connections(request=None)
-
         client.list_channel_connections(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11212,8 +11184,6 @@ def test_create_channel_connection_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_channel_connection(request=None)
 
-        client.create_channel_connection(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11235,8 +11205,6 @@ def test_delete_channel_connection_empty_call_grpc():
             type(client.transport.delete_channel_connection),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.delete_channel_connection(request=None)
-
         client.delete_channel_connection(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11262,8 +11230,6 @@ def test_get_google_channel_config_empty_call_grpc():
         call.return_value = google_channel_config.GoogleChannelConfig()
         client.get_google_channel_config(request=None)
 
-        client.get_google_channel_config(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11285,8 +11251,6 @@ def test_update_google_channel_config_empty_call_grpc():
             type(client.transport.update_google_channel_config),
             '__call__') as call:
         call.return_value = gce_google_channel_config.GoogleChannelConfig()
-        client.update_google_channel_config(request=None)
-
         client.update_google_channel_config(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11335,8 +11299,6 @@ async def test_get_trigger_empty_call_grpc_asyncio():
         ))
         await client.get_trigger(request=None)
 
-        await client.get_trigger(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11363,8 +11325,6 @@ async def test_list_triggers_empty_call_grpc_asyncio():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        await client.list_triggers(request=None)
-
         await client.list_triggers(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11394,8 +11354,6 @@ async def test_create_trigger_empty_call_grpc_asyncio():
         )
         await client.create_trigger(request=None)
 
-        await client.create_trigger(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11423,8 +11381,6 @@ async def test_update_trigger_empty_call_grpc_asyncio():
         )
         await client.update_trigger(request=None)
 
-        await client.update_trigger(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11450,8 +11406,6 @@ async def test_delete_trigger_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.delete_trigger(request=None)
-
         await client.delete_trigger(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11486,8 +11440,6 @@ async def test_get_channel_empty_call_grpc_asyncio():
         ))
         await client.get_channel(request=None)
 
-        await client.get_channel(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11514,8 +11466,6 @@ async def test_list_channels_empty_call_grpc_asyncio():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        await client.list_channels(request=None)
-
         await client.list_channels(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11545,8 +11495,6 @@ async def test_create_channel_empty_call_grpc_asyncio():
         )
         await client.create_channel(request=None)
 
-        await client.create_channel(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11574,8 +11522,6 @@ async def test_update_channel_empty_call_grpc_asyncio():
         )
         await client.update_channel(request=None)
 
-        await client.update_channel(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11601,8 +11547,6 @@ async def test_delete_channel_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.delete_channel(request=None)
-
         await client.delete_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11633,8 +11577,6 @@ async def test_get_provider_empty_call_grpc_asyncio():
         ))
         await client.get_provider(request=None)
 
-        await client.get_provider(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11661,8 +11603,6 @@ async def test_list_providers_empty_call_grpc_asyncio():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        await client.list_providers(request=None)
-
         await client.list_providers(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11695,8 +11635,6 @@ async def test_get_channel_connection_empty_call_grpc_asyncio():
         ))
         await client.get_channel_connection(request=None)
 
-        await client.get_channel_connection(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11723,8 +11661,6 @@ async def test_list_channel_connections_empty_call_grpc_asyncio():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        await client.list_channel_connections(request=None)
-
         await client.list_channel_connections(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11754,8 +11690,6 @@ async def test_create_channel_connection_empty_call_grpc_asyncio():
         )
         await client.create_channel_connection(request=None)
 
-        await client.create_channel_connection(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11781,8 +11715,6 @@ async def test_delete_channel_connection_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.delete_channel_connection(request=None)
-
         await client.delete_channel_connection(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11813,8 +11745,6 @@ async def test_get_google_channel_config_empty_call_grpc_asyncio():
         ))
         await client.get_google_channel_config(request=None)
 
-        await client.get_google_channel_config(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11841,8 +11771,6 @@ async def test_update_google_channel_config_empty_call_grpc_asyncio():
             name='name_value',
             crypto_key_name='crypto_key_name_value',
         ))
-        await client.update_google_channel_config(request=None)
-
         await client.update_google_channel_config(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14501,8 +14429,8 @@ def test_get_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_trigger), '__call__') as call:
-
+            type(client.transport.get_trigger),
+            '__call__') as call:
         client.get_trigger(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14523,8 +14451,8 @@ def test_list_triggers_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_triggers), '__call__') as call:
-
+            type(client.transport.list_triggers),
+            '__call__') as call:
         client.list_triggers(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14545,8 +14473,8 @@ def test_create_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_trigger), '__call__') as call:
-
+            type(client.transport.create_trigger),
+            '__call__') as call:
         client.create_trigger(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14567,8 +14495,8 @@ def test_update_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_trigger), '__call__') as call:
-
+            type(client.transport.update_trigger),
+            '__call__') as call:
         client.update_trigger(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14589,8 +14517,8 @@ def test_delete_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_trigger), '__call__') as call:
-
+            type(client.transport.delete_trigger),
+            '__call__') as call:
         client.delete_trigger(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14611,8 +14539,8 @@ def test_get_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_channel), '__call__') as call:
-
+            type(client.transport.get_channel),
+            '__call__') as call:
         client.get_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14633,8 +14561,8 @@ def test_list_channels_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_channels), '__call__') as call:
-
+            type(client.transport.list_channels),
+            '__call__') as call:
         client.list_channels(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14655,8 +14583,8 @@ def test_create_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_channel_), '__call__') as call:
-
+            type(client.transport.create_channel_),
+            '__call__') as call:
         client.create_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14677,8 +14605,8 @@ def test_update_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_channel), '__call__') as call:
-
+            type(client.transport.update_channel),
+            '__call__') as call:
         client.update_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14699,8 +14627,8 @@ def test_delete_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_channel), '__call__') as call:
-
+            type(client.transport.delete_channel),
+            '__call__') as call:
         client.delete_channel(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14721,8 +14649,8 @@ def test_get_provider_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_provider), '__call__') as call:
-
+            type(client.transport.get_provider),
+            '__call__') as call:
         client.get_provider(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14743,8 +14671,8 @@ def test_list_providers_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_providers), '__call__') as call:
-
+            type(client.transport.list_providers),
+            '__call__') as call:
         client.list_providers(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14765,8 +14693,8 @@ def test_get_channel_connection_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_channel_connection), '__call__') as call:
-
+            type(client.transport.get_channel_connection),
+            '__call__') as call:
         client.get_channel_connection(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14787,8 +14715,8 @@ def test_list_channel_connections_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_channel_connections), '__call__') as call:
-
+            type(client.transport.list_channel_connections),
+            '__call__') as call:
         client.list_channel_connections(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14809,8 +14737,8 @@ def test_create_channel_connection_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_channel_connection), '__call__') as call:
-
+            type(client.transport.create_channel_connection),
+            '__call__') as call:
         client.create_channel_connection(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14831,8 +14759,8 @@ def test_delete_channel_connection_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_channel_connection), '__call__') as call:
-
+            type(client.transport.delete_channel_connection),
+            '__call__') as call:
         client.delete_channel_connection(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14853,8 +14781,8 @@ def test_get_google_channel_config_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_google_channel_config), '__call__') as call:
-
+            type(client.transport.get_google_channel_config),
+            '__call__') as call:
         client.get_google_channel_config(request=None)
 
         # Establish that the underlying stub method was called.
@@ -14875,8 +14803,8 @@ def test_update_google_channel_config_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_google_channel_config), '__call__') as call:
-
+            type(client.transport.update_google_channel_config),
+            '__call__') as call:
         client.update_google_channel_config(request=None)
 
         # Establish that the underlying stub method was called.

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -14501,17 +14501,7 @@ def test_get_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_trigger),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = trigger.Trigger()
-        # Convert return value to protobuf type
-        return_value = trigger.Trigger.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_trigger), '__call__') as call:
 
         client.get_trigger(request=None)
 
@@ -14533,17 +14523,7 @@ def test_list_triggers_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_triggers),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = eventarc.ListTriggersResponse()
-        # Convert return value to protobuf type
-        return_value = eventarc.ListTriggersResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_triggers), '__call__') as call:
 
         client.list_triggers(request=None)
 
@@ -14565,15 +14545,7 @@ def test_create_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_trigger),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.create_trigger), '__call__') as call:
 
         client.create_trigger(request=None)
 
@@ -14595,15 +14567,7 @@ def test_update_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_trigger),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.update_trigger), '__call__') as call:
 
         client.update_trigger(request=None)
 
@@ -14625,15 +14589,7 @@ def test_delete_trigger_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_trigger),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.delete_trigger), '__call__') as call:
 
         client.delete_trigger(request=None)
 
@@ -14655,17 +14611,7 @@ def test_get_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_channel),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = channel.Channel()
-        # Convert return value to protobuf type
-        return_value = channel.Channel.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_channel), '__call__') as call:
 
         client.get_channel(request=None)
 
@@ -14687,17 +14633,7 @@ def test_list_channels_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_channels),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = eventarc.ListChannelsResponse()
-        # Convert return value to protobuf type
-        return_value = eventarc.ListChannelsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_channels), '__call__') as call:
 
         client.list_channels(request=None)
 
@@ -14719,15 +14655,7 @@ def test_create_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_channel_),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.create_channel_), '__call__') as call:
 
         client.create_channel(request=None)
 
@@ -14749,15 +14677,7 @@ def test_update_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_channel),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.update_channel), '__call__') as call:
 
         client.update_channel(request=None)
 
@@ -14779,15 +14699,7 @@ def test_delete_channel_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_channel),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.delete_channel), '__call__') as call:
 
         client.delete_channel(request=None)
 
@@ -14809,17 +14721,7 @@ def test_get_provider_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_provider),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = discovery.Provider()
-        # Convert return value to protobuf type
-        return_value = discovery.Provider.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_provider), '__call__') as call:
 
         client.get_provider(request=None)
 
@@ -14841,17 +14743,7 @@ def test_list_providers_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_providers),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = eventarc.ListProvidersResponse()
-        # Convert return value to protobuf type
-        return_value = eventarc.ListProvidersResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_providers), '__call__') as call:
 
         client.list_providers(request=None)
 
@@ -14873,17 +14765,7 @@ def test_get_channel_connection_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_channel_connection),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = channel_connection.ChannelConnection()
-        # Convert return value to protobuf type
-        return_value = channel_connection.ChannelConnection.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_channel_connection), '__call__') as call:
 
         client.get_channel_connection(request=None)
 
@@ -14905,17 +14787,7 @@ def test_list_channel_connections_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_channel_connections),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = eventarc.ListChannelConnectionsResponse()
-        # Convert return value to protobuf type
-        return_value = eventarc.ListChannelConnectionsResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_channel_connections), '__call__') as call:
 
         client.list_channel_connections(request=None)
 
@@ -14937,15 +14809,7 @@ def test_create_channel_connection_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_channel_connection),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.create_channel_connection), '__call__') as call:
 
         client.create_channel_connection(request=None)
 
@@ -14967,15 +14831,7 @@ def test_delete_channel_connection_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_channel_connection),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.delete_channel_connection), '__call__') as call:
 
         client.delete_channel_connection(request=None)
 
@@ -14997,17 +14853,7 @@ def test_get_google_channel_config_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_google_channel_config),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = google_channel_config.GoogleChannelConfig()
-        # Convert return value to protobuf type
-        return_value = google_channel_config.GoogleChannelConfig.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_google_channel_config), '__call__') as call:
 
         client.get_google_channel_config(request=None)
 
@@ -15029,17 +14875,7 @@ def test_update_google_channel_config_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_google_channel_config),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = gce_google_channel_config.GoogleChannelConfig()
-        # Convert return value to protobuf type
-        return_value = gce_google_channel_config.GoogleChannelConfig.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.update_google_channel_config), '__call__') as call:
 
         client.update_google_channel_config(request=None)
 

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -10852,16 +10852,19 @@ def test_initialize_client_w_grpc():
 def test_get_trigger_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_trigger),
             '__call__') as call:
         call.return_value = trigger.Trigger()
         client.get_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetTriggerRequest()
@@ -10874,16 +10877,19 @@ def test_get_trigger_empty_call_grpc():
 def test_list_triggers_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_triggers),
             '__call__') as call:
         call.return_value = eventarc.ListTriggersResponse()
         client.list_triggers(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_triggers(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListTriggersRequest()
@@ -10896,16 +10902,19 @@ def test_list_triggers_empty_call_grpc():
 def test_create_trigger_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_trigger),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.CreateTriggerRequest()
@@ -10918,16 +10927,19 @@ def test_create_trigger_empty_call_grpc():
 def test_update_trigger_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_trigger),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.update_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.UpdateTriggerRequest()
@@ -10940,16 +10952,19 @@ def test_update_trigger_empty_call_grpc():
 def test_delete_trigger_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_trigger),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.delete_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.DeleteTriggerRequest()
@@ -10962,16 +10977,19 @@ def test_delete_trigger_empty_call_grpc():
 def test_get_channel_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_channel),
             '__call__') as call:
         call.return_value = channel.Channel()
         client.get_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetChannelRequest()
@@ -10984,16 +11002,19 @@ def test_get_channel_empty_call_grpc():
 def test_list_channels_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_channels),
             '__call__') as call:
         call.return_value = eventarc.ListChannelsResponse()
         client.list_channels(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_channels(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListChannelsRequest()
@@ -11006,16 +11027,19 @@ def test_list_channels_empty_call_grpc():
 def test_create_channel_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_channel_),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.CreateChannelRequest()
@@ -11028,16 +11052,19 @@ def test_create_channel_empty_call_grpc():
 def test_update_channel_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_channel),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.update_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.UpdateChannelRequest()
@@ -11050,16 +11077,19 @@ def test_update_channel_empty_call_grpc():
 def test_delete_channel_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_channel),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.delete_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.DeleteChannelRequest()
@@ -11072,16 +11102,19 @@ def test_delete_channel_empty_call_grpc():
 def test_get_provider_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_provider),
             '__call__') as call:
         call.return_value = discovery.Provider()
         client.get_provider(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_provider(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetProviderRequest()
@@ -11094,16 +11127,19 @@ def test_get_provider_empty_call_grpc():
 def test_list_providers_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_providers),
             '__call__') as call:
         call.return_value = eventarc.ListProvidersResponse()
         client.list_providers(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_providers(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListProvidersRequest()
@@ -11116,16 +11152,19 @@ def test_list_providers_empty_call_grpc():
 def test_get_channel_connection_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_channel_connection),
             '__call__') as call:
         call.return_value = channel_connection.ChannelConnection()
         client.get_channel_connection(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetChannelConnectionRequest()
@@ -11138,16 +11177,19 @@ def test_get_channel_connection_empty_call_grpc():
 def test_list_channel_connections_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_channel_connections),
             '__call__') as call:
         call.return_value = eventarc.ListChannelConnectionsResponse()
         client.list_channel_connections(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_channel_connections(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListChannelConnectionsRequest()
@@ -11160,16 +11202,19 @@ def test_list_channel_connections_empty_call_grpc():
 def test_create_channel_connection_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_channel_connection),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_channel_connection(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.CreateChannelConnectionRequest()
@@ -11182,16 +11227,19 @@ def test_create_channel_connection_empty_call_grpc():
 def test_delete_channel_connection_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_channel_connection),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.delete_channel_connection(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.DeleteChannelConnectionRequest()
@@ -11204,16 +11252,19 @@ def test_delete_channel_connection_empty_call_grpc():
 def test_get_google_channel_config_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_google_channel_config),
             '__call__') as call:
         call.return_value = google_channel_config.GoogleChannelConfig()
         client.get_google_channel_config(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_google_channel_config(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetGoogleChannelConfigRequest()
@@ -11226,16 +11277,19 @@ def test_get_google_channel_config_empty_call_grpc():
 def test_update_google_channel_config_empty_call_grpc():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_google_channel_config),
             '__call__') as call:
         call.return_value = gce_google_channel_config.GoogleChannelConfig()
         client.update_google_channel_config(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_google_channel_config(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.UpdateGoogleChannelConfigRequest()
@@ -11264,9 +11318,10 @@ def test_initialize_client_w_grpc_asyncio():
 async def test_get_trigger_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_trigger),
             '__call__') as call:
@@ -11280,7 +11335,9 @@ async def test_get_trigger_empty_call_grpc_asyncio():
         ))
         await client.get_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetTriggerRequest()
@@ -11294,9 +11351,10 @@ async def test_get_trigger_empty_call_grpc_asyncio():
 async def test_list_triggers_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_triggers),
             '__call__') as call:
@@ -11307,7 +11365,9 @@ async def test_list_triggers_empty_call_grpc_asyncio():
         ))
         await client.list_triggers(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_triggers(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListTriggersRequest()
@@ -11321,9 +11381,10 @@ async def test_list_triggers_empty_call_grpc_asyncio():
 async def test_create_trigger_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_trigger),
             '__call__') as call:
@@ -11333,7 +11394,9 @@ async def test_create_trigger_empty_call_grpc_asyncio():
         )
         await client.create_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.CreateTriggerRequest()
@@ -11347,9 +11410,10 @@ async def test_create_trigger_empty_call_grpc_asyncio():
 async def test_update_trigger_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_trigger),
             '__call__') as call:
@@ -11359,7 +11423,9 @@ async def test_update_trigger_empty_call_grpc_asyncio():
         )
         await client.update_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.UpdateTriggerRequest()
@@ -11373,9 +11439,10 @@ async def test_update_trigger_empty_call_grpc_asyncio():
 async def test_delete_trigger_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_trigger),
             '__call__') as call:
@@ -11385,7 +11452,9 @@ async def test_delete_trigger_empty_call_grpc_asyncio():
         )
         await client.delete_trigger(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.DeleteTriggerRequest()
@@ -11399,9 +11468,10 @@ async def test_delete_trigger_empty_call_grpc_asyncio():
 async def test_get_channel_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_channel),
             '__call__') as call:
@@ -11416,7 +11486,9 @@ async def test_get_channel_empty_call_grpc_asyncio():
         ))
         await client.get_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetChannelRequest()
@@ -11430,9 +11502,10 @@ async def test_get_channel_empty_call_grpc_asyncio():
 async def test_list_channels_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_channels),
             '__call__') as call:
@@ -11443,7 +11516,9 @@ async def test_list_channels_empty_call_grpc_asyncio():
         ))
         await client.list_channels(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_channels(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListChannelsRequest()
@@ -11457,9 +11532,10 @@ async def test_list_channels_empty_call_grpc_asyncio():
 async def test_create_channel_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_channel_),
             '__call__') as call:
@@ -11469,7 +11545,9 @@ async def test_create_channel_empty_call_grpc_asyncio():
         )
         await client.create_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.CreateChannelRequest()
@@ -11483,9 +11561,10 @@ async def test_create_channel_empty_call_grpc_asyncio():
 async def test_update_channel_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_channel),
             '__call__') as call:
@@ -11495,7 +11574,9 @@ async def test_update_channel_empty_call_grpc_asyncio():
         )
         await client.update_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.UpdateChannelRequest()
@@ -11509,9 +11590,10 @@ async def test_update_channel_empty_call_grpc_asyncio():
 async def test_delete_channel_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_channel),
             '__call__') as call:
@@ -11521,7 +11603,9 @@ async def test_delete_channel_empty_call_grpc_asyncio():
         )
         await client.delete_channel(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_channel(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.DeleteChannelRequest()
@@ -11535,9 +11619,10 @@ async def test_delete_channel_empty_call_grpc_asyncio():
 async def test_get_provider_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_provider),
             '__call__') as call:
@@ -11548,7 +11633,9 @@ async def test_get_provider_empty_call_grpc_asyncio():
         ))
         await client.get_provider(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_provider(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetProviderRequest()
@@ -11562,9 +11649,10 @@ async def test_get_provider_empty_call_grpc_asyncio():
 async def test_list_providers_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_providers),
             '__call__') as call:
@@ -11575,7 +11663,9 @@ async def test_list_providers_empty_call_grpc_asyncio():
         ))
         await client.list_providers(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_providers(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListProvidersRequest()
@@ -11589,9 +11679,10 @@ async def test_list_providers_empty_call_grpc_asyncio():
 async def test_get_channel_connection_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_channel_connection),
             '__call__') as call:
@@ -11604,7 +11695,9 @@ async def test_get_channel_connection_empty_call_grpc_asyncio():
         ))
         await client.get_channel_connection(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetChannelConnectionRequest()
@@ -11618,9 +11711,10 @@ async def test_get_channel_connection_empty_call_grpc_asyncio():
 async def test_list_channel_connections_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_channel_connections),
             '__call__') as call:
@@ -11631,7 +11725,9 @@ async def test_list_channel_connections_empty_call_grpc_asyncio():
         ))
         await client.list_channel_connections(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_channel_connections(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.ListChannelConnectionsRequest()
@@ -11645,9 +11741,10 @@ async def test_list_channel_connections_empty_call_grpc_asyncio():
 async def test_create_channel_connection_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_channel_connection),
             '__call__') as call:
@@ -11657,7 +11754,9 @@ async def test_create_channel_connection_empty_call_grpc_asyncio():
         )
         await client.create_channel_connection(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.CreateChannelConnectionRequest()
@@ -11671,9 +11770,10 @@ async def test_create_channel_connection_empty_call_grpc_asyncio():
 async def test_delete_channel_connection_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_channel_connection),
             '__call__') as call:
@@ -11683,7 +11783,9 @@ async def test_delete_channel_connection_empty_call_grpc_asyncio():
         )
         await client.delete_channel_connection(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.DeleteChannelConnectionRequest()
@@ -11697,9 +11799,10 @@ async def test_delete_channel_connection_empty_call_grpc_asyncio():
 async def test_get_google_channel_config_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_google_channel_config),
             '__call__') as call:
@@ -11710,7 +11813,9 @@ async def test_get_google_channel_config_empty_call_grpc_asyncio():
         ))
         await client.get_google_channel_config(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_google_channel_config(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.GetGoogleChannelConfigRequest()
@@ -11724,9 +11829,10 @@ async def test_get_google_channel_config_empty_call_grpc_asyncio():
 async def test_update_google_channel_config_empty_call_grpc_asyncio():
     client = EventarcAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_google_channel_config),
             '__call__') as call:
@@ -11737,7 +11843,9 @@ async def test_update_google_channel_config_empty_call_grpc_asyncio():
         ))
         await client.update_google_channel_config(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_google_channel_config(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = eventarc.UpdateGoogleChannelConfigRequest()
@@ -14381,6 +14489,566 @@ def test_initialize_client_w_rest():
         transport="rest"
     )
     assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_trigger_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_trigger),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = trigger.Trigger()
+        # Convert return value to protobuf type
+        return_value = trigger.Trigger.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.GetTriggerRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_triggers_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_triggers),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = eventarc.ListTriggersResponse()
+        # Convert return value to protobuf type
+        return_value = eventarc.ListTriggersResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_triggers(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.ListTriggersRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_create_trigger_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.create_trigger),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.create_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.CreateTriggerRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_update_trigger_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.update_trigger),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.update_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.UpdateTriggerRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_delete_trigger_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.delete_trigger),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.delete_trigger(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.DeleteTriggerRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_channel_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_channel),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = channel.Channel()
+        # Convert return value to protobuf type
+        return_value = channel.Channel.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_channel(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.GetChannelRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_channels_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_channels),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = eventarc.ListChannelsResponse()
+        # Convert return value to protobuf type
+        return_value = eventarc.ListChannelsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_channels(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.ListChannelsRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_create_channel_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.create_channel_),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.create_channel(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.CreateChannelRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_update_channel_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.update_channel),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.update_channel(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.UpdateChannelRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_delete_channel_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.delete_channel),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.delete_channel(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.DeleteChannelRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_provider_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_provider),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = discovery.Provider()
+        # Convert return value to protobuf type
+        return_value = discovery.Provider.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_provider(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.GetProviderRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_providers_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_providers),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = eventarc.ListProvidersResponse()
+        # Convert return value to protobuf type
+        return_value = eventarc.ListProvidersResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_providers(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.ListProvidersRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_channel_connection_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_channel_connection),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = channel_connection.ChannelConnection()
+        # Convert return value to protobuf type
+        return_value = channel_connection.ChannelConnection.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.GetChannelConnectionRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_channel_connections_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_channel_connections),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = eventarc.ListChannelConnectionsResponse()
+        # Convert return value to protobuf type
+        return_value = eventarc.ListChannelConnectionsResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_channel_connections(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.ListChannelConnectionsRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_create_channel_connection_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.create_channel_connection),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.create_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.CreateChannelConnectionRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_delete_channel_connection_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.delete_channel_connection),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.delete_channel_connection(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.DeleteChannelConnectionRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_google_channel_config_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_google_channel_config),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = google_channel_config.GoogleChannelConfig()
+        # Convert return value to protobuf type
+        return_value = google_channel_config.GoogleChannelConfig.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_google_channel_config(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.GetGoogleChannelConfigRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_update_google_channel_config_empty_call_rest():
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.update_google_channel_config),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = gce_google_channel_config.GoogleChannelConfig()
+        # Convert return value to protobuf type
+        return_value = gce_google_channel_config.GoogleChannelConfig.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.update_google_channel_config(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = eventarc.UpdateGoogleChannelConfigRequest()
+
+        assert args[0] == request_msg
 
 
 def test_eventarc_rest_lro_client():

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -10925,16 +10925,19 @@ def test_initialize_client_w_grpc():
 def test_list_buckets_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_buckets),
             '__call__') as call:
         call.return_value = logging_config.ListBucketsResponse()
         client.list_buckets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_buckets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListBucketsRequest()
@@ -10947,16 +10950,19 @@ def test_list_buckets_empty_call_grpc():
 def test_get_bucket_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_bucket),
             '__call__') as call:
         call.return_value = logging_config.LogBucket()
         client.get_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetBucketRequest()
@@ -10969,16 +10975,19 @@ def test_get_bucket_empty_call_grpc():
 def test_create_bucket_async_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_bucket_async),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_bucket_async(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_bucket_async(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
@@ -10991,16 +11000,19 @@ def test_create_bucket_async_empty_call_grpc():
 def test_update_bucket_async_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_bucket_async),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.update_bucket_async(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_bucket_async(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
@@ -11013,16 +11025,19 @@ def test_update_bucket_async_empty_call_grpc():
 def test_create_bucket_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_bucket),
             '__call__') as call:
         call.return_value = logging_config.LogBucket()
         client.create_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
@@ -11035,16 +11050,19 @@ def test_create_bucket_empty_call_grpc():
 def test_update_bucket_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_bucket),
             '__call__') as call:
         call.return_value = logging_config.LogBucket()
         client.update_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
@@ -11057,16 +11075,19 @@ def test_update_bucket_empty_call_grpc():
 def test_delete_bucket_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_bucket),
             '__call__') as call:
         call.return_value = None
         client.delete_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteBucketRequest()
@@ -11079,16 +11100,19 @@ def test_delete_bucket_empty_call_grpc():
 def test_undelete_bucket_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.undelete_bucket),
             '__call__') as call:
         call.return_value = None
         client.undelete_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.undelete_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UndeleteBucketRequest()
@@ -11101,16 +11125,19 @@ def test_undelete_bucket_empty_call_grpc():
 def test_list_views_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_views),
             '__call__') as call:
         call.return_value = logging_config.ListViewsResponse()
         client.list_views(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_views(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListViewsRequest()
@@ -11123,16 +11150,19 @@ def test_list_views_empty_call_grpc():
 def test_get_view_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_view),
             '__call__') as call:
         call.return_value = logging_config.LogView()
         client.get_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetViewRequest()
@@ -11145,16 +11175,19 @@ def test_get_view_empty_call_grpc():
 def test_create_view_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_view),
             '__call__') as call:
         call.return_value = logging_config.LogView()
         client.create_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateViewRequest()
@@ -11167,16 +11200,19 @@ def test_create_view_empty_call_grpc():
 def test_update_view_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_view),
             '__call__') as call:
         call.return_value = logging_config.LogView()
         client.update_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateViewRequest()
@@ -11189,16 +11225,19 @@ def test_update_view_empty_call_grpc():
 def test_delete_view_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_view),
             '__call__') as call:
         call.return_value = None
         client.delete_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteViewRequest()
@@ -11211,16 +11250,19 @@ def test_delete_view_empty_call_grpc():
 def test_list_sinks_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_sinks),
             '__call__') as call:
         call.return_value = logging_config.ListSinksResponse()
         client.list_sinks(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_sinks(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListSinksRequest()
@@ -11233,16 +11275,19 @@ def test_list_sinks_empty_call_grpc():
 def test_get_sink_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_sink),
             '__call__') as call:
         call.return_value = logging_config.LogSink()
         client.get_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSinkRequest()
@@ -11255,16 +11300,19 @@ def test_get_sink_empty_call_grpc():
 def test_create_sink_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_sink),
             '__call__') as call:
         call.return_value = logging_config.LogSink()
         client.create_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateSinkRequest()
@@ -11277,16 +11325,19 @@ def test_create_sink_empty_call_grpc():
 def test_update_sink_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_sink),
             '__call__') as call:
         call.return_value = logging_config.LogSink()
         client.update_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSinkRequest()
@@ -11299,16 +11350,19 @@ def test_update_sink_empty_call_grpc():
 def test_delete_sink_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_sink),
             '__call__') as call:
         call.return_value = None
         client.delete_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteSinkRequest()
@@ -11321,16 +11375,19 @@ def test_delete_sink_empty_call_grpc():
 def test_create_link_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_link),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_link(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_link(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateLinkRequest()
@@ -11343,16 +11400,19 @@ def test_create_link_empty_call_grpc():
 def test_delete_link_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_link),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.delete_link(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_link(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteLinkRequest()
@@ -11365,16 +11425,19 @@ def test_delete_link_empty_call_grpc():
 def test_list_links_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_links),
             '__call__') as call:
         call.return_value = logging_config.ListLinksResponse()
         client.list_links(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_links(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListLinksRequest()
@@ -11387,16 +11450,19 @@ def test_list_links_empty_call_grpc():
 def test_get_link_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_link),
             '__call__') as call:
         call.return_value = logging_config.Link()
         client.get_link(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_link(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetLinkRequest()
@@ -11409,16 +11475,19 @@ def test_get_link_empty_call_grpc():
 def test_list_exclusions_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_exclusions),
             '__call__') as call:
         call.return_value = logging_config.ListExclusionsResponse()
         client.list_exclusions(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_exclusions(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListExclusionsRequest()
@@ -11431,16 +11500,19 @@ def test_list_exclusions_empty_call_grpc():
 def test_get_exclusion_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_exclusion),
             '__call__') as call:
         call.return_value = logging_config.LogExclusion()
         client.get_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetExclusionRequest()
@@ -11453,16 +11525,19 @@ def test_get_exclusion_empty_call_grpc():
 def test_create_exclusion_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_exclusion),
             '__call__') as call:
         call.return_value = logging_config.LogExclusion()
         client.create_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateExclusionRequest()
@@ -11475,16 +11550,19 @@ def test_create_exclusion_empty_call_grpc():
 def test_update_exclusion_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_exclusion),
             '__call__') as call:
         call.return_value = logging_config.LogExclusion()
         client.update_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateExclusionRequest()
@@ -11497,16 +11575,19 @@ def test_update_exclusion_empty_call_grpc():
 def test_delete_exclusion_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_exclusion),
             '__call__') as call:
         call.return_value = None
         client.delete_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteExclusionRequest()
@@ -11519,16 +11600,19 @@ def test_delete_exclusion_empty_call_grpc():
 def test_get_cmek_settings_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_cmek_settings),
             '__call__') as call:
         call.return_value = logging_config.CmekSettings()
         client.get_cmek_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_cmek_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetCmekSettingsRequest()
@@ -11541,16 +11625,19 @@ def test_get_cmek_settings_empty_call_grpc():
 def test_update_cmek_settings_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_cmek_settings),
             '__call__') as call:
         call.return_value = logging_config.CmekSettings()
         client.update_cmek_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_cmek_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateCmekSettingsRequest()
@@ -11563,16 +11650,19 @@ def test_update_cmek_settings_empty_call_grpc():
 def test_get_settings_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_settings),
             '__call__') as call:
         call.return_value = logging_config.Settings()
         client.get_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSettingsRequest()
@@ -11585,16 +11675,19 @@ def test_get_settings_empty_call_grpc():
 def test_update_settings_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_settings),
             '__call__') as call:
         call.return_value = logging_config.Settings()
         client.update_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSettingsRequest()
@@ -11607,16 +11700,19 @@ def test_update_settings_empty_call_grpc():
 def test_copy_log_entries_empty_call_grpc():
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.copy_log_entries),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.copy_log_entries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.copy_log_entries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CopyLogEntriesRequest()
@@ -11645,9 +11741,10 @@ def test_initialize_client_w_grpc_asyncio():
 async def test_list_buckets_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_buckets),
             '__call__') as call:
@@ -11657,7 +11754,9 @@ async def test_list_buckets_empty_call_grpc_asyncio():
         ))
         await client.list_buckets(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_buckets(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListBucketsRequest()
@@ -11671,9 +11770,10 @@ async def test_list_buckets_empty_call_grpc_asyncio():
 async def test_get_bucket_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_bucket),
             '__call__') as call:
@@ -11689,7 +11789,9 @@ async def test_get_bucket_empty_call_grpc_asyncio():
         ))
         await client.get_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetBucketRequest()
@@ -11703,9 +11805,10 @@ async def test_get_bucket_empty_call_grpc_asyncio():
 async def test_create_bucket_async_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_bucket_async),
             '__call__') as call:
@@ -11715,7 +11818,9 @@ async def test_create_bucket_async_empty_call_grpc_asyncio():
         )
         await client.create_bucket_async(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_bucket_async(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
@@ -11729,9 +11834,10 @@ async def test_create_bucket_async_empty_call_grpc_asyncio():
 async def test_update_bucket_async_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_bucket_async),
             '__call__') as call:
@@ -11741,7 +11847,9 @@ async def test_update_bucket_async_empty_call_grpc_asyncio():
         )
         await client.update_bucket_async(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_bucket_async(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
@@ -11755,9 +11863,10 @@ async def test_update_bucket_async_empty_call_grpc_asyncio():
 async def test_create_bucket_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_bucket),
             '__call__') as call:
@@ -11773,7 +11882,9 @@ async def test_create_bucket_empty_call_grpc_asyncio():
         ))
         await client.create_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateBucketRequest()
@@ -11787,9 +11898,10 @@ async def test_create_bucket_empty_call_grpc_asyncio():
 async def test_update_bucket_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_bucket),
             '__call__') as call:
@@ -11805,7 +11917,9 @@ async def test_update_bucket_empty_call_grpc_asyncio():
         ))
         await client.update_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateBucketRequest()
@@ -11819,9 +11933,10 @@ async def test_update_bucket_empty_call_grpc_asyncio():
 async def test_delete_bucket_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_bucket),
             '__call__') as call:
@@ -11829,7 +11944,9 @@ async def test_delete_bucket_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteBucketRequest()
@@ -11843,9 +11960,10 @@ async def test_delete_bucket_empty_call_grpc_asyncio():
 async def test_undelete_bucket_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.undelete_bucket),
             '__call__') as call:
@@ -11853,7 +11971,9 @@ async def test_undelete_bucket_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.undelete_bucket(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.undelete_bucket(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UndeleteBucketRequest()
@@ -11867,9 +11987,10 @@ async def test_undelete_bucket_empty_call_grpc_asyncio():
 async def test_list_views_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_views),
             '__call__') as call:
@@ -11879,7 +12000,9 @@ async def test_list_views_empty_call_grpc_asyncio():
         ))
         await client.list_views(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_views(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListViewsRequest()
@@ -11893,9 +12016,10 @@ async def test_list_views_empty_call_grpc_asyncio():
 async def test_get_view_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_view),
             '__call__') as call:
@@ -11907,7 +12031,9 @@ async def test_get_view_empty_call_grpc_asyncio():
         ))
         await client.get_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetViewRequest()
@@ -11921,9 +12047,10 @@ async def test_get_view_empty_call_grpc_asyncio():
 async def test_create_view_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_view),
             '__call__') as call:
@@ -11935,7 +12062,9 @@ async def test_create_view_empty_call_grpc_asyncio():
         ))
         await client.create_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateViewRequest()
@@ -11949,9 +12078,10 @@ async def test_create_view_empty_call_grpc_asyncio():
 async def test_update_view_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_view),
             '__call__') as call:
@@ -11963,7 +12093,9 @@ async def test_update_view_empty_call_grpc_asyncio():
         ))
         await client.update_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateViewRequest()
@@ -11977,9 +12109,10 @@ async def test_update_view_empty_call_grpc_asyncio():
 async def test_delete_view_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_view),
             '__call__') as call:
@@ -11987,7 +12120,9 @@ async def test_delete_view_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_view(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_view(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteViewRequest()
@@ -12001,9 +12136,10 @@ async def test_delete_view_empty_call_grpc_asyncio():
 async def test_list_sinks_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_sinks),
             '__call__') as call:
@@ -12013,7 +12149,9 @@ async def test_list_sinks_empty_call_grpc_asyncio():
         ))
         await client.list_sinks(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_sinks(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListSinksRequest()
@@ -12027,9 +12165,10 @@ async def test_list_sinks_empty_call_grpc_asyncio():
 async def test_get_sink_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_sink),
             '__call__') as call:
@@ -12046,7 +12185,9 @@ async def test_get_sink_empty_call_grpc_asyncio():
         ))
         await client.get_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSinkRequest()
@@ -12060,9 +12201,10 @@ async def test_get_sink_empty_call_grpc_asyncio():
 async def test_create_sink_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_sink),
             '__call__') as call:
@@ -12079,7 +12221,9 @@ async def test_create_sink_empty_call_grpc_asyncio():
         ))
         await client.create_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateSinkRequest()
@@ -12093,9 +12237,10 @@ async def test_create_sink_empty_call_grpc_asyncio():
 async def test_update_sink_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_sink),
             '__call__') as call:
@@ -12112,7 +12257,9 @@ async def test_update_sink_empty_call_grpc_asyncio():
         ))
         await client.update_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSinkRequest()
@@ -12126,9 +12273,10 @@ async def test_update_sink_empty_call_grpc_asyncio():
 async def test_delete_sink_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_sink),
             '__call__') as call:
@@ -12136,7 +12284,9 @@ async def test_delete_sink_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_sink(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_sink(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteSinkRequest()
@@ -12150,9 +12300,10 @@ async def test_delete_sink_empty_call_grpc_asyncio():
 async def test_create_link_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_link),
             '__call__') as call:
@@ -12162,7 +12313,9 @@ async def test_create_link_empty_call_grpc_asyncio():
         )
         await client.create_link(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_link(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateLinkRequest()
@@ -12176,9 +12329,10 @@ async def test_create_link_empty_call_grpc_asyncio():
 async def test_delete_link_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_link),
             '__call__') as call:
@@ -12188,7 +12342,9 @@ async def test_delete_link_empty_call_grpc_asyncio():
         )
         await client.delete_link(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_link(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteLinkRequest()
@@ -12202,9 +12358,10 @@ async def test_delete_link_empty_call_grpc_asyncio():
 async def test_list_links_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_links),
             '__call__') as call:
@@ -12214,7 +12371,9 @@ async def test_list_links_empty_call_grpc_asyncio():
         ))
         await client.list_links(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_links(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListLinksRequest()
@@ -12228,9 +12387,10 @@ async def test_list_links_empty_call_grpc_asyncio():
 async def test_get_link_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_link),
             '__call__') as call:
@@ -12242,7 +12402,9 @@ async def test_get_link_empty_call_grpc_asyncio():
         ))
         await client.get_link(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_link(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetLinkRequest()
@@ -12256,9 +12418,10 @@ async def test_get_link_empty_call_grpc_asyncio():
 async def test_list_exclusions_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_exclusions),
             '__call__') as call:
@@ -12268,7 +12431,9 @@ async def test_list_exclusions_empty_call_grpc_asyncio():
         ))
         await client.list_exclusions(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_exclusions(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.ListExclusionsRequest()
@@ -12282,9 +12447,10 @@ async def test_list_exclusions_empty_call_grpc_asyncio():
 async def test_get_exclusion_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_exclusion),
             '__call__') as call:
@@ -12297,7 +12463,9 @@ async def test_get_exclusion_empty_call_grpc_asyncio():
         ))
         await client.get_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetExclusionRequest()
@@ -12311,9 +12479,10 @@ async def test_get_exclusion_empty_call_grpc_asyncio():
 async def test_create_exclusion_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_exclusion),
             '__call__') as call:
@@ -12326,7 +12495,9 @@ async def test_create_exclusion_empty_call_grpc_asyncio():
         ))
         await client.create_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CreateExclusionRequest()
@@ -12340,9 +12511,10 @@ async def test_create_exclusion_empty_call_grpc_asyncio():
 async def test_update_exclusion_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_exclusion),
             '__call__') as call:
@@ -12355,7 +12527,9 @@ async def test_update_exclusion_empty_call_grpc_asyncio():
         ))
         await client.update_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateExclusionRequest()
@@ -12369,9 +12543,10 @@ async def test_update_exclusion_empty_call_grpc_asyncio():
 async def test_delete_exclusion_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_exclusion),
             '__call__') as call:
@@ -12379,7 +12554,9 @@ async def test_delete_exclusion_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_exclusion(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_exclusion(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.DeleteExclusionRequest()
@@ -12393,9 +12570,10 @@ async def test_delete_exclusion_empty_call_grpc_asyncio():
 async def test_get_cmek_settings_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_cmek_settings),
             '__call__') as call:
@@ -12408,7 +12586,9 @@ async def test_get_cmek_settings_empty_call_grpc_asyncio():
         ))
         await client.get_cmek_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_cmek_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetCmekSettingsRequest()
@@ -12422,9 +12602,10 @@ async def test_get_cmek_settings_empty_call_grpc_asyncio():
 async def test_update_cmek_settings_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_cmek_settings),
             '__call__') as call:
@@ -12437,7 +12618,9 @@ async def test_update_cmek_settings_empty_call_grpc_asyncio():
         ))
         await client.update_cmek_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_cmek_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateCmekSettingsRequest()
@@ -12451,9 +12634,10 @@ async def test_update_cmek_settings_empty_call_grpc_asyncio():
 async def test_get_settings_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_settings),
             '__call__') as call:
@@ -12467,7 +12651,9 @@ async def test_get_settings_empty_call_grpc_asyncio():
         ))
         await client.get_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.GetSettingsRequest()
@@ -12481,9 +12667,10 @@ async def test_get_settings_empty_call_grpc_asyncio():
 async def test_update_settings_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_settings),
             '__call__') as call:
@@ -12497,7 +12684,9 @@ async def test_update_settings_empty_call_grpc_asyncio():
         ))
         await client.update_settings(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_settings(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.UpdateSettingsRequest()
@@ -12511,9 +12700,10 @@ async def test_update_settings_empty_call_grpc_asyncio():
 async def test_copy_log_entries_empty_call_grpc_asyncio():
     client = ConfigServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.copy_log_entries),
             '__call__') as call:
@@ -12523,7 +12713,9 @@ async def test_copy_log_entries_empty_call_grpc_asyncio():
         )
         await client.copy_log_entries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.copy_log_entries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_config.CopyLogEntriesRequest()

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -10935,8 +10935,6 @@ def test_list_buckets_empty_call_grpc():
         call.return_value = logging_config.ListBucketsResponse()
         client.list_buckets(request=None)
 
-        client.list_buckets(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -10958,8 +10956,6 @@ def test_get_bucket_empty_call_grpc():
             type(client.transport.get_bucket),
             '__call__') as call:
         call.return_value = logging_config.LogBucket()
-        client.get_bucket(request=None)
-
         client.get_bucket(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10985,8 +10981,6 @@ def test_create_bucket_async_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_bucket_async(request=None)
 
-        client.create_bucket_async(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11008,8 +11002,6 @@ def test_update_bucket_async_empty_call_grpc():
             type(client.transport.update_bucket_async),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.update_bucket_async(request=None)
-
         client.update_bucket_async(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11035,8 +11027,6 @@ def test_create_bucket_empty_call_grpc():
         call.return_value = logging_config.LogBucket()
         client.create_bucket(request=None)
 
-        client.create_bucket(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11058,8 +11048,6 @@ def test_update_bucket_empty_call_grpc():
             type(client.transport.update_bucket),
             '__call__') as call:
         call.return_value = logging_config.LogBucket()
-        client.update_bucket(request=None)
-
         client.update_bucket(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11085,8 +11073,6 @@ def test_delete_bucket_empty_call_grpc():
         call.return_value = None
         client.delete_bucket(request=None)
 
-        client.delete_bucket(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11108,8 +11094,6 @@ def test_undelete_bucket_empty_call_grpc():
             type(client.transport.undelete_bucket),
             '__call__') as call:
         call.return_value = None
-        client.undelete_bucket(request=None)
-
         client.undelete_bucket(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11135,8 +11119,6 @@ def test_list_views_empty_call_grpc():
         call.return_value = logging_config.ListViewsResponse()
         client.list_views(request=None)
 
-        client.list_views(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11158,8 +11140,6 @@ def test_get_view_empty_call_grpc():
             type(client.transport.get_view),
             '__call__') as call:
         call.return_value = logging_config.LogView()
-        client.get_view(request=None)
-
         client.get_view(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11185,8 +11165,6 @@ def test_create_view_empty_call_grpc():
         call.return_value = logging_config.LogView()
         client.create_view(request=None)
 
-        client.create_view(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11208,8 +11186,6 @@ def test_update_view_empty_call_grpc():
             type(client.transport.update_view),
             '__call__') as call:
         call.return_value = logging_config.LogView()
-        client.update_view(request=None)
-
         client.update_view(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11235,8 +11211,6 @@ def test_delete_view_empty_call_grpc():
         call.return_value = None
         client.delete_view(request=None)
 
-        client.delete_view(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11258,8 +11232,6 @@ def test_list_sinks_empty_call_grpc():
             type(client.transport.list_sinks),
             '__call__') as call:
         call.return_value = logging_config.ListSinksResponse()
-        client.list_sinks(request=None)
-
         client.list_sinks(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11285,8 +11257,6 @@ def test_get_sink_empty_call_grpc():
         call.return_value = logging_config.LogSink()
         client.get_sink(request=None)
 
-        client.get_sink(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11308,8 +11278,6 @@ def test_create_sink_empty_call_grpc():
             type(client.transport.create_sink),
             '__call__') as call:
         call.return_value = logging_config.LogSink()
-        client.create_sink(request=None)
-
         client.create_sink(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11335,8 +11303,6 @@ def test_update_sink_empty_call_grpc():
         call.return_value = logging_config.LogSink()
         client.update_sink(request=None)
 
-        client.update_sink(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11358,8 +11324,6 @@ def test_delete_sink_empty_call_grpc():
             type(client.transport.delete_sink),
             '__call__') as call:
         call.return_value = None
-        client.delete_sink(request=None)
-
         client.delete_sink(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11385,8 +11349,6 @@ def test_create_link_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_link(request=None)
 
-        client.create_link(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11408,8 +11370,6 @@ def test_delete_link_empty_call_grpc():
             type(client.transport.delete_link),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.delete_link(request=None)
-
         client.delete_link(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11435,8 +11395,6 @@ def test_list_links_empty_call_grpc():
         call.return_value = logging_config.ListLinksResponse()
         client.list_links(request=None)
 
-        client.list_links(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11458,8 +11416,6 @@ def test_get_link_empty_call_grpc():
             type(client.transport.get_link),
             '__call__') as call:
         call.return_value = logging_config.Link()
-        client.get_link(request=None)
-
         client.get_link(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11485,8 +11441,6 @@ def test_list_exclusions_empty_call_grpc():
         call.return_value = logging_config.ListExclusionsResponse()
         client.list_exclusions(request=None)
 
-        client.list_exclusions(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11508,8 +11462,6 @@ def test_get_exclusion_empty_call_grpc():
             type(client.transport.get_exclusion),
             '__call__') as call:
         call.return_value = logging_config.LogExclusion()
-        client.get_exclusion(request=None)
-
         client.get_exclusion(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11535,8 +11487,6 @@ def test_create_exclusion_empty_call_grpc():
         call.return_value = logging_config.LogExclusion()
         client.create_exclusion(request=None)
 
-        client.create_exclusion(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11558,8 +11508,6 @@ def test_update_exclusion_empty_call_grpc():
             type(client.transport.update_exclusion),
             '__call__') as call:
         call.return_value = logging_config.LogExclusion()
-        client.update_exclusion(request=None)
-
         client.update_exclusion(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11585,8 +11533,6 @@ def test_delete_exclusion_empty_call_grpc():
         call.return_value = None
         client.delete_exclusion(request=None)
 
-        client.delete_exclusion(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11608,8 +11554,6 @@ def test_get_cmek_settings_empty_call_grpc():
             type(client.transport.get_cmek_settings),
             '__call__') as call:
         call.return_value = logging_config.CmekSettings()
-        client.get_cmek_settings(request=None)
-
         client.get_cmek_settings(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11635,8 +11579,6 @@ def test_update_cmek_settings_empty_call_grpc():
         call.return_value = logging_config.CmekSettings()
         client.update_cmek_settings(request=None)
 
-        client.update_cmek_settings(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11658,8 +11600,6 @@ def test_get_settings_empty_call_grpc():
             type(client.transport.get_settings),
             '__call__') as call:
         call.return_value = logging_config.Settings()
-        client.get_settings(request=None)
-
         client.get_settings(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11685,8 +11625,6 @@ def test_update_settings_empty_call_grpc():
         call.return_value = logging_config.Settings()
         client.update_settings(request=None)
 
-        client.update_settings(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11708,8 +11646,6 @@ def test_copy_log_entries_empty_call_grpc():
             type(client.transport.copy_log_entries),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.copy_log_entries(request=None)
-
         client.copy_log_entries(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11754,8 +11690,6 @@ async def test_list_buckets_empty_call_grpc_asyncio():
         ))
         await client.list_buckets(request=None)
 
-        await client.list_buckets(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11789,8 +11723,6 @@ async def test_get_bucket_empty_call_grpc_asyncio():
         ))
         await client.get_bucket(request=None)
 
-        await client.get_bucket(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11818,8 +11750,6 @@ async def test_create_bucket_async_empty_call_grpc_asyncio():
         )
         await client.create_bucket_async(request=None)
 
-        await client.create_bucket_async(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11845,8 +11775,6 @@ async def test_update_bucket_async_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.update_bucket_async(request=None)
-
         await client.update_bucket_async(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11882,8 +11810,6 @@ async def test_create_bucket_empty_call_grpc_asyncio():
         ))
         await client.create_bucket(request=None)
 
-        await client.create_bucket(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11917,8 +11843,6 @@ async def test_update_bucket_empty_call_grpc_asyncio():
         ))
         await client.update_bucket(request=None)
 
-        await client.update_bucket(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11942,8 +11866,6 @@ async def test_delete_bucket_empty_call_grpc_asyncio():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        await client.delete_bucket(request=None)
-
         await client.delete_bucket(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11971,8 +11893,6 @@ async def test_undelete_bucket_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.undelete_bucket(request=None)
 
-        await client.undelete_bucket(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -11998,8 +11918,6 @@ async def test_list_views_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListViewsResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.list_views(request=None)
-
         await client.list_views(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12031,8 +11949,6 @@ async def test_get_view_empty_call_grpc_asyncio():
         ))
         await client.get_view(request=None)
 
-        await client.get_view(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12060,8 +11976,6 @@ async def test_create_view_empty_call_grpc_asyncio():
             description='description_value',
             filter='filter_value',
         ))
-        await client.create_view(request=None)
-
         await client.create_view(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12093,8 +12007,6 @@ async def test_update_view_empty_call_grpc_asyncio():
         ))
         await client.update_view(request=None)
 
-        await client.update_view(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12118,8 +12030,6 @@ async def test_delete_view_empty_call_grpc_asyncio():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        await client.delete_view(request=None)
-
         await client.delete_view(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12147,8 +12057,6 @@ async def test_list_sinks_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListSinksResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.list_sinks(request=None)
-
         await client.list_sinks(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12185,8 +12093,6 @@ async def test_get_sink_empty_call_grpc_asyncio():
         ))
         await client.get_sink(request=None)
 
-        await client.get_sink(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12219,8 +12125,6 @@ async def test_create_sink_empty_call_grpc_asyncio():
             writer_identity='writer_identity_value',
             include_children=True,
         ))
-        await client.create_sink(request=None)
-
         await client.create_sink(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12257,8 +12161,6 @@ async def test_update_sink_empty_call_grpc_asyncio():
         ))
         await client.update_sink(request=None)
 
-        await client.update_sink(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12282,8 +12184,6 @@ async def test_delete_sink_empty_call_grpc_asyncio():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        await client.delete_sink(request=None)
-
         await client.delete_sink(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12313,8 +12213,6 @@ async def test_create_link_empty_call_grpc_asyncio():
         )
         await client.create_link(request=None)
 
-        await client.create_link(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12342,8 +12240,6 @@ async def test_delete_link_empty_call_grpc_asyncio():
         )
         await client.delete_link(request=None)
 
-        await client.delete_link(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12369,8 +12265,6 @@ async def test_list_links_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListLinksResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.list_links(request=None)
-
         await client.list_links(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12402,8 +12296,6 @@ async def test_get_link_empty_call_grpc_asyncio():
         ))
         await client.get_link(request=None)
 
-        await client.get_link(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12429,8 +12321,6 @@ async def test_list_exclusions_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListExclusionsResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.list_exclusions(request=None)
-
         await client.list_exclusions(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12463,8 +12353,6 @@ async def test_get_exclusion_empty_call_grpc_asyncio():
         ))
         await client.get_exclusion(request=None)
 
-        await client.get_exclusion(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12493,8 +12381,6 @@ async def test_create_exclusion_empty_call_grpc_asyncio():
             filter='filter_value',
             disabled=True,
         ))
-        await client.create_exclusion(request=None)
-
         await client.create_exclusion(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12527,8 +12413,6 @@ async def test_update_exclusion_empty_call_grpc_asyncio():
         ))
         await client.update_exclusion(request=None)
 
-        await client.update_exclusion(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12552,8 +12436,6 @@ async def test_delete_exclusion_empty_call_grpc_asyncio():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        await client.delete_exclusion(request=None)
-
         await client.delete_exclusion(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12586,8 +12468,6 @@ async def test_get_cmek_settings_empty_call_grpc_asyncio():
         ))
         await client.get_cmek_settings(request=None)
 
-        await client.get_cmek_settings(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12616,8 +12496,6 @@ async def test_update_cmek_settings_empty_call_grpc_asyncio():
             kms_key_version_name='kms_key_version_name_value',
             service_account_id='service_account_id_value',
         ))
-        await client.update_cmek_settings(request=None)
-
         await client.update_cmek_settings(request=None)
 
         # Establish that the underlying stub method was called.
@@ -12651,8 +12529,6 @@ async def test_get_settings_empty_call_grpc_asyncio():
         ))
         await client.get_settings(request=None)
 
-        await client.get_settings(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12684,8 +12560,6 @@ async def test_update_settings_empty_call_grpc_asyncio():
         ))
         await client.update_settings(request=None)
 
-        await client.update_settings(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -12711,8 +12585,6 @@ async def test_copy_log_entries_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.copy_log_entries(request=None)
-
         await client.copy_log_entries(request=None)
 
         # Establish that the underlying stub method was called.

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -2923,8 +2923,6 @@ def test_delete_log_empty_call_grpc():
         call.return_value = None
         client.delete_log(request=None)
 
-        client.delete_log(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2946,8 +2944,6 @@ def test_write_log_entries_empty_call_grpc():
             type(client.transport.write_log_entries),
             '__call__') as call:
         call.return_value = logging.WriteLogEntriesResponse()
-        client.write_log_entries(request=None)
-
         client.write_log_entries(request=None)
 
         # Establish that the underlying stub method was called.
@@ -2973,8 +2969,6 @@ def test_list_log_entries_empty_call_grpc():
         call.return_value = logging.ListLogEntriesResponse()
         client.list_log_entries(request=None)
 
-        client.list_log_entries(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2998,8 +2992,6 @@ def test_list_monitored_resource_descriptors_empty_call_grpc():
         call.return_value = logging.ListMonitoredResourceDescriptorsResponse()
         client.list_monitored_resource_descriptors(request=None)
 
-        client.list_monitored_resource_descriptors(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -3021,8 +3013,6 @@ def test_list_logs_empty_call_grpc():
             type(client.transport.list_logs),
             '__call__') as call:
         call.return_value = logging.ListLogsResponse()
-        client.list_logs(request=None)
-
         client.list_logs(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3065,8 +3055,6 @@ async def test_delete_log_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_log(request=None)
 
-        await client.delete_log(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -3091,8 +3079,6 @@ async def test_write_log_entries_empty_call_grpc_asyncio():
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging.WriteLogEntriesResponse(
         ))
-        await client.write_log_entries(request=None)
-
         await client.write_log_entries(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3122,8 +3108,6 @@ async def test_list_log_entries_empty_call_grpc_asyncio():
         ))
         await client.list_log_entries(request=None)
 
-        await client.list_log_entries(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -3149,8 +3133,6 @@ async def test_list_monitored_resource_descriptors_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(logging.ListMonitoredResourceDescriptorsResponse(
             next_page_token='next_page_token_value',
         ))
-        await client.list_monitored_resource_descriptors(request=None)
-
         await client.list_monitored_resource_descriptors(request=None)
 
         # Establish that the underlying stub method was called.
@@ -3179,8 +3161,6 @@ async def test_list_logs_empty_call_grpc_asyncio():
             log_names=['log_names_value'],
             next_page_token='next_page_token_value',
         ))
-        await client.list_logs(request=None)
-
         await client.list_logs(request=None)
 
         # Establish that the underlying stub method was called.

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -2913,16 +2913,19 @@ def test_initialize_client_w_grpc():
 def test_delete_log_empty_call_grpc():
     client = LoggingServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_log),
             '__call__') as call:
         call.return_value = None
         client.delete_log(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_log(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.DeleteLogRequest()
@@ -2935,16 +2938,19 @@ def test_delete_log_empty_call_grpc():
 def test_write_log_entries_empty_call_grpc():
     client = LoggingServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.write_log_entries),
             '__call__') as call:
         call.return_value = logging.WriteLogEntriesResponse()
         client.write_log_entries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.write_log_entries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.WriteLogEntriesRequest()
@@ -2957,16 +2963,19 @@ def test_write_log_entries_empty_call_grpc():
 def test_list_log_entries_empty_call_grpc():
     client = LoggingServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_log_entries),
             '__call__') as call:
         call.return_value = logging.ListLogEntriesResponse()
         client.list_log_entries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_log_entries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogEntriesRequest()
@@ -2979,16 +2988,19 @@ def test_list_log_entries_empty_call_grpc():
 def test_list_monitored_resource_descriptors_empty_call_grpc():
     client = LoggingServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_monitored_resource_descriptors),
             '__call__') as call:
         call.return_value = logging.ListMonitoredResourceDescriptorsResponse()
         client.list_monitored_resource_descriptors(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_monitored_resource_descriptors(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListMonitoredResourceDescriptorsRequest()
@@ -3001,16 +3013,19 @@ def test_list_monitored_resource_descriptors_empty_call_grpc():
 def test_list_logs_empty_call_grpc():
     client = LoggingServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_logs),
             '__call__') as call:
         call.return_value = logging.ListLogsResponse()
         client.list_logs(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_logs(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogsRequest()
@@ -3039,9 +3054,10 @@ def test_initialize_client_w_grpc_asyncio():
 async def test_delete_log_empty_call_grpc_asyncio():
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_log),
             '__call__') as call:
@@ -3049,7 +3065,9 @@ async def test_delete_log_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_log(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_log(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.DeleteLogRequest()
@@ -3063,9 +3081,10 @@ async def test_delete_log_empty_call_grpc_asyncio():
 async def test_write_log_entries_empty_call_grpc_asyncio():
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.write_log_entries),
             '__call__') as call:
@@ -3074,7 +3093,9 @@ async def test_write_log_entries_empty_call_grpc_asyncio():
         ))
         await client.write_log_entries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.write_log_entries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.WriteLogEntriesRequest()
@@ -3088,9 +3109,10 @@ async def test_write_log_entries_empty_call_grpc_asyncio():
 async def test_list_log_entries_empty_call_grpc_asyncio():
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_log_entries),
             '__call__') as call:
@@ -3100,7 +3122,9 @@ async def test_list_log_entries_empty_call_grpc_asyncio():
         ))
         await client.list_log_entries(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_log_entries(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogEntriesRequest()
@@ -3114,9 +3138,10 @@ async def test_list_log_entries_empty_call_grpc_asyncio():
 async def test_list_monitored_resource_descriptors_empty_call_grpc_asyncio():
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_monitored_resource_descriptors),
             '__call__') as call:
@@ -3126,7 +3151,9 @@ async def test_list_monitored_resource_descriptors_empty_call_grpc_asyncio():
         ))
         await client.list_monitored_resource_descriptors(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_monitored_resource_descriptors(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListMonitoredResourceDescriptorsRequest()
@@ -3140,9 +3167,10 @@ async def test_list_monitored_resource_descriptors_empty_call_grpc_asyncio():
 async def test_list_logs_empty_call_grpc_asyncio():
     client = LoggingServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_logs),
             '__call__') as call:
@@ -3153,7 +3181,9 @@ async def test_list_logs_empty_call_grpc_asyncio():
         ))
         await client.list_logs(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_logs(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging.ListLogsRequest()

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2710,8 +2710,6 @@ def test_list_log_metrics_empty_call_grpc():
         call.return_value = logging_metrics.ListLogMetricsResponse()
         client.list_log_metrics(request=None)
 
-        client.list_log_metrics(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2733,8 +2731,6 @@ def test_get_log_metric_empty_call_grpc():
             type(client.transport.get_log_metric),
             '__call__') as call:
         call.return_value = logging_metrics.LogMetric()
-        client.get_log_metric(request=None)
-
         client.get_log_metric(request=None)
 
         # Establish that the underlying stub method was called.
@@ -2760,8 +2756,6 @@ def test_create_log_metric_empty_call_grpc():
         call.return_value = logging_metrics.LogMetric()
         client.create_log_metric(request=None)
 
-        client.create_log_metric(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2785,8 +2779,6 @@ def test_update_log_metric_empty_call_grpc():
         call.return_value = logging_metrics.LogMetric()
         client.update_log_metric(request=None)
 
-        client.update_log_metric(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2808,8 +2800,6 @@ def test_delete_log_metric_empty_call_grpc():
             type(client.transport.delete_log_metric),
             '__call__') as call:
         call.return_value = None
-        client.delete_log_metric(request=None)
-
         client.delete_log_metric(request=None)
 
         # Establish that the underlying stub method was called.
@@ -2854,8 +2844,6 @@ async def test_list_log_metrics_empty_call_grpc_asyncio():
         ))
         await client.list_log_metrics(request=None)
 
-        await client.list_log_metrics(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2887,8 +2875,6 @@ async def test_get_log_metric_empty_call_grpc_asyncio():
             value_extractor='value_extractor_value',
             version=logging_metrics.LogMetric.ApiVersion.V1,
         ))
-        await client.get_log_metric(request=None)
-
         await client.get_log_metric(request=None)
 
         # Establish that the underlying stub method was called.
@@ -2924,8 +2910,6 @@ async def test_create_log_metric_empty_call_grpc_asyncio():
         ))
         await client.create_log_metric(request=None)
 
-        await client.create_log_metric(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2959,8 +2943,6 @@ async def test_update_log_metric_empty_call_grpc_asyncio():
         ))
         await client.update_log_metric(request=None)
 
-        await client.update_log_metric(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -2984,8 +2966,6 @@ async def test_delete_log_metric_empty_call_grpc_asyncio():
             '__call__') as call:
         # Designate an appropriate return value for the call.
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
-        await client.delete_log_metric(request=None)
-
         await client.delete_log_metric(request=None)
 
         # Establish that the underlying stub method was called.

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2700,16 +2700,19 @@ def test_initialize_client_w_grpc():
 def test_list_log_metrics_empty_call_grpc():
     client = MetricsServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_log_metrics),
             '__call__') as call:
         call.return_value = logging_metrics.ListLogMetricsResponse()
         client.list_log_metrics(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_log_metrics(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.ListLogMetricsRequest()
@@ -2722,16 +2725,19 @@ def test_list_log_metrics_empty_call_grpc():
 def test_get_log_metric_empty_call_grpc():
     client = MetricsServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_log_metric),
             '__call__') as call:
         call.return_value = logging_metrics.LogMetric()
         client.get_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.GetLogMetricRequest()
@@ -2744,16 +2750,19 @@ def test_get_log_metric_empty_call_grpc():
 def test_create_log_metric_empty_call_grpc():
     client = MetricsServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_log_metric),
             '__call__') as call:
         call.return_value = logging_metrics.LogMetric()
         client.create_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.CreateLogMetricRequest()
@@ -2766,16 +2775,19 @@ def test_create_log_metric_empty_call_grpc():
 def test_update_log_metric_empty_call_grpc():
     client = MetricsServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_log_metric),
             '__call__') as call:
         call.return_value = logging_metrics.LogMetric()
         client.update_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.UpdateLogMetricRequest()
@@ -2788,16 +2800,19 @@ def test_update_log_metric_empty_call_grpc():
 def test_delete_log_metric_empty_call_grpc():
     client = MetricsServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_log_metric),
             '__call__') as call:
         call.return_value = None
         client.delete_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.DeleteLogMetricRequest()
@@ -2826,9 +2841,10 @@ def test_initialize_client_w_grpc_asyncio():
 async def test_list_log_metrics_empty_call_grpc_asyncio():
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_log_metrics),
             '__call__') as call:
@@ -2838,7 +2854,9 @@ async def test_list_log_metrics_empty_call_grpc_asyncio():
         ))
         await client.list_log_metrics(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_log_metrics(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.ListLogMetricsRequest()
@@ -2852,9 +2870,10 @@ async def test_list_log_metrics_empty_call_grpc_asyncio():
 async def test_get_log_metric_empty_call_grpc_asyncio():
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_log_metric),
             '__call__') as call:
@@ -2870,7 +2889,9 @@ async def test_get_log_metric_empty_call_grpc_asyncio():
         ))
         await client.get_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.GetLogMetricRequest()
@@ -2884,9 +2905,10 @@ async def test_get_log_metric_empty_call_grpc_asyncio():
 async def test_create_log_metric_empty_call_grpc_asyncio():
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_log_metric),
             '__call__') as call:
@@ -2902,7 +2924,9 @@ async def test_create_log_metric_empty_call_grpc_asyncio():
         ))
         await client.create_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.CreateLogMetricRequest()
@@ -2916,9 +2940,10 @@ async def test_create_log_metric_empty_call_grpc_asyncio():
 async def test_update_log_metric_empty_call_grpc_asyncio():
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_log_metric),
             '__call__') as call:
@@ -2934,7 +2959,9 @@ async def test_update_log_metric_empty_call_grpc_asyncio():
         ))
         await client.update_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.UpdateLogMetricRequest()
@@ -2948,9 +2975,10 @@ async def test_update_log_metric_empty_call_grpc_asyncio():
 async def test_delete_log_metric_empty_call_grpc_asyncio():
     client = MetricsServiceV2AsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_log_metric),
             '__call__') as call:
@@ -2958,7 +2986,9 @@ async def test_delete_log_metric_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(None)
         await client.delete_log_metric(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_log_metric(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = logging_metrics.DeleteLogMetricRequest()

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6669,8 +6669,6 @@ def test_list_instances_empty_call_grpc():
         call.return_value = cloud_redis.ListInstancesResponse()
         client.list_instances(request=None)
 
-        client.list_instances(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -6692,8 +6690,6 @@ def test_get_instance_empty_call_grpc():
             type(client.transport.get_instance),
             '__call__') as call:
         call.return_value = cloud_redis.Instance()
-        client.get_instance(request=None)
-
         client.get_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -6719,8 +6715,6 @@ def test_get_instance_auth_string_empty_call_grpc():
         call.return_value = cloud_redis.InstanceAuthString()
         client.get_instance_auth_string(request=None)
 
-        client.get_instance_auth_string(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -6742,8 +6736,6 @@ def test_create_instance_empty_call_grpc():
             type(client.transport.create_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.create_instance(request=None)
-
         client.create_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -6769,8 +6761,6 @@ def test_update_instance_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.update_instance(request=None)
 
-        client.update_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -6792,8 +6782,6 @@ def test_upgrade_instance_empty_call_grpc():
             type(client.transport.upgrade_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.upgrade_instance(request=None)
-
         client.upgrade_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -6819,8 +6807,6 @@ def test_import_instance_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.import_instance(request=None)
 
-        client.import_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -6842,8 +6828,6 @@ def test_export_instance_empty_call_grpc():
             type(client.transport.export_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.export_instance(request=None)
-
         client.export_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -6869,8 +6853,6 @@ def test_failover_instance_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.failover_instance(request=None)
 
-        client.failover_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -6894,8 +6876,6 @@ def test_delete_instance_empty_call_grpc():
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.delete_instance(request=None)
 
-        client.delete_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -6917,8 +6897,6 @@ def test_reschedule_maintenance_empty_call_grpc():
             type(client.transport.reschedule_maintenance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
-        client.reschedule_maintenance(request=None)
-
         client.reschedule_maintenance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -6962,8 +6940,6 @@ async def test_list_instances_empty_call_grpc_asyncio():
             next_page_token='next_page_token_value',
             unreachable=['unreachable_value'],
         ))
-        await client.list_instances(request=None)
-
         await client.list_instances(request=None)
 
         # Establish that the underlying stub method was called.
@@ -7019,8 +6995,6 @@ async def test_get_instance_empty_call_grpc_asyncio():
         ))
         await client.get_instance(request=None)
 
-        await client.get_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -7046,8 +7020,6 @@ async def test_get_instance_auth_string_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.InstanceAuthString(
             auth_string='auth_string_value',
         ))
-        await client.get_instance_auth_string(request=None)
-
         await client.get_instance_auth_string(request=None)
 
         # Establish that the underlying stub method was called.
@@ -7077,8 +7049,6 @@ async def test_create_instance_empty_call_grpc_asyncio():
         )
         await client.create_instance(request=None)
 
-        await client.create_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -7104,8 +7074,6 @@ async def test_update_instance_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.update_instance(request=None)
-
         await client.update_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -7135,8 +7103,6 @@ async def test_upgrade_instance_empty_call_grpc_asyncio():
         )
         await client.upgrade_instance(request=None)
 
-        await client.upgrade_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -7162,8 +7128,6 @@ async def test_import_instance_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.import_instance(request=None)
-
         await client.import_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -7193,8 +7157,6 @@ async def test_export_instance_empty_call_grpc_asyncio():
         )
         await client.export_instance(request=None)
 
-        await client.export_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -7220,8 +7182,6 @@ async def test_failover_instance_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.failover_instance(request=None)
-
         await client.failover_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -7251,8 +7211,6 @@ async def test_delete_instance_empty_call_grpc_asyncio():
         )
         await client.delete_instance(request=None)
 
-        await client.delete_instance(request=None)
-
         # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
@@ -7278,8 +7236,6 @@ async def test_reschedule_maintenance_empty_call_grpc_asyncio():
         call.return_value = grpc_helpers_async.FakeUnaryUnaryCall(
             operations_pb2.Operation(name='operations/spam')
         )
-        await client.reschedule_maintenance(request=None)
-
         await client.reschedule_maintenance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -8851,8 +8807,8 @@ def test_list_instances_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_instances), '__call__') as call:
-
+            type(client.transport.list_instances),
+            '__call__') as call:
         client.list_instances(request=None)
 
         # Establish that the underlying stub method was called.
@@ -8873,8 +8829,8 @@ def test_get_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance), '__call__') as call:
-
+            type(client.transport.get_instance),
+            '__call__') as call:
         client.get_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -8895,8 +8851,8 @@ def test_get_instance_auth_string_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance_auth_string), '__call__') as call:
-
+            type(client.transport.get_instance_auth_string),
+            '__call__') as call:
         client.get_instance_auth_string(request=None)
 
         # Establish that the underlying stub method was called.
@@ -8917,8 +8873,8 @@ def test_create_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_instance), '__call__') as call:
-
+            type(client.transport.create_instance),
+            '__call__') as call:
         client.create_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -8939,8 +8895,8 @@ def test_update_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_instance), '__call__') as call:
-
+            type(client.transport.update_instance),
+            '__call__') as call:
         client.update_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -8961,8 +8917,8 @@ def test_upgrade_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.upgrade_instance), '__call__') as call:
-
+            type(client.transport.upgrade_instance),
+            '__call__') as call:
         client.upgrade_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -8983,8 +8939,8 @@ def test_import_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.import_instance), '__call__') as call:
-
+            type(client.transport.import_instance),
+            '__call__') as call:
         client.import_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -9005,8 +8961,8 @@ def test_export_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.export_instance), '__call__') as call:
-
+            type(client.transport.export_instance),
+            '__call__') as call:
         client.export_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -9027,8 +8983,8 @@ def test_failover_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.failover_instance), '__call__') as call:
-
+            type(client.transport.failover_instance),
+            '__call__') as call:
         client.failover_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -9049,8 +9005,8 @@ def test_delete_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_instance), '__call__') as call:
-
+            type(client.transport.delete_instance),
+            '__call__') as call:
         client.delete_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -9071,8 +9027,8 @@ def test_reschedule_maintenance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.reschedule_maintenance), '__call__') as call:
-
+            type(client.transport.reschedule_maintenance),
+            '__call__') as call:
         client.reschedule_maintenance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10763,8 +10719,8 @@ async def test_list_instances_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_instances), '__call__') as call:
-
+            type(client.transport.list_instances),
+            '__call__') as call:
         await client.list_instances(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10788,8 +10744,8 @@ async def test_get_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance), '__call__') as call:
-
+            type(client.transport.get_instance),
+            '__call__') as call:
         await client.get_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10813,8 +10769,8 @@ async def test_get_instance_auth_string_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance_auth_string), '__call__') as call:
-
+            type(client.transport.get_instance_auth_string),
+            '__call__') as call:
         await client.get_instance_auth_string(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10838,8 +10794,8 @@ async def test_create_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_instance), '__call__') as call:
-
+            type(client.transport.create_instance),
+            '__call__') as call:
         await client.create_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10863,8 +10819,8 @@ async def test_update_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_instance), '__call__') as call:
-
+            type(client.transport.update_instance),
+            '__call__') as call:
         await client.update_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10888,8 +10844,8 @@ async def test_upgrade_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.upgrade_instance), '__call__') as call:
-
+            type(client.transport.upgrade_instance),
+            '__call__') as call:
         await client.upgrade_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10913,8 +10869,8 @@ async def test_import_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.import_instance), '__call__') as call:
-
+            type(client.transport.import_instance),
+            '__call__') as call:
         await client.import_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10938,8 +10894,8 @@ async def test_export_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.export_instance), '__call__') as call:
-
+            type(client.transport.export_instance),
+            '__call__') as call:
         await client.export_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10963,8 +10919,8 @@ async def test_failover_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.failover_instance), '__call__') as call:
-
+            type(client.transport.failover_instance),
+            '__call__') as call:
         await client.failover_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -10988,8 +10944,8 @@ async def test_delete_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_instance), '__call__') as call:
-
+            type(client.transport.delete_instance),
+            '__call__') as call:
         await client.delete_instance(request=None)
 
         # Establish that the underlying stub method was called.
@@ -11013,8 +10969,8 @@ async def test_reschedule_maintenance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.reschedule_maintenance), '__call__') as call:
-
+            type(client.transport.reschedule_maintenance),
+            '__call__') as call:
         await client.reschedule_maintenance(request=None)
 
         # Establish that the underlying stub method was called.

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -8851,17 +8851,7 @@ def test_list_instances_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_instances),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = cloud_redis.ListInstancesResponse()
-        # Convert return value to protobuf type
-        return_value = cloud_redis.ListInstancesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_instances), '__call__') as call:
 
         client.list_instances(request=None)
 
@@ -8883,17 +8873,7 @@ def test_get_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = cloud_redis.Instance()
-        # Convert return value to protobuf type
-        return_value = cloud_redis.Instance.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_instance), '__call__') as call:
 
         client.get_instance(request=None)
 
@@ -8915,17 +8895,7 @@ def test_get_instance_auth_string_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance_auth_string),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = cloud_redis.InstanceAuthString()
-        # Convert return value to protobuf type
-        return_value = cloud_redis.InstanceAuthString.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_instance_auth_string), '__call__') as call:
 
         client.get_instance_auth_string(request=None)
 
@@ -8947,15 +8917,7 @@ def test_create_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.create_instance), '__call__') as call:
 
         client.create_instance(request=None)
 
@@ -8977,15 +8939,7 @@ def test_update_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.update_instance), '__call__') as call:
 
         client.update_instance(request=None)
 
@@ -9007,15 +8961,7 @@ def test_upgrade_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.upgrade_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.upgrade_instance), '__call__') as call:
 
         client.upgrade_instance(request=None)
 
@@ -9037,15 +8983,7 @@ def test_import_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.import_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.import_instance), '__call__') as call:
 
         client.import_instance(request=None)
 
@@ -9067,15 +9005,7 @@ def test_export_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.export_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.export_instance), '__call__') as call:
 
         client.export_instance(request=None)
 
@@ -9097,15 +9027,7 @@ def test_failover_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.failover_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.failover_instance), '__call__') as call:
 
         client.failover_instance(request=None)
 
@@ -9127,15 +9049,7 @@ def test_delete_instance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.delete_instance), '__call__') as call:
 
         client.delete_instance(request=None)
 
@@ -9157,15 +9071,7 @@ def test_reschedule_maintenance_empty_call_rest():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.reschedule_maintenance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.reschedule_maintenance), '__call__') as call:
 
         client.reschedule_maintenance(request=None)
 
@@ -10857,17 +10763,7 @@ async def test_list_instances_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.list_instances),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = cloud_redis.ListInstancesResponse()
-        # Convert return value to protobuf type
-        return_value = cloud_redis.ListInstancesResponse.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.list_instances), '__call__') as call:
 
         await client.list_instances(request=None)
 
@@ -10892,17 +10788,7 @@ async def test_get_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = cloud_redis.Instance()
-        # Convert return value to protobuf type
-        return_value = cloud_redis.Instance.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_instance), '__call__') as call:
 
         await client.get_instance(request=None)
 
@@ -10927,17 +10813,7 @@ async def test_get_instance_auth_string_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.get_instance_auth_string),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = cloud_redis.InstanceAuthString()
-        # Convert return value to protobuf type
-        return_value = cloud_redis.InstanceAuthString.pb(return_value)
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.get_instance_auth_string), '__call__') as call:
 
         await client.get_instance_auth_string(request=None)
 
@@ -10962,15 +10838,7 @@ async def test_create_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.create_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.create_instance), '__call__') as call:
 
         await client.create_instance(request=None)
 
@@ -10995,15 +10863,7 @@ async def test_update_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.update_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.update_instance), '__call__') as call:
 
         await client.update_instance(request=None)
 
@@ -11028,15 +10888,7 @@ async def test_upgrade_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.upgrade_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.upgrade_instance), '__call__') as call:
 
         await client.upgrade_instance(request=None)
 
@@ -11061,15 +10913,7 @@ async def test_import_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.import_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.import_instance), '__call__') as call:
 
         await client.import_instance(request=None)
 
@@ -11094,15 +10938,7 @@ async def test_export_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.export_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.export_instance), '__call__') as call:
 
         await client.export_instance(request=None)
 
@@ -11127,15 +10963,7 @@ async def test_failover_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.failover_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.failover_instance), '__call__') as call:
 
         await client.failover_instance(request=None)
 
@@ -11160,15 +10988,7 @@ async def test_delete_instance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.delete_instance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.delete_instance), '__call__') as call:
 
         await client.delete_instance(request=None)
 
@@ -11193,15 +11013,7 @@ async def test_reschedule_maintenance_empty_call_rest_asyncio():
 
     # Mock the actual call, and fake the request.
     with mock.patch.object(
-            type(client.transport.reschedule_maintenance),
-            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
-        req.return_value = mock.Mock()
-        req.return_value.status_code = 200
-        return_value = operations_pb2.Operation(name='operations/spam')
-        json_return_value = json_format.MessageToJson(return_value)
-
-        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
-        call.return_value = req.return_value
+            type(client.transport.reschedule_maintenance), '__call__') as call:
 
         await client.reschedule_maintenance(request=None)
 

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -10848,6 +10848,8 @@ def test_initialize_client_w_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_list_instances_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -10881,6 +10883,8 @@ async def test_list_instances_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_get_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -10914,6 +10918,8 @@ async def test_get_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_get_instance_auth_string_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -10947,6 +10953,8 @@ async def test_get_instance_auth_string_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_create_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -10978,6 +10986,8 @@ async def test_create_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_update_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -11009,6 +11019,8 @@ async def test_update_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_upgrade_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -11040,6 +11052,8 @@ async def test_upgrade_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_import_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -11071,6 +11085,8 @@ async def test_import_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_export_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -11102,6 +11118,8 @@ async def test_export_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_failover_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -11133,6 +11151,8 @@ async def test_failover_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_delete_instance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",
@@ -11164,6 +11184,8 @@ async def test_delete_instance_empty_call_rest_asyncio():
 # i.e. request == None and no flattened fields passed, work.
 @pytest.mark.asyncio
 async def test_reschedule_maintenance_empty_call_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio",

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6659,16 +6659,19 @@ def test_initialize_client_w_grpc():
 def test_list_instances_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_instances),
             '__call__') as call:
         call.return_value = cloud_redis.ListInstancesResponse()
         client.list_instances(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.list_instances(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.ListInstancesRequest()
@@ -6681,16 +6684,19 @@ def test_list_instances_empty_call_grpc():
 def test_get_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_instance),
             '__call__') as call:
         call.return_value = cloud_redis.Instance()
         client.get_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.GetInstanceRequest()
@@ -6703,16 +6709,19 @@ def test_get_instance_empty_call_grpc():
 def test_get_instance_auth_string_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_instance_auth_string),
             '__call__') as call:
         call.return_value = cloud_redis.InstanceAuthString()
         client.get_instance_auth_string(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.get_instance_auth_string(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.GetInstanceAuthStringRequest()
@@ -6725,16 +6734,19 @@ def test_get_instance_auth_string_empty_call_grpc():
 def test_create_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.create_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.create_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.CreateInstanceRequest()
@@ -6747,16 +6759,19 @@ def test_create_instance_empty_call_grpc():
 def test_update_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.update_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.update_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.UpdateInstanceRequest()
@@ -6769,16 +6784,19 @@ def test_update_instance_empty_call_grpc():
 def test_upgrade_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.upgrade_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.upgrade_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.upgrade_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.UpgradeInstanceRequest()
@@ -6791,16 +6809,19 @@ def test_upgrade_instance_empty_call_grpc():
 def test_import_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.import_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.import_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.import_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.ImportInstanceRequest()
@@ -6813,16 +6834,19 @@ def test_import_instance_empty_call_grpc():
 def test_export_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.export_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.export_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.export_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.ExportInstanceRequest()
@@ -6835,16 +6859,19 @@ def test_export_instance_empty_call_grpc():
 def test_failover_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.failover_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.failover_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.failover_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.FailoverInstanceRequest()
@@ -6857,16 +6884,19 @@ def test_failover_instance_empty_call_grpc():
 def test_delete_instance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_instance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.delete_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.delete_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.DeleteInstanceRequest()
@@ -6879,16 +6909,19 @@ def test_delete_instance_empty_call_grpc():
 def test_reschedule_maintenance_empty_call_grpc():
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.reschedule_maintenance),
             '__call__') as call:
         call.return_value = operations_pb2.Operation(name='operations/op')
         client.reschedule_maintenance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        client.reschedule_maintenance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.RescheduleMaintenanceRequest()
@@ -6917,9 +6950,10 @@ def test_initialize_client_w_grpc_asyncio():
 async def test_list_instances_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.list_instances),
             '__call__') as call:
@@ -6930,7 +6964,9 @@ async def test_list_instances_empty_call_grpc_asyncio():
         ))
         await client.list_instances(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.list_instances(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.ListInstancesRequest()
@@ -6944,9 +6980,10 @@ async def test_list_instances_empty_call_grpc_asyncio():
 async def test_get_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_instance),
             '__call__') as call:
@@ -6982,7 +7019,9 @@ async def test_get_instance_empty_call_grpc_asyncio():
         ))
         await client.get_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.GetInstanceRequest()
@@ -6996,9 +7035,10 @@ async def test_get_instance_empty_call_grpc_asyncio():
 async def test_get_instance_auth_string_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.get_instance_auth_string),
             '__call__') as call:
@@ -7008,7 +7048,9 @@ async def test_get_instance_auth_string_empty_call_grpc_asyncio():
         ))
         await client.get_instance_auth_string(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.get_instance_auth_string(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.GetInstanceAuthStringRequest()
@@ -7022,9 +7064,10 @@ async def test_get_instance_auth_string_empty_call_grpc_asyncio():
 async def test_create_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.create_instance),
             '__call__') as call:
@@ -7034,7 +7077,9 @@ async def test_create_instance_empty_call_grpc_asyncio():
         )
         await client.create_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.create_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.CreateInstanceRequest()
@@ -7048,9 +7093,10 @@ async def test_create_instance_empty_call_grpc_asyncio():
 async def test_update_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.update_instance),
             '__call__') as call:
@@ -7060,7 +7106,9 @@ async def test_update_instance_empty_call_grpc_asyncio():
         )
         await client.update_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.update_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.UpdateInstanceRequest()
@@ -7074,9 +7122,10 @@ async def test_update_instance_empty_call_grpc_asyncio():
 async def test_upgrade_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.upgrade_instance),
             '__call__') as call:
@@ -7086,7 +7135,9 @@ async def test_upgrade_instance_empty_call_grpc_asyncio():
         )
         await client.upgrade_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.upgrade_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.UpgradeInstanceRequest()
@@ -7100,9 +7151,10 @@ async def test_upgrade_instance_empty_call_grpc_asyncio():
 async def test_import_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.import_instance),
             '__call__') as call:
@@ -7112,7 +7164,9 @@ async def test_import_instance_empty_call_grpc_asyncio():
         )
         await client.import_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.import_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.ImportInstanceRequest()
@@ -7126,9 +7180,10 @@ async def test_import_instance_empty_call_grpc_asyncio():
 async def test_export_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.export_instance),
             '__call__') as call:
@@ -7138,7 +7193,9 @@ async def test_export_instance_empty_call_grpc_asyncio():
         )
         await client.export_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.export_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.ExportInstanceRequest()
@@ -7152,9 +7209,10 @@ async def test_export_instance_empty_call_grpc_asyncio():
 async def test_failover_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.failover_instance),
             '__call__') as call:
@@ -7164,7 +7222,9 @@ async def test_failover_instance_empty_call_grpc_asyncio():
         )
         await client.failover_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.failover_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.FailoverInstanceRequest()
@@ -7178,9 +7238,10 @@ async def test_failover_instance_empty_call_grpc_asyncio():
 async def test_delete_instance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.delete_instance),
             '__call__') as call:
@@ -7190,7 +7251,9 @@ async def test_delete_instance_empty_call_grpc_asyncio():
         )
         await client.delete_instance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.delete_instance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.DeleteInstanceRequest()
@@ -7204,9 +7267,10 @@ async def test_delete_instance_empty_call_grpc_asyncio():
 async def test_reschedule_maintenance_empty_call_grpc_asyncio():
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
     )
 
-    # Mock the actual call within the gRPC stub, and fake the request.
+    # Mock the actual call, and fake the request.
     with mock.patch.object(
             type(client.transport.reschedule_maintenance),
             '__call__') as call:
@@ -7216,7 +7280,9 @@ async def test_reschedule_maintenance_empty_call_grpc_asyncio():
         )
         await client.reschedule_maintenance(request=None)
 
-        # Establish that the underlying gRPC stub method was called.
+        await client.reschedule_maintenance(request=None)
+
+        # Establish that the underlying stub method was called.
         call.assert_called()
         _, args, _ = call.mock_calls[0]
         request_msg = cloud_redis.RescheduleMaintenanceRequest()
@@ -8773,6 +8839,342 @@ def test_initialize_client_w_rest():
         transport="rest"
     )
     assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_list_instances_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_instances),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = cloud_redis.ListInstancesResponse()
+        # Convert return value to protobuf type
+        return_value = cloud_redis.ListInstancesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.list_instances(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.ListInstancesRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = cloud_redis.Instance()
+        # Convert return value to protobuf type
+        return_value = cloud_redis.Instance.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.GetInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_get_instance_auth_string_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_instance_auth_string),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = cloud_redis.InstanceAuthString()
+        # Convert return value to protobuf type
+        return_value = cloud_redis.InstanceAuthString.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.get_instance_auth_string(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.GetInstanceAuthStringRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_create_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.create_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.create_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.CreateInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_update_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.update_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.update_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.UpdateInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_upgrade_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.upgrade_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.upgrade_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.UpgradeInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_import_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.import_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.import_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.ImportInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_export_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.export_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.export_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.ExportInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_failover_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.failover_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.failover_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.FailoverInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_delete_instance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.delete_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.delete_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.DeleteInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+def test_reschedule_maintenance_empty_call_rest():
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.reschedule_maintenance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        client.reschedule_maintenance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.RescheduleMaintenanceRequest()
+
+        assert args[0] == request_msg
 
 
 def test_cloud_redis_rest_lro_client():
@@ -10440,6 +10842,353 @@ def test_initialize_client_w_rest_asyncio():
         transport="rest_asyncio"
     )
     assert client is not None
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_list_instances_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.list_instances),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = cloud_redis.ListInstancesResponse()
+        # Convert return value to protobuf type
+        return_value = cloud_redis.ListInstancesResponse.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.list_instances(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.ListInstancesRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_get_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = cloud_redis.Instance()
+        # Convert return value to protobuf type
+        return_value = cloud_redis.Instance.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.get_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.GetInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_get_instance_auth_string_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.get_instance_auth_string),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = cloud_redis.InstanceAuthString()
+        # Convert return value to protobuf type
+        return_value = cloud_redis.InstanceAuthString.pb(return_value)
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.get_instance_auth_string(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.GetInstanceAuthStringRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_create_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.create_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.create_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.CreateInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_update_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.update_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.update_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.UpdateInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_upgrade_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.upgrade_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.upgrade_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.UpgradeInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_import_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.import_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.import_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.ImportInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_export_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.export_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.export_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.ExportInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_failover_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.failover_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.failover_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.FailoverInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_delete_instance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.delete_instance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.delete_instance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.DeleteInstanceRequest()
+
+        assert args[0] == request_msg
+
+
+# This test is a coverage failsafe to make sure that totally empty calls,
+# i.e. request == None and no flattened fields passed, work.
+@pytest.mark.asyncio
+async def test_reschedule_maintenance_empty_call_rest_asyncio():
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    # Mock the actual call, and fake the request.
+    with mock.patch.object(
+            type(client.transport.reschedule_maintenance),
+            '__call__') as call, mock.patch.object(type(client.transport._session), 'request') as req:
+        req.return_value = mock.Mock()
+        req.return_value.status_code = 200
+        return_value = operations_pb2.Operation(name='operations/spam')
+        json_return_value = json_format.MessageToJson(return_value)
+
+        req.return_value.read = mock.AsyncMock(return_value=json_return_value)
+        call.return_value = req.return_value
+
+        await client.reschedule_maintenance(request=None)
+
+        # Establish that the underlying stub method was called.
+        call.assert_called()
+        _, args, _ = call.mock_calls[0]
+        request_msg = cloud_redis.RescheduleMaintenanceRequest()
+
+        assert args[0] == request_msg
 
 
 def test_cloud_redis_rest_asyncio_lro_client():


### PR DESCRIPTION
This PR adds routing parameter tests for REST transport

This PR depends on https://github.com/googleapis/gapic-generator-python/pull/2133 and https://github.com/googleapis/gapic-generator-python/pull/2131. Please review those PRs first.

Fixes https://github.com/googleapis/gapic-generator-python/issues/2159
Closes b/364925979