### PR TITLE
tests: improve coverage when generating clients with transport=rest

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
@@ -93,9 +93,11 @@ class {{ service.name }}Transport(abc.ABC):
             always_use_jwt_access (Optional[bool]): Whether self signed JWT should
                 be used for service account credentials.
         """
+        {% if 'grpc' in opts.transport %}
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
         if ':' not in host:
             host += ':443'
+        {% endif %}
         self._host = host
 
         scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
@@ -103,8 +105,10 @@ class {{ service.name }}Transport(abc.ABC):
         # Save the scopes.
         self._scopes = scopes
 
+        {% if 'grpc' in opts.transport %}
         if not hasattr(self, "_ignore_credentials"):
             self._ignore_credentials: bool = False
+        {% endif %}
 
         # If no credentials are provided, then determine the appropriate
         # defaults.
@@ -117,7 +121,7 @@ class {{ service.name }}Transport(abc.ABC):
                                 **scopes_kwargs,
                                 quota_project_id=quota_project_id
                             )
-        elif credentials is None and not self._ignore_credentials:
+        elif credentials is None{% if 'grpc' in opts.transport %} and not self._ignore_credentials{% endif %}:
             credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
 
         # If the credentials are service account credentials, then always try to use self signed JWT.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -107,8 +107,10 @@ class {{ service.name }}Transport(abc.ABC):
 
         # Save the scopes.
         self._scopes = scopes
+        {% if 'grpc' in opts.transport %}
         if not hasattr(self, "_ignore_credentials"):
             self._ignore_credentials: bool = False
+        {% endif %}
 
         # If no credentials are provided, then determine the appropriate
         # defaults.
@@ -121,7 +123,7 @@ class {{ service.name }}Transport(abc.ABC):
                                 **scopes_kwargs,
                                 quota_project_id=quota_project_id
                             )
-        elif credentials is None and not self._ignore_credentials:
+        elif credentials is None{% if 'grpc' in opts.transport %} and not self._ignore_credentials{% endif %}:
             credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
@@ -134,9 +136,11 @@ class {{ service.name }}Transport(abc.ABC):
         # Save the credentials.
         self._credentials = credentials
 
+        {% if 'grpc' in opts.transport %}
         # Save the hostname. Default to port 443 (HTTPS) if none is specified.
         if ':' not in host:
             host += ':443'
+        {% endif %}
         self._host = host
 
     @property

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1160,30 +1160,6 @@ def test_{{ service.name|snake_case }}_auth_adc():
         )
 
 
-{% if 'grpc' in opts.transport %}
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.{{ service.name }}GrpcTransport,
-        transports.{{ service.name }}GrpcAsyncIOTransport,
-    ],
-)
-def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus", scopes=["1", "2"])
-        adc.assert_called_once_with(
-            scopes=["1", "2"],
-            default_scopes=(
-                {%- for scope in service.oauth_scopes %}
-                '{{ scope }}',
-                {%- endfor %}),
-            quota_project_id="octopus",
-        )
-
-
 {% if 'grpc' in opts.transport and 'rest' in opts.transport %}
 @pytest.mark.parametrize(
     "transport_class",
@@ -1222,6 +1198,30 @@ def test_{{ service.name|snake_case }}_transport_auth_gdch_credentials(transport
             gdch_mock.with_gdch_audience.assert_called_once_with(
                 e
             )
+
+
+{% if 'grpc' in opts.transport %}
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.{{ service.name }}GrpcTransport,
+        transports.{{ service.name }}GrpcAsyncIOTransport,
+    ],
+)
+def test_{{ service.name|snake_case }}_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(
+                {%- for scope in service.oauth_scopes %}
+                '{{ scope }}',
+                {%- endfor %}),
+            quota_project_id="octopus",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3675,26 +3675,6 @@ def test_iam_credentials_auth_adc():
     [
         transports.IAMCredentialsGrpcTransport,
         transports.IAMCredentialsGrpcAsyncIOTransport,
-    ],
-)
-def test_iam_credentials_transport_auth_adc(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus", scopes=["1", "2"])
-        adc.assert_called_once_with(
-            scopes=["1", "2"],
-            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.IAMCredentialsGrpcTransport,
-        transports.IAMCredentialsGrpcAsyncIOTransport,
         transports.IAMCredentialsRestTransport,
     ],
 )
@@ -3711,6 +3691,26 @@ def test_iam_credentials_transport_auth_gdch_credentials(transport_class):
             gdch_mock.with_gdch_audience.assert_called_once_with(
                 e
             )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.IAMCredentialsGrpcTransport,
+        transports.IAMCredentialsGrpcAsyncIOTransport,
+    ],
+)
+def test_iam_credentials_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
+            quota_project_id="octopus",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -14895,26 +14895,6 @@ def test_eventarc_auth_adc():
     [
         transports.EventarcGrpcTransport,
         transports.EventarcGrpcAsyncIOTransport,
-    ],
-)
-def test_eventarc_transport_auth_adc(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus", scopes=["1", "2"])
-        adc.assert_called_once_with(
-            scopes=["1", "2"],
-            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.EventarcGrpcTransport,
-        transports.EventarcGrpcAsyncIOTransport,
         transports.EventarcRestTransport,
     ],
 )
@@ -14931,6 +14911,26 @@ def test_eventarc_transport_auth_gdch_credentials(transport_class):
             gdch_mock.with_gdch_audience.assert_called_once_with(
                 e
             )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.EventarcGrpcTransport,
+        transports.EventarcGrpcAsyncIOTransport,
+    ],
+)
+def test_eventarc_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
+            quota_project_id="octopus",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12676,26 +12676,6 @@ def test_config_service_v2_auth_adc():
         transports.ConfigServiceV2GrpcAsyncIOTransport,
     ],
 )
-def test_config_service_v2_transport_auth_adc(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus", scopes=["1", "2"])
-        adc.assert_called_once_with(
-            scopes=["1", "2"],
-            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.ConfigServiceV2GrpcTransport,
-        transports.ConfigServiceV2GrpcAsyncIOTransport,
-    ],
-)
 def test_config_service_v2_transport_auth_gdch_credentials(transport_class):
     host = 'https://language.com'
     api_audience_tests = [None, 'https://language2.com']
@@ -12709,6 +12689,26 @@ def test_config_service_v2_transport_auth_gdch_credentials(transport_class):
             gdch_mock.with_gdch_audience.assert_called_once_with(
                 e
             )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.ConfigServiceV2GrpcTransport,
+        transports.ConfigServiceV2GrpcAsyncIOTransport,
+    ],
+)
+def test_config_service_v2_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',),
+            quota_project_id="octopus",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3223,26 +3223,6 @@ def test_logging_service_v2_auth_adc():
         transports.LoggingServiceV2GrpcAsyncIOTransport,
     ],
 )
-def test_logging_service_v2_transport_auth_adc(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus", scopes=["1", "2"])
-        adc.assert_called_once_with(
-            scopes=["1", "2"],
-            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.LoggingServiceV2GrpcTransport,
-        transports.LoggingServiceV2GrpcAsyncIOTransport,
-    ],
-)
 def test_logging_service_v2_transport_auth_gdch_credentials(transport_class):
     host = 'https://language.com'
     api_audience_tests = [None, 'https://language2.com']
@@ -3256,6 +3236,26 @@ def test_logging_service_v2_transport_auth_gdch_credentials(transport_class):
             gdch_mock.with_gdch_audience.assert_called_once_with(
                 e
             )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.LoggingServiceV2GrpcTransport,
+        transports.LoggingServiceV2GrpcAsyncIOTransport,
+    ],
+)
+def test_logging_service_v2_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
+            quota_project_id="octopus",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3027,26 +3027,6 @@ def test_metrics_service_v2_auth_adc():
         transports.MetricsServiceV2GrpcAsyncIOTransport,
     ],
 )
-def test_metrics_service_v2_transport_auth_adc(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus", scopes=["1", "2"])
-        adc.assert_called_once_with(
-            scopes=["1", "2"],
-            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.MetricsServiceV2GrpcTransport,
-        transports.MetricsServiceV2GrpcAsyncIOTransport,
-    ],
-)
 def test_metrics_service_v2_transport_auth_gdch_credentials(transport_class):
     host = 'https://language.com'
     api_audience_tests = [None, 'https://language2.com']
@@ -3060,6 +3040,26 @@ def test_metrics_service_v2_transport_auth_gdch_credentials(transport_class):
             gdch_mock.with_gdch_audience.assert_called_once_with(
                 e
             )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.MetricsServiceV2GrpcTransport,
+        transports.MetricsServiceV2GrpcAsyncIOTransport,
+    ],
+)
+def test_metrics_service_v2_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',                'https://www.googleapis.com/auth/cloud-platform.read-only',                'https://www.googleapis.com/auth/logging.admin',                'https://www.googleapis.com/auth/logging.read',                'https://www.googleapis.com/auth/logging.write',),
+            quota_project_id="octopus",
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11171,26 +11171,6 @@ def test_cloud_redis_auth_adc():
     [
         transports.CloudRedisGrpcTransport,
         transports.CloudRedisGrpcAsyncIOTransport,
-    ],
-)
-def test_cloud_redis_transport_auth_adc(transport_class):
-    # If credentials and host are not provided, the transport class should use
-    # ADC credentials.
-    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
-        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
-        transport_class(quota_project_id="octopus", scopes=["1", "2"])
-        adc.assert_called_once_with(
-            scopes=["1", "2"],
-            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
-            quota_project_id="octopus",
-        )
-
-
-@pytest.mark.parametrize(
-    "transport_class",
-    [
-        transports.CloudRedisGrpcTransport,
-        transports.CloudRedisGrpcAsyncIOTransport,
         transports.CloudRedisRestTransport,
     ],
 )
@@ -11207,6 +11187,26 @@ def test_cloud_redis_transport_auth_gdch_credentials(transport_class):
             gdch_mock.with_gdch_audience.assert_called_once_with(
                 e
             )
+
+
+@pytest.mark.parametrize(
+    "transport_class",
+    [
+        transports.CloudRedisGrpcTransport,
+        transports.CloudRedisGrpcAsyncIOTransport,
+    ],
+)
+def test_cloud_redis_transport_auth_adc(transport_class):
+    # If credentials and host are not provided, the transport class should use
+    # ADC credentials.
+    with mock.patch.object(google.auth, 'default', autospec=True) as adc:
+        adc.return_value = (ga_credentials.AnonymousCredentials(), None)
+        transport_class(quota_project_id="octopus", scopes=["1", "2"])
+        adc.assert_called_once_with(
+            scopes=["1", "2"],
+            default_scopes=(                'https://www.googleapis.com/auth/cloud-platform',),
+            quota_project_id="octopus",
+        )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
This PR fixes the following coverage issue when generating showcase tests with `transport=rest`" instead of `transport=grpc+rest`


```
google/showcase_v1beta1/services/identity/transports/base.py            91      2     14      3    95%   87->92, 105, 116
```

With the changes in this PR, I see code coverage increase from 95% to 100%

```
google/showcase_v1beta1/services/echo/transports/base.py               104      0     10      0   100%
```

Towards https://github.com/googleapis/google-cloud-python/issues/16325