### PR TITLE
fix: Added underscores in services/types in index.rst.j2

### DIFF
--- a/gapic/templates/docs/index.rst.j2
+++ b/gapic/templates/docs/index.rst.j2
@@ -3,5 +3,5 @@ API Reference
 .. toctree::
     :maxdepth: 2
     
-    {{ api.naming.versioned_module_name }}/services
-    {{ api.naming.versioned_module_name }}/types
+    {{ api.naming.versioned_module_name }}/services_
+    {{ api.naming.versioned_module_name }}/types_

--- a/tests/integration/goldens/asset/docs/index.rst
+++ b/tests/integration/goldens/asset/docs/index.rst
@@ -3,5 +3,5 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
-    asset_v1/services
-    asset_v1/types
+    asset_v1/services_
+    asset_v1/types_

--- a/tests/integration/goldens/credentials/docs/index.rst
+++ b/tests/integration/goldens/credentials/docs/index.rst
@@ -3,5 +3,5 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
-    credentials_v1/services
-    credentials_v1/types
+    credentials_v1/services_
+    credentials_v1/types_

--- a/tests/integration/goldens/eventarc/docs/index.rst
+++ b/tests/integration/goldens/eventarc/docs/index.rst
@@ -3,5 +3,5 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
-    eventarc_v1/services
-    eventarc_v1/types
+    eventarc_v1/services_
+    eventarc_v1/types_

--- a/tests/integration/goldens/logging/docs/index.rst
+++ b/tests/integration/goldens/logging/docs/index.rst
@@ -3,5 +3,5 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
-    logging_v2/services
-    logging_v2/types
+    logging_v2/services_
+    logging_v2/types_

--- a/tests/integration/goldens/redis/docs/index.rst
+++ b/tests/integration/goldens/redis/docs/index.rst
@@ -3,5 +3,5 @@ API Reference
 .. toctree::
     :maxdepth: 2
 
-    redis_v1/services
-    redis_v1/types
+    redis_v1/services_
+    redis_v1/types_


### PR DESCRIPTION
Need to update these references to be consistent with `services_.rst` and `types_.rst`
