### PR TITLE
chore: update auth version in showcase tests

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -103,7 +103,11 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             url_scheme=url_scheme,
             api_audience=None
         )
-        self._session = AsyncAuthorizedSession(self._credentials)
+        {# Note: Type for creds is ignored because of incorrect type hint for creds in the client layer.
+         # TODO(https://github.com/googleapis/gapic-generator-python/issues/2177): Remove `# type: ignore` once
+         # we update the type hints for credentials to include asynchronous credentials in the client layer.
+        #}
+        self._session = AsyncAuthorizedSession(self._credentials)  # type: ignore
         self._wrap_with_kind = True
         self._prep_wrapped_messages(client_info)
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -13,7 +13,7 @@ try:
 {# NOTE: `pragma: NO COVER` is needed since the coverage for presubmits isn't combined. #}
 except ImportError as e:  # pragma: NO COVER
     {# TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged. #}
-    raise ImportError("async rest transport requires google.auth >= 2.35.0 with aiohttp extra. Install google-auth with the aiohttp extra using `pip install google-auth[aiohttp]==2.35.0`.") from e
+    raise ImportError("async rest transport requires google-auth >= 2.35.0 with aiohttp extra. Install google-auth with the aiohttp extra using `pip install google-auth[aiohttp]==2.35.0`.") from e
 
 from google.auth.aio import credentials as ga_credentials_async  # type: ignore
 
@@ -21,6 +21,13 @@ from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import retry_async as retries
 from google.api_core import rest_helpers
+
+try:
+    from google.api_core import rest_streaming_async # type: ignore
+    HAS_ASYNC_REST_SUPPORT_IN_CORE = True
+{# NOTE: `pragma: NO COVER` is needed since the coverage for presubmits isn't combined. #}
+except ImportError as e:  # pragma: NO COVER
+    raise ImportError("async rest transport requires google-api-core >= 2.20.0. Install google-api-core using `pip install google-api-core==2.35.0`.") from e
 
 from google.protobuf import json_format
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -7,6 +7,7 @@
 
 
 import google.auth
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2187): Add an `async_rest` extra for GAPICs and update the error message to include that the extra needs to be installed. #}
 try:
     import aiohttp # type: ignore
     from google.auth.aio.transport.sessions import AsyncAuthorizedSession # type: ignore

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -54,6 +54,16 @@ try:
 {# NOTE: `pragma: NO COVER` is needed since the coverage for presubmits isn't combined. #}
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2121): Remove this condition when async rest is GA. #}
+{% if rest_async_io_enabled %}
+
+try:
+    from google.api_core import rest_streaming_async
+    HAS_ASYNC_REST_SUPPORT_IN_CORE = True
+{# NOTE: `pragma: NO COVER` is needed since the coverage for presubmits isn't combined. #}
+except ImportError: # pragma: NO COVER
+    HAS_ASYNC_REST_SUPPORT_IN_CORE = False
+{% endif %}
 
 {# Import the service itself as well as every proto module that it imports. #}
 {% filter sort_lines %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1832,6 +1832,8 @@ def test_transport_kind_{{ transport_name }}():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     {% endif %}
     transport = {{ get_client(service, is_async) }}.get_transport_class("{{ transport_name }}")(
         credentials={{get_credentials(is_async)}}
@@ -1856,6 +1858,8 @@ def test_transport_kind_{{ transport_name }}():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     {% endif %}
     client = {{ get_client(service, is_async) }}(
         credentials={{get_credentials(is_async)}},
@@ -1875,6 +1879,8 @@ def test_unsupported_parameter_rest_asyncio():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     options = client_options.ClientOptions(quota_project_id="octopus")
     {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2137): Remove `type: ignore` once we add a version check for google-api-core. #}
     with pytest.raises(core_exceptions.AsyncRestUnsupportedParameterError, match="google.api_core.client_options.ClientOptions.quota_project_id") as exc:  # type: ignore
@@ -1961,6 +1967,8 @@ def test_unsupported_parameter_rest_asyncio():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     {% endif %}
 
     client = {{ get_client(service, is_async) }}(
@@ -1990,6 +1998,8 @@ def test_initialize_client_w_{{transport_name}}():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     {% endif %}
     client = {{ get_client(service, is_async) }}(
         credentials={{get_credentials(is_async)}},
@@ -2020,6 +2030,8 @@ def test_initialize_client_w_{{transport_name}}():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     {% endif %}
     client = {{ get_client(service, is_async) }}(
         credentials={{get_credentials(is_async)}},
@@ -2086,6 +2098,8 @@ def test_initialize_client_w_{{transport_name}}():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     {% endif %}
     client = {{ get_client(service, is_async) }}(

--- a/noxfile.py
+++ b/noxfile.py
@@ -364,10 +364,8 @@ def showcase_w_rest_async(
             pytest_command.extend(["--ignore", str(ignore_path)])
 
         # Note: google-api-core and google-auth are re-installed here to override the version installed in constraints.
-        # TODO(https://github.com/googleapis/python-api-core/pull/694): Update the version of google-api-core once the linked PR is merged.
-        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]@git+https://github.com/googleapis/python-api-core.git@7dea20d73878eca93b61bb82ae6ddf335fb3a8ca")
-        # TODO(https://github.com/googleapis/google-auth-library-python/pull/1577): Update the version of google-auth once the linked PR is merged.
-        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]==2.35.0rc0")
+        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]==2.20.0")
+        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]==2.35.0")
         session.run(
             *pytest_command,
             env=env,
@@ -473,10 +471,8 @@ def showcase_unit_w_rest_async(
     with showcase_library(session, templates=templates, other_opts=other_opts, rest_async_io_enabled=True) as lib:
         session.chdir(lib)
         # Note: google-api-core and google-auth are re-installed here to override the version installed in constraints.
-        # TODO(https://github.com/googleapis/python-api-core/pull/694): Update the version of google-api-core once the linked PR is merged and released.
-        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]@git+https://github.com/googleapis/python-api-core.git@7dea20d73878eca93b61bb82ae6ddf335fb3a8ca")
-        # TODO(https://github.com/googleapis/google-auth-library-python/pull/1592): Update the version of google-auth to `2.35.0` once released.
-        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]==2.35.0rc0")
+        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]==2.20.0")
+        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]==2.35.0")
         run_showcase_unit_tests(session)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -363,9 +363,6 @@ def showcase_w_rest_async(
             ignore_path = test_directory / ignore_file
             pytest_command.extend(["--ignore", str(ignore_path)])
 
-        # Note: google-api-core and google-auth are re-installed here to override the version installed in constraints.
-        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]==2.20.0")
-        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]==2.35.0")
         session.run(
             *pytest_command,
             env=env,
@@ -470,9 +467,6 @@ def showcase_unit_w_rest_async(
     """Run the generated unit tests with async rest transport against the Showcase library."""
     with showcase_library(session, templates=templates, other_opts=other_opts, rest_async_io_enabled=True) as lib:
         session.chdir(lib)
-        # Note: google-api-core and google-auth are re-installed here to override the version installed in constraints.
-        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]==2.20.0")
-        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]==2.35.0")
         run_showcase_unit_tests(session)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -363,6 +363,8 @@ def showcase_w_rest_async(
             ignore_path = test_directory / ignore_file
             pytest_command.extend(["--ignore", str(ignore_path)])
 
+        # Note: google-auth is re-installed here with aiohttp option to override the version installed in constraints.
+        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]")
         session.run(
             *pytest_command,
             env=env,
@@ -467,6 +469,8 @@ def showcase_unit_w_rest_async(
     """Run the generated unit tests with async rest transport against the Showcase library."""
     with showcase_library(session, templates=templates, other_opts=other_opts, rest_async_io_enabled=True) as lib:
         session.chdir(lib)
+        # Note: google-auth is re-installed here with aiohttp option to override the version installed in constraints.
+        session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]")
         run_showcase_unit_tests(session)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -363,6 +363,8 @@ def showcase_w_rest_async(
             ignore_path = test_directory / ignore_file
             pytest_command.extend(["--ignore", str(ignore_path)])
 
+        # Note: google-api-core is re-installed here because async-rest is not compatible with the minimum version of api-core.
+        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]")
         # Note: google-auth is re-installed here with aiohttp option to override the version installed in constraints.
         session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]")
         session.run(
@@ -469,6 +471,8 @@ def showcase_unit_w_rest_async(
     """Run the generated unit tests with async rest transport against the Showcase library."""
     with showcase_library(session, templates=templates, other_opts=other_opts, rest_async_io_enabled=True) as lib:
         session.chdir(lib)
+        # Note: google-api-core is re-installed here because async-rest is not compatible with the minimum version of api-core.
+        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]")
         # Note: google-auth is re-installed here with aiohttp option to override the version installed in constraints.
         session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]")
         run_showcase_unit_tests(session)

--- a/noxfile.py
+++ b/noxfile.py
@@ -363,8 +363,6 @@ def showcase_w_rest_async(
             ignore_path = test_directory / ignore_file
             pytest_command.extend(["--ignore", str(ignore_path)])
 
-        # Note: google-api-core is re-installed here because async-rest is not compatible with the minimum version of api-core.
-        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]")
         # Note: google-auth is re-installed here with aiohttp option to override the version installed in constraints.
         session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]")
         session.run(
@@ -471,8 +469,6 @@ def showcase_unit_w_rest_async(
     """Run the generated unit tests with async rest transport against the Showcase library."""
     with showcase_library(session, templates=templates, other_opts=other_opts, rest_async_io_enabled=True) as lib:
         session.chdir(lib)
-        # Note: google-api-core is re-installed here because async-rest is not compatible with the minimum version of api-core.
-        session.install('--no-cache-dir', '--force-reinstall', "google-api-core[grpc]")
         # Note: google-auth is re-installed here with aiohttp option to override the version installed in constraints.
         session.install('--no-cache-dir', '--force-reinstall', "google-auth[aiohttp]")
         run_showcase_unit_tests(session)

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -129,7 +129,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             url_scheme=url_scheme,
             api_audience=None
         )
-        self._session = AsyncAuthorizedSession(self._credentials)
+        self._session = AsyncAuthorizedSession(self._credentials)  # type: ignore
         self._wrap_with_kind = True
         self._prep_wrapped_messages(client_info)
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -19,7 +19,7 @@ try:
     import aiohttp # type: ignore
     from google.auth.aio.transport.sessions import AsyncAuthorizedSession # type: ignore
 except ImportError as e:  # pragma: NO COVER
-    raise ImportError("async rest transport requires google.auth >= 2.35.0 with aiohttp extra. Install google-auth with the aiohttp extra using `pip install google-auth[aiohttp]==2.35.0`.") from e
+    raise ImportError("async rest transport requires google-auth >= 2.35.0 with aiohttp extra. Install google-auth with the aiohttp extra using `pip install google-auth[aiohttp]==2.35.0`.") from e
 
 from google.auth.aio import credentials as ga_credentials_async  # type: ignore
 
@@ -27,6 +27,12 @@ from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
 from google.api_core import retry_async as retries
 from google.api_core import rest_helpers
+
+try:
+    from google.api_core import rest_streaming_async # type: ignore
+    HAS_ASYNC_REST_SUPPORT_IN_CORE = True
+except ImportError as e:  # pragma: NO COVER
+    raise ImportError("async rest transport requires google-api-core >= 2.20.0. Install google-api-core using `pip install google-api-core==2.35.0`.") from e
 
 from google.protobuf import json_format
 

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -48,6 +48,12 @@ try:
 except ImportError: # pragma: NO COVER
     HAS_GOOGLE_AUTH_AIO = False
 
+try:
+    from google.api_core import rest_streaming_async
+    HAS_ASYNC_REST_SUPPORT_IN_CORE = True
+except ImportError: # pragma: NO COVER
+    HAS_ASYNC_REST_SUPPORT_IN_CORE = False
+
 from google.api_core import client_options
 from google.api_core import exceptions as core_exceptions
 from google.api_core import future
@@ -8458,6 +8464,8 @@ def test_transport_kind_rest_asyncio():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     transport = CloudRedisAsyncClient.get_transport_class("rest_asyncio")(
         credentials=async_anonymous_credentials()
     )
@@ -8470,6 +8478,8 @@ async def test_list_instances_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8490,6 +8500,8 @@ async def test_get_instance_rest_asyncio_bad_request(request_type=cloud_redis.Ge
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio"
@@ -8519,6 +8531,8 @@ async def test_get_instance_rest_asyncio_call_success(request_type):
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8610,6 +8624,8 @@ async def test_get_instance_auth_string_rest_asyncio_bad_request(request_type=cl
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio"
@@ -8639,6 +8655,8 @@ async def test_get_instance_auth_string_rest_asyncio_call_success(request_type):
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8678,6 +8696,8 @@ async def test_create_instance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8698,6 +8718,8 @@ async def test_update_instance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8718,6 +8740,8 @@ async def test_upgrade_instance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8738,6 +8762,8 @@ async def test_import_instance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8758,6 +8784,8 @@ async def test_export_instance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8778,6 +8806,8 @@ async def test_failover_instance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8798,6 +8828,8 @@ async def test_delete_instance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8818,6 +8850,8 @@ async def test_reschedule_maintenance_rest_asyncio_error():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
 
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
@@ -8837,6 +8871,8 @@ def test_initialize_client_w_rest_asyncio():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio"
@@ -8849,6 +8885,8 @@ def test_unsupported_parameter_rest_asyncio():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     options = client_options.ClientOptions(quota_project_id="octopus")
     with pytest.raises(core_exceptions.AsyncRestUnsupportedParameterError, match="google.api_core.client_options.ClientOptions.quota_project_id") as exc:  # type: ignore
         client = CloudRedisAsyncClient(
@@ -10566,6 +10604,8 @@ async def test_transport_close_rest_asyncio():
         pytest.skip("google-auth >= 2.35.0 is required for async rest transport.")
     elif not HAS_AIOHTTP_INSTALLED:
         pytest.skip("aiohttp is required for async rest transport.")
+    elif not HAS_ASYNC_REST_SUPPORT_IN_CORE:
+        pytest.skip("google-api-core >= 2.20.0 is required for async rest transport.")
     client = CloudRedisAsyncClient(
         credentials=async_anonymous_credentials(),
         transport="rest_asyncio"


### PR DESCRIPTION
This PR overrides the auth version to install `google-auth` with `aiohttp` option and also silences mypy warnings for type hint mismatch for credentials.