### PR TITLE
fix: add default library settings for incorrect lib version

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -711,11 +711,9 @@ class API:
         # - if library settings are not specified in the service config.
         # - if library_settings.version != self.naming.proto_package (proto package name)
         if self.naming.proto_package not in result:
-            result = {
-                self.naming.proto_package: client_pb2.ClientLibrarySettings(
+            result[self.naming.proto_package] = client_pb2.ClientLibrarySettings(
                     version=self.naming.proto_package
                 )
-            }
 
         return result
 

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -712,7 +712,7 @@ class API:
         # - if library_settings.version != self.naming.proto_package (proto package name)
         if self.naming.proto_package not in result:
             result[self.naming.proto_package] = client_pb2.ClientLibrarySettings(
-                    version=self.naming.proto_package
+                version=self.naming.proto_package
                 )
 
         return result

--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -706,8 +706,11 @@ class API:
             for library_setting in self.service_yaml_config.publishing.library_settings
         }
 
-        # Add default settings for the current proto package
-        if not result:
+        # NOTE: Add default settings for the current proto package
+        # for the following cases:
+        # - if library settings are not specified in the service config.
+        # - if library_settings.version != self.naming.proto_package (proto package name)
+        if self.naming.proto_package not in result:
             result = {
                 self.naming.proto_package: client_pb2.ClientLibrarySettings(
                     version=self.naming.proto_package

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -2741,6 +2741,35 @@ def test_read_empty_python_settings_from_service_yaml():
         == client_pb2.PythonSettings.ExperimentalFeatures()
     assert api_schema.all_library_settings["google.example.v1beta1"].python_settings.experimental_features.rest_async_io_enabled \
         == False
+    assert api_schema.all_library_settings[api_schema.naming.proto_package].python_settings \
+        == client_pb2.PythonSettings()
+
+
+def test_incorrect_library_settings_version():
+# NOTE: This test case ensures that the generator is able to read
+# from the default library settings if the version specified against the
+# library settings in the service yaml of an API differs from the version
+# of the API.
+    service_yaml_config = {
+        "apis": [
+            {"name": "google.example.v1beta1.ServiceOne.Example1"},
+        ],
+        "publishing": {
+            "library_settings": [
+                {
+                    "version": "google.example.v1",
+                    "python_settings": {
+                        "experimental_features": {"rest_async_io_enabled": True},
+                    },
+                }
+            ]
+        },
+    }
+    cli_options = Options(service_yaml_config=service_yaml_config)
+    fd = get_file_descriptor_proto_for_tests(fields=[])
+    api_schema = api.API.build(fd, "google.example.v1beta1", opts=cli_options)
+    assert api_schema.all_library_settings[api_schema.naming.proto_package].python_settings \
+        == client_pb2.PythonSettings()
 
 
 def test_python_settings_duplicate_version_raises_error():

--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -2746,10 +2746,10 @@ def test_read_empty_python_settings_from_service_yaml():
 
 
 def test_incorrect_library_settings_version():
-# NOTE: This test case ensures that the generator is able to read
-# from the default library settings if the version specified against the
-# library settings in the service yaml of an API differs from the version
-# of the API.
+    # NOTE: This test case ensures that the generator is able to read
+    # from the default library settings if the version specified against the
+    # library settings in the service yaml of an API differs from the version
+    # of the API.
     service_yaml_config = {
         "apis": [
             {"name": "google.example.v1beta1.ServiceOne.Example1"},


### PR DESCRIPTION
consider the case where `self.naming.proto_package` differs from `library_settings.version`. Ideally, this shouldn't happen but if the version configured against `library_settings.version` is incorrect, it breaks our generator.

As an example, see: https://github.com/googleapis/googleapis/blob/master/google/cloud/confidentialcomputing/v1alpha1/confidentialcomputing_v1alpha1.yaml#L63 where the service yaml file for confidentialcomputing specifies an incorrect version for library settings.
In this case:
- `self.naming.proto_package = google.cloud.confidentialcomputing.v1alpha1`
- `library_settings.version = google.cloud.confidentialcomputing.v1`