### PR TITLE
fix: allow google-cloud-documentai 3.x

### DIFF
--- a/gapic/templates/_pypi_packages.j2
+++ b/gapic/templates/_pypi_packages.j2
@@ -11,7 +11,7 @@ Note: Set the minimum version for google-cloud-documentai to 2.0.0 which has sup
     ("google", "apps", "script", "type"): {"package_name": "google-apps-script-type", "lower_bound": "0.2.0", "upper_bound": "1.0.0dev"},
     ("google", "geo", "type"): {"package_name": "google-geo-type", "lower_bound": "0.1.0", "upper_bound": "1.0.0dev"},
     ("google", "identity", "accesscontextmanager", "v1"): {"package_name": "google-cloud-access-context-manager", "lower_bound": "0.1.2", "upper_bound": "1.0.0dev"},
-    ("google", "cloud", "documentai", "v1"): {"package_name": "google-cloud-documentai", "lower_bound": "2.0.0", "upper_bound": "3.0.0dev"},
+    ("google", "cloud", "documentai", "v1"): {"package_name": "google-cloud-documentai", "lower_bound": "2.0.0", "upper_bound": "4.0.0dev"},
     ("google", "cloud", "kms", "v1"): {"package_name": "google-cloud-kms", "lower_bound": "2.3.0", "upper_bound": "4.0.0dev"},
     ("google", "cloud", "osconfig", "v1"): {"package_name": "google-cloud-os-config", "lower_bound": "1.0.0", "upper_bound": "2.0.0dev"},
     ("google", "iam", "v1"): {"package_name": "grpc-google-iam-v1", "lower_bound": "0.12.4", "upper_bound": "1.0.0dev"},


### PR DESCRIPTION
`google-cloud-documentai` 3.0.0 will be released next week. We need to bump the upper bound in `_pypi_packages.j2` 

https://github.com/googleapis/gapic-generator-python/blob/aaef013a40b78b575edd09d27013b3cc6560a080/gapic/templates/_pypi_packages.j2#L14

https://pypi.org/project/google-cloud-documentai
