### PR TITLE
fix: allow `google-cloud-kms` 3.x

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -12,7 +12,7 @@ Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has sup
     ("google", "geo", "type"): {"package_name": "google-geo-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
     ("google", "identity", "accesscontextmanager", "v1"): {"package_name": "google-cloud-access-context-manager", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},
     ("google", "cloud", "documentai", "v1"): {"package_name": "google-cloud-documentai", "lower_bound": "2.0.0", "upper_bound": "3.0.0dev"},
-    ("google", "cloud", "kms", "v1"): {"package_name": "google-cloud-kms", "lower_bound": "2.3.0", "upper_bound": "3.0.0dev"},
+    ("google", "cloud", "kms", "v1"): {"package_name": "google-cloud-kms", "lower_bound": "2.3.0", "upper_bound": "4.0.0dev"},
     ("google", "cloud", "osconfig", "v1"): {"package_name": "google-cloud-os-config", "lower_bound": "1.0.0", "upper_bound": "2.0.0dev"},
     ("google", "iam", "v1"): {"package_name": "grpc-google-iam-v1", "lower_bound": "0.12.4", "upper_bound": "1.0.0dev"},
     ("google", "iam", "v2"): {"package_name": "google-cloud-iam", "lower_bound": "2.12.2", "upper_bound": "3.0.0dev"},


### PR DESCRIPTION
`google-cloud-kms` 3.0.0 was released on September 23 2024. We need to bump the upper bound in `_pypi_packages.j2` 

https://github.com/googleapis/gapic-generator-python/blob/034191e839ce387cc706084af4d32af6ac8395fb/gapic/templates/_pypi_packages.j2#L15

https://pypi.org/project/google-cloud-kms/3.0.0/

Closes https://github.com/googleapis/google-cloud-python/pull/13162