### PR TITLE
chore: update required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -16,8 +16,8 @@ branchProtectionRules:
     - 'showcase (3.12, showcase)'
     - 'showcase (3.7, showcase_alternative_templates)'
     - 'showcase (3.12, showcase_alternative_templates)'
-    - 'showcase (3.7, _w_rest_async)'
-    - 'showcase (3.12, _w_rest_async)'
+    - 'showcase (3.7, showcase_w_rest_async)'
+    - 'showcase (3.12, showcase_w_rest_async)'
     # TODO(dovs): reenable these when the mtls tests have been debugged and fixed
     # See #1218 for details
     # - 'showcase-mtls (showcase_mtls)'


### PR DESCRIPTION
The required checks are `showcase (3.12, _w_rest_async)` but they should be `showcase (3.12, showcase_w_rest_async)`

https://github.com/googleapis/gapic-generator-python/blob/d78910f7217d2d1a45662ae01365611b2f33a142/.github/sync-repo-settings.yaml#L19-L20