### PR TITLE
feat: add support for metadata in unary calls - prototype 1

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
@@ -31,6 +31,9 @@
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             {{ shared_macros.client_method_metadata_argument()|indent(8) }} = {{ shared_macros.client_method_metadata_default_value() }},
+            {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+            raw_response_callback: Optional[callable] = None,
+            {% endif %}
             {% if method.extended_lro and not full_extended_lro %}{# This is a hack to preserve backwards compatibility with the "unary" surfaces #}
             ) -> {{ method.extended_lro.operation_type.ident }}:
             {% elif not method.server_streaming %}
@@ -69,6 +72,12 @@
                 should be retried.
             timeout (float): The timeout for this request.
             {{ shared_macros.client_method_metadata_argument_doc()|indent(4) }}
+            {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
+            {% endif %}
         {% if not method.void %}
 
         Returns:
@@ -141,7 +150,21 @@
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.{{ method.transport_safe_name|snake_case}}]
+        
+        with_call = False
+        {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        {% endif %}
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.{{ method.transport_safe_name|snake_case}}]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.{{ method.transport_safe_name|snake_case}}]
 
 {{ shared_macros.create_metadata(method) }}
 {{ shared_macros.add_api_version_header_to_metadata(service.version) }}
@@ -161,6 +184,14 @@
             timeout=timeout,
             metadata=metadata,
         )
+
+        {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])            
+            response = response[0]
+        {% endif %}
+
         {% if method.lro %}
 
         # Wrap the response in an operation future.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
@@ -32,7 +32,7 @@
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             {{ shared_macros.client_method_metadata_argument()|indent(8) }} = {{ shared_macros.client_method_metadata_default_value() }},
             {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             {% endif %}
             {% if method.extended_lro and not full_extended_lro %}{# This is a hack to preserve backwards compatibility with the "unary" surfaces #}
             ) -> {{ method.extended_lro.operation_type.ident }}:
@@ -73,7 +73,7 @@
             timeout (float): The timeout for this request.
             {{ shared_macros.client_method_metadata_argument_doc()|indent(4) }}
             {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -150,21 +150,21 @@
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        
-        with_call = False
+        wrapped_methods = None
+
         {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
         {% endif %}
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.{{ method.transport_safe_name|snake_case}}]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.{{ method.transport_safe_name|snake_case}}]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.{{ method.transport_safe_name|snake_case }}]        
 
 {{ shared_macros.create_metadata(method) }}
 {{ shared_macros.add_api_version_header_to_metadata(service.version) }}
@@ -186,10 +186,11 @@
         )
 
         {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])            
-            response = response[0]
+                call_metadata = {{ service.client_name }}CallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
         {% endif %}
 
         {% if method.lro %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -239,6 +239,39 @@ def _get_http_options():
 {% macro prep_wrapped_messages_async_method(api, service) %}
 def _prep_wrapped_messages(self, client_info):
     """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+    if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+        self._wrapped_methods_with_call = {
+            {% for method in service.methods.values() %}
+            {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+            self.{{ method.transport_safe_name|snake_case }}: self._wrap_method(
+                self.{{ method.transport_safe_name|snake_case }},
+                {% if method.retry %}
+                default_retry=retries.AsyncRetry(
+                    {% if method.retry.initial_backoff %}
+                    initial={{ method.retry.initial_backoff }},
+                    {% endif %}
+                    {% if method.retry.max_backoff %}
+                    maximum={{ method.retry.max_backoff }},
+                    {% endif %}
+                    {% if method.retry.backoff_multiplier %}
+                    multiplier={{ method.retry.backoff_multiplier }},
+                    {% endif %}
+                    predicate=retries.if_exception_type(
+                        {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
+                        core_exceptions.{{ ex.__name__ }},
+                        {% endfor %}
+                    ),
+                    deadline={{ method.timeout }},
+                ),
+                {% endif %}
+                default_timeout={{ method.timeout }},
+                client_info=client_info,
+                with_call=True,
+            ),
+            {% endif %}{# if not method.void and not method.lro and not method.client_streaming and not method.server_streaming #}
+            {% endfor %}{# method in service.methods.values() #}
+        }
+
     self._wrapped_methods = {
         {% for method in service.methods.values() %}
         self.{{ method.transport_safe_name|snake_case }}: self._wrap_method(
@@ -292,6 +325,8 @@ def _wrap_method(self, func, *args, **kwargs):
     {# TODO: Remove `pragma: NO COVER` once https://github.com/googleapis/python-api-core/pull/688 is merged. #}
     if self._wrap_with_kind:  # pragma: NO COVER
         kwargs["kind"] = self.kind
+    if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+        kwargs.pop("with_call", None) 
     return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 {% endmacro %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -46,9 +46,21 @@ from google.cloud.location import locations_pb2 # type: ignore
 from google.longrunning import operations_pb2 # type: ignore
 {% endif %}
 {% endfilter %}
+from .transports.base import BaseCallMetadata
 from .transports.base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import {{ service.grpc_asyncio_transport_name }}
 from .client import {{ service.client_name }}
+
+
+
+class {{ service.async_client_name }}CallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 {# TODO(yon-mg): handle rest transport async client interaction #}
@@ -259,7 +271,7 @@ class {{ service.async_client_name }}:
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             {{ shared_macros.client_method_metadata_argument()|indent(8) }} = {{ shared_macros.client_method_metadata_default_value() }},
             {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             {% endif %}
             {% if not method.server_streaming %}
             ) -> {{ method.client_output_async.ident }}:
@@ -298,7 +310,7 @@ class {{ service.async_client_name }}:
             timeout (float): The timeout for this request.
             {{ shared_macros.client_method_metadata_argument_doc()|indent(4) }}
             {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -368,20 +380,21 @@ class {{ service.async_client_name }}:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
         {% endif %}
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.{{ method.transport_safe_name|snake_case }}]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.{{ method.transport_safe_name|snake_case }}]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.{{ method.transport_safe_name|snake_case }}]
 
 {{ shared_macros.create_metadata(method) }}
 {{ shared_macros.add_api_version_header_to_metadata(service.version) }}
@@ -403,10 +416,16 @@ class {{ service.async_client_name }}:
             metadata=metadata,
         )
         {% if not method.void and not method.lro and not method.server_streaming and not method.client_streaming %}
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = {{ service.async_client_name }}CallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
         {% endif %}
         {% if method.lro %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -10,9 +10,7 @@ from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Opt
 {% if api.all_method_settings.values()|map(attribute="auto_populated_fields", default=[])|list %}
 import uuid
 {% endif %}
-{% if service.any_deprecated %}
 import warnings
-{% endif %}
 
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}} import gapic_version as package_version
@@ -260,6 +258,9 @@ class {{ service.async_client_name }}:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             {{ shared_macros.client_method_metadata_argument()|indent(8) }} = {{ shared_macros.client_method_metadata_default_value() }},
+            {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+            raw_response_callback: Optional[callable] = None,
+            {% endif %}
             {% if not method.server_streaming %}
             ) -> {{ method.client_output_async.ident }}:
             {% else %}
@@ -296,6 +297,12 @@ class {{ service.async_client_name }}:
                 should be retried.
             timeout (float): The timeout for this request.
             {{ shared_macros.client_method_metadata_argument_doc()|indent(4) }}
+            {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
+            {% endif %}
         {% if not method.void %}
 
         Returns:
@@ -361,7 +368,20 @@ class {{ service.async_client_name }}:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.{{ method.transport_safe_name|snake_case }}]
+        with_call = False
+        {% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming %}
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        {% endif %}
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.{{ method.transport_safe_name|snake_case }}]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.{{ method.transport_safe_name|snake_case }}]
 
 {{ shared_macros.create_metadata(method) }}
 {{ shared_macros.add_api_version_header_to_metadata(service.version) }}
@@ -382,6 +402,12 @@ class {{ service.async_client_name }}:
             timeout=timeout,
             metadata=metadata,
         )
+        {% if not method.void and not method.lro and not method.server_streaming and not method.client_streaming %}
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
+        {% endif %}
         {% if method.lro %}
 
         # Wrap the response in an operation future.

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -62,6 +62,7 @@ from .transports.base import {{ service.name }}Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc import {{ service.grpc_transport_name }}
 from .transports.grpc_asyncio import {{ service.grpc_asyncio_transport_name }}
 {% endif %}
+from .transports.base import BaseCallMetadata
 {% if 'rest' in opts.transport %}
 from .transports.rest import {{ service.name }}RestTransport
 {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2121): Remove this condition when async rest is GA. #}
@@ -76,6 +77,16 @@ except ImportError as e: # pragma: NO COVER
 
 {% endif %}{# if rest_async_io_enabled #}
 {% endif %}
+
+
+class {{ service.client_name }}CallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class {{ service.client_name }}Meta(type):

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -3,6 +3,7 @@
 {% block content %}
 
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
@@ -144,6 +145,39 @@ class {{ service.name }}Transport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+            {% for method in service.methods.values() %}
+            {% if not method.lro and not method.client_streaming and not method.server_streaming %}
+                self.{{ method.transport_safe_name|snake_case }}: gapic_v1.method.wrap_method(
+                    self.{{ method.transport_safe_name|snake_case }},
+                    {% if method.retry %}
+                    default_retry=retries.Retry(
+                        {% if method.retry.initial_backoff %}
+                        initial={{ method.retry.initial_backoff }},
+                        {% endif %}
+                        {% if method.retry.max_backoff %}
+                        maximum={{ method.retry.max_backoff }},
+                        {% endif %}
+                        {% if method.retry.backoff_multiplier %}
+                        multiplier={{ method.retry.backoff_multiplier }},
+                        {% endif %}
+                        predicate=retries.if_exception_type(
+                            {% for ex in method.retry.retryable_exceptions|sort(attribute='__name__') %}
+                            core_exceptions.{{ ex.__name__ }},
+                            {% endfor %}
+                        ),
+                        deadline={{ method.timeout }},
+                    ),
+                    {% endif %}
+                    default_timeout={{ method.timeout }},
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            {% endif %}{# if not method.lro and not method.client_streaming and not method.server_streaming #}
+            {% endfor %}{# method in service.methods.values() #}
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             {% for method in service.methods.values() %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -4,7 +4,7 @@
 
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}} import gapic_version as package_version
@@ -52,6 +52,18 @@ from {{ (api.naming.module_namespace + (api.naming.versioned_module_name,) + ser
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+    
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class {{ service.name }}Transport(abc.ABC):
     """Abstract transport class for {{ service.name }}."""

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -33,6 +33,7 @@ import warnings
 {{ shared_macros.operations_mixin_imports(api, service, opts) }}
 
 from .rest_base import _Base{{ service.name }}RestTransport
+from .base import BaseCallMetadata
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
 try:
@@ -209,7 +210,7 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                 timeout: Optional[float]=None,
                 {{ shared_macros.client_method_metadata_argument()|indent(8) }}={{ shared_macros.client_method_metadata_default_value() }},
                 with_call: bool = False,
-                ){% if not method.void %} -> {% if not method.server_streaming %}{{method.output.ident}}{% else %}rest_streaming.ResponseIterator{% endif %}{% endif %}:
+                ){% if not method.void %} -> {% if not method.server_streaming %}Union[{{method.output.ident}}, Tuple[{{method.output.ident}}, BaseCallMetadata]]{% else %}rest_streaming.ResponseIterator{% endif %}{% endif %}:
     {% if method.http_options and not method.client_streaming %}
             r"""Call the {{- ' ' -}}
             {{ (method.name|snake_case).replace('_',' ')|wrap(
@@ -252,10 +253,16 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             {% endif %}{# method.lro #}
             resp = self._interceptor.post_{{ method.name|snake_case }}(resp)
+            {% if not method.server_streaming %}
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
+            {% else %}
+            return resp
+            {% endif %}
 
             {% endif %}{# method.void #}
     {% else %}{# method.http_options and not method.client_streaming #}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -193,6 +193,10 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
     class _{{method.name}}(_Base{{ service.name }}RestTransport._Base{{method.name}}, {{service.name}}RestStub):
         def __hash__(self):
             return hash("{{service.name}}RestTransport.{{method.name}}")
+        {% if not method.lro and not method.client_streaming and not method.server_streaming %}
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
+        {% endif %}
         {% if method.http_options and not method.client_streaming %}
 
         {% set body_spec = method.http_options[0].body %}
@@ -204,6 +208,7 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 {{ shared_macros.client_method_metadata_argument()|indent(8) }}={{ shared_macros.client_method_metadata_default_value() }},
+                with_call: bool = False,
                 ){% if not method.void %} -> {% if not method.server_streaming %}{{method.output.ident}}{% else %}rest_streaming.ResponseIterator{% endif %}{% endif %}:
     {% if method.http_options and not method.client_streaming %}
             r"""Call the {{- ' ' -}}
@@ -247,7 +252,10 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             {% endif %}{# method.lro #}
             resp = self._interceptor.post_{{ method.name|snake_case }}(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
             {% endif %}{# method.void #}
     {% else %}{# method.http_options and not method.client_streaming #}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -57,6 +57,7 @@ from typing import Any, Dict, List, Callable, Tuple, Optional, Sequence, Union
 
 from .rest_base import _Base{{ service.name }}RestTransport
 
+from .base import BaseCallMetadata
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
 try:
@@ -71,6 +72,21 @@ DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
 )
 
 {{ shared_macros.create_interceptor_class(api, service, method, is_async=True) }}
+
+class AsyncCallMetadata(BaseCallMetadata):
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata)
+
+    async def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
+
 
 @dataclasses.dataclass
 class Async{{service.name}}RestStub:
@@ -170,7 +186,7 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                     {{ shared_macros.client_method_metadata_argument()|indent(12) }}={{ shared_macros.client_method_metadata_default_value() }},
                     with_call: bool = False,
                     {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2169): Update return type for client streaming method. #}
-                    ){% if not method.void %} -> {% if not method.server_streaming %}{{method.output.ident}}{% else %}rest_streaming_async.AsyncResponseIterator{% endif %}{% endif %}:
+                    ){% if not method.void %} -> {% if not method.server_streaming %}Union[{{method.output.ident}}, Tuple[{{method.output.ident}}, BaseCallMetadata]]{% else %}rest_streaming_async.AsyncResponseIterator{% endif %}{% endif %}:
         {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2169): Implement client streaming method. #}
          {% if method.http_options and not method.client_streaming %}
             r"""Call the {{- ' ' -}}
@@ -213,7 +229,9 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             {% endif %}{# if method.server_streaming #}
             resp = await self._interceptor.post_{{ method.name|snake_case }}(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -5,6 +5,7 @@
 
 {% block content %}
 
+import inspect
 
 import google.auth
 try:
@@ -152,6 +153,10 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
         def __hash__(self):
             return hash("Async{{service.name}}RestTransport.{{method.name}}")
 
+        {% if not method.lro and not method.client_streaming and not method.server_streaming %}
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
+        {% endif %}
         {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2169): Implement client streaming method. #}
         {% if method.http_options and not method.client_streaming %}
         {% set body_spec = method.http_options[0].body %}
@@ -163,6 +168,7 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     {{ shared_macros.client_method_metadata_argument()|indent(12) }}={{ shared_macros.client_method_metadata_default_value() }},
+                    with_call: bool = False,
                     {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2169): Update return type for client streaming method. #}
                     ){% if not method.void %} -> {% if not method.server_streaming %}{{method.output.ident}}{% else %}rest_streaming_async.AsyncResponseIterator{% endif %}{% endif %}:
         {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2169): Implement client streaming method. #}
@@ -206,7 +212,10 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             {% endif %}{# if method.server_streaming #}
             resp = await self._interceptor.post_{{ method.name|snake_case }}(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
             {% endif %}{# method.void #}
          

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1006,7 +1006,8 @@ def test_transport_adc(transport_class):
 {{ test_macros.transport_kind_test(**conf) }}
 {{ test_macros.run_transport_tests_for_config(**conf) }}
 {{ test_macros.empty_call_test(**conf) }}
-
+{{ test_macros.method_call_test_with_metadata_callback(**conf) }}
+{{ test_macros.method_call_test_with_metadata_callback_raises_warning_old_api_core(**conf) }}
 {{ test_macros.routing_parameter_test(**conf) }}
 {% if service.has_lro %}
 {{ test_macros.lro_client_test(**conf) }}
@@ -1021,6 +1022,7 @@ def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = {{ service.client_name }}(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1549,6 +1549,180 @@ def test_{{ method_name }}_rest_no_http_options():
 {% endwith %}{# method_name #}
 {% endmacro %}
 
+
+{% macro method_call_test_with_metadata_callback(method, service, api, transport, is_async=False) %}
+{% set transport_name = get_transport_name(transport, is_async) %}
+{% for method in service.methods.values() %}
+{% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming and not method.extended_lro %}
+{% with method_name = method.name|snake_case + "_unary" if method.operation_service else method.safe_name|snake_case %}
+{% set await_prefix = get_await_prefix(is_async) %}
+{% set async_method_prefix = "async " if is_async else "" %}
+{% set async_mock_prefix = "Async" if is_async else "" %}
+{% if is_async %}
+@pytest.mark.asyncio
+{% endif %}{# is_async #}
+{% if ('rest' in transport_name and method.http_options) or 'rest' not in transport_name %}
+{{ async_method_prefix }}def test_{{ method_name }}_with_metadata_callback_{{transport_name}}():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    {% if 'async' in transport_name %}
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+    {% else %}
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+    {% endif %}
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    {% if transport_name == 'rest_asyncio' %}
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    {% endif %}
+    client = {{ get_client(service=service, is_async=is_async) }}(
+        credentials={{ get_credentials(is_async=is_async) }},
+        transport="{{ transport_name }}",
+    )
+
+    response_obj = {{ method.output.ident }}(
+        {% for field in method.output.fields.values() | rejectattr('message')%}
+        {% if not field.oneof or field.proto3_optional %}
+        {{ field.name }}={{ field.mock_value }},
+        {% endif %}
+        {% endfor %}
+    )
+{% if 'grpc' in transport_name %}
+    {% if not is_async %}
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+    {% else %}
+    with mock.patch.object(
+        type(client.transport.{{ method.transport_safe_name|snake_case }}), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+    {% endif %}
+{% else %}
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        {% if method.input.ident.is_proto_plus_type %}
+        pb_request = {{ method.input.ident }}.pb({{ method.input.ident }}())
+        {% else %}
+        pb_request = {{ method.input.ident }}()
+        {% endif %}{# if method.input.ident.is_proto_plus_type #}
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "{{ method.http_options[0].method }}",
+            'query_params': pb_request,
+        }
+        {% if method.http_options[0].body %}
+        transcode_result['body'] = pb_request
+        {% endif %}
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = {{ method.output.ident }}.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        {% if is_async %}
+        response_value.read = mock.AsyncMock(return_value=json_response_obj.encode('UTF-8'))
+        {% else %}
+        call.return_value.content = json_response_obj
+        {% endif %}
+{% endif %}
+        mocked_callback = mock.{{ async_mock_prefix }}Mock()
+        response = {{ await_prefix }}client.{{ method_name }}(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+{% if 'grpc' in transport_name %}
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+{% else %}
+        mocked_callback.assert_called_with(response_value)
+{% endif %}
+        {% if is_async %}
+        assert isinstance(response, {{ method.client_output_async.ident }})
+        {% else %}
+        assert isinstance(response, {{ method.client_output.ident }})
+        {% endif %}
+
+{% endif %}
+{% endwith %}{# method_name #}
+{% endif %}
+{% endfor %}
+{% endmacro %}
+
+
+{#
+    TODO: Make this test unconditional once the minimum supported version of
+    `google-api-core` becomes 2.24.0 or higher. 
+#}
+{% macro method_call_test_with_metadata_callback_raises_warning_old_api_core(method, service, api, transport, is_async=False) %}
+{% set transport_name = get_transport_name(transport, is_async) %}
+{% for method in service.methods.values() %}
+{% if not method.void and not method.lro and not method.client_streaming and not method.server_streaming and not method.extended_lro %}
+{% with method_name = method.name|snake_case + "_unary" if method.operation_service else method.safe_name|snake_case %}
+{% set await_prefix = get_await_prefix(is_async) %}
+{% set async_method_prefix = "async " if is_async else "" %}
+{% set async_mock_prefix = "Async" if is_async else "" %}
+{% if is_async %}
+@pytest.mark.asyncio
+{% endif %}{# is_async #}
+{{ async_method_prefix }}def test_{{ method_name }}_with_metadata_callback_raises_warning_if_no_metadata_{{transport_name}}():
+    {% if transport_name == 'rest_asyncio' %}
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    {% endif %}
+    {% if transport_name == 'grpc_asyncio' %}
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+    {% else %}
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+    {% endif %}
+
+    client = {{ get_client(service=service, is_async=is_async) }}(
+        credentials={{ get_credentials(is_async=is_async) }},
+        transport="{{ transport_name }}",
+    )
+
+    with mock.patch.object(
+    {% if not is_async %}
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = {{ method.output.ident }}()
+    {% else %}
+        type(client.transport.{{ method.transport_safe_name|snake_case }}), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall({{ method.output.ident }}())
+        call.side_effect = (mocked_grpc_callable, )
+    {% endif %}
+        mocked_callback = mock.{{ async_mock_prefix }}Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = {{ await_prefix }}client.{{ method_name }}(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            {% if is_async %}
+            assert isinstance(response, {{ method.client_output_async.ident }})
+            {% else %}
+            assert isinstance(response, {{ method.client_output.ident }})
+            {% endif %}
+
+{% endwith %}{# method_name #}
+{% endif %}
+{% endfor %}
+{% endmacro %}
+
 {% macro get_credentials(is_async=False) %}
 {{- 'async_anonymous_credentials()' if is_async else 'ga_credentials.AnonymousCredentials()' -}}
 {% endmacro %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1591,11 +1591,13 @@ def test_{{ method_name }}_rest_no_http_options():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
     {% else %}
     with mock.patch.object(
         type(client.transport.{{ method.transport_safe_name|snake_case }}), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
     {% endif %}
 {% else %}
@@ -1621,6 +1623,7 @@ def test_{{ method_name }}_rest_no_http_options():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -1637,11 +1640,7 @@ def test_{{ method_name }}_rest_no_http_options():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-{% if 'grpc' in transport_name %}
-        mocked_callback.assert_called_with(mocked_grpc_callable)
-{% else %}
-        mocked_callback.assert_called_with(response_value)
-{% endif %}
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         {% if is_async %}
         assert isinstance(response, {{ method.client_output_async.ident }})
         {% else %}

--- a/noxfile.py
+++ b/noxfile.py
@@ -324,6 +324,9 @@ def showcase_library(
             # Install the library without a constraints file.
             session.install("-e", tmp_dir)
 
+        # TODO : Remove this once a newer version of google-api-core is published
+        if session.python != "3.7":
+            session.install("google-api-core[grpc] @ git+https://github.com/googleapis/python-api-core.git@async-metadata-call", "--ignore-installed")
         yield tmp_dir
 
 
@@ -339,15 +342,16 @@ def showcase(
     with showcase_library(session, templates=templates, other_opts=other_opts):
         session.install("pytest", "pytest-asyncio")
         test_directory = Path("tests", "system")
-        ignore_file = env.get("IGNORE_FILE")
+        ignore_files = env.get("IGNORE_FILES")
         pytest_command = [
             "py.test",
             "--quiet",
             *(session.posargs or [str(test_directory)]),
         ]
-        if ignore_file:
-            ignore_path = test_directory / ignore_file
-            pytest_command.extend(["--ignore", str(ignore_path)])
+        if ignore_files:
+            for ignore_file in ignore_files.split(","):
+                ignore_path = test_directory / ignore_file
+                pytest_command.extend(["--ignore", str(ignore_path)])
 
         session.run(
             *pytest_command,
@@ -418,7 +422,7 @@ def showcase_alternative_templates(session):
         session,
         templates=templates,
         other_opts=("old-naming",),
-        env={"GAPIC_PYTHON_ASYNC": "False", "IGNORE_FILE": "test_universe_domain.py"},
+        env={"GAPIC_PYTHON_ASYNC": "False", "IGNORE_FILES": "test_universe_domain.py,test_request_metadata.py"},
     )
 
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
+import warnings
 
 from google.cloud.asset_v1 import gapic_version as package_version
 
@@ -332,7 +333,11 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.export_assets]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.export_assets]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.export_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -371,6 +376,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListAssetsAsyncPager:
         r"""Lists assets with time and resource types and returns
         paged results in response.
@@ -424,6 +430,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.ListAssetsAsyncPager:
@@ -454,7 +464,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_assets]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_assets]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -474,6 +495,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -495,6 +520,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.BatchGetAssetsHistoryResponse:
         r"""Batch gets the update history of assets that overlap a time
         window. For IAM_POLICY content, this API outputs history when
@@ -540,6 +566,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.BatchGetAssetsHistoryResponse:
@@ -553,7 +583,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.batch_get_assets_history]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.batch_get_assets_history]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.batch_get_assets_history]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -573,6 +614,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -584,6 +629,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.Feed:
         r"""Creates a feed in a parent
         project/folder/organization to listen to its asset
@@ -644,6 +690,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.Feed:
@@ -677,7 +727,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_feed]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_feed]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -697,6 +758,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -708,6 +773,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.Feed:
         r"""Gets details about an asset feed.
 
@@ -756,6 +822,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.Feed:
@@ -789,7 +859,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_feed]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_feed]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -809,6 +890,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -820,6 +905,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.ListFeedsResponse:
         r"""Lists all asset feeds in a parent
         project/folder/organization.
@@ -871,6 +957,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.ListFeedsResponse:
@@ -896,7 +986,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_feeds]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_feeds]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_feeds]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -916,6 +1017,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -927,6 +1032,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.Feed:
         r"""Updates an asset feed configuration.
 
@@ -979,6 +1085,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.Feed:
@@ -1012,7 +1122,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_feed]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_feed]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1032,6 +1153,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1109,7 +1234,11 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_feed]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_feed]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1139,6 +1268,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.SearchAllResourcesAsyncPager:
         r"""Searches all Google Cloud resources within the specified scope,
         such as a project, folder, or organization. The caller must be
@@ -1293,6 +1423,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.SearchAllResourcesAsyncPager:
@@ -1327,7 +1461,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.search_all_resources]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.search_all_resources]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.search_all_resources]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1347,6 +1492,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1370,6 +1519,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.SearchAllIamPoliciesAsyncPager:
         r"""Searches all IAM policies within the specified scope, such as a
         project, folder, or organization. The caller must be granted the
@@ -1488,6 +1638,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.SearchAllIamPoliciesAsyncPager:
@@ -1520,7 +1674,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.search_all_iam_policies]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.search_all_iam_policies]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.search_all_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1540,6 +1705,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1561,6 +1730,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.AnalyzeIamPolicyResponse:
         r"""Analyzes IAM policies to answer which identities have
         what accesses on which resources.
@@ -1605,6 +1775,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.AnalyzeIamPolicyResponse:
@@ -1620,7 +1794,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_iam_policy]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_iam_policy]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_iam_policy]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1640,6 +1825,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1729,7 +1918,11 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_iam_policy_longrunning]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_iam_policy_longrunning]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_iam_policy_longrunning]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1767,6 +1960,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.AnalyzeMoveResponse:
         r"""Analyze moving a resource to a specified destination
         without kicking off the actual move. The analysis is
@@ -1814,6 +2008,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.AnalyzeMoveResponse:
@@ -1829,7 +2027,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_move]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_move]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_move]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1849,6 +2058,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1859,6 +2072,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.QueryAssetsResponse:
         r"""Issue a job that queries assets using a SQL statement compatible
         with `BigQuery Standard
@@ -1914,6 +2128,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.QueryAssetsResponse:
@@ -1927,7 +2145,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.query_assets]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.query_assets]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.query_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1947,6 +2176,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1960,6 +2193,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Creates a saved query in a parent
         project/folder/organization.
@@ -2035,6 +2269,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.SavedQuery:
@@ -2066,7 +2304,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_saved_query]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_saved_query]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2086,6 +2335,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2097,6 +2350,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Gets details about a saved query.
 
@@ -2147,6 +2401,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.SavedQuery:
@@ -2174,7 +2432,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_saved_query]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_saved_query]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2194,6 +2463,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2205,6 +2478,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListSavedQueriesAsyncPager:
         r"""Lists all saved queries in a parent
         project/folder/organization.
@@ -2258,6 +2532,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.ListSavedQueriesAsyncPager:
@@ -2288,7 +2566,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_saved_queries]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_saved_queries]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_saved_queries]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2308,6 +2597,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2331,6 +2624,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Updates a saved query.
 
@@ -2389,6 +2683,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.SavedQuery:
@@ -2418,7 +2716,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_saved_query]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_saved_query]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2438,6 +2747,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2517,7 +2830,11 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_saved_query]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_saved_query]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2544,6 +2861,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.BatchGetEffectiveIamPoliciesResponse:
         r"""Gets effective IAM policies for a batch of resources.
 
@@ -2585,6 +2903,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.BatchGetEffectiveIamPoliciesResponse:
@@ -2600,7 +2922,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.batch_get_effective_iam_policies]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.batch_get_effective_iam_policies]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.batch_get_effective_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2620,6 +2953,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2633,6 +2970,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.AnalyzeOrgPoliciesAsyncPager:
         r"""Analyzes organization policies under a scope.
 
@@ -2709,6 +3047,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.AnalyzeOrgPoliciesAsyncPager:
@@ -2743,7 +3085,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policies]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_org_policies]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2763,6 +3116,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2787,6 +3144,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedContainersAsyncPager:
         r"""Analyzes organization policies governed containers
         (projects, folders or organization) under a scope.
@@ -2863,6 +3221,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.AnalyzeOrgPolicyGovernedContainersAsyncPager:
@@ -2897,7 +3259,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policy_governed_containers]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_org_policy_governed_containers]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policy_governed_containers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2917,6 +3290,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2941,6 +3318,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedAssetsAsyncPager:
         r"""Analyzes organization policies governed assets (Google Cloud
         resources or policies) under a scope. This RPC supports custom
@@ -3046,6 +3424,10 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.AnalyzeOrgPolicyGovernedAssetsAsyncPager:
@@ -3080,7 +3462,18 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policy_governed_assets]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_org_policy_governed_assets]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policy_governed_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3100,6 +3493,10 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -43,9 +43,20 @@ from google.protobuf import field_mask_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
 from google.rpc import status_pb2  # type: ignore
 from google.type import expr_pb2  # type: ignore
+from .transports.base import BaseCallMetadata
 from .transports.base import AssetServiceTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import AssetServiceGrpcAsyncIOTransport
 from .client import AssetServiceClient
+
+
+class AssetServiceAsyncClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class AssetServiceAsyncClient:
@@ -333,11 +344,12 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.export_assets]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.export_assets]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.export_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -376,7 +388,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListAssetsAsyncPager:
         r"""Lists assets with time and resource types and returns
         paged results in response.
@@ -430,7 +442,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -464,18 +476,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_assets]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_assets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -495,10 +508,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -520,7 +539,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.BatchGetAssetsHistoryResponse:
         r"""Batch gets the update history of assets that overlap a time
         window. For IAM_POLICY content, this API outputs history when
@@ -566,7 +585,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -583,18 +602,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.batch_get_assets_history]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.batch_get_assets_history]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.batch_get_assets_history]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -614,10 +634,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -629,7 +655,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.Feed:
         r"""Creates a feed in a parent
         project/folder/organization to listen to its asset
@@ -690,7 +716,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -727,18 +753,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_feed]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_feed]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -758,10 +785,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -773,7 +806,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.Feed:
         r"""Gets details about an asset feed.
 
@@ -822,7 +855,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -859,18 +892,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_feed]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_feed]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -890,10 +924,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -905,7 +945,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.ListFeedsResponse:
         r"""Lists all asset feeds in a parent
         project/folder/organization.
@@ -957,7 +997,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -986,18 +1026,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_feeds]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_feeds]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_feeds]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1017,10 +1058,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1032,7 +1079,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.Feed:
         r"""Updates an asset feed configuration.
 
@@ -1085,7 +1132,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1122,18 +1169,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_feed]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_feed]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1153,10 +1201,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1234,11 +1288,12 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_feed]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_feed]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1268,7 +1323,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.SearchAllResourcesAsyncPager:
         r"""Searches all Google Cloud resources within the specified scope,
         such as a project, folder, or organization. The caller must be
@@ -1423,7 +1478,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1461,18 +1516,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.search_all_resources]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.search_all_resources]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.search_all_resources]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1492,10 +1548,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1519,7 +1581,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.SearchAllIamPoliciesAsyncPager:
         r"""Searches all IAM policies within the specified scope, such as a
         project, folder, or organization. The caller must be granted the
@@ -1638,7 +1700,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1674,18 +1736,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.search_all_iam_policies]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.search_all_iam_policies]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.search_all_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1705,10 +1768,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1730,7 +1799,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.AnalyzeIamPolicyResponse:
         r"""Analyzes IAM policies to answer which identities have
         what accesses on which resources.
@@ -1775,7 +1844,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1794,18 +1863,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_iam_policy]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_iam_policy]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.analyze_iam_policy]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1825,10 +1895,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1918,11 +1994,12 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_iam_policy_longrunning]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_iam_policy_longrunning]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.analyze_iam_policy_longrunning]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1960,7 +2037,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.AnalyzeMoveResponse:
         r"""Analyze moving a resource to a specified destination
         without kicking off the actual move. The analysis is
@@ -2008,7 +2085,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2027,18 +2104,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_move]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_move]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.analyze_move]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2058,10 +2136,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2072,7 +2156,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.QueryAssetsResponse:
         r"""Issue a job that queries assets using a SQL statement compatible
         with `BigQuery Standard
@@ -2128,7 +2212,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2145,18 +2229,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.query_assets]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.query_assets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.query_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2176,10 +2261,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2193,7 +2284,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Creates a saved query in a parent
         project/folder/organization.
@@ -2269,7 +2360,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2304,18 +2395,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_saved_query]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_saved_query]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2335,10 +2427,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2350,7 +2448,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Gets details about a saved query.
 
@@ -2401,7 +2499,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2432,18 +2530,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_saved_query]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_saved_query]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2463,10 +2562,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2478,7 +2583,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListSavedQueriesAsyncPager:
         r"""Lists all saved queries in a parent
         project/folder/organization.
@@ -2532,7 +2637,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2566,18 +2671,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_saved_queries]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_saved_queries]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_saved_queries]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2597,10 +2703,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2624,7 +2736,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Updates a saved query.
 
@@ -2683,7 +2795,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2716,18 +2828,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_saved_query]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_saved_query]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2747,10 +2860,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2830,11 +2949,12 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_saved_query]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_saved_query]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2861,7 +2981,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.BatchGetEffectiveIamPoliciesResponse:
         r"""Gets effective IAM policies for a batch of resources.
 
@@ -2903,7 +3023,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2922,18 +3042,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.batch_get_effective_iam_policies]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.batch_get_effective_iam_policies]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.batch_get_effective_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2953,10 +3074,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2970,7 +3097,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.AnalyzeOrgPoliciesAsyncPager:
         r"""Analyzes organization policies under a scope.
 
@@ -3047,7 +3174,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3085,18 +3212,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_org_policies]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policies]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.analyze_org_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3116,10 +3244,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -3144,7 +3278,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedContainersAsyncPager:
         r"""Analyzes organization policies governed containers
         (projects, folders or organization) under a scope.
@@ -3221,7 +3355,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3259,18 +3393,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_org_policy_governed_containers]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policy_governed_containers]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.analyze_org_policy_governed_containers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3290,10 +3425,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -3318,7 +3459,7 @@ class AssetServiceAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedAssetsAsyncPager:
         r"""Analyzes organization policies governed assets (Google Cloud
         resources or policies) under a scope. This RPC supports custom
@@ -3424,7 +3565,7 @@ class AssetServiceAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3462,18 +3603,19 @@ class AssetServiceAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.analyze_org_policy_governed_assets]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.analyze_org_policy_governed_assets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.analyze_org_policy_governed_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3493,10 +3635,16 @@ class AssetServiceAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = AssetServiceAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -49,7 +49,18 @@ from google.type import expr_pb2  # type: ignore
 from .transports.base import AssetServiceTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import AssetServiceGrpcTransport
 from .transports.grpc_asyncio import AssetServiceGrpcAsyncIOTransport
+from .transports.base import BaseCallMetadata
 from .transports.rest import AssetServiceRestTransport
+
+
+class AssetServiceClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class AssetServiceClientMeta(type):
@@ -703,12 +714,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.export_assets]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.export_assets]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.export_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -747,7 +758,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListAssetsPager:
         r"""Lists assets with time and resource types and returns
         paged results in response.
@@ -801,7 +812,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -834,19 +845,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_assets]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_assets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -867,10 +878,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -892,7 +904,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.BatchGetAssetsHistoryResponse:
         r"""Batch gets the update history of assets that overlap a time
         window. For IAM_POLICY content, this API outputs history when
@@ -938,7 +950,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -955,19 +967,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.batch_get_assets_history]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.batch_get_assets_history]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.batch_get_assets_history]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -988,10 +1000,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1003,7 +1016,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.Feed:
         r"""Creates a feed in a parent
         project/folder/organization to listen to its asset
@@ -1064,7 +1077,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1100,19 +1113,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_feed]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_feed]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1133,10 +1146,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1148,7 +1162,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.Feed:
         r"""Gets details about an asset feed.
 
@@ -1197,7 +1211,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1233,19 +1247,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_feed]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_feed]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1266,10 +1280,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1281,7 +1296,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.ListFeedsResponse:
         r"""Lists all asset feeds in a parent
         project/folder/organization.
@@ -1333,7 +1348,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1361,19 +1376,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_feeds]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_feeds]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_feeds]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1394,10 +1409,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1409,7 +1425,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.Feed:
         r"""Updates an asset feed configuration.
 
@@ -1462,7 +1478,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1498,19 +1514,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_feed]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_feed]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1531,10 +1547,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1611,12 +1628,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_feed]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_feed]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1646,7 +1663,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.SearchAllResourcesPager:
         r"""Searches all Google Cloud resources within the specified scope,
         such as a project, folder, or organization. The caller must be
@@ -1801,7 +1818,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1838,19 +1855,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.search_all_resources]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.search_all_resources]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.search_all_resources]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1871,10 +1888,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1898,7 +1916,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.SearchAllIamPoliciesPager:
         r"""Searches all IAM policies within the specified scope, such as a
         project, folder, or organization. The caller must be granted the
@@ -2017,7 +2035,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2052,19 +2070,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.search_all_iam_policies]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.search_all_iam_policies]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.search_all_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2085,10 +2103,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2110,7 +2129,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.AnalyzeIamPolicyResponse:
         r"""Analyzes IAM policies to answer which identities have
         what accesses on which resources.
@@ -2155,7 +2174,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2174,19 +2193,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_iam_policy]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.analyze_iam_policy]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.analyze_iam_policy]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2207,10 +2226,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2300,12 +2320,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_iam_policy_longrunning]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.analyze_iam_policy_longrunning]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.analyze_iam_policy_longrunning]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2343,7 +2363,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.AnalyzeMoveResponse:
         r"""Analyze moving a resource to a specified destination
         without kicking off the actual move. The analysis is
@@ -2391,7 +2411,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2410,19 +2430,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_move]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.analyze_move]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.analyze_move]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2443,10 +2463,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2457,7 +2478,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.QueryAssetsResponse:
         r"""Issue a job that queries assets using a SQL statement compatible
         with `BigQuery Standard
@@ -2513,7 +2534,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2530,19 +2551,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.query_assets]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.query_assets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.query_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2563,10 +2584,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2580,7 +2602,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Creates a saved query in a parent
         project/folder/organization.
@@ -2656,7 +2678,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2690,19 +2712,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_saved_query]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_saved_query]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2723,10 +2745,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2738,7 +2761,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Gets details about a saved query.
 
@@ -2789,7 +2812,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2819,19 +2842,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_saved_query]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_saved_query]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2852,10 +2875,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2867,7 +2891,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListSavedQueriesPager:
         r"""Lists all saved queries in a parent
         project/folder/organization.
@@ -2921,7 +2945,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2954,19 +2978,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_saved_queries]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_saved_queries]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_saved_queries]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2987,10 +3011,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3014,7 +3039,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Updates a saved query.
 
@@ -3073,7 +3098,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3105,19 +3130,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_saved_query]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_saved_query]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3138,10 +3163,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3220,12 +3246,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_saved_query]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_saved_query]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3252,7 +3278,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> asset_service.BatchGetEffectiveIamPoliciesResponse:
         r"""Gets effective IAM policies for a batch of resources.
 
@@ -3294,7 +3320,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3313,19 +3339,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.batch_get_effective_iam_policies]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.batch_get_effective_iam_policies]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.batch_get_effective_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3346,10 +3372,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3363,7 +3390,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.AnalyzeOrgPoliciesPager:
         r"""Analyzes organization policies under a scope.
 
@@ -3440,7 +3467,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3477,19 +3504,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_org_policies]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.analyze_org_policies]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.analyze_org_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3510,10 +3537,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3538,7 +3566,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedContainersPager:
         r"""Analyzes organization policies governed containers
         (projects, folders or organization) under a scope.
@@ -3615,7 +3643,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3652,19 +3680,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_org_policy_governed_containers]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.analyze_org_policy_governed_containers]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.analyze_org_policy_governed_containers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3685,10 +3713,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3713,7 +3742,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedAssetsPager:
         r"""Analyzes organization policies governed assets (Google Cloud
         resources or policies) under a scope. This RPC supports custom
@@ -3819,7 +3848,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3856,19 +3885,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_org_policy_governed_assets]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.analyze_org_policy_governed_assets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.analyze_org_policy_governed_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3889,10 +3918,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = AssetServiceClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -703,7 +703,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.export_assets]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.export_assets]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.export_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -742,6 +747,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListAssetsPager:
         r"""Lists assets with time and resource types and returns
         paged results in response.
@@ -795,6 +801,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.ListAssetsPager:
@@ -824,7 +834,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_assets]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_assets]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -844,6 +866,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -865,6 +892,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.BatchGetAssetsHistoryResponse:
         r"""Batch gets the update history of assets that overlap a time
         window. For IAM_POLICY content, this API outputs history when
@@ -910,6 +938,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.BatchGetAssetsHistoryResponse:
@@ -923,7 +955,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.batch_get_assets_history]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.batch_get_assets_history]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.batch_get_assets_history]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -944,6 +988,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -954,6 +1003,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.Feed:
         r"""Creates a feed in a parent
         project/folder/organization to listen to its asset
@@ -1014,6 +1064,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.Feed:
@@ -1046,7 +1100,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_feed]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_feed]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1067,6 +1133,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1077,6 +1148,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.Feed:
         r"""Gets details about an asset feed.
 
@@ -1125,6 +1197,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.Feed:
@@ -1157,7 +1233,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_feed]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_feed]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1178,6 +1266,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1188,6 +1281,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.ListFeedsResponse:
         r"""Lists all asset feeds in a parent
         project/folder/organization.
@@ -1239,6 +1333,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.ListFeedsResponse:
@@ -1263,7 +1361,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_feeds]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_feeds]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_feeds]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1284,6 +1394,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1294,6 +1409,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.Feed:
         r"""Updates an asset feed configuration.
 
@@ -1346,6 +1462,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.Feed:
@@ -1378,7 +1498,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_feed]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_feed]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1398,6 +1530,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1474,7 +1611,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_feed]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_feed]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_feed]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1504,6 +1646,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.SearchAllResourcesPager:
         r"""Searches all Google Cloud resources within the specified scope,
         such as a project, folder, or organization. The caller must be
@@ -1658,6 +1801,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.SearchAllResourcesPager:
@@ -1691,7 +1838,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.search_all_resources]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.search_all_resources]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.search_all_resources]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1711,6 +1870,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1734,6 +1898,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.SearchAllIamPoliciesPager:
         r"""Searches all IAM policies within the specified scope, such as a
         project, folder, or organization. The caller must be granted the
@@ -1852,6 +2017,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.SearchAllIamPoliciesPager:
@@ -1883,7 +2052,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.search_all_iam_policies]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.search_all_iam_policies]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.search_all_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1903,6 +2084,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1924,6 +2110,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.AnalyzeIamPolicyResponse:
         r"""Analyzes IAM policies to answer which identities have
         what accesses on which resources.
@@ -1968,6 +2155,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.AnalyzeIamPolicyResponse:
@@ -1983,7 +2174,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.analyze_iam_policy]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_iam_policy]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.analyze_iam_policy]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2003,6 +2206,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2092,7 +2300,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.analyze_iam_policy_longrunning]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_iam_policy_longrunning]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.analyze_iam_policy_longrunning]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2130,6 +2343,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.AnalyzeMoveResponse:
         r"""Analyze moving a resource to a specified destination
         without kicking off the actual move. The analysis is
@@ -2177,6 +2391,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.AnalyzeMoveResponse:
@@ -2192,7 +2410,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.analyze_move]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_move]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.analyze_move]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2213,6 +2443,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2222,6 +2457,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.QueryAssetsResponse:
         r"""Issue a job that queries assets using a SQL statement compatible
         with `BigQuery Standard
@@ -2277,6 +2513,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.QueryAssetsResponse:
@@ -2290,7 +2530,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.query_assets]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.query_assets]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.query_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2311,6 +2563,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2323,6 +2580,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Creates a saved query in a parent
         project/folder/organization.
@@ -2398,6 +2656,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.SavedQuery:
@@ -2428,7 +2690,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_saved_query]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_saved_query]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2449,6 +2723,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2459,6 +2738,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Gets details about a saved query.
 
@@ -2509,6 +2789,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.SavedQuery:
@@ -2535,7 +2819,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_saved_query]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_saved_query]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2556,6 +2852,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2566,6 +2867,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListSavedQueriesPager:
         r"""Lists all saved queries in a parent
         project/folder/organization.
@@ -2619,6 +2921,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.ListSavedQueriesPager:
@@ -2648,7 +2954,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_saved_queries]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_saved_queries]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_saved_queries]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2668,6 +2986,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2691,6 +3014,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.SavedQuery:
         r"""Updates a saved query.
 
@@ -2749,6 +3073,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.SavedQuery:
@@ -2777,7 +3105,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_saved_query]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_saved_query]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2797,6 +3137,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2875,7 +3220,12 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_saved_query]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_saved_query]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_saved_query]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2902,6 +3252,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> asset_service.BatchGetEffectiveIamPoliciesResponse:
         r"""Gets effective IAM policies for a batch of resources.
 
@@ -2943,6 +3294,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.types.BatchGetEffectiveIamPoliciesResponse:
@@ -2958,7 +3313,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.batch_get_effective_iam_policies]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.batch_get_effective_iam_policies]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.batch_get_effective_iam_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2979,6 +3346,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2991,6 +3363,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.AnalyzeOrgPoliciesPager:
         r"""Analyzes organization policies under a scope.
 
@@ -3067,6 +3440,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.AnalyzeOrgPoliciesPager:
@@ -3100,7 +3477,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.analyze_org_policies]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_org_policies]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.analyze_org_policies]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3120,6 +3509,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3144,6 +3538,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedContainersPager:
         r"""Analyzes organization policies governed containers
         (projects, folders or organization) under a scope.
@@ -3220,6 +3615,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.AnalyzeOrgPolicyGovernedContainersPager:
@@ -3253,7 +3652,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.analyze_org_policy_governed_containers]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_org_policy_governed_containers]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.analyze_org_policy_governed_containers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3273,6 +3684,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3297,6 +3713,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.AnalyzeOrgPolicyGovernedAssetsPager:
         r"""Analyzes organization policies governed assets (Google Cloud
         resources or policies) under a scope. This RPC supports custom
@@ -3402,6 +3819,10 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.asset_v1.services.asset_service.pagers.AnalyzeOrgPolicyGovernedAssetsPager:
@@ -3435,7 +3856,19 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.analyze_org_policy_governed_assets]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.analyze_org_policy_governed_assets]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.analyze_org_policy_governed_assets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3455,6 +3888,11 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -15,7 +15,7 @@
 #
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.cloud.asset_v1 import gapic_version as package_version
 
@@ -34,6 +34,18 @@ from google.protobuf import empty_pb2  # type: ignore
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class AssetServiceTransport(abc.ABC):
     """Abstract transport class for AssetService."""

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 from google.cloud.asset_v1 import gapic_version as package_version
@@ -120,6 +121,205 @@ class AssetServiceTransport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_assets: gapic_v1.method.wrap_method(
+                    self.list_assets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.batch_get_assets_history: gapic_v1.method.wrap_method(
+                    self.batch_get_assets_history,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_feed: gapic_v1.method.wrap_method(
+                    self.create_feed,
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_feed: gapic_v1.method.wrap_method(
+                    self.get_feed,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_feeds: gapic_v1.method.wrap_method(
+                    self.list_feeds,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_feed: gapic_v1.method.wrap_method(
+                    self.update_feed,
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.delete_feed: gapic_v1.method.wrap_method(
+                    self.delete_feed,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.search_all_resources: gapic_v1.method.wrap_method(
+                    self.search_all_resources,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=15.0,
+                    ),
+                    default_timeout=15.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.search_all_iam_policies: gapic_v1.method.wrap_method(
+                    self.search_all_iam_policies,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=15.0,
+                    ),
+                    default_timeout=15.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_iam_policy: gapic_v1.method.wrap_method(
+                    self.analyze_iam_policy,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=300.0,
+                    ),
+                    default_timeout=300.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_move: gapic_v1.method.wrap_method(
+                    self.analyze_move,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.query_assets: gapic_v1.method.wrap_method(
+                    self.query_assets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_saved_query: gapic_v1.method.wrap_method(
+                    self.create_saved_query,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_saved_query: gapic_v1.method.wrap_method(
+                    self.get_saved_query,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_saved_queries: gapic_v1.method.wrap_method(
+                    self.list_saved_queries,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_saved_query: gapic_v1.method.wrap_method(
+                    self.update_saved_query,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.delete_saved_query: gapic_v1.method.wrap_method(
+                    self.delete_saved_query,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.batch_get_effective_iam_policies: gapic_v1.method.wrap_method(
+                    self.batch_get_effective_iam_policies,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_org_policies: gapic_v1.method.wrap_method(
+                    self.analyze_org_policies,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_org_policy_governed_containers: gapic_v1.method.wrap_method(
+                    self.analyze_org_policy_governed_containers,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_org_policy_governed_assets: gapic_v1.method.wrap_method(
+                    self.analyze_org_policy_governed_assets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.export_assets: gapic_v1.method.wrap_method(

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/grpc_asyncio.py
@@ -942,6 +942,183 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_assets: self._wrap_method(
+                    self.list_assets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.batch_get_assets_history: self._wrap_method(
+                    self.batch_get_assets_history,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_feed: self._wrap_method(
+                    self.create_feed,
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_feed: self._wrap_method(
+                    self.get_feed,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_feeds: self._wrap_method(
+                    self.list_feeds,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_feed: self._wrap_method(
+                    self.update_feed,
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.search_all_resources: self._wrap_method(
+                    self.search_all_resources,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=15.0,
+                    ),
+                    default_timeout=15.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.search_all_iam_policies: self._wrap_method(
+                    self.search_all_iam_policies,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=15.0,
+                    ),
+                    default_timeout=15.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_iam_policy: self._wrap_method(
+                    self.analyze_iam_policy,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=300.0,
+                    ),
+                    default_timeout=300.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_move: self._wrap_method(
+                    self.analyze_move,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.query_assets: self._wrap_method(
+                    self.query_assets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_saved_query: self._wrap_method(
+                    self.create_saved_query,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_saved_query: self._wrap_method(
+                    self.get_saved_query,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_saved_queries: self._wrap_method(
+                    self.list_saved_queries,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_saved_query: self._wrap_method(
+                    self.update_saved_query,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.batch_get_effective_iam_policies: self._wrap_method(
+                    self.batch_get_effective_iam_policies,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_org_policies: self._wrap_method(
+                    self.analyze_org_policies,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_org_policy_governed_containers: self._wrap_method(
+                    self.analyze_org_policy_governed_containers,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.analyze_org_policy_governed_assets: self._wrap_method(
+                    self.analyze_org_policy_governed_assets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.export_assets: self._wrap_method(
                 self.export_assets,
@@ -1137,6 +1314,8 @@ class AssetServiceGrpcAsyncIOTransport(AssetServiceTransport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -38,6 +38,7 @@ from google.longrunning import operations_pb2  # type: ignore
 
 
 from .rest_base import _BaseAssetServiceRestTransport
+from .base import BaseCallMetadata
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
 try:
@@ -798,7 +799,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.AnalyzeIamPolicyResponse:
+                ) -> Union[asset_service.AnalyzeIamPolicyResponse, Tuple[asset_service.AnalyzeIamPolicyResponse, BaseCallMetadata]]:
             r"""Call the analyze iam policy method over HTTP.
 
             Args:
@@ -842,7 +843,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -879,7 +882,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the analyze iam policy
         longrunning method over HTTP.
 
@@ -925,7 +928,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy_longrunning(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -963,7 +968,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.AnalyzeMoveResponse:
+                ) -> Union[asset_service.AnalyzeMoveResponse, Tuple[asset_service.AnalyzeMoveResponse, BaseCallMetadata]]:
             r"""Call the analyze move method over HTTP.
 
             Args:
@@ -1007,7 +1012,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_move(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1045,7 +1052,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.AnalyzeOrgPoliciesResponse:
+                ) -> Union[asset_service.AnalyzeOrgPoliciesResponse, Tuple[asset_service.AnalyzeOrgPoliciesResponse, BaseCallMetadata]]:
             r"""Call the analyze org policies method over HTTP.
 
             Args:
@@ -1089,7 +1096,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policies(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1127,7 +1136,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.AnalyzeOrgPolicyGovernedAssetsResponse:
+                ) -> Union[asset_service.AnalyzeOrgPolicyGovernedAssetsResponse, Tuple[asset_service.AnalyzeOrgPolicyGovernedAssetsResponse, BaseCallMetadata]]:
             r"""Call the analyze org policy
         governed assets method over HTTP.
 
@@ -1172,7 +1181,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_assets(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1210,7 +1221,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.AnalyzeOrgPolicyGovernedContainersResponse:
+                ) -> Union[asset_service.AnalyzeOrgPolicyGovernedContainersResponse, Tuple[asset_service.AnalyzeOrgPolicyGovernedContainersResponse, BaseCallMetadata]]:
             r"""Call the analyze org policy
         governed containers method over HTTP.
 
@@ -1255,7 +1266,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_containers(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1293,7 +1306,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.BatchGetAssetsHistoryResponse:
+                ) -> Union[asset_service.BatchGetAssetsHistoryResponse, Tuple[asset_service.BatchGetAssetsHistoryResponse, BaseCallMetadata]]:
             r"""Call the batch get assets history method over HTTP.
 
             Args:
@@ -1334,7 +1347,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_assets_history(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1372,7 +1387,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.BatchGetEffectiveIamPoliciesResponse:
+                ) -> Union[asset_service.BatchGetEffectiveIamPoliciesResponse, Tuple[asset_service.BatchGetEffectiveIamPoliciesResponse, BaseCallMetadata]]:
             r"""Call the batch get effective iam
         policies method over HTTP.
 
@@ -1417,7 +1432,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_effective_iam_policies(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1456,7 +1473,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.Feed:
+                ) -> Union[asset_service.Feed, Tuple[asset_service.Feed, BaseCallMetadata]]:
             r"""Call the create feed method over HTTP.
 
             Args:
@@ -1507,7 +1524,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_feed(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1546,7 +1565,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.SavedQuery:
+                ) -> Union[asset_service.SavedQuery, Tuple[asset_service.SavedQuery, BaseCallMetadata]]:
             r"""Call the create saved query method over HTTP.
 
             Args:
@@ -1591,7 +1610,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_saved_query(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1756,7 +1777,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the export assets method over HTTP.
 
             Args:
@@ -1800,7 +1821,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_assets(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1838,7 +1861,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.Feed:
+                ) -> Union[asset_service.Feed, Tuple[asset_service.Feed, BaseCallMetadata]]:
             r"""Call the get feed method over HTTP.
 
             Args:
@@ -1887,7 +1910,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_feed(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1925,7 +1950,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.SavedQuery:
+                ) -> Union[asset_service.SavedQuery, Tuple[asset_service.SavedQuery, BaseCallMetadata]]:
             r"""Call the get saved query method over HTTP.
 
             Args:
@@ -1968,7 +1993,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_saved_query(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2006,7 +2033,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.ListAssetsResponse:
+                ) -> Union[asset_service.ListAssetsResponse, Tuple[asset_service.ListAssetsResponse, BaseCallMetadata]]:
             r"""Call the list assets method over HTTP.
 
             Args:
@@ -2047,7 +2074,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_assets(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2085,7 +2114,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.ListFeedsResponse:
+                ) -> Union[asset_service.ListFeedsResponse, Tuple[asset_service.ListFeedsResponse, BaseCallMetadata]]:
             r"""Call the list feeds method over HTTP.
 
             Args:
@@ -2126,7 +2155,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_feeds(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2164,7 +2195,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.ListSavedQueriesResponse:
+                ) -> Union[asset_service.ListSavedQueriesResponse, Tuple[asset_service.ListSavedQueriesResponse, BaseCallMetadata]]:
             r"""Call the list saved queries method over HTTP.
 
             Args:
@@ -2205,7 +2236,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_saved_queries(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2244,7 +2277,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.QueryAssetsResponse:
+                ) -> Union[asset_service.QueryAssetsResponse, Tuple[asset_service.QueryAssetsResponse, BaseCallMetadata]]:
             r"""Call the query assets method over HTTP.
 
             Args:
@@ -2287,7 +2320,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_query_assets(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2325,7 +2360,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.SearchAllIamPoliciesResponse:
+                ) -> Union[asset_service.SearchAllIamPoliciesResponse, Tuple[asset_service.SearchAllIamPoliciesResponse, BaseCallMetadata]]:
             r"""Call the search all iam policies method over HTTP.
 
             Args:
@@ -2366,7 +2401,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_iam_policies(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2404,7 +2441,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.SearchAllResourcesResponse:
+                ) -> Union[asset_service.SearchAllResourcesResponse, Tuple[asset_service.SearchAllResourcesResponse, BaseCallMetadata]]:
             r"""Call the search all resources method over HTTP.
 
             Args:
@@ -2445,7 +2482,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_resources(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2484,7 +2523,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.Feed:
+                ) -> Union[asset_service.Feed, Tuple[asset_service.Feed, BaseCallMetadata]]:
             r"""Call the update feed method over HTTP.
 
             Args:
@@ -2535,7 +2574,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_feed(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2574,7 +2615,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> asset_service.SavedQuery:
+                ) -> Union[asset_service.SavedQuery, Tuple[asset_service.SavedQuery, BaseCallMetadata]]:
             r"""Call the update saved query method over HTTP.
 
             Args:
@@ -2619,7 +2660,9 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_saved_query(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -767,6 +767,8 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
     class _AnalyzeIamPolicy(_BaseAssetServiceRestTransport._BaseAnalyzeIamPolicy, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.AnalyzeIamPolicy")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -795,6 +797,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.AnalyzeIamPolicyResponse:
             r"""Call the analyze iam policy method over HTTP.
 
@@ -838,7 +841,10 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _AnalyzeIamPolicyLongrunning(_BaseAssetServiceRestTransport._BaseAnalyzeIamPolicyLongrunning, AssetServiceRestStub):
         def __hash__(self):
@@ -872,6 +878,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the analyze iam policy
         longrunning method over HTTP.
@@ -917,11 +924,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy_longrunning(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _AnalyzeMove(_BaseAssetServiceRestTransport._BaseAnalyzeMove, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.AnalyzeMove")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -950,6 +962,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.AnalyzeMoveResponse:
             r"""Call the analyze move method over HTTP.
 
@@ -993,11 +1006,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_move(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _AnalyzeOrgPolicies(_BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicies, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.AnalyzeOrgPolicies")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1026,6 +1044,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.AnalyzeOrgPoliciesResponse:
             r"""Call the analyze org policies method over HTTP.
 
@@ -1069,11 +1088,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policies(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _AnalyzeOrgPolicyGovernedAssets(_BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedAssets, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.AnalyzeOrgPolicyGovernedAssets")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1102,6 +1126,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.AnalyzeOrgPolicyGovernedAssetsResponse:
             r"""Call the analyze org policy
         governed assets method over HTTP.
@@ -1146,11 +1171,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_assets(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _AnalyzeOrgPolicyGovernedContainers(_BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedContainers, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.AnalyzeOrgPolicyGovernedContainers")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1179,6 +1209,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.AnalyzeOrgPolicyGovernedContainersResponse:
             r"""Call the analyze org policy
         governed containers method over HTTP.
@@ -1223,11 +1254,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_containers(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _BatchGetAssetsHistory(_BaseAssetServiceRestTransport._BaseBatchGetAssetsHistory, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.BatchGetAssetsHistory")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1256,6 +1292,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.BatchGetAssetsHistoryResponse:
             r"""Call the batch get assets history method over HTTP.
 
@@ -1296,11 +1333,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_assets_history(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _BatchGetEffectiveIamPolicies(_BaseAssetServiceRestTransport._BaseBatchGetEffectiveIamPolicies, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.BatchGetEffectiveIamPolicies")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1329,6 +1371,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.BatchGetEffectiveIamPoliciesResponse:
             r"""Call the batch get effective iam
         policies method over HTTP.
@@ -1373,11 +1416,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_effective_iam_policies(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _CreateFeed(_BaseAssetServiceRestTransport._BaseCreateFeed, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.CreateFeed")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1407,6 +1455,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.Feed:
             r"""Call the create feed method over HTTP.
 
@@ -1457,11 +1506,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_feed(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _CreateSavedQuery(_BaseAssetServiceRestTransport._BaseCreateSavedQuery, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.CreateSavedQuery")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1491,6 +1545,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.SavedQuery:
             r"""Call the create saved query method over HTTP.
 
@@ -1535,11 +1590,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_saved_query(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _DeleteFeed(_BaseAssetServiceRestTransport._BaseDeleteFeed, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.DeleteFeed")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1568,6 +1628,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ):
             r"""Call the delete feed method over HTTP.
 
@@ -1601,6 +1662,8 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
     class _DeleteSavedQuery(_BaseAssetServiceRestTransport._BaseDeleteSavedQuery, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.DeleteSavedQuery")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1629,6 +1692,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ):
             r"""Call the delete saved query method over HTTP.
 
@@ -1691,6 +1755,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the export assets method over HTTP.
 
@@ -1734,11 +1799,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_assets(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetFeed(_BaseAssetServiceRestTransport._BaseGetFeed, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.GetFeed")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1767,6 +1837,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.Feed:
             r"""Call the get feed method over HTTP.
 
@@ -1815,11 +1886,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_feed(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetSavedQuery(_BaseAssetServiceRestTransport._BaseGetSavedQuery, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.GetSavedQuery")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1848,6 +1924,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.SavedQuery:
             r"""Call the get saved query method over HTTP.
 
@@ -1890,11 +1967,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_saved_query(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListAssets(_BaseAssetServiceRestTransport._BaseListAssets, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.ListAssets")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1923,6 +2005,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.ListAssetsResponse:
             r"""Call the list assets method over HTTP.
 
@@ -1963,11 +2046,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_assets(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListFeeds(_BaseAssetServiceRestTransport._BaseListFeeds, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.ListFeeds")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1996,6 +2084,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.ListFeedsResponse:
             r"""Call the list feeds method over HTTP.
 
@@ -2036,11 +2125,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_feeds(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListSavedQueries(_BaseAssetServiceRestTransport._BaseListSavedQueries, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.ListSavedQueries")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -2069,6 +2163,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.ListSavedQueriesResponse:
             r"""Call the list saved queries method over HTTP.
 
@@ -2109,11 +2204,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_saved_queries(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _QueryAssets(_BaseAssetServiceRestTransport._BaseQueryAssets, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.QueryAssets")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -2143,6 +2243,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.QueryAssetsResponse:
             r"""Call the query assets method over HTTP.
 
@@ -2185,11 +2286,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_query_assets(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _SearchAllIamPolicies(_BaseAssetServiceRestTransport._BaseSearchAllIamPolicies, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.SearchAllIamPolicies")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -2218,6 +2324,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.SearchAllIamPoliciesResponse:
             r"""Call the search all iam policies method over HTTP.
 
@@ -2258,11 +2365,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_iam_policies(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _SearchAllResources(_BaseAssetServiceRestTransport._BaseSearchAllResources, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.SearchAllResources")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -2291,6 +2403,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.SearchAllResourcesResponse:
             r"""Call the search all resources method over HTTP.
 
@@ -2331,11 +2444,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_resources(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpdateFeed(_BaseAssetServiceRestTransport._BaseUpdateFeed, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.UpdateFeed")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -2365,6 +2483,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.Feed:
             r"""Call the update feed method over HTTP.
 
@@ -2415,11 +2534,16 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_feed(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpdateSavedQuery(_BaseAssetServiceRestTransport._BaseUpdateSavedQuery, AssetServiceRestStub):
         def __hash__(self):
             return hash("AssetServiceRestTransport.UpdateSavedQuery")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -2449,6 +2573,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> asset_service.SavedQuery:
             r"""Call the update saved query method over HTTP.
 
@@ -2493,7 +2618,10 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_saved_query(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     @property
     def analyze_iam_policy(self) -> Callable[

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -13434,6 +13434,1014 @@ def test_analyze_org_policy_governed_assets_empty_call_grpc():
         assert args[0] == request_msg
 
 
+def test_list_assets_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.ListAssetsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListAssetsPager)
+
+def test_batch_get_assets_history_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.BatchGetAssetsHistoryResponse(
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.batch_get_assets_history(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
+
+def test_create_feed_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.create_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.Feed)
+
+def test_get_feed_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.Feed)
+
+def test_list_feeds_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.ListFeedsResponse(
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_feeds(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.ListFeedsResponse)
+
+def test_update_feed_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.Feed)
+
+def test_search_all_resources_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.SearchAllResourcesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.search_all_resources(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.SearchAllResourcesPager)
+
+def test_search_all_iam_policies_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.SearchAllIamPoliciesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.search_all_iam_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.SearchAllIamPoliciesPager)
+
+def test_analyze_iam_policy_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.AnalyzeIamPolicyResponse(
+        fully_explored=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.analyze_iam_policy(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
+
+def test_analyze_move_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.AnalyzeMoveResponse(
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.analyze_move(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.AnalyzeMoveResponse)
+
+def test_query_assets_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.QueryAssetsResponse(
+        job_reference='job_reference_value',
+        done=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.query_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.QueryAssetsResponse)
+
+def test_create_saved_query_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.create_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.SavedQuery)
+
+def test_get_saved_query_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.SavedQuery)
+
+def test_list_saved_queries_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.ListSavedQueriesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_saved_queries(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListSavedQueriesPager)
+
+def test_update_saved_query_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.SavedQuery)
+
+def test_batch_get_effective_iam_policies_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.BatchGetEffectiveIamPoliciesResponse(
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.batch_get_effective_iam_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
+
+def test_analyze_org_policies_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPoliciesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.analyze_org_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.AnalyzeOrgPoliciesPager)
+
+def test_analyze_org_policy_governed_containers_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPolicyGovernedContainersResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.analyze_org_policy_governed_containers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersPager)
+
+def test_analyze_org_policy_governed_assets_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.analyze_org_policy_governed_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsPager)
+
+
+def test_list_assets_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.ListAssetsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListAssetsPager)
+
+def test_batch_get_assets_history_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.BatchGetAssetsHistoryResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.batch_get_assets_history(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
+
+def test_create_feed_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.Feed()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+def test_get_feed_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.Feed()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+def test_list_feeds_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.ListFeedsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_feeds(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.ListFeedsResponse)
+
+def test_update_feed_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.Feed()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+def test_search_all_resources_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SearchAllResourcesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.search_all_resources(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.SearchAllResourcesPager)
+
+def test_search_all_iam_policies_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SearchAllIamPoliciesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.search_all_iam_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.SearchAllIamPoliciesPager)
+
+def test_analyze_iam_policy_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeIamPolicyResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_iam_policy(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
+
+def test_analyze_move_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeMoveResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_move(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.AnalyzeMoveResponse)
+
+def test_query_assets_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.QueryAssetsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.query_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.QueryAssetsResponse)
+
+def test_create_saved_query_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SavedQuery()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+def test_get_saved_query_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SavedQuery()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+def test_list_saved_queries_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.ListSavedQueriesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_saved_queries(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListSavedQueriesPager)
+
+def test_update_saved_query_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SavedQuery()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+def test_batch_get_effective_iam_policies_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.BatchGetEffectiveIamPoliciesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.batch_get_effective_iam_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
+
+def test_analyze_org_policies_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeOrgPoliciesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_org_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPoliciesPager)
+
+def test_analyze_org_policy_governed_containers_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_org_policy_governed_containers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersPager)
+
+def test_analyze_org_policy_governed_assets_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_org_policy_governed_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsPager)
+
+
 def test_transport_kind_grpc_asyncio():
     transport = AssetServiceAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
@@ -14082,6 +15090,1071 @@ async def test_analyze_org_policy_governed_assets_empty_call_grpc_asyncio():
         request_msg = asset_service.AnalyzeOrgPolicyGovernedAssetsRequest()
 
         assert args[0] == request_msg
+
+
+@pytest.mark.asyncio
+async def test_list_assets_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.ListAssetsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_assets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListAssetsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_batch_get_assets_history_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.BatchGetAssetsHistoryResponse(
+    )
+    with mock.patch.object(
+        type(client.transport.batch_get_assets_history), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.batch_get_assets_history(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
+
+@pytest.mark.asyncio
+async def test_create_feed_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.create_feed), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.create_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.Feed)
+
+@pytest.mark.asyncio
+async def test_get_feed_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.get_feed), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.Feed)
+
+@pytest.mark.asyncio
+async def test_list_feeds_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.ListFeedsResponse(
+    )
+    with mock.patch.object(
+        type(client.transport.list_feeds), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_feeds(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.ListFeedsResponse)
+
+@pytest.mark.asyncio
+async def test_update_feed_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.update_feed), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.Feed)
+
+@pytest.mark.asyncio
+async def test_search_all_resources_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.SearchAllResourcesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.search_all_resources), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.search_all_resources(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.SearchAllResourcesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_search_all_iam_policies_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.SearchAllIamPoliciesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.search_all_iam_policies), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.search_all_iam_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.SearchAllIamPoliciesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_analyze_iam_policy_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.AnalyzeIamPolicyResponse(
+        fully_explored=True,
+    )
+    with mock.patch.object(
+        type(client.transport.analyze_iam_policy), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.analyze_iam_policy(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
+
+@pytest.mark.asyncio
+async def test_analyze_move_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.AnalyzeMoveResponse(
+    )
+    with mock.patch.object(
+        type(client.transport.analyze_move), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.analyze_move(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.AnalyzeMoveResponse)
+
+@pytest.mark.asyncio
+async def test_query_assets_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.QueryAssetsResponse(
+        job_reference='job_reference_value',
+        done=True,
+    )
+    with mock.patch.object(
+        type(client.transport.query_assets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.query_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.QueryAssetsResponse)
+
+@pytest.mark.asyncio
+async def test_create_saved_query_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(
+        type(client.transport.create_saved_query), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.create_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.SavedQuery)
+
+@pytest.mark.asyncio
+async def test_get_saved_query_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_saved_query), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.SavedQuery)
+
+@pytest.mark.asyncio
+async def test_list_saved_queries_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.ListSavedQueriesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_saved_queries), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_saved_queries(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListSavedQueriesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_update_saved_query_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(
+        type(client.transport.update_saved_query), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.SavedQuery)
+
+@pytest.mark.asyncio
+async def test_batch_get_effective_iam_policies_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.BatchGetEffectiveIamPoliciesResponse(
+    )
+    with mock.patch.object(
+        type(client.transport.batch_get_effective_iam_policies), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.batch_get_effective_iam_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
+
+@pytest.mark.asyncio
+async def test_analyze_org_policies_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPoliciesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.analyze_org_policies), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.analyze_org_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.AnalyzeOrgPoliciesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_analyze_org_policy_governed_containers_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPolicyGovernedContainersResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.analyze_org_policy_governed_containers), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.analyze_org_policy_governed_containers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersAsyncPager)
+
+@pytest.mark.asyncio
+async def test_analyze_org_policy_governed_assets_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.analyze_org_policy_governed_assets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.analyze_org_policy_governed_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsAsyncPager)
+
+
+@pytest.mark.asyncio
+async def test_list_assets_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_assets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListAssetsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListAssetsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_batch_get_assets_history_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.batch_get_assets_history), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.BatchGetAssetsHistoryResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.batch_get_assets_history(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
+
+@pytest.mark.asyncio
+async def test_create_feed_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.create_feed), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.Feed())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.create_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+@pytest.mark.asyncio
+async def test_get_feed_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_feed), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.Feed())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+@pytest.mark.asyncio
+async def test_list_feeds_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_feeds), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListFeedsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_feeds(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.ListFeedsResponse)
+
+@pytest.mark.asyncio
+async def test_update_feed_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_feed), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.Feed())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+@pytest.mark.asyncio
+async def test_search_all_resources_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.search_all_resources), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SearchAllResourcesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.search_all_resources(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.SearchAllResourcesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_search_all_iam_policies_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.search_all_iam_policies), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SearchAllIamPoliciesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.search_all_iam_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.SearchAllIamPoliciesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_analyze_iam_policy_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.analyze_iam_policy), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeIamPolicyResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.analyze_iam_policy(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
+
+@pytest.mark.asyncio
+async def test_analyze_move_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.analyze_move), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeMoveResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.analyze_move(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.AnalyzeMoveResponse)
+
+@pytest.mark.asyncio
+async def test_query_assets_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.query_assets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.QueryAssetsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.query_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.QueryAssetsResponse)
+
+@pytest.mark.asyncio
+async def test_create_saved_query_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.create_saved_query), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SavedQuery())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.create_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+@pytest.mark.asyncio
+async def test_get_saved_query_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_saved_query), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SavedQuery())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+@pytest.mark.asyncio
+async def test_list_saved_queries_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_saved_queries), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.ListSavedQueriesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_saved_queries(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListSavedQueriesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_update_saved_query_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_saved_query), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.SavedQuery())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+@pytest.mark.asyncio
+async def test_batch_get_effective_iam_policies_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.batch_get_effective_iam_policies), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.BatchGetEffectiveIamPoliciesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.batch_get_effective_iam_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
+
+@pytest.mark.asyncio
+async def test_analyze_org_policies_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.analyze_org_policies), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeOrgPoliciesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.analyze_org_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPoliciesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_analyze_org_policy_governed_containers_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.analyze_org_policy_governed_containers), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeOrgPolicyGovernedContainersResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.analyze_org_policy_governed_containers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersAsyncPager)
+
+@pytest.mark.asyncio
+async def test_analyze_org_policy_governed_assets_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.analyze_org_policy_governed_assets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(asset_service.AnalyzeOrgPolicyGovernedAssetsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.analyze_org_policy_governed_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsAsyncPager)
 
 
 def test_transport_kind_rest():
@@ -17062,6 +19135,1342 @@ def test_analyze_org_policy_governed_assets_empty_call_rest():
         assert args[0] == request_msg
 
 
+def test_list_assets_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.ListAssetsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.ListAssetsRequest.pb(asset_service.ListAssetsRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.ListAssetsResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListAssetsPager)
+
+def test_batch_get_assets_history_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.BatchGetAssetsHistoryResponse(
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.BatchGetAssetsHistoryRequest.pb(asset_service.BatchGetAssetsHistoryRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.BatchGetAssetsHistoryResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.batch_get_assets_history(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
+
+def test_create_feed_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.CreateFeedRequest.pb(asset_service.CreateFeedRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "post",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.Feed.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.create_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.Feed)
+
+def test_get_feed_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.GetFeedRequest.pb(asset_service.GetFeedRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.Feed.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.Feed)
+
+def test_list_feeds_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.ListFeedsResponse(
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.ListFeedsRequest.pb(asset_service.ListFeedsRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.ListFeedsResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_feeds(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.ListFeedsResponse)
+
+def test_update_feed_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.Feed(
+        name='name_value',
+        asset_names=['asset_names_value'],
+        asset_types=['asset_types_value'],
+        content_type=asset_service.ContentType.RESOURCE,
+        relationship_types=['relationship_types_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.UpdateFeedRequest.pb(asset_service.UpdateFeedRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "patch",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.Feed.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.update_feed(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.Feed)
+
+def test_search_all_resources_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.SearchAllResourcesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.SearchAllResourcesRequest.pb(asset_service.SearchAllResourcesRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.SearchAllResourcesResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.search_all_resources(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.SearchAllResourcesPager)
+
+def test_search_all_iam_policies_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.SearchAllIamPoliciesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.SearchAllIamPoliciesRequest.pb(asset_service.SearchAllIamPoliciesRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.SearchAllIamPoliciesResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.search_all_iam_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.SearchAllIamPoliciesPager)
+
+def test_analyze_iam_policy_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.AnalyzeIamPolicyResponse(
+        fully_explored=True,
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.AnalyzeIamPolicyRequest.pb(asset_service.AnalyzeIamPolicyRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.AnalyzeIamPolicyResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.analyze_iam_policy(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
+
+def test_analyze_move_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.AnalyzeMoveResponse(
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.AnalyzeMoveRequest.pb(asset_service.AnalyzeMoveRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.AnalyzeMoveResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.analyze_move(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.AnalyzeMoveResponse)
+
+def test_query_assets_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.QueryAssetsResponse(
+        job_reference='job_reference_value',
+        done=True,
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.QueryAssetsRequest.pb(asset_service.QueryAssetsRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "post",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.QueryAssetsResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.query_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.QueryAssetsResponse)
+
+def test_create_saved_query_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.CreateSavedQueryRequest.pb(asset_service.CreateSavedQueryRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "post",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.SavedQuery.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.create_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.SavedQuery)
+
+def test_get_saved_query_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.GetSavedQueryRequest.pb(asset_service.GetSavedQueryRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.SavedQuery.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.SavedQuery)
+
+def test_list_saved_queries_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.ListSavedQueriesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.ListSavedQueriesRequest.pb(asset_service.ListSavedQueriesRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.ListSavedQueriesResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_saved_queries(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListSavedQueriesPager)
+
+def test_update_saved_query_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.SavedQuery(
+        name='name_value',
+        description='description_value',
+        creator='creator_value',
+        last_updater='last_updater_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.UpdateSavedQueryRequest.pb(asset_service.UpdateSavedQueryRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "patch",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.SavedQuery.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.update_saved_query(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.SavedQuery)
+
+def test_batch_get_effective_iam_policies_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.BatchGetEffectiveIamPoliciesResponse(
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.BatchGetEffectiveIamPoliciesRequest.pb(asset_service.BatchGetEffectiveIamPoliciesRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.BatchGetEffectiveIamPoliciesResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.batch_get_effective_iam_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
+
+def test_analyze_org_policies_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPoliciesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.AnalyzeOrgPoliciesRequest.pb(asset_service.AnalyzeOrgPoliciesRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.AnalyzeOrgPoliciesResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.analyze_org_policies(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.AnalyzeOrgPoliciesPager)
+
+def test_analyze_org_policy_governed_containers_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPolicyGovernedContainersResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.AnalyzeOrgPolicyGovernedContainersRequest.pb(asset_service.AnalyzeOrgPolicyGovernedContainersRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.AnalyzeOrgPolicyGovernedContainersResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.analyze_org_policy_governed_containers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersPager)
+
+def test_analyze_org_policy_governed_assets_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = asset_service.AnalyzeOrgPolicyGovernedAssetsRequest.pb(asset_service.AnalyzeOrgPolicyGovernedAssetsRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.analyze_org_policy_governed_assets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsPager)
+
+
+def test_list_assets_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.ListAssetsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListAssetsPager)
+
+def test_batch_get_assets_history_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.BatchGetAssetsHistoryResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.batch_get_assets_history(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
+
+def test_create_feed_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.Feed()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+def test_get_feed_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.Feed()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+def test_list_feeds_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.ListFeedsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_feeds(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.ListFeedsResponse)
+
+def test_update_feed_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.Feed()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_feed(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.Feed)
+
+def test_search_all_resources_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SearchAllResourcesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.search_all_resources(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.SearchAllResourcesPager)
+
+def test_search_all_iam_policies_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SearchAllIamPoliciesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.search_all_iam_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.SearchAllIamPoliciesPager)
+
+def test_analyze_iam_policy_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeIamPolicyResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_iam_policy(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
+
+def test_analyze_move_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeMoveResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_move(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.AnalyzeMoveResponse)
+
+def test_query_assets_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.QueryAssetsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.query_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.QueryAssetsResponse)
+
+def test_create_saved_query_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SavedQuery()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+def test_get_saved_query_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SavedQuery()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+def test_list_saved_queries_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.ListSavedQueriesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_saved_queries(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListSavedQueriesPager)
+
+def test_update_saved_query_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.SavedQuery()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_saved_query(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.SavedQuery)
+
+def test_batch_get_effective_iam_policies_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.BatchGetEffectiveIamPoliciesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.batch_get_effective_iam_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
+
+def test_analyze_org_policies_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeOrgPoliciesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_org_policies(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPoliciesPager)
+
+def test_analyze_org_policy_governed_containers_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeOrgPolicyGovernedContainersResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_org_policy_governed_containers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersPager)
+
+def test_analyze_org_policy_governed_assets_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = AssetServiceClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.analyze_org_policy_governed_assets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsPager)
+
+
 def test_asset_service_rest_lro_client():
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -17082,6 +20491,7 @@ def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = AssetServiceClient(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -13449,13 +13449,14 @@ def test_list_assets_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_assets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListAssetsPager)
 
 def test_batch_get_assets_history_with_metadata_callback_grpc():
@@ -13472,13 +13473,14 @@ def test_batch_get_assets_history_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.batch_get_assets_history(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
 
 def test_create_feed_with_metadata_callback_grpc():
@@ -13500,13 +13502,14 @@ def test_create_feed_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.create_feed(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 def test_get_feed_with_metadata_callback_grpc():
@@ -13528,13 +13531,14 @@ def test_get_feed_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_feed(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 def test_list_feeds_with_metadata_callback_grpc():
@@ -13551,13 +13555,14 @@ def test_list_feeds_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_feeds(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.ListFeedsResponse)
 
 def test_update_feed_with_metadata_callback_grpc():
@@ -13579,13 +13584,14 @@ def test_update_feed_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_feed(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 def test_search_all_resources_with_metadata_callback_grpc():
@@ -13603,13 +13609,14 @@ def test_search_all_resources_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.search_all_resources(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.SearchAllResourcesPager)
 
 def test_search_all_iam_policies_with_metadata_callback_grpc():
@@ -13627,13 +13634,14 @@ def test_search_all_iam_policies_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.search_all_iam_policies(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.SearchAllIamPoliciesPager)
 
 def test_analyze_iam_policy_with_metadata_callback_grpc():
@@ -13651,13 +13659,14 @@ def test_analyze_iam_policy_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.analyze_iam_policy(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
 
 def test_analyze_move_with_metadata_callback_grpc():
@@ -13674,13 +13683,14 @@ def test_analyze_move_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.analyze_move(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.AnalyzeMoveResponse)
 
 def test_query_assets_with_metadata_callback_grpc():
@@ -13699,13 +13709,14 @@ def test_query_assets_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.query_assets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.QueryAssetsResponse)
 
 def test_create_saved_query_with_metadata_callback_grpc():
@@ -13726,13 +13737,14 @@ def test_create_saved_query_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.create_saved_query(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 def test_get_saved_query_with_metadata_callback_grpc():
@@ -13753,13 +13765,14 @@ def test_get_saved_query_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_saved_query(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 def test_list_saved_queries_with_metadata_callback_grpc():
@@ -13777,13 +13790,14 @@ def test_list_saved_queries_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_saved_queries(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListSavedQueriesPager)
 
 def test_update_saved_query_with_metadata_callback_grpc():
@@ -13804,13 +13818,14 @@ def test_update_saved_query_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_saved_query(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 def test_batch_get_effective_iam_policies_with_metadata_callback_grpc():
@@ -13827,13 +13842,14 @@ def test_batch_get_effective_iam_policies_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.batch_get_effective_iam_policies(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
 
 def test_analyze_org_policies_with_metadata_callback_grpc():
@@ -13851,13 +13867,14 @@ def test_analyze_org_policies_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.analyze_org_policies(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPoliciesPager)
 
 def test_analyze_org_policy_governed_containers_with_metadata_callback_grpc():
@@ -13875,13 +13892,14 @@ def test_analyze_org_policy_governed_containers_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.analyze_org_policy_governed_containers(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersPager)
 
 def test_analyze_org_policy_governed_assets_with_metadata_callback_grpc():
@@ -13899,13 +13917,14 @@ def test_analyze_org_policy_governed_assets_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.analyze_org_policy_governed_assets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsPager)
 
 
@@ -15108,13 +15127,14 @@ async def test_list_assets_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_assets), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_assets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListAssetsAsyncPager)
 
 @pytest.mark.asyncio
@@ -15132,13 +15152,14 @@ async def test_batch_get_assets_history_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.batch_get_assets_history), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.batch_get_assets_history(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
 
 @pytest.mark.asyncio
@@ -15161,13 +15182,14 @@ async def test_create_feed_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.create_feed), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.create_feed(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 @pytest.mark.asyncio
@@ -15190,13 +15212,14 @@ async def test_get_feed_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_feed), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_feed(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 @pytest.mark.asyncio
@@ -15214,13 +15237,14 @@ async def test_list_feeds_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_feeds), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_feeds(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.ListFeedsResponse)
 
 @pytest.mark.asyncio
@@ -15243,13 +15267,14 @@ async def test_update_feed_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_feed), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_feed(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 @pytest.mark.asyncio
@@ -15268,13 +15293,14 @@ async def test_search_all_resources_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.search_all_resources), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.search_all_resources(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.SearchAllResourcesAsyncPager)
 
 @pytest.mark.asyncio
@@ -15293,13 +15319,14 @@ async def test_search_all_iam_policies_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.search_all_iam_policies), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.search_all_iam_policies(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.SearchAllIamPoliciesAsyncPager)
 
 @pytest.mark.asyncio
@@ -15318,13 +15345,14 @@ async def test_analyze_iam_policy_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.analyze_iam_policy), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.analyze_iam_policy(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
 
 @pytest.mark.asyncio
@@ -15342,13 +15370,14 @@ async def test_analyze_move_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.analyze_move), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.analyze_move(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.AnalyzeMoveResponse)
 
 @pytest.mark.asyncio
@@ -15368,13 +15397,14 @@ async def test_query_assets_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.query_assets), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.query_assets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.QueryAssetsResponse)
 
 @pytest.mark.asyncio
@@ -15396,13 +15426,14 @@ async def test_create_saved_query_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.create_saved_query), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.create_saved_query(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 @pytest.mark.asyncio
@@ -15424,13 +15455,14 @@ async def test_get_saved_query_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_saved_query), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_saved_query(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 @pytest.mark.asyncio
@@ -15449,13 +15481,14 @@ async def test_list_saved_queries_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_saved_queries), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_saved_queries(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListSavedQueriesAsyncPager)
 
 @pytest.mark.asyncio
@@ -15477,13 +15510,14 @@ async def test_update_saved_query_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_saved_query), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_saved_query(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 @pytest.mark.asyncio
@@ -15501,13 +15535,14 @@ async def test_batch_get_effective_iam_policies_with_metadata_callback_grpc_asyn
     with mock.patch.object(
         type(client.transport.batch_get_effective_iam_policies), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.batch_get_effective_iam_policies(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
 
 @pytest.mark.asyncio
@@ -15526,13 +15561,14 @@ async def test_analyze_org_policies_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.analyze_org_policies), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.analyze_org_policies(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPoliciesAsyncPager)
 
 @pytest.mark.asyncio
@@ -15551,13 +15587,14 @@ async def test_analyze_org_policy_governed_containers_with_metadata_callback_grp
     with mock.patch.object(
         type(client.transport.analyze_org_policy_governed_containers), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.analyze_org_policy_governed_containers(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersAsyncPager)
 
 @pytest.mark.asyncio
@@ -15576,13 +15613,14 @@ async def test_analyze_org_policy_governed_assets_with_metadata_callback_grpc_as
     with mock.patch.object(
         type(client.transport.analyze_org_policy_governed_assets), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.analyze_org_policy_governed_assets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsAsyncPager)
 
 
@@ -19162,6 +19200,7 @@ def test_list_assets_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19173,7 +19212,7 @@ def test_list_assets_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListAssetsPager)
 
 def test_batch_get_assets_history_with_metadata_callback_rest():
@@ -19202,6 +19241,7 @@ def test_batch_get_assets_history_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19213,7 +19253,7 @@ def test_batch_get_assets_history_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.BatchGetAssetsHistoryResponse)
 
 def test_create_feed_with_metadata_callback_rest():
@@ -19248,6 +19288,7 @@ def test_create_feed_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19259,7 +19300,7 @@ def test_create_feed_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 def test_get_feed_with_metadata_callback_rest():
@@ -19293,6 +19334,7 @@ def test_get_feed_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19304,7 +19346,7 @@ def test_get_feed_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 def test_list_feeds_with_metadata_callback_rest():
@@ -19333,6 +19375,7 @@ def test_list_feeds_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19344,7 +19387,7 @@ def test_list_feeds_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.ListFeedsResponse)
 
 def test_update_feed_with_metadata_callback_rest():
@@ -19379,6 +19422,7 @@ def test_update_feed_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19390,7 +19434,7 @@ def test_update_feed_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.Feed)
 
 def test_search_all_resources_with_metadata_callback_rest():
@@ -19420,6 +19464,7 @@ def test_search_all_resources_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19431,7 +19476,7 @@ def test_search_all_resources_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.SearchAllResourcesPager)
 
 def test_search_all_iam_policies_with_metadata_callback_rest():
@@ -19461,6 +19506,7 @@ def test_search_all_iam_policies_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19472,7 +19518,7 @@ def test_search_all_iam_policies_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.SearchAllIamPoliciesPager)
 
 def test_analyze_iam_policy_with_metadata_callback_rest():
@@ -19502,6 +19548,7 @@ def test_analyze_iam_policy_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19513,7 +19560,7 @@ def test_analyze_iam_policy_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.AnalyzeIamPolicyResponse)
 
 def test_analyze_move_with_metadata_callback_rest():
@@ -19542,6 +19589,7 @@ def test_analyze_move_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19553,7 +19601,7 @@ def test_analyze_move_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.AnalyzeMoveResponse)
 
 def test_query_assets_with_metadata_callback_rest():
@@ -19585,6 +19633,7 @@ def test_query_assets_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19596,7 +19645,7 @@ def test_query_assets_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.QueryAssetsResponse)
 
 def test_create_saved_query_with_metadata_callback_rest():
@@ -19630,6 +19679,7 @@ def test_create_saved_query_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19641,7 +19691,7 @@ def test_create_saved_query_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 def test_get_saved_query_with_metadata_callback_rest():
@@ -19674,6 +19724,7 @@ def test_get_saved_query_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19685,7 +19736,7 @@ def test_get_saved_query_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 def test_list_saved_queries_with_metadata_callback_rest():
@@ -19715,6 +19766,7 @@ def test_list_saved_queries_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19726,7 +19778,7 @@ def test_list_saved_queries_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListSavedQueriesPager)
 
 def test_update_saved_query_with_metadata_callback_rest():
@@ -19760,6 +19812,7 @@ def test_update_saved_query_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19771,7 +19824,7 @@ def test_update_saved_query_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.SavedQuery)
 
 def test_batch_get_effective_iam_policies_with_metadata_callback_rest():
@@ -19800,6 +19853,7 @@ def test_batch_get_effective_iam_policies_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19811,7 +19865,7 @@ def test_batch_get_effective_iam_policies_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, asset_service.BatchGetEffectiveIamPoliciesResponse)
 
 def test_analyze_org_policies_with_metadata_callback_rest():
@@ -19841,6 +19895,7 @@ def test_analyze_org_policies_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19852,7 +19907,7 @@ def test_analyze_org_policies_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPoliciesPager)
 
 def test_analyze_org_policy_governed_containers_with_metadata_callback_rest():
@@ -19882,6 +19937,7 @@ def test_analyze_org_policy_governed_containers_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19893,7 +19949,7 @@ def test_analyze_org_policy_governed_containers_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedContainersPager)
 
 def test_analyze_org_policy_governed_assets_with_metadata_callback_rest():
@@ -19923,6 +19979,7 @@ def test_analyze_org_policy_governed_assets_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -19934,7 +19991,7 @@ def test_analyze_org_policy_governed_assets_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.AnalyzeOrgPolicyGovernedAssetsPager)
 
 

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
@@ -36,9 +36,20 @@ except AttributeError:  # pragma: NO COVER
 from google.iam.credentials_v1.types import common
 from google.protobuf import duration_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
+from .transports.base import BaseCallMetadata
 from .transports.base import IAMCredentialsTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import IAMCredentialsGrpcAsyncIOTransport
 from .client import IAMCredentialsClient
+
+
+class IAMCredentialsAsyncClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class IAMCredentialsAsyncClient:
@@ -249,7 +260,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.GenerateAccessTokenResponse:
         r"""Generates an OAuth 2.0 access token for a service
         account.
@@ -342,7 +353,7 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -377,18 +388,19 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.generate_access_token]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.generate_access_token]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.generate_access_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -408,10 +420,16 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = IAMCredentialsAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -426,7 +444,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.GenerateIdTokenResponse:
         r"""Generates an OpenID Connect ID token for a service
         account.
@@ -513,7 +531,7 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -548,18 +566,19 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.generate_id_token]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.generate_id_token]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.generate_id_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -579,10 +598,16 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = IAMCredentialsAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -596,7 +621,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.SignBlobResponse:
         r"""Signs a blob using a service account's system-managed
         private key.
@@ -672,7 +697,7 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -705,18 +730,19 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.sign_blob]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.sign_blob]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.sign_blob]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -736,10 +762,16 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = IAMCredentialsAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -753,7 +785,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.SignJwtResponse:
         r"""Signs a JWT using a service account's system-managed
         private key.
@@ -832,7 +864,7 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -865,18 +897,19 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.sign_jwt]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.sign_jwt]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.sign_jwt]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -896,10 +929,16 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = IAMCredentialsAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
+import warnings
 
 from google.iam.credentials_v1 import gapic_version as package_version
 
@@ -248,6 +249,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.GenerateAccessTokenResponse:
         r"""Generates an OAuth 2.0 access token for a service
         account.
@@ -340,6 +342,10 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.GenerateAccessTokenResponse:
@@ -371,7 +377,18 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.generate_access_token]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.generate_access_token]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.generate_access_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -391,6 +408,10 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -405,6 +426,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.GenerateIdTokenResponse:
         r"""Generates an OpenID Connect ID token for a service
         account.
@@ -491,6 +513,10 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.GenerateIdTokenResponse:
@@ -522,7 +548,18 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.generate_id_token]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.generate_id_token]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.generate_id_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -542,6 +579,10 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -555,6 +596,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.SignBlobResponse:
         r"""Signs a blob using a service account's system-managed
         private key.
@@ -630,6 +672,10 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.SignBlobResponse:
@@ -659,7 +705,18 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.sign_blob]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.sign_blob]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.sign_blob]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -679,6 +736,10 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -692,6 +753,7 @@ class IAMCredentialsAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.SignJwtResponse:
         r"""Signs a JWT using a service account's system-managed
         private key.
@@ -770,6 +832,10 @@ class IAMCredentialsAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.SignJwtResponse:
@@ -799,7 +865,18 @@ class IAMCredentialsAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.sign_jwt]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.sign_jwt]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.sign_jwt]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -819,6 +896,10 @@ class IAMCredentialsAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -42,7 +42,18 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from .transports.base import IAMCredentialsTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import IAMCredentialsGrpcTransport
 from .transports.grpc_asyncio import IAMCredentialsGrpcAsyncIOTransport
+from .transports.base import BaseCallMetadata
 from .transports.rest import IAMCredentialsRestTransport
+
+
+class IAMCredentialsClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class IAMCredentialsClientMeta(type):
@@ -565,7 +576,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.GenerateAccessTokenResponse:
         r"""Generates an OAuth 2.0 access token for a service
         account.
@@ -658,7 +669,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -692,19 +703,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.generate_access_token]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.generate_access_token]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.generate_access_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -725,10 +736,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = IAMCredentialsClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -743,7 +755,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.GenerateIdTokenResponse:
         r"""Generates an OpenID Connect ID token for a service
         account.
@@ -830,7 +842,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -864,19 +876,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.generate_id_token]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.generate_id_token]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.generate_id_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -897,10 +909,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = IAMCredentialsClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -914,7 +927,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.SignBlobResponse:
         r"""Signs a blob using a service account's system-managed
         private key.
@@ -990,7 +1003,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1022,19 +1035,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.sign_blob]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.sign_blob]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.sign_blob]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1055,10 +1068,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = IAMCredentialsClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1072,7 +1086,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> common.SignJwtResponse:
         r"""Signs a JWT using a service account's system-managed
         private key.
@@ -1151,7 +1165,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1183,19 +1197,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.sign_jwt]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.sign_jwt]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.sign_jwt]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1216,10 +1230,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = IAMCredentialsClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -565,6 +565,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.GenerateAccessTokenResponse:
         r"""Generates an OAuth 2.0 access token for a service
         account.
@@ -657,6 +658,10 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.GenerateAccessTokenResponse:
@@ -687,7 +692,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.generate_access_token]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.generate_access_token]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.generate_access_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -708,6 +725,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -721,6 +743,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.GenerateIdTokenResponse:
         r"""Generates an OpenID Connect ID token for a service
         account.
@@ -807,6 +830,10 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.GenerateIdTokenResponse:
@@ -837,7 +864,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.generate_id_token]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.generate_id_token]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.generate_id_token]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -858,6 +897,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -870,6 +914,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.SignBlobResponse:
         r"""Signs a blob using a service account's system-managed
         private key.
@@ -945,6 +990,10 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.SignBlobResponse:
@@ -973,7 +1022,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.sign_blob]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.sign_blob]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.sign_blob]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -994,6 +1055,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1006,6 +1072,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> common.SignJwtResponse:
         r"""Signs a JWT using a service account's system-managed
         private key.
@@ -1084,6 +1151,10 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.iam.credentials_v1.types.SignJwtResponse:
@@ -1112,7 +1183,19 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.sign_jwt]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.sign_jwt]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.sign_jwt]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1132,6 +1215,11 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
@@ -15,7 +15,7 @@
 #
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.iam.credentials_v1 import gapic_version as package_version
 
@@ -31,6 +31,18 @@ from google.iam.credentials_v1.types import common
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class IAMCredentialsTransport(abc.ABC):
     """Abstract transport class for IAMCredentials."""

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 from google.iam.credentials_v1 import gapic_version as package_version
@@ -117,6 +118,74 @@ class IAMCredentialsTransport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.generate_access_token: gapic_v1.method.wrap_method(
+                    self.generate_access_token,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.generate_id_token: gapic_v1.method.wrap_method(
+                    self.generate_id_token,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.sign_blob: gapic_v1.method.wrap_method(
+                    self.sign_blob,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.sign_jwt: gapic_v1.method.wrap_method(
+                    self.sign_jwt,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.generate_access_token: gapic_v1.method.wrap_method(

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/grpc_asyncio.py
@@ -356,6 +356,74 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.generate_access_token: self._wrap_method(
+                    self.generate_access_token,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.generate_id_token: self._wrap_method(
+                    self.generate_id_token,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.sign_blob: self._wrap_method(
+                    self.sign_blob,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.sign_jwt: self._wrap_method(
+                    self.sign_jwt,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.generate_access_token: self._wrap_method(
                 self.generate_access_token,
@@ -422,6 +490,8 @@ class IAMCredentialsGrpcAsyncIOTransport(IAMCredentialsTransport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -35,6 +35,7 @@ from google.iam.credentials_v1.types import common
 
 
 from .rest_base import _BaseIAMCredentialsRestTransport
+from .base import BaseCallMetadata
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
 try:
@@ -303,7 +304,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> common.GenerateAccessTokenResponse:
+                ) -> Union[common.GenerateAccessTokenResponse, Tuple[common.GenerateAccessTokenResponse, BaseCallMetadata]]:
             r"""Call the generate access token method over HTTP.
 
             Args:
@@ -346,7 +347,9 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_access_token(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -385,7 +388,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> common.GenerateIdTokenResponse:
+                ) -> Union[common.GenerateIdTokenResponse, Tuple[common.GenerateIdTokenResponse, BaseCallMetadata]]:
             r"""Call the generate id token method over HTTP.
 
             Args:
@@ -428,7 +431,9 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_id_token(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -467,7 +472,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> common.SignBlobResponse:
+                ) -> Union[common.SignBlobResponse, Tuple[common.SignBlobResponse, BaseCallMetadata]]:
             r"""Call the sign blob method over HTTP.
 
             Args:
@@ -510,7 +515,9 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_blob(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -549,7 +556,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> common.SignJwtResponse:
+                ) -> Union[common.SignJwtResponse, Tuple[common.SignJwtResponse, BaseCallMetadata]]:
             r"""Call the sign jwt method over HTTP.
 
             Args:
@@ -592,7 +599,9 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_jwt(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -271,6 +271,8 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
     class _GenerateAccessToken(_BaseIAMCredentialsRestTransport._BaseGenerateAccessToken, IAMCredentialsRestStub):
         def __hash__(self):
             return hash("IAMCredentialsRestTransport.GenerateAccessToken")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -300,6 +302,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> common.GenerateAccessTokenResponse:
             r"""Call the generate access token method over HTTP.
 
@@ -342,11 +345,16 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_access_token(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GenerateIdToken(_BaseIAMCredentialsRestTransport._BaseGenerateIdToken, IAMCredentialsRestStub):
         def __hash__(self):
             return hash("IAMCredentialsRestTransport.GenerateIdToken")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -376,6 +384,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> common.GenerateIdTokenResponse:
             r"""Call the generate id token method over HTTP.
 
@@ -418,11 +427,16 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_id_token(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _SignBlob(_BaseIAMCredentialsRestTransport._BaseSignBlob, IAMCredentialsRestStub):
         def __hash__(self):
             return hash("IAMCredentialsRestTransport.SignBlob")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -452,6 +466,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> common.SignBlobResponse:
             r"""Call the sign blob method over HTTP.
 
@@ -494,11 +509,16 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_blob(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _SignJwt(_BaseIAMCredentialsRestTransport._BaseSignJwt, IAMCredentialsRestStub):
         def __hash__(self):
             return hash("IAMCredentialsRestTransport.SignJwt")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -528,6 +548,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> common.SignJwtResponse:
             r"""Call the sign jwt method over HTTP.
 
@@ -570,7 +591,10 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_jwt(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     @property
     def generate_access_token(self) -> Callable[

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -2966,13 +2966,14 @@ def test_generate_access_token_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.generate_access_token(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.GenerateAccessTokenResponse)
 
 def test_generate_id_token_with_metadata_callback_grpc():
@@ -2990,13 +2991,14 @@ def test_generate_id_token_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.generate_id_token(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.GenerateIdTokenResponse)
 
 def test_sign_blob_with_metadata_callback_grpc():
@@ -3015,13 +3017,14 @@ def test_sign_blob_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.sign_blob(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.SignBlobResponse)
 
 def test_sign_jwt_with_metadata_callback_grpc():
@@ -3040,13 +3043,14 @@ def test_sign_jwt_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.sign_jwt(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.SignJwtResponse)
 
 
@@ -3304,13 +3308,14 @@ async def test_generate_access_token_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.generate_access_token), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.generate_access_token(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.GenerateAccessTokenResponse)
 
 @pytest.mark.asyncio
@@ -3329,13 +3334,14 @@ async def test_generate_id_token_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.generate_id_token), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.generate_id_token(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.GenerateIdTokenResponse)
 
 @pytest.mark.asyncio
@@ -3355,13 +3361,14 @@ async def test_sign_blob_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.sign_blob), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.sign_blob(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.SignBlobResponse)
 
 @pytest.mark.asyncio
@@ -3381,13 +3388,14 @@ async def test_sign_jwt_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.sign_jwt), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.sign_jwt(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.SignJwtResponse)
 
 
@@ -4042,6 +4050,7 @@ def test_generate_access_token_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -4053,7 +4062,7 @@ def test_generate_access_token_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.GenerateAccessTokenResponse)
 
 def test_generate_id_token_with_metadata_callback_rest():
@@ -4084,6 +4093,7 @@ def test_generate_id_token_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -4095,7 +4105,7 @@ def test_generate_id_token_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.GenerateIdTokenResponse)
 
 def test_sign_blob_with_metadata_callback_rest():
@@ -4127,6 +4137,7 @@ def test_sign_blob_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -4138,7 +4149,7 @@ def test_sign_blob_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.SignBlobResponse)
 
 def test_sign_jwt_with_metadata_callback_rest():
@@ -4170,6 +4181,7 @@ def test_sign_jwt_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -4181,7 +4193,7 @@ def test_sign_jwt_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, common.SignJwtResponse)
 
 

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -2951,6 +2951,218 @@ def test_sign_jwt_empty_call_grpc():
         assert args[0] == request_msg
 
 
+def test_generate_access_token_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = common.GenerateAccessTokenResponse(
+        access_token='access_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.generate_access_token(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.GenerateAccessTokenResponse)
+
+def test_generate_id_token_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = common.GenerateIdTokenResponse(
+        token='token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.generate_id_token(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.GenerateIdTokenResponse)
+
+def test_sign_blob_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = common.SignBlobResponse(
+        key_id='key_id_value',
+        signed_blob=b'signed_blob_blob',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.sign_blob(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.SignBlobResponse)
+
+def test_sign_jwt_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = common.SignJwtResponse(
+        key_id='key_id_value',
+        signed_jwt='signed_jwt_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.sign_jwt(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.SignJwtResponse)
+
+
+def test_generate_access_token_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.GenerateAccessTokenResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.generate_access_token(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.GenerateAccessTokenResponse)
+
+def test_generate_id_token_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.GenerateIdTokenResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.generate_id_token(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.GenerateIdTokenResponse)
+
+def test_sign_blob_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.SignBlobResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.sign_blob(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.SignBlobResponse)
+
+def test_sign_jwt_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.SignJwtResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.sign_jwt(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.SignJwtResponse)
+
+
 def test_transport_kind_grpc_asyncio():
     transport = IAMCredentialsAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
@@ -3074,6 +3286,230 @@ async def test_sign_jwt_empty_call_grpc_asyncio():
         request_msg = common.SignJwtRequest()
 
         assert args[0] == request_msg
+
+
+@pytest.mark.asyncio
+async def test_generate_access_token_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = common.GenerateAccessTokenResponse(
+        access_token='access_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.generate_access_token), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.generate_access_token(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.GenerateAccessTokenResponse)
+
+@pytest.mark.asyncio
+async def test_generate_id_token_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = common.GenerateIdTokenResponse(
+        token='token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.generate_id_token), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.generate_id_token(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.GenerateIdTokenResponse)
+
+@pytest.mark.asyncio
+async def test_sign_blob_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = common.SignBlobResponse(
+        key_id='key_id_value',
+        signed_blob=b'signed_blob_blob',
+    )
+    with mock.patch.object(
+        type(client.transport.sign_blob), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.sign_blob(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.SignBlobResponse)
+
+@pytest.mark.asyncio
+async def test_sign_jwt_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = common.SignJwtResponse(
+        key_id='key_id_value',
+        signed_jwt='signed_jwt_value',
+    )
+    with mock.patch.object(
+        type(client.transport.sign_jwt), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.sign_jwt(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, common.SignJwtResponse)
+
+
+@pytest.mark.asyncio
+async def test_generate_access_token_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.generate_access_token), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(common.GenerateAccessTokenResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.generate_access_token(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.GenerateAccessTokenResponse)
+
+@pytest.mark.asyncio
+async def test_generate_id_token_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.generate_id_token), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(common.GenerateIdTokenResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.generate_id_token(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.GenerateIdTokenResponse)
+
+@pytest.mark.asyncio
+async def test_sign_blob_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.sign_blob), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(common.SignBlobResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.sign_blob(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.SignBlobResponse)
+
+@pytest.mark.asyncio
+async def test_sign_jwt_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.sign_jwt), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(common.SignJwtResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.sign_jwt(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.SignJwtResponse)
 
 
 def test_transport_kind_rest():
@@ -3578,10 +4014,295 @@ def test_sign_jwt_empty_call_rest():
         assert args[0] == request_msg
 
 
+def test_generate_access_token_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = common.GenerateAccessTokenResponse(
+        access_token='access_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = common.GenerateAccessTokenRequest.pb(common.GenerateAccessTokenRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "post",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = common.GenerateAccessTokenResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.generate_access_token(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, common.GenerateAccessTokenResponse)
+
+def test_generate_id_token_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = common.GenerateIdTokenResponse(
+        token='token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = common.GenerateIdTokenRequest.pb(common.GenerateIdTokenRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "post",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = common.GenerateIdTokenResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.generate_id_token(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, common.GenerateIdTokenResponse)
+
+def test_sign_blob_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = common.SignBlobResponse(
+        key_id='key_id_value',
+        signed_blob=b'signed_blob_blob',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = common.SignBlobRequest.pb(common.SignBlobRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "post",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = common.SignBlobResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.sign_blob(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, common.SignBlobResponse)
+
+def test_sign_jwt_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = common.SignJwtResponse(
+        key_id='key_id_value',
+        signed_jwt='signed_jwt_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = common.SignJwtRequest.pb(common.SignJwtRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "post",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = common.SignJwtResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.sign_jwt(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, common.SignJwtResponse)
+
+
+def test_generate_access_token_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.GenerateAccessTokenResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.generate_access_token(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.GenerateAccessTokenResponse)
+
+def test_generate_id_token_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.GenerateIdTokenResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.generate_id_token(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.GenerateIdTokenResponse)
+
+def test_sign_blob_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.SignBlobResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.sign_blob(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.SignBlobResponse)
+
+def test_sign_jwt_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = IAMCredentialsClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = common.SignJwtResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.sign_jwt(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, common.SignJwtResponse)
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = IAMCredentialsClient(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
+import warnings
 
 from google.cloud.eventarc_v1 import gapic_version as package_version
 
@@ -272,6 +273,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> trigger.Trigger:
         r"""Get a single trigger.
 
@@ -319,6 +321,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.Trigger:
@@ -346,7 +352,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_trigger]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_trigger]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -366,6 +383,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -377,6 +398,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListTriggersAsyncPager:
         r"""List triggers.
 
@@ -425,6 +447,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListTriggersAsyncPager:
@@ -454,7 +480,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_triggers]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_triggers]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_triggers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -474,6 +511,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -606,7 +647,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_trigger]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_trigger]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -747,7 +792,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_trigger]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_trigger]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -879,7 +928,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_trigger]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_trigger]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -918,6 +971,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> channel.Channel:
         r"""Get a single Channel.
 
@@ -965,6 +1019,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.Channel:
@@ -998,7 +1056,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_channel]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_channel]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1018,6 +1087,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1029,6 +1102,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListChannelsAsyncPager:
         r"""List channels.
 
@@ -1077,6 +1151,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListChannelsAsyncPager:
@@ -1106,7 +1184,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_channels]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_channels]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_channels]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1126,6 +1215,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1258,7 +1351,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_channel_]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_channel_]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_channel_]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1391,7 +1488,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_channel]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_channel]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1515,7 +1616,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_channel]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_channel]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1554,6 +1659,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> discovery.Provider:
         r"""Get a single Provider.
 
@@ -1601,6 +1707,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.Provider:
@@ -1628,7 +1738,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_provider]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_provider]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_provider]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1648,6 +1769,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1659,6 +1784,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListProvidersAsyncPager:
         r"""List providers.
 
@@ -1707,6 +1833,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListProvidersAsyncPager:
@@ -1736,7 +1866,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_providers]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_providers]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_providers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1756,6 +1897,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1778,6 +1923,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> channel_connection.ChannelConnection:
         r"""Get a single ChannelConnection.
 
@@ -1825,6 +1971,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.ChannelConnection:
@@ -1857,7 +2007,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_channel_connection]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_channel_connection]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1877,6 +2038,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1888,6 +2053,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListChannelConnectionsAsyncPager:
         r"""List channel connections.
 
@@ -1936,6 +2102,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListChannelConnectionsAsyncPager:
@@ -1966,7 +2136,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_channel_connections]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_channel_connections]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_channel_connections]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1986,6 +2167,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2118,7 +2303,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_channel_connection]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_channel_connection]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2240,7 +2429,11 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_channel_connection]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_channel_connection]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2279,6 +2472,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> google_channel_config.GoogleChannelConfig:
         r"""Get a GoogleChannelConfig
 
@@ -2326,6 +2520,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.GoogleChannelConfig:
@@ -2359,7 +2557,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_google_channel_config]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_google_channel_config]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2379,6 +2588,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2391,6 +2604,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> gce_google_channel_config.GoogleChannelConfig:
         r"""Update a single GoogleChannelConfig
 
@@ -2448,6 +2662,10 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.GoogleChannelConfig:
@@ -2483,7 +2701,18 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_google_channel_config]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_google_channel_config]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2503,6 +2732,10 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/async_client.py
@@ -52,9 +52,20 @@ from google.iam.v1 import policy_pb2  # type: ignore
 from google.longrunning import operations_pb2 # type: ignore
 from google.protobuf import field_mask_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
+from .transports.base import BaseCallMetadata
 from .transports.base import EventarcTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import EventarcGrpcAsyncIOTransport
 from .client import EventarcClient
+
+
+class EventarcAsyncClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class EventarcAsyncClient:
@@ -273,7 +284,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> trigger.Trigger:
         r"""Get a single trigger.
 
@@ -321,7 +332,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -352,18 +363,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_trigger]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_trigger]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -383,10 +395,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -398,7 +416,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListTriggersAsyncPager:
         r"""List triggers.
 
@@ -447,7 +465,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -480,18 +498,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_triggers]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_triggers]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_triggers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -511,10 +530,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -647,11 +672,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_trigger]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_trigger]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -792,11 +818,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_trigger]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_trigger]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -928,11 +955,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_trigger]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_trigger]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -971,7 +999,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> channel.Channel:
         r"""Get a single Channel.
 
@@ -1019,7 +1047,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1056,18 +1084,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_channel]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_channel]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1087,10 +1116,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1102,7 +1137,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListChannelsAsyncPager:
         r"""List channels.
 
@@ -1151,7 +1186,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1184,18 +1219,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_channels]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_channels]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_channels]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1215,10 +1251,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1351,11 +1393,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_channel_]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_channel_]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_channel_]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1488,11 +1531,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_channel]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_channel]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1616,11 +1660,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_channel]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_channel]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1659,7 +1704,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> discovery.Provider:
         r"""Get a single Provider.
 
@@ -1707,7 +1752,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1738,18 +1783,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_provider]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_provider]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_provider]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1769,10 +1815,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1784,7 +1836,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListProvidersAsyncPager:
         r"""List providers.
 
@@ -1833,7 +1885,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1866,18 +1918,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_providers]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_providers]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_providers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1897,10 +1950,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1923,7 +1982,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> channel_connection.ChannelConnection:
         r"""Get a single ChannelConnection.
 
@@ -1971,7 +2030,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2007,18 +2066,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_channel_connection]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_channel_connection]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2038,10 +2098,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2053,7 +2119,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListChannelConnectionsAsyncPager:
         r"""List channel connections.
 
@@ -2102,7 +2168,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2136,18 +2202,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_channel_connections]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_channel_connections]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_channel_connections]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2167,10 +2234,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2303,11 +2376,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_channel_connection]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_channel_connection]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2429,11 +2503,12 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_channel_connection]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_channel_connection]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2472,7 +2547,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> google_channel_config.GoogleChannelConfig:
         r"""Get a GoogleChannelConfig
 
@@ -2520,7 +2595,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2557,18 +2632,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_google_channel_config]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_google_channel_config]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2588,10 +2664,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2604,7 +2686,7 @@ class EventarcAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> gce_google_channel_config.GoogleChannelConfig:
         r"""Update a single GoogleChannelConfig
 
@@ -2662,7 +2744,7 @@ class EventarcAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2701,18 +2783,19 @@ class EventarcAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_google_channel_config]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_google_channel_config]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2732,10 +2815,16 @@ class EventarcAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = EventarcAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -58,7 +58,18 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from .transports.base import EventarcTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import EventarcGrpcTransport
 from .transports.grpc_asyncio import EventarcGrpcAsyncIOTransport
+from .transports.base import BaseCallMetadata
 from .transports.rest import EventarcRestTransport
+
+
+class EventarcClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class EventarcClientMeta(type):
@@ -670,7 +681,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> trigger.Trigger:
         r"""Get a single trigger.
 
@@ -718,7 +729,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -748,19 +759,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_trigger]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_trigger]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -781,10 +792,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -796,7 +808,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListTriggersPager:
         r"""List triggers.
 
@@ -845,7 +857,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -877,19 +889,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_triggers]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_triggers]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_triggers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -910,10 +922,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1045,12 +1058,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_trigger]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_trigger]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1190,12 +1203,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_trigger]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_trigger]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1326,12 +1339,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_trigger]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_trigger]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1370,7 +1383,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> channel.Channel:
         r"""Get a single Channel.
 
@@ -1418,7 +1431,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1454,19 +1467,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_channel]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_channel]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1487,10 +1500,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1502,7 +1516,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListChannelsPager:
         r"""List channels.
 
@@ -1551,7 +1565,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1583,19 +1597,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_channels]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_channels]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_channels]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1616,10 +1630,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1751,12 +1766,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_channel_]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_channel_]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_channel_]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1888,12 +1903,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_channel]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_channel]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2016,12 +2031,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_channel]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_channel]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2060,7 +2075,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> discovery.Provider:
         r"""Get a single Provider.
 
@@ -2108,7 +2123,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2138,19 +2153,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_provider]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_provider]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_provider]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2171,10 +2186,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2186,7 +2202,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListProvidersPager:
         r"""List providers.
 
@@ -2235,7 +2251,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2267,19 +2283,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_providers]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_providers]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_providers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2300,10 +2316,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2326,7 +2343,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> channel_connection.ChannelConnection:
         r"""Get a single ChannelConnection.
 
@@ -2374,7 +2391,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2409,19 +2426,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_channel_connection]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_channel_connection]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2442,10 +2459,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2457,7 +2475,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListChannelConnectionsPager:
         r"""List channel connections.
 
@@ -2506,7 +2524,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2539,19 +2557,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_channel_connections]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_channel_connections]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_channel_connections]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2572,10 +2590,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2707,12 +2726,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_channel_connection]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_channel_connection]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2833,12 +2852,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_channel_connection]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_channel_connection]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2877,7 +2896,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> google_channel_config.GoogleChannelConfig:
         r"""Get a GoogleChannelConfig
 
@@ -2925,7 +2944,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2961,19 +2980,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_google_channel_config]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_google_channel_config]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2994,10 +3013,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3010,7 +3030,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> gce_google_channel_config.GoogleChannelConfig:
         r"""Update a single GoogleChannelConfig
 
@@ -3068,7 +3088,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3106,19 +3126,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_google_channel_config]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_google_channel_config]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3139,10 +3159,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = EventarcClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -670,6 +670,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> trigger.Trigger:
         r"""Get a single trigger.
 
@@ -717,6 +718,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.Trigger:
@@ -743,7 +748,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_trigger]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_trigger]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -764,6 +781,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -774,6 +796,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListTriggersPager:
         r"""List triggers.
 
@@ -822,6 +845,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListTriggersPager:
@@ -850,7 +877,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_triggers]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_triggers]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_triggers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -870,6 +909,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1001,7 +1045,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_trigger]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_trigger]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1141,7 +1190,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_trigger]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_trigger]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1272,7 +1326,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_trigger]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_trigger]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_trigger]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1311,6 +1370,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> channel.Channel:
         r"""Get a single Channel.
 
@@ -1358,6 +1418,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.Channel:
@@ -1390,7 +1454,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_channel]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_channel]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1411,6 +1487,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1421,6 +1502,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListChannelsPager:
         r"""List channels.
 
@@ -1469,6 +1551,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListChannelsPager:
@@ -1497,7 +1583,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_channels]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_channels]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_channels]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1517,6 +1615,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1648,7 +1751,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_channel_]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_channel_]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_channel_]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1780,7 +1888,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_channel]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_channel]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1903,7 +2016,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_channel]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_channel]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_channel]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1942,6 +2060,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> discovery.Provider:
         r"""Get a single Provider.
 
@@ -1989,6 +2108,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.Provider:
@@ -2015,7 +2138,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_provider]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_provider]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_provider]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2036,6 +2171,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2046,6 +2186,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListProvidersPager:
         r"""List providers.
 
@@ -2094,6 +2235,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListProvidersPager:
@@ -2122,7 +2267,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_providers]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_providers]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_providers]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2142,6 +2299,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2164,6 +2326,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> channel_connection.ChannelConnection:
         r"""Get a single ChannelConnection.
 
@@ -2211,6 +2374,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.ChannelConnection:
@@ -2242,7 +2409,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_channel_connection]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_channel_connection]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2263,6 +2442,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2273,6 +2457,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListChannelConnectionsPager:
         r"""List channel connections.
 
@@ -2321,6 +2506,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.services.eventarc.pagers.ListChannelConnectionsPager:
@@ -2350,7 +2539,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_channel_connections]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_channel_connections]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_channel_connections]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2370,6 +2571,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2501,7 +2707,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_channel_connection]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_channel_connection]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2622,7 +2833,12 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_channel_connection]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_channel_connection]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_channel_connection]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2661,6 +2877,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> google_channel_config.GoogleChannelConfig:
         r"""Get a GoogleChannelConfig
 
@@ -2708,6 +2925,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.GoogleChannelConfig:
@@ -2740,7 +2961,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_google_channel_config]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_google_channel_config]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2761,6 +2994,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2772,6 +3010,7 @@ class EventarcClient(metaclass=EventarcClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> gce_google_channel_config.GoogleChannelConfig:
         r"""Update a single GoogleChannelConfig
 
@@ -2829,6 +3068,10 @@ class EventarcClient(metaclass=EventarcClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.eventarc_v1.types.GoogleChannelConfig:
@@ -2863,7 +3106,19 @@ class EventarcClient(metaclass=EventarcClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_google_channel_config]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_google_channel_config]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_google_channel_config]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2883,6 +3138,11 @@ class EventarcClient(metaclass=EventarcClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
@@ -15,7 +15,7 @@
 #
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.cloud.eventarc_v1 import gapic_version as package_version
 
@@ -42,6 +42,18 @@ from google.longrunning import operations_pb2 # type: ignore
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class EventarcTransport(abc.ABC):
     """Abstract transport class for Eventarc."""

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 from google.cloud.eventarc_v1 import gapic_version as package_version
@@ -128,6 +129,70 @@ class EventarcTransport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.get_trigger: gapic_v1.method.wrap_method(
+                    self.get_trigger,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_triggers: gapic_v1.method.wrap_method(
+                    self.list_triggers,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_channel: gapic_v1.method.wrap_method(
+                    self.get_channel,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_channels: gapic_v1.method.wrap_method(
+                    self.list_channels,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_provider: gapic_v1.method.wrap_method(
+                    self.get_provider,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_providers: gapic_v1.method.wrap_method(
+                    self.list_providers,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_channel_connection: gapic_v1.method.wrap_method(
+                    self.get_channel_connection,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_channel_connections: gapic_v1.method.wrap_method(
+                    self.list_channel_connections,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_google_channel_config: gapic_v1.method.wrap_method(
+                    self.get_google_channel_config,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_google_channel_config: gapic_v1.method.wrap_method(
+                    self.update_google_channel_config,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.get_trigger: gapic_v1.method.wrap_method(

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/grpc_asyncio.py
@@ -740,6 +740,70 @@ class EventarcGrpcAsyncIOTransport(EventarcTransport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.get_trigger: self._wrap_method(
+                    self.get_trigger,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_triggers: self._wrap_method(
+                    self.list_triggers,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_channel: self._wrap_method(
+                    self.get_channel,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_channels: self._wrap_method(
+                    self.list_channels,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_provider: self._wrap_method(
+                    self.get_provider,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_providers: self._wrap_method(
+                    self.list_providers,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_channel_connection: self._wrap_method(
+                    self.get_channel_connection,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_channel_connections: self._wrap_method(
+                    self.list_channel_connections,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_google_channel_config: self._wrap_method(
+                    self.get_google_channel_config,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_google_channel_config: self._wrap_method(
+                    self.update_google_channel_config,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.get_trigger: self._wrap_method(
                 self.get_trigger,
@@ -881,6 +945,8 @@ class EventarcGrpcAsyncIOTransport(EventarcTransport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -46,6 +46,7 @@ from google.longrunning import operations_pb2  # type: ignore
 
 
 from .rest_base import _BaseEventarcRestTransport
+from .base import BaseCallMetadata
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
 try:
@@ -895,7 +896,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the create channel method over HTTP.
 
             Args:
@@ -940,7 +941,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -977,7 +980,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the create channel connection method over HTTP.
 
             Args:
@@ -1022,7 +1025,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel_connection(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1059,7 +1064,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the create trigger method over HTTP.
 
             Args:
@@ -1104,7 +1109,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_trigger(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1140,7 +1147,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the delete channel method over HTTP.
 
             Args:
@@ -1183,7 +1190,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1219,7 +1228,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the delete channel connection method over HTTP.
 
             Args:
@@ -1262,7 +1271,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel_connection(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1298,7 +1309,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the delete trigger method over HTTP.
 
             Args:
@@ -1341,7 +1352,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_trigger(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1379,7 +1392,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> channel.Channel:
+                ) -> Union[channel.Channel, Tuple[channel.Channel, BaseCallMetadata]]:
             r"""Call the get channel method over HTTP.
 
             Args:
@@ -1429,7 +1442,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1467,7 +1482,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> channel_connection.ChannelConnection:
+                ) -> Union[channel_connection.ChannelConnection, Tuple[channel_connection.ChannelConnection, BaseCallMetadata]]:
             r"""Call the get channel connection method over HTTP.
 
             Args:
@@ -1516,7 +1531,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel_connection(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1554,7 +1571,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> google_channel_config.GoogleChannelConfig:
+                ) -> Union[google_channel_config.GoogleChannelConfig, Tuple[google_channel_config.GoogleChannelConfig, BaseCallMetadata]]:
             r"""Call the get google channel config method over HTTP.
 
             Args:
@@ -1604,7 +1621,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_google_channel_config(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1642,7 +1661,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> discovery.Provider:
+                ) -> Union[discovery.Provider, Tuple[discovery.Provider, BaseCallMetadata]]:
             r"""Call the get provider method over HTTP.
 
             Args:
@@ -1686,7 +1705,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_provider(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1724,7 +1745,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> trigger.Trigger:
+                ) -> Union[trigger.Trigger, Tuple[trigger.Trigger, BaseCallMetadata]]:
             r"""Call the get trigger method over HTTP.
 
             Args:
@@ -1768,7 +1789,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_trigger(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1806,7 +1829,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> eventarc.ListChannelConnectionsResponse:
+                ) -> Union[eventarc.ListChannelConnectionsResponse, Tuple[eventarc.ListChannelConnectionsResponse, BaseCallMetadata]]:
             r"""Call the list channel connections method over HTTP.
 
             Args:
@@ -1850,7 +1873,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channel_connections(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1888,7 +1913,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> eventarc.ListChannelsResponse:
+                ) -> Union[eventarc.ListChannelsResponse, Tuple[eventarc.ListChannelsResponse, BaseCallMetadata]]:
             r"""Call the list channels method over HTTP.
 
             Args:
@@ -1930,7 +1955,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channels(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1968,7 +1995,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> eventarc.ListProvidersResponse:
+                ) -> Union[eventarc.ListProvidersResponse, Tuple[eventarc.ListProvidersResponse, BaseCallMetadata]]:
             r"""Call the list providers method over HTTP.
 
             Args:
@@ -2010,7 +2037,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_providers(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2048,7 +2077,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> eventarc.ListTriggersResponse:
+                ) -> Union[eventarc.ListTriggersResponse, Tuple[eventarc.ListTriggersResponse, BaseCallMetadata]]:
             r"""Call the list triggers method over HTTP.
 
             Args:
@@ -2090,7 +2119,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_triggers(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2127,7 +2158,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the update channel method over HTTP.
 
             Args:
@@ -2172,7 +2203,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_channel(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2211,7 +2244,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> gce_google_channel_config.GoogleChannelConfig:
+                ) -> Union[gce_google_channel_config.GoogleChannelConfig, Tuple[gce_google_channel_config.GoogleChannelConfig, BaseCallMetadata]]:
             r"""Call the update google channel
         config method over HTTP.
 
@@ -2264,7 +2297,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_google_channel_config(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -2301,7 +2336,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the update trigger method over HTTP.
 
             Args:
@@ -2346,7 +2381,9 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_trigger(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -894,6 +894,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the create channel method over HTTP.
 
@@ -938,7 +939,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _CreateChannelConnection(_BaseEventarcRestTransport._BaseCreateChannelConnection, EventarcRestStub):
         def __hash__(self):
@@ -972,6 +976,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the create channel connection method over HTTP.
 
@@ -1016,7 +1021,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel_connection(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _CreateTrigger(_BaseEventarcRestTransport._BaseCreateTrigger, EventarcRestStub):
         def __hash__(self):
@@ -1050,6 +1058,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the create trigger method over HTTP.
 
@@ -1094,7 +1103,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_trigger(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _DeleteChannel(_BaseEventarcRestTransport._BaseDeleteChannel, EventarcRestStub):
         def __hash__(self):
@@ -1127,6 +1139,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the delete channel method over HTTP.
 
@@ -1169,7 +1182,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _DeleteChannelConnection(_BaseEventarcRestTransport._BaseDeleteChannelConnection, EventarcRestStub):
         def __hash__(self):
@@ -1202,6 +1218,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the delete channel connection method over HTTP.
 
@@ -1244,7 +1261,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel_connection(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _DeleteTrigger(_BaseEventarcRestTransport._BaseDeleteTrigger, EventarcRestStub):
         def __hash__(self):
@@ -1277,6 +1297,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the delete trigger method over HTTP.
 
@@ -1319,11 +1340,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_trigger(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetChannel(_BaseEventarcRestTransport._BaseGetChannel, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.GetChannel")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1352,6 +1378,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> channel.Channel:
             r"""Call the get channel method over HTTP.
 
@@ -1401,11 +1428,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetChannelConnection(_BaseEventarcRestTransport._BaseGetChannelConnection, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.GetChannelConnection")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1434,6 +1466,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> channel_connection.ChannelConnection:
             r"""Call the get channel connection method over HTTP.
 
@@ -1482,11 +1515,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel_connection(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetGoogleChannelConfig(_BaseEventarcRestTransport._BaseGetGoogleChannelConfig, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.GetGoogleChannelConfig")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1515,6 +1553,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> google_channel_config.GoogleChannelConfig:
             r"""Call the get google channel config method over HTTP.
 
@@ -1564,11 +1603,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_google_channel_config(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetProvider(_BaseEventarcRestTransport._BaseGetProvider, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.GetProvider")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1597,6 +1641,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> discovery.Provider:
             r"""Call the get provider method over HTTP.
 
@@ -1640,11 +1685,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_provider(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetTrigger(_BaseEventarcRestTransport._BaseGetTrigger, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.GetTrigger")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1673,6 +1723,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> trigger.Trigger:
             r"""Call the get trigger method over HTTP.
 
@@ -1716,11 +1767,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_trigger(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListChannelConnections(_BaseEventarcRestTransport._BaseListChannelConnections, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.ListChannelConnections")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1749,6 +1805,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> eventarc.ListChannelConnectionsResponse:
             r"""Call the list channel connections method over HTTP.
 
@@ -1792,11 +1849,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channel_connections(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListChannels(_BaseEventarcRestTransport._BaseListChannels, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.ListChannels")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1825,6 +1887,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> eventarc.ListChannelsResponse:
             r"""Call the list channels method over HTTP.
 
@@ -1866,11 +1929,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channels(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListProviders(_BaseEventarcRestTransport._BaseListProviders, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.ListProviders")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1899,6 +1967,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> eventarc.ListProvidersResponse:
             r"""Call the list providers method over HTTP.
 
@@ -1940,11 +2009,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_providers(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListTriggers(_BaseEventarcRestTransport._BaseListTriggers, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.ListTriggers")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1973,6 +2047,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> eventarc.ListTriggersResponse:
             r"""Call the list triggers method over HTTP.
 
@@ -2014,7 +2089,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_triggers(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpdateChannel(_BaseEventarcRestTransport._BaseUpdateChannel, EventarcRestStub):
         def __hash__(self):
@@ -2048,6 +2126,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the update channel method over HTTP.
 
@@ -2092,11 +2171,16 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_channel(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpdateGoogleChannelConfig(_BaseEventarcRestTransport._BaseUpdateGoogleChannelConfig, EventarcRestStub):
         def __hash__(self):
             return hash("EventarcRestTransport.UpdateGoogleChannelConfig")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -2126,6 +2210,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> gce_google_channel_config.GoogleChannelConfig:
             r"""Call the update google channel
         config method over HTTP.
@@ -2178,7 +2263,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_google_channel_config(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpdateTrigger(_BaseEventarcRestTransport._BaseUpdateTrigger, EventarcRestStub):
         def __hash__(self):
@@ -2212,6 +2300,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the update trigger method over HTTP.
 
@@ -2256,7 +2345,10 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_trigger(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     @property
     def create_channel_(self) -> Callable[

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -11200,6 +11200,547 @@ def test_update_google_channel_config_empty_call_grpc():
         assert args[0] == request_msg
 
 
+def test_get_trigger_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = trigger.Trigger(
+        name='name_value',
+        uid='uid_value',
+        service_account='service_account_value',
+        channel='channel_value',
+        etag='etag_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_trigger(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, trigger.Trigger)
+
+def test_list_triggers_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = eventarc.ListTriggersResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_triggers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListTriggersPager)
+
+def test_get_channel_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = channel.Channel(
+        name='name_value',
+        uid='uid_value',
+        provider='provider_value',
+        state=channel.Channel.State.PENDING,
+        activation_token='activation_token_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_channel(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, channel.Channel)
+
+def test_list_channels_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = eventarc.ListChannelsResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_channels(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListChannelsPager)
+
+def test_get_provider_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = discovery.Provider(
+        name='name_value',
+        display_name='display_name_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_provider(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, discovery.Provider)
+
+def test_list_providers_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = eventarc.ListProvidersResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_providers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListProvidersPager)
+
+def test_get_channel_connection_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = channel_connection.ChannelConnection(
+        name='name_value',
+        uid='uid_value',
+        channel='channel_value',
+        activation_token='activation_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_channel_connection(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, channel_connection.ChannelConnection)
+
+def test_list_channel_connections_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = eventarc.ListChannelConnectionsResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_channel_connections(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListChannelConnectionsPager)
+
+def test_get_google_channel_config_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = google_channel_config.GoogleChannelConfig(
+        name='name_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_google_channel_config(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, google_channel_config.GoogleChannelConfig)
+
+def test_update_google_channel_config_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = gce_google_channel_config.GoogleChannelConfig(
+        name='name_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_google_channel_config(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
+
+
+def test_get_trigger_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = trigger.Trigger()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_trigger(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, trigger.Trigger)
+
+def test_list_triggers_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListTriggersResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_triggers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListTriggersPager)
+
+def test_get_channel_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = channel.Channel()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_channel(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, channel.Channel)
+
+def test_list_channels_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListChannelsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_channels(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListChannelsPager)
+
+def test_get_provider_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = discovery.Provider()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_provider(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, discovery.Provider)
+
+def test_list_providers_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListProvidersResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_providers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListProvidersPager)
+
+def test_get_channel_connection_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = channel_connection.ChannelConnection()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_channel_connection(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, channel_connection.ChannelConnection)
+
+def test_list_channel_connections_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListChannelConnectionsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_channel_connections(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListChannelConnectionsPager)
+
+def test_get_google_channel_config_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = google_channel_config.GoogleChannelConfig()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_google_channel_config(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, google_channel_config.GoogleChannelConfig)
+
+def test_update_google_channel_config_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = gce_google_channel_config.GoogleChannelConfig()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_google_channel_config(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
+
+
 def test_transport_kind_grpc_asyncio():
     transport = EventarcAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
@@ -11718,6 +12259,577 @@ async def test_update_google_channel_config_empty_call_grpc_asyncio():
         request_msg = eventarc.UpdateGoogleChannelConfigRequest()
 
         assert args[0] == request_msg
+
+
+@pytest.mark.asyncio
+async def test_get_trigger_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = trigger.Trigger(
+        name='name_value',
+        uid='uid_value',
+        service_account='service_account_value',
+        channel='channel_value',
+        etag='etag_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_trigger), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_trigger(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, trigger.Trigger)
+
+@pytest.mark.asyncio
+async def test_list_triggers_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = eventarc.ListTriggersResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.list_triggers), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_triggers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListTriggersAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_channel_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = channel.Channel(
+        name='name_value',
+        uid='uid_value',
+        provider='provider_value',
+        state=channel.Channel.State.PENDING,
+        activation_token='activation_token_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_channel), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_channel(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, channel.Channel)
+
+@pytest.mark.asyncio
+async def test_list_channels_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = eventarc.ListChannelsResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.list_channels), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_channels(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListChannelsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_provider_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = discovery.Provider(
+        name='name_value',
+        display_name='display_name_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_provider), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_provider(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, discovery.Provider)
+
+@pytest.mark.asyncio
+async def test_list_providers_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = eventarc.ListProvidersResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.list_providers), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_providers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListProvidersAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_channel_connection_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = channel_connection.ChannelConnection(
+        name='name_value',
+        uid='uid_value',
+        channel='channel_value',
+        activation_token='activation_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_channel_connection), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_channel_connection(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, channel_connection.ChannelConnection)
+
+@pytest.mark.asyncio
+async def test_list_channel_connections_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = eventarc.ListChannelConnectionsResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.list_channel_connections), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_channel_connections(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListChannelConnectionsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_google_channel_config_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = google_channel_config.GoogleChannelConfig(
+        name='name_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_google_channel_config), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_google_channel_config(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, google_channel_config.GoogleChannelConfig)
+
+@pytest.mark.asyncio
+async def test_update_google_channel_config_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = gce_google_channel_config.GoogleChannelConfig(
+        name='name_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(
+        type(client.transport.update_google_channel_config), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_google_channel_config(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
+
+
+@pytest.mark.asyncio
+async def test_get_trigger_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_trigger), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(trigger.Trigger())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_trigger(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, trigger.Trigger)
+
+@pytest.mark.asyncio
+async def test_list_triggers_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_triggers), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(eventarc.ListTriggersResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_triggers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListTriggersAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_channel_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_channel), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(channel.Channel())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_channel(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, channel.Channel)
+
+@pytest.mark.asyncio
+async def test_list_channels_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_channels), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(eventarc.ListChannelsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_channels(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListChannelsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_provider_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_provider), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(discovery.Provider())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_provider(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, discovery.Provider)
+
+@pytest.mark.asyncio
+async def test_list_providers_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_providers), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(eventarc.ListProvidersResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_providers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListProvidersAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_channel_connection_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_channel_connection), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(channel_connection.ChannelConnection())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_channel_connection(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, channel_connection.ChannelConnection)
+
+@pytest.mark.asyncio
+async def test_list_channel_connections_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_channel_connections), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(eventarc.ListChannelConnectionsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_channel_connections(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListChannelConnectionsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_google_channel_config_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_google_channel_config), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(google_channel_config.GoogleChannelConfig())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_google_channel_config(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, google_channel_config.GoogleChannelConfig)
+
+@pytest.mark.asyncio
+async def test_update_google_channel_config_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_google_channel_config), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(gce_google_channel_config.GoogleChannelConfig())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_google_channel_config(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
 
 
 def test_transport_kind_rest():
@@ -14754,6 +15866,718 @@ def test_update_google_channel_config_empty_call_rest():
         assert args[0] == request_msg
 
 
+def test_get_trigger_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = trigger.Trigger(
+        name='name_value',
+        uid='uid_value',
+        service_account='service_account_value',
+        channel='channel_value',
+        etag='etag_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.GetTriggerRequest.pb(eventarc.GetTriggerRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = trigger.Trigger.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_trigger(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, trigger.Trigger)
+
+def test_list_triggers_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = eventarc.ListTriggersResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.ListTriggersRequest.pb(eventarc.ListTriggersRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = eventarc.ListTriggersResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_triggers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListTriggersPager)
+
+def test_get_channel_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = channel.Channel(
+        name='name_value',
+        uid='uid_value',
+        provider='provider_value',
+        state=channel.Channel.State.PENDING,
+        activation_token='activation_token_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.GetChannelRequest.pb(eventarc.GetChannelRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = channel.Channel.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_channel(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, channel.Channel)
+
+def test_list_channels_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = eventarc.ListChannelsResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.ListChannelsRequest.pb(eventarc.ListChannelsRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = eventarc.ListChannelsResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_channels(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListChannelsPager)
+
+def test_get_provider_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = discovery.Provider(
+        name='name_value',
+        display_name='display_name_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.GetProviderRequest.pb(eventarc.GetProviderRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = discovery.Provider.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_provider(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, discovery.Provider)
+
+def test_list_providers_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = eventarc.ListProvidersResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.ListProvidersRequest.pb(eventarc.ListProvidersRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = eventarc.ListProvidersResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_providers(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListProvidersPager)
+
+def test_get_channel_connection_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = channel_connection.ChannelConnection(
+        name='name_value',
+        uid='uid_value',
+        channel='channel_value',
+        activation_token='activation_token_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.GetChannelConnectionRequest.pb(eventarc.GetChannelConnectionRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = channel_connection.ChannelConnection.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_channel_connection(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, channel_connection.ChannelConnection)
+
+def test_list_channel_connections_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = eventarc.ListChannelConnectionsResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.ListChannelConnectionsRequest.pb(eventarc.ListChannelConnectionsRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = eventarc.ListChannelConnectionsResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_channel_connections(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListChannelConnectionsPager)
+
+def test_get_google_channel_config_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = google_channel_config.GoogleChannelConfig(
+        name='name_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.GetGoogleChannelConfigRequest.pb(eventarc.GetGoogleChannelConfigRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = google_channel_config.GoogleChannelConfig.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_google_channel_config(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, google_channel_config.GoogleChannelConfig)
+
+def test_update_google_channel_config_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = gce_google_channel_config.GoogleChannelConfig(
+        name='name_value',
+        crypto_key_name='crypto_key_name_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = eventarc.UpdateGoogleChannelConfigRequest.pb(eventarc.UpdateGoogleChannelConfigRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "patch",
+            'query_params': pb_request,
+        }
+        transcode_result['body'] = pb_request
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = gce_google_channel_config.GoogleChannelConfig.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.update_google_channel_config(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
+
+
+def test_get_trigger_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = trigger.Trigger()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_trigger(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, trigger.Trigger)
+
+def test_list_triggers_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListTriggersResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_triggers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListTriggersPager)
+
+def test_get_channel_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = channel.Channel()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_channel(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, channel.Channel)
+
+def test_list_channels_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListChannelsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_channels(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListChannelsPager)
+
+def test_get_provider_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = discovery.Provider()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_provider(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, discovery.Provider)
+
+def test_list_providers_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListProvidersResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_providers(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListProvidersPager)
+
+def test_get_channel_connection_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = channel_connection.ChannelConnection()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_channel_connection(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, channel_connection.ChannelConnection)
+
+def test_list_channel_connections_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = eventarc.ListChannelConnectionsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_channel_connections(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListChannelConnectionsPager)
+
+def test_get_google_channel_config_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = google_channel_config.GoogleChannelConfig()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_google_channel_config(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, google_channel_config.GoogleChannelConfig)
+
+def test_update_google_channel_config_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = EventarcClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = gce_google_channel_config.GoogleChannelConfig()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_google_channel_config(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
+
+
 def test_eventarc_rest_lro_client():
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
@@ -14774,6 +16598,7 @@ def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = EventarcClient(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -11219,13 +11219,14 @@ def test_get_trigger_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_trigger(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, trigger.Trigger)
 
 def test_list_triggers_with_metadata_callback_grpc():
@@ -11244,13 +11245,14 @@ def test_list_triggers_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_triggers(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListTriggersPager)
 
 def test_get_channel_with_metadata_callback_grpc():
@@ -11273,13 +11275,14 @@ def test_get_channel_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_channel(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, channel.Channel)
 
 def test_list_channels_with_metadata_callback_grpc():
@@ -11298,13 +11301,14 @@ def test_list_channels_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_channels(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListChannelsPager)
 
 def test_get_provider_with_metadata_callback_grpc():
@@ -11323,13 +11327,14 @@ def test_get_provider_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_provider(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, discovery.Provider)
 
 def test_list_providers_with_metadata_callback_grpc():
@@ -11348,13 +11353,14 @@ def test_list_providers_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_providers(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListProvidersPager)
 
 def test_get_channel_connection_with_metadata_callback_grpc():
@@ -11375,13 +11381,14 @@ def test_get_channel_connection_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_channel_connection(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, channel_connection.ChannelConnection)
 
 def test_list_channel_connections_with_metadata_callback_grpc():
@@ -11400,13 +11407,14 @@ def test_list_channel_connections_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_channel_connections(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListChannelConnectionsPager)
 
 def test_get_google_channel_config_with_metadata_callback_grpc():
@@ -11425,13 +11433,14 @@ def test_get_google_channel_config_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_google_channel_config(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, google_channel_config.GoogleChannelConfig)
 
 def test_update_google_channel_config_with_metadata_callback_grpc():
@@ -11450,13 +11459,14 @@ def test_update_google_channel_config_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_google_channel_config(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
 
 
@@ -12281,13 +12291,14 @@ async def test_get_trigger_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_trigger), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_trigger(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, trigger.Trigger)
 
 @pytest.mark.asyncio
@@ -12307,13 +12318,14 @@ async def test_list_triggers_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_triggers), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_triggers(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListTriggersAsyncPager)
 
 @pytest.mark.asyncio
@@ -12337,13 +12349,14 @@ async def test_get_channel_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_channel), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_channel(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, channel.Channel)
 
 @pytest.mark.asyncio
@@ -12363,13 +12376,14 @@ async def test_list_channels_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_channels), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_channels(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListChannelsAsyncPager)
 
 @pytest.mark.asyncio
@@ -12389,13 +12403,14 @@ async def test_get_provider_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_provider), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_provider(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, discovery.Provider)
 
 @pytest.mark.asyncio
@@ -12415,13 +12430,14 @@ async def test_list_providers_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_providers), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_providers(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListProvidersAsyncPager)
 
 @pytest.mark.asyncio
@@ -12443,13 +12459,14 @@ async def test_get_channel_connection_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_channel_connection), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_channel_connection(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, channel_connection.ChannelConnection)
 
 @pytest.mark.asyncio
@@ -12469,13 +12486,14 @@ async def test_list_channel_connections_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_channel_connections), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_channel_connections(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListChannelConnectionsAsyncPager)
 
 @pytest.mark.asyncio
@@ -12495,13 +12513,14 @@ async def test_get_google_channel_config_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_google_channel_config), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_google_channel_config(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, google_channel_config.GoogleChannelConfig)
 
 @pytest.mark.asyncio
@@ -12521,13 +12540,14 @@ async def test_update_google_channel_config_with_metadata_callback_grpc_asyncio(
     with mock.patch.object(
         type(client.transport.update_google_channel_config), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_google_channel_config(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
 
 
@@ -15897,6 +15917,7 @@ def test_get_trigger_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -15908,7 +15929,7 @@ def test_get_trigger_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, trigger.Trigger)
 
 def test_list_triggers_with_metadata_callback_rest():
@@ -15939,6 +15960,7 @@ def test_list_triggers_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -15950,7 +15972,7 @@ def test_list_triggers_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListTriggersPager)
 
 def test_get_channel_with_metadata_callback_rest():
@@ -15985,6 +16007,7 @@ def test_get_channel_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -15996,7 +16019,7 @@ def test_get_channel_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, channel.Channel)
 
 def test_list_channels_with_metadata_callback_rest():
@@ -16027,6 +16050,7 @@ def test_list_channels_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -16038,7 +16062,7 @@ def test_list_channels_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListChannelsPager)
 
 def test_get_provider_with_metadata_callback_rest():
@@ -16069,6 +16093,7 @@ def test_get_provider_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -16080,7 +16105,7 @@ def test_get_provider_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, discovery.Provider)
 
 def test_list_providers_with_metadata_callback_rest():
@@ -16111,6 +16136,7 @@ def test_list_providers_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -16122,7 +16148,7 @@ def test_list_providers_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListProvidersPager)
 
 def test_get_channel_connection_with_metadata_callback_rest():
@@ -16155,6 +16181,7 @@ def test_get_channel_connection_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -16166,7 +16193,7 @@ def test_get_channel_connection_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, channel_connection.ChannelConnection)
 
 def test_list_channel_connections_with_metadata_callback_rest():
@@ -16197,6 +16224,7 @@ def test_list_channel_connections_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -16208,7 +16236,7 @@ def test_list_channel_connections_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListChannelConnectionsPager)
 
 def test_get_google_channel_config_with_metadata_callback_rest():
@@ -16239,6 +16267,7 @@ def test_get_google_channel_config_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -16250,7 +16279,7 @@ def test_get_google_channel_config_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, google_channel_config.GoogleChannelConfig)
 
 def test_update_google_channel_config_with_metadata_callback_rest():
@@ -16282,6 +16311,7 @@ def test_update_google_channel_config_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -16293,7 +16323,7 @@ def test_update_google_channel_config_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, gce_google_channel_config.GoogleChannelConfig)
 
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
+import warnings
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
@@ -249,6 +250,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListBucketsAsyncPager:
         r"""Lists log buckets.
 
@@ -307,6 +309,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListBucketsAsyncPager:
@@ -337,7 +343,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_buckets]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_buckets]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_buckets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -357,6 +374,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -378,6 +399,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogBucket:
         r"""Gets a log bucket.
 
@@ -417,6 +439,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogBucket:
@@ -432,7 +458,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_bucket]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_bucket]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -452,6 +489,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -527,7 +568,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_bucket_async]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_bucket_async]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -632,7 +677,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_bucket_async]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_bucket_async]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -670,6 +719,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogBucket:
         r"""Creates a log bucket that can be used to store log
         entries. After a bucket has been created, the bucket's
@@ -712,6 +762,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogBucket:
@@ -727,7 +781,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_bucket]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_bucket]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -747,6 +812,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -757,6 +826,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogBucket:
         r"""Updates a log bucket.
 
@@ -802,6 +872,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogBucket:
@@ -817,7 +891,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_bucket]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_bucket]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -837,6 +922,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -897,7 +986,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_bucket]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_bucket]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -971,7 +1064,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.undelete_bucket]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.undelete_bucket]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.undelete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -999,6 +1096,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListViewsAsyncPager:
         r"""Lists views on a log bucket.
 
@@ -1049,6 +1147,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListViewsAsyncPager:
@@ -1079,7 +1181,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_views]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_views]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_views]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1099,6 +1212,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1120,6 +1237,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogView:
         r"""Gets a view on a log bucket..
 
@@ -1159,6 +1277,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogView:
@@ -1174,7 +1296,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_view]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_view]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1194,6 +1327,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1204,6 +1341,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogView:
         r"""Creates a view over log entries in a log bucket. A
         bucket may contain a maximum of 30 views.
@@ -1245,6 +1383,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogView:
@@ -1260,7 +1402,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_view]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_view]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1280,6 +1433,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1290,6 +1447,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogView:
         r"""Updates a view on a log bucket. This method replaces the
         following fields in the existing view with values from the new
@@ -1333,6 +1491,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogView:
@@ -1348,7 +1510,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_view]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_view]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1368,6 +1541,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1426,7 +1603,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_view]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_view]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1454,6 +1635,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListSinksAsyncPager:
         r"""Lists sinks.
 
@@ -1508,6 +1690,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListSinksAsyncPager:
@@ -1537,7 +1723,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_sinks]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_sinks]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_sinks]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1557,6 +1754,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1579,6 +1780,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogSink:
         r"""Gets a sink.
 
@@ -1635,6 +1837,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogSink:
@@ -1669,7 +1875,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_sink]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_sink]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1689,6 +1906,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1701,6 +1922,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogSink:
         r"""Creates a sink that exports specified log entries to a
         destination. The export of newly-ingested log entries begins
@@ -1773,6 +1995,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogSink:
@@ -1809,7 +2035,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_sink]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_sink]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1829,6 +2066,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1842,6 +2083,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogSink:
         r"""Updates a sink. This method replaces the following fields in the
         existing sink with values from the new sink: ``destination``,
@@ -1938,6 +2180,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogSink:
@@ -1976,7 +2222,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_sink]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_sink]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1996,6 +2253,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2083,7 +2344,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_sink]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_sink]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2221,7 +2486,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_link]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_link]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2352,7 +2621,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_link]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_link]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2391,6 +2664,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLinksAsyncPager:
         r"""Lists links.
 
@@ -2443,6 +2717,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListLinksAsyncPager:
@@ -2473,7 +2751,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_links]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_links]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_links]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2493,6 +2782,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2515,6 +2808,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.Link:
         r"""Gets a link.
 
@@ -2565,6 +2859,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.Link:
@@ -2592,7 +2890,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_link]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_link]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2612,6 +2921,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2623,6 +2936,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListExclusionsAsyncPager:
         r"""Lists all the exclusions on the \_Default sink in a parent
         resource.
@@ -2678,6 +2992,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListExclusionsAsyncPager:
@@ -2707,7 +3025,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_exclusions]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_exclusions]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_exclusions]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2727,6 +3056,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2749,6 +3082,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Gets the description of an exclusion in the \_Default sink.
 
@@ -2805,6 +3139,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogExclusion:
@@ -2837,7 +3175,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_exclusion]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_exclusion]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2857,6 +3206,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2869,6 +3222,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Creates a new exclusion in the \_Default sink in a specified
         parent resource. Only log entries belonging to that resource can
@@ -2942,6 +3296,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogExclusion:
@@ -2976,7 +3334,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_exclusion]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_exclusion]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2996,6 +3365,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -3009,6 +3382,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Changes one or more properties of an existing exclusion in the
         \_Default sink.
@@ -3093,6 +3467,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogExclusion:
@@ -3129,7 +3507,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_exclusion]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_exclusion]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3149,6 +3538,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -3235,7 +3628,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_exclusion]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_exclusion]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3262,6 +3659,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Gets the Logging CMEK settings for the given resource.
 
@@ -3315,6 +3713,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.CmekSettings:
@@ -3340,7 +3742,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_cmek_settings]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_cmek_settings]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3360,6 +3773,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -3370,6 +3787,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Updates the Log Router CMEK settings for the given resource.
 
@@ -3428,6 +3846,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.CmekSettings:
@@ -3453,7 +3875,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_cmek_settings]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_cmek_settings]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3473,6 +3906,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -3484,6 +3921,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.Settings:
         r"""Gets the Log Router settings for the given resource.
 
@@ -3562,6 +4000,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.Settings:
@@ -3590,7 +4032,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_settings]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_settings]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3610,6 +4063,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -3622,6 +4079,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.Settings:
         r"""Updates the Log Router settings for the given resource.
 
@@ -3707,6 +4165,10 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.Settings:
@@ -3737,7 +4199,18 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_settings]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_settings]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3757,6 +4230,10 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -3831,7 +4308,11 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.copy_log_entries]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.copy_log_entries]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.copy_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/async_client.py
@@ -41,9 +41,20 @@ from google.longrunning import operations_pb2 # type: ignore
 from google.protobuf import empty_pb2  # type: ignore
 from google.protobuf import field_mask_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
+from .transports.base import BaseCallMetadata
 from .transports.base import ConfigServiceV2Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import ConfigServiceV2GrpcAsyncIOTransport
 from .client import ConfigServiceV2Client
+
+
+class ConfigServiceV2AsyncClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class ConfigServiceV2AsyncClient:
@@ -250,7 +261,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListBucketsAsyncPager:
         r"""Lists log buckets.
 
@@ -309,7 +320,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -343,18 +354,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_buckets]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_buckets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_buckets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -374,10 +386,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -399,7 +417,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogBucket:
         r"""Gets a log bucket.
 
@@ -439,7 +457,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -458,18 +476,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_bucket]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_bucket]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -489,10 +508,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -568,11 +593,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_bucket_async]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_bucket_async]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -677,11 +703,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_bucket_async]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_bucket_async]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -719,7 +746,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogBucket:
         r"""Creates a log bucket that can be used to store log
         entries. After a bucket has been created, the bucket's
@@ -762,7 +789,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -781,18 +808,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_bucket]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_bucket]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -812,10 +840,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -826,7 +860,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogBucket:
         r"""Updates a log bucket.
 
@@ -872,7 +906,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -891,18 +925,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_bucket]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_bucket]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -922,10 +957,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -986,11 +1027,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_bucket]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_bucket]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1064,11 +1106,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.undelete_bucket]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.undelete_bucket]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.undelete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1096,7 +1139,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListViewsAsyncPager:
         r"""Lists views on a log bucket.
 
@@ -1147,7 +1190,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1181,18 +1224,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_views]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_views]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_views]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1212,10 +1256,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1237,7 +1287,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogView:
         r"""Gets a view on a log bucket..
 
@@ -1277,7 +1327,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1296,18 +1346,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_view]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_view]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1327,10 +1378,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1341,7 +1398,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogView:
         r"""Creates a view over log entries in a log bucket. A
         bucket may contain a maximum of 30 views.
@@ -1383,7 +1440,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1402,18 +1459,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_view]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_view]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1433,10 +1491,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1447,7 +1511,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogView:
         r"""Updates a view on a log bucket. This method replaces the
         following fields in the existing view with values from the new
@@ -1491,7 +1555,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1510,18 +1574,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_view]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_view]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1541,10 +1606,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1603,11 +1674,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_view]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_view]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1635,7 +1707,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListSinksAsyncPager:
         r"""Lists sinks.
 
@@ -1690,7 +1762,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1723,18 +1795,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_sinks]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_sinks]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_sinks]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1754,10 +1827,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1780,7 +1859,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogSink:
         r"""Gets a sink.
 
@@ -1837,7 +1916,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -1875,18 +1954,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_sink]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_sink]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1906,10 +1986,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1922,7 +2008,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogSink:
         r"""Creates a sink that exports specified log entries to a
         destination. The export of newly-ingested log entries begins
@@ -1995,7 +2081,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2035,18 +2121,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_sink]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_sink]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2066,10 +2153,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2083,7 +2176,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogSink:
         r"""Updates a sink. This method replaces the following fields in the
         existing sink with values from the new sink: ``destination``,
@@ -2180,7 +2273,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2222,18 +2315,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_sink]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_sink]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2253,10 +2347,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2344,11 +2444,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_sink]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_sink]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2486,11 +2587,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_link]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_link]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2621,11 +2723,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_link]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_link]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2664,7 +2767,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLinksAsyncPager:
         r"""Lists links.
 
@@ -2717,7 +2820,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2751,18 +2854,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_links]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_links]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_links]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2782,10 +2886,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -2808,7 +2918,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.Link:
         r"""Gets a link.
 
@@ -2859,7 +2969,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -2890,18 +3000,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_link]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_link]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2921,10 +3032,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2936,7 +3053,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListExclusionsAsyncPager:
         r"""Lists all the exclusions on the \_Default sink in a parent
         resource.
@@ -2992,7 +3109,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3025,18 +3142,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_exclusions]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_exclusions]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_exclusions]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3056,10 +3174,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -3082,7 +3206,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Gets the description of an exclusion in the \_Default sink.
 
@@ -3139,7 +3263,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3175,18 +3299,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_exclusion]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_exclusion]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3206,10 +3331,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3222,7 +3353,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Creates a new exclusion in the \_Default sink in a specified
         parent resource. Only log entries belonging to that resource can
@@ -3296,7 +3427,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3334,18 +3465,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_exclusion]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_exclusion]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3365,10 +3497,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3382,7 +3520,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Changes one or more properties of an existing exclusion in the
         \_Default sink.
@@ -3467,7 +3605,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3507,18 +3645,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_exclusion]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_exclusion]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3538,10 +3677,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3628,11 +3773,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_exclusion]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_exclusion]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3659,7 +3805,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Gets the Logging CMEK settings for the given resource.
 
@@ -3713,7 +3859,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3742,18 +3888,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_cmek_settings]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_cmek_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3773,10 +3920,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3787,7 +3940,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Updates the Log Router CMEK settings for the given resource.
 
@@ -3846,7 +3999,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -3875,18 +4028,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_cmek_settings]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_cmek_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3906,10 +4060,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3921,7 +4081,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.Settings:
         r"""Gets the Log Router settings for the given resource.
 
@@ -4000,7 +4160,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -4032,18 +4192,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_settings]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4063,10 +4224,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -4079,7 +4246,7 @@ class ConfigServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.Settings:
         r"""Updates the Log Router settings for the given resource.
 
@@ -4165,7 +4332,7 @@ class ConfigServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -4199,18 +4366,19 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_settings]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4230,10 +4398,16 @@ class ConfigServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = ConfigServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -4308,11 +4482,12 @@ class ConfigServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.copy_log_entries]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.copy_log_entries]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.copy_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -618,6 +618,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListBucketsPager:
         r"""Lists log buckets.
 
@@ -676,6 +677,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListBucketsPager:
@@ -705,7 +710,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_buckets]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_buckets]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_buckets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -725,6 +742,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -746,6 +768,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogBucket:
         r"""Gets a log bucket.
 
@@ -785,6 +808,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogBucket:
@@ -800,7 +827,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_bucket]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_bucket]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -820,6 +859,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -895,7 +939,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_bucket_async]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_bucket_async]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1000,7 +1049,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_bucket_async]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_bucket_async]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1038,6 +1092,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogBucket:
         r"""Creates a log bucket that can be used to store log
         entries. After a bucket has been created, the bucket's
@@ -1080,6 +1135,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogBucket:
@@ -1095,7 +1154,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_bucket]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_bucket]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1116,6 +1187,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1125,6 +1201,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogBucket:
         r"""Updates a log bucket.
 
@@ -1170,6 +1247,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogBucket:
@@ -1185,7 +1266,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_bucket]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_bucket]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1205,6 +1298,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1265,7 +1363,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_bucket]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_bucket]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1339,7 +1442,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.undelete_bucket]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.undelete_bucket]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.undelete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1367,6 +1475,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListViewsPager:
         r"""Lists views on a log bucket.
 
@@ -1417,6 +1526,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListViewsPager:
@@ -1446,7 +1559,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_views]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_views]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_views]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1466,6 +1591,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1487,6 +1617,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogView:
         r"""Gets a view on a log bucket..
 
@@ -1526,6 +1657,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogView:
@@ -1541,7 +1676,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_view]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_view]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1562,6 +1709,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1571,6 +1723,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogView:
         r"""Creates a view over log entries in a log bucket. A
         bucket may contain a maximum of 30 views.
@@ -1612,6 +1765,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogView:
@@ -1627,7 +1784,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_view]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_view]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1648,6 +1817,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -1657,6 +1831,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogView:
         r"""Updates a view on a log bucket. This method replaces the
         following fields in the existing view with values from the new
@@ -1700,6 +1875,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogView:
@@ -1715,7 +1894,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_view]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_view]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1735,6 +1926,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1793,7 +1989,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_view]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_view]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1821,6 +2022,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListSinksPager:
         r"""Lists sinks.
 
@@ -1875,6 +2077,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListSinksPager:
@@ -1903,7 +2109,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_sinks]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_sinks]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_sinks]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1923,6 +2141,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1945,6 +2168,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogSink:
         r"""Gets a sink.
 
@@ -2001,6 +2225,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogSink:
@@ -2034,7 +2262,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_sink]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_sink]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2055,6 +2295,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2066,6 +2311,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogSink:
         r"""Creates a sink that exports specified log entries to a
         destination. The export of newly-ingested log entries begins
@@ -2138,6 +2384,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogSink:
@@ -2173,7 +2423,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_sink]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_sink]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2194,6 +2456,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2206,6 +2473,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogSink:
         r"""Updates a sink. This method replaces the following fields in the
         existing sink with values from the new sink: ``destination``,
@@ -2302,6 +2570,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogSink:
@@ -2339,7 +2611,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_sink]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_sink]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2359,6 +2643,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -2445,7 +2734,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_sink]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_sink]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2582,7 +2876,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_link]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_link]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2712,7 +3011,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_link]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_link]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2751,6 +3055,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLinksPager:
         r"""Lists links.
 
@@ -2803,6 +3108,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListLinksPager:
@@ -2832,7 +3141,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_links]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_links]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_links]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2852,6 +3173,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2874,6 +3200,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.Link:
         r"""Gets a link.
 
@@ -2924,6 +3251,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.Link:
@@ -2950,7 +3281,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_link]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_link]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2971,6 +3314,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -2981,6 +3329,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListExclusionsPager:
         r"""Lists all the exclusions on the \_Default sink in a parent
         resource.
@@ -3036,6 +3385,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.config_service_v2.pagers.ListExclusionsPager:
@@ -3064,7 +3417,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_exclusions]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_exclusions]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_exclusions]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3084,6 +3449,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3106,6 +3476,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Gets the description of an exclusion in the \_Default sink.
 
@@ -3162,6 +3533,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogExclusion:
@@ -3193,7 +3568,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_exclusion]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_exclusion]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3214,6 +3601,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -3225,6 +3617,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Creates a new exclusion in the \_Default sink in a specified
         parent resource. Only log entries belonging to that resource can
@@ -3298,6 +3691,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogExclusion:
@@ -3331,7 +3728,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_exclusion]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_exclusion]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3352,6 +3761,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -3364,6 +3778,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Changes one or more properties of an existing exclusion in the
         \_Default sink.
@@ -3448,6 +3863,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogExclusion:
@@ -3483,7 +3902,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_exclusion]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_exclusion]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3503,6 +3934,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -3588,7 +4024,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_exclusion]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_exclusion]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3615,6 +4056,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Gets the Logging CMEK settings for the given resource.
 
@@ -3668,6 +4110,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.CmekSettings:
@@ -3693,7 +4139,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_cmek_settings]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_cmek_settings]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3714,6 +4172,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -3723,6 +4186,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Updates the Log Router CMEK settings for the given resource.
 
@@ -3781,6 +4245,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.CmekSettings:
@@ -3806,7 +4274,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_cmek_settings]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_cmek_settings]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3827,6 +4307,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -3837,6 +4322,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.Settings:
         r"""Gets the Log Router settings for the given resource.
 
@@ -3915,6 +4401,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.Settings:
@@ -3942,7 +4432,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_settings]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_settings]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3963,6 +4465,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -3974,6 +4481,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_config.Settings:
         r"""Updates the Log Router settings for the given resource.
 
@@ -4059,6 +4567,10 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.Settings:
@@ -4088,7 +4600,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_settings]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_settings]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4108,6 +4632,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -4182,7 +4711,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.copy_log_entries]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.copy_log_entries]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.copy_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -47,6 +47,17 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from .transports.base import ConfigServiceV2Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc import ConfigServiceV2GrpcTransport
 from .transports.grpc_asyncio import ConfigServiceV2GrpcAsyncIOTransport
+from .transports.base import BaseCallMetadata
+
+
+class ConfigServiceV2ClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class ConfigServiceV2ClientMeta(type):
@@ -618,7 +629,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListBucketsPager:
         r"""Lists log buckets.
 
@@ -677,7 +688,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -710,19 +721,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_buckets]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_buckets]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_buckets]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -743,10 +754,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -768,7 +780,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogBucket:
         r"""Gets a log bucket.
 
@@ -808,7 +820,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -827,19 +839,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_bucket]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_bucket]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -860,10 +872,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -939,12 +952,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_bucket_async]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_bucket_async]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1049,12 +1062,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_bucket_async]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_bucket_async]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_bucket_async]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1092,7 +1105,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogBucket:
         r"""Creates a log bucket that can be used to store log
         entries. After a bucket has been created, the bucket's
@@ -1135,7 +1148,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1154,19 +1167,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_bucket]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_bucket]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1187,10 +1200,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1201,7 +1215,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogBucket:
         r"""Updates a log bucket.
 
@@ -1247,7 +1261,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1266,19 +1280,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_bucket]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_bucket]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1299,10 +1313,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1363,12 +1378,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_bucket]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_bucket]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1442,12 +1457,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.undelete_bucket]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.undelete_bucket]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.undelete_bucket]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1475,7 +1490,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListViewsPager:
         r"""Lists views on a log bucket.
 
@@ -1526,7 +1541,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1559,19 +1574,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_views]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_views]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_views]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1592,10 +1607,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1617,7 +1633,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogView:
         r"""Gets a view on a log bucket..
 
@@ -1657,7 +1673,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1676,19 +1692,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_view]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_view]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1709,10 +1725,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1723,7 +1740,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogView:
         r"""Creates a view over log entries in a log bucket. A
         bucket may contain a maximum of 30 views.
@@ -1765,7 +1782,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1784,19 +1801,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_view]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_view]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1817,10 +1834,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1831,7 +1849,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogView:
         r"""Updates a view on a log bucket. This method replaces the
         following fields in the existing view with values from the new
@@ -1875,7 +1893,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1894,19 +1912,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_view]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_view]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1927,10 +1945,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1989,12 +2008,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_view]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_view]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_view]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2022,7 +2041,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListSinksPager:
         r"""Lists sinks.
 
@@ -2077,7 +2096,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2109,19 +2128,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_sinks]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_sinks]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_sinks]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2142,10 +2161,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -2168,7 +2188,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogSink:
         r"""Gets a sink.
 
@@ -2225,7 +2245,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2262,19 +2282,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_sink]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_sink]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2295,10 +2315,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2311,7 +2332,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogSink:
         r"""Creates a sink that exports specified log entries to a
         destination. The export of newly-ingested log entries begins
@@ -2384,7 +2405,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2423,19 +2444,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_sink]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_sink]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2456,10 +2477,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2473,7 +2495,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogSink:
         r"""Updates a sink. This method replaces the following fields in the
         existing sink with values from the new sink: ``destination``,
@@ -2570,7 +2592,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -2611,19 +2633,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_sink]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_sink]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2644,10 +2666,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -2734,12 +2757,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_sink]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_sink]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_sink]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2876,12 +2899,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_link]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_link]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3011,12 +3034,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_link]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_link]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3055,7 +3078,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLinksPager:
         r"""Lists links.
 
@@ -3108,7 +3131,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3141,19 +3164,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_links]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_links]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_links]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3174,10 +3197,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3200,7 +3224,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.Link:
         r"""Gets a link.
 
@@ -3251,7 +3275,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3281,19 +3305,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_link]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_link]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_link]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3314,10 +3338,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3329,7 +3354,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListExclusionsPager:
         r"""Lists all the exclusions on the \_Default sink in a parent
         resource.
@@ -3385,7 +3410,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3417,19 +3442,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_exclusions]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_exclusions]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_exclusions]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3450,10 +3475,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -3476,7 +3502,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Gets the description of an exclusion in the \_Default sink.
 
@@ -3533,7 +3559,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3568,19 +3594,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_exclusion]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_exclusion]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3601,10 +3627,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3617,7 +3644,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Creates a new exclusion in the \_Default sink in a specified
         parent resource. Only log entries belonging to that resource can
@@ -3691,7 +3718,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3728,19 +3755,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_exclusion]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_exclusion]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3761,10 +3788,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -3778,7 +3806,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.LogExclusion:
         r"""Changes one or more properties of an existing exclusion in the
         \_Default sink.
@@ -3863,7 +3891,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -3902,19 +3930,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_exclusion]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_exclusion]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -3935,10 +3963,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -4024,12 +4053,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_exclusion]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_exclusion]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_exclusion]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4056,7 +4085,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Gets the Logging CMEK settings for the given resource.
 
@@ -4110,7 +4139,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -4139,19 +4168,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_cmek_settings]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_cmek_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4172,10 +4201,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -4186,7 +4216,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.CmekSettings:
         r"""Updates the Log Router CMEK settings for the given resource.
 
@@ -4245,7 +4275,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -4274,19 +4304,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_cmek_settings]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_cmek_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_cmek_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4307,10 +4337,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -4322,7 +4353,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.Settings:
         r"""Gets the Log Router settings for the given resource.
 
@@ -4401,7 +4432,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -4432,19 +4463,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_settings]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4465,10 +4496,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -4481,7 +4513,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_config.Settings:
         r"""Updates the Log Router settings for the given resource.
 
@@ -4567,7 +4599,7 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -4600,19 +4632,19 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_settings]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_settings]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_settings]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -4633,10 +4665,11 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = ConfigServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -4711,12 +4744,12 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.copy_log_entries]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.copy_log_entries]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.copy_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -15,7 +15,7 @@
 #
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
@@ -34,6 +34,18 @@ from google.protobuf import empty_pb2  # type: ignore
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class ConfigServiceV2Transport(abc.ABC):
     """Abstract transport class for ConfigServiceV2."""

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 from google.cloud.logging_v2 import gapic_version as package_version
@@ -123,6 +124,249 @@ class ConfigServiceV2Transport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_buckets: gapic_v1.method.wrap_method(
+                    self.list_buckets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_bucket: gapic_v1.method.wrap_method(
+                    self.get_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_bucket: gapic_v1.method.wrap_method(
+                    self.create_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_bucket: gapic_v1.method.wrap_method(
+                    self.update_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.delete_bucket: gapic_v1.method.wrap_method(
+                    self.delete_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.undelete_bucket: gapic_v1.method.wrap_method(
+                    self.undelete_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_views: gapic_v1.method.wrap_method(
+                    self.list_views,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_view: gapic_v1.method.wrap_method(
+                    self.get_view,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_view: gapic_v1.method.wrap_method(
+                    self.create_view,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_view: gapic_v1.method.wrap_method(
+                    self.update_view,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.delete_view: gapic_v1.method.wrap_method(
+                    self.delete_view,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_sinks: gapic_v1.method.wrap_method(
+                    self.list_sinks,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_sink: gapic_v1.method.wrap_method(
+                    self.get_sink,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_sink: gapic_v1.method.wrap_method(
+                    self.create_sink,
+                    default_timeout=120.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_sink: gapic_v1.method.wrap_method(
+                    self.update_sink,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.delete_sink: gapic_v1.method.wrap_method(
+                    self.delete_sink,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_links: gapic_v1.method.wrap_method(
+                    self.list_links,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_link: gapic_v1.method.wrap_method(
+                    self.get_link,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_exclusions: gapic_v1.method.wrap_method(
+                    self.list_exclusions,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_exclusion: gapic_v1.method.wrap_method(
+                    self.get_exclusion,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_exclusion: gapic_v1.method.wrap_method(
+                    self.create_exclusion,
+                    default_timeout=120.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_exclusion: gapic_v1.method.wrap_method(
+                    self.update_exclusion,
+                    default_timeout=120.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.delete_exclusion: gapic_v1.method.wrap_method(
+                    self.delete_exclusion,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_cmek_settings: gapic_v1.method.wrap_method(
+                    self.get_cmek_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_cmek_settings: gapic_v1.method.wrap_method(
+                    self.update_cmek_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_settings: gapic_v1.method.wrap_method(
+                    self.get_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_settings: gapic_v1.method.wrap_method(
+                    self.update_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.list_buckets: gapic_v1.method.wrap_method(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/grpc_asyncio.py
@@ -1192,6 +1192,197 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_buckets: self._wrap_method(
+                    self.list_buckets,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_bucket: self._wrap_method(
+                    self.get_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_bucket: self._wrap_method(
+                    self.create_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_bucket: self._wrap_method(
+                    self.update_bucket,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_views: self._wrap_method(
+                    self.list_views,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_view: self._wrap_method(
+                    self.get_view,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_view: self._wrap_method(
+                    self.create_view,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_view: self._wrap_method(
+                    self.update_view,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_sinks: self._wrap_method(
+                    self.list_sinks,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_sink: self._wrap_method(
+                    self.get_sink,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_sink: self._wrap_method(
+                    self.create_sink,
+                    default_timeout=120.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_sink: self._wrap_method(
+                    self.update_sink,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_links: self._wrap_method(
+                    self.list_links,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_link: self._wrap_method(
+                    self.get_link,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_exclusions: self._wrap_method(
+                    self.list_exclusions,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_exclusion: self._wrap_method(
+                    self.get_exclusion,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_exclusion: self._wrap_method(
+                    self.create_exclusion,
+                    default_timeout=120.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_exclusion: self._wrap_method(
+                    self.update_exclusion,
+                    default_timeout=120.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_cmek_settings: self._wrap_method(
+                    self.get_cmek_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_cmek_settings: self._wrap_method(
+                    self.update_cmek_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_settings: self._wrap_method(
+                    self.get_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_settings: self._wrap_method(
+                    self.update_settings,
+                    default_timeout=None,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.list_buckets: self._wrap_method(
                 self.list_buckets,
@@ -1450,6 +1641,8 @@ class ConfigServiceV2GrpcAsyncIOTransport(ConfigServiceV2Transport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -38,9 +38,20 @@ from google.cloud.logging_v2.services.logging_service_v2 import pagers
 from google.cloud.logging_v2.types import log_entry
 from google.cloud.logging_v2.types import logging
 from google.longrunning import operations_pb2 # type: ignore
+from .transports.base import BaseCallMetadata
 from .transports.base import LoggingServiceV2Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import LoggingServiceV2GrpcAsyncIOTransport
 from .client import LoggingServiceV2Client
+
+
+class LoggingServiceV2AsyncClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class LoggingServiceV2AsyncClient:
@@ -314,11 +325,12 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_log]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_log]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_log]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -349,7 +361,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging.WriteLogEntriesResponse:
         r"""Writes log entries to Logging. This API method is the
         only way to send log entries to Logging. This method is
@@ -484,7 +496,7 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -520,18 +532,19 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.write_log_entries]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.write_log_entries]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.write_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -543,10 +556,16 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = LoggingServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -560,7 +579,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLogEntriesAsyncPager:
         r"""Lists log entries. Use this method to retrieve log entries that
         originated from a project/folder/organization/billing account.
@@ -651,7 +670,7 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -688,18 +707,19 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_log_entries]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_log_entries]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -711,10 +731,16 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = LoggingServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -736,7 +762,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListMonitoredResourceDescriptorsAsyncPager:
         r"""Lists the descriptors for monitored resource types
         used by Logging.
@@ -778,7 +804,7 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -800,18 +826,19 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_monitored_resource_descriptors]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_monitored_resource_descriptors]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_monitored_resource_descriptors]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -823,10 +850,16 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = LoggingServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -849,7 +882,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLogsAsyncPager:
         r"""Lists the logs in projects, organizations, folders,
         or billing accounts. Only logs that have entries are
@@ -903,7 +936,7 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -937,18 +970,19 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_logs]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_logs]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_logs]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -968,10 +1002,16 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = LoggingServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -1053,11 +1093,12 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.tail_log_entries]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.tail_log_entries]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.tail_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, AsyncIterable, Awaitable, AsyncIterator, Sequence, Tuple, Type, Union
+import warnings
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
@@ -313,7 +314,11 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_log]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_log]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_log]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -344,6 +349,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging.WriteLogEntriesResponse:
         r"""Writes log entries to Logging. This API method is the
         only way to send log entries to Logging. This method is
@@ -478,6 +484,10 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.WriteLogEntriesResponse:
@@ -510,7 +520,18 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.write_log_entries]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.write_log_entries]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.write_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -522,6 +543,10 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -535,6 +560,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLogEntriesAsyncPager:
         r"""Lists log entries. Use this method to retrieve log entries that
         originated from a project/folder/organization/billing account.
@@ -625,6 +651,10 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.logging_service_v2.pagers.ListLogEntriesAsyncPager:
@@ -658,7 +688,18 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_log_entries]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_log_entries]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -670,6 +711,10 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -691,6 +736,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListMonitoredResourceDescriptorsAsyncPager:
         r"""Lists the descriptors for monitored resource types
         used by Logging.
@@ -732,6 +778,10 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.logging_service_v2.pagers.ListMonitoredResourceDescriptorsAsyncPager:
@@ -750,7 +800,18 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_monitored_resource_descriptors]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_monitored_resource_descriptors]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_monitored_resource_descriptors]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()
@@ -762,6 +823,10 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -784,6 +849,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLogsAsyncPager:
         r"""Lists the logs in projects, organizations, folders,
         or billing accounts. Only logs that have entries are
@@ -837,6 +903,10 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.logging_service_v2.pagers.ListLogsAsyncPager:
@@ -867,7 +937,18 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_logs]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_logs]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_logs]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -887,6 +968,10 @@ class LoggingServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -968,7 +1053,11 @@ class LoggingServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.tail_log_entries]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.tail_log_entries]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.tail_log_entries]
 
         # Validate the universe domain.
         self._client._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -627,7 +627,12 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_log]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_log]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_log]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -658,6 +663,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging.WriteLogEntriesResponse:
         r"""Writes log entries to Logging. This API method is the
         only way to send log entries to Logging. This method is
@@ -792,6 +798,10 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.WriteLogEntriesResponse:
@@ -822,7 +832,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.write_log_entries]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.write_log_entries]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.write_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -834,6 +856,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -847,6 +874,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLogEntriesPager:
         r"""Lists log entries. Use this method to retrieve log entries that
         originated from a project/folder/organization/billing account.
@@ -937,6 +965,10 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.logging_service_v2.pagers.ListLogEntriesPager:
@@ -969,7 +1001,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_log_entries]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_log_entries]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -981,6 +1025,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1002,6 +1051,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListMonitoredResourceDescriptorsPager:
         r"""Lists the descriptors for monitored resource types
         used by Logging.
@@ -1043,6 +1093,10 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.logging_service_v2.pagers.ListMonitoredResourceDescriptorsPager:
@@ -1061,7 +1115,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_monitored_resource_descriptors]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_monitored_resource_descriptors]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_monitored_resource_descriptors]
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1073,6 +1139,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1095,6 +1166,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLogsPager:
         r"""Lists the logs in projects, organizations, folders,
         or billing accounts. Only logs that have entries are
@@ -1148,6 +1220,10 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.logging_service_v2.pagers.ListLogsPager:
@@ -1177,7 +1253,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_logs]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_logs]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_logs]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1197,6 +1285,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1278,7 +1371,12 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.tail_log_entries]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.tail_log_entries]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.tail_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -44,6 +44,17 @@ from google.longrunning import operations_pb2 # type: ignore
 from .transports.base import LoggingServiceV2Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc import LoggingServiceV2GrpcTransport
 from .transports.grpc_asyncio import LoggingServiceV2GrpcAsyncIOTransport
+from .transports.base import BaseCallMetadata
+
+
+class LoggingServiceV2ClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class LoggingServiceV2ClientMeta(type):
@@ -627,12 +638,12 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_log]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_log]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_log]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -663,7 +674,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging.WriteLogEntriesResponse:
         r"""Writes log entries to Logging. This API method is the
         only way to send log entries to Logging. This method is
@@ -798,7 +809,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -832,19 +843,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.write_log_entries]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.write_log_entries]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.write_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -857,10 +868,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = LoggingServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -874,7 +886,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLogEntriesPager:
         r"""Lists log entries. Use this method to retrieve log entries that
         originated from a project/folder/organization/billing account.
@@ -965,7 +977,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1001,19 +1013,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_log_entries]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_log_entries]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1026,10 +1038,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = LoggingServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1051,7 +1064,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListMonitoredResourceDescriptorsPager:
         r"""Lists the descriptors for monitored resource types
         used by Logging.
@@ -1093,7 +1106,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1115,19 +1128,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_monitored_resource_descriptors]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_monitored_resource_descriptors]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_monitored_resource_descriptors]
 
         # Validate the universe domain.
         self._validate_universe_domain()
@@ -1140,10 +1153,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = LoggingServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1166,7 +1180,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLogsPager:
         r"""Lists the logs in projects, organizations, folders,
         or billing accounts. Only logs that have entries are
@@ -1220,7 +1234,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1253,19 +1267,19 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_logs]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_logs]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_logs]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1286,10 +1300,11 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = LoggingServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -1371,12 +1386,12 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.tail_log_entries]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.tail_log_entries]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.tail_log_entries]
 
         # Validate the universe domain.
         self._validate_universe_domain()

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -15,7 +15,7 @@
 #
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
@@ -33,6 +33,18 @@ from google.protobuf import empty_pb2  # type: ignore
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class LoggingServiceV2Transport(abc.ABC):
     """Abstract transport class for LoggingServiceV2."""

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 from google.cloud.logging_v2 import gapic_version as package_version
@@ -123,6 +124,95 @@ class LoggingServiceV2Transport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.delete_log: gapic_v1.method.wrap_method(
+                    self.delete_log,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.write_log_entries: gapic_v1.method.wrap_method(
+                    self.write_log_entries,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_log_entries: gapic_v1.method.wrap_method(
+                    self.list_log_entries,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_monitored_resource_descriptors: gapic_v1.method.wrap_method(
+                    self.list_monitored_resource_descriptors,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_logs: gapic_v1.method.wrap_method(
+                    self.list_logs,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.delete_log: gapic_v1.method.wrap_method(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/grpc_asyncio.py
@@ -416,6 +416,78 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.write_log_entries: self._wrap_method(
+                    self.write_log_entries,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_log_entries: self._wrap_method(
+                    self.list_log_entries,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_monitored_resource_descriptors: self._wrap_method(
+                    self.list_monitored_resource_descriptors,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.list_logs: self._wrap_method(
+                    self.list_logs,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.delete_log: self._wrap_method(
                 self.delete_log,
@@ -533,6 +605,8 @@ class LoggingServiceV2GrpcAsyncIOTransport(LoggingServiceV2Transport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -39,9 +39,20 @@ from google.cloud.logging_v2.services.metrics_service_v2 import pagers
 from google.cloud.logging_v2.types import logging_metrics
 from google.longrunning import operations_pb2 # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
+from .transports.base import BaseCallMetadata
 from .transports.base import MetricsServiceV2Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import MetricsServiceV2GrpcAsyncIOTransport
 from .client import MetricsServiceV2Client
+
+
+class MetricsServiceV2AsyncClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class MetricsServiceV2AsyncClient:
@@ -236,7 +247,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLogMetricsAsyncPager:
         r"""Lists logs-based metrics.
 
@@ -288,7 +299,7 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -322,18 +333,19 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_log_metrics]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_log_metrics]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_log_metrics]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -353,10 +365,16 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = MetricsServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -379,7 +397,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Gets a logs-based metric.
 
@@ -429,7 +447,7 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -470,18 +488,19 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_log_metric]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_log_metric]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -501,10 +520,16 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = MetricsServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -517,7 +542,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates a logs-based metric.
 
@@ -583,7 +608,7 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -626,18 +651,19 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_log_metric]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_log_metric]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -657,10 +683,16 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = MetricsServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -673,7 +705,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates or updates a logs-based metric.
 
@@ -738,7 +770,7 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -781,18 +813,19 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_log_metric]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_log_metric]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -812,10 +845,16 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = MetricsServiceV2AsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -894,11 +933,12 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_log_metric]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_log_metric]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/async_client.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
+import warnings
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
@@ -235,6 +236,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLogMetricsAsyncPager:
         r"""Lists logs-based metrics.
 
@@ -286,6 +288,10 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.metrics_service_v2.pagers.ListLogMetricsAsyncPager:
@@ -316,7 +322,18 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_log_metrics]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_log_metrics]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_log_metrics]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -336,6 +353,10 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -358,6 +379,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Gets a logs-based metric.
 
@@ -407,6 +429,10 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogMetric:
@@ -444,7 +470,18 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_log_metric]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_log_metric]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -464,6 +501,10 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -476,6 +517,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates a logs-based metric.
 
@@ -541,6 +583,10 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogMetric:
@@ -580,7 +626,18 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_log_metric]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_log_metric]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -600,6 +657,10 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -612,6 +673,7 @@ class MetricsServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates or updates a logs-based metric.
 
@@ -676,6 +738,10 @@ class MetricsServiceV2AsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogMetric:
@@ -715,7 +781,18 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_log_metric]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_log_metric]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -735,6 +812,10 @@ class MetricsServiceV2AsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -813,7 +894,11 @@ class MetricsServiceV2AsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_log_metric]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_log_metric]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -45,6 +45,17 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from .transports.base import MetricsServiceV2Transport, DEFAULT_CLIENT_INFO
 from .transports.grpc import MetricsServiceV2GrpcTransport
 from .transports.grpc_asyncio import MetricsServiceV2GrpcAsyncIOTransport
+from .transports.base import BaseCallMetadata
+
+
+class MetricsServiceV2ClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class MetricsServiceV2ClientMeta(type):
@@ -550,7 +561,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListLogMetricsPager:
         r"""Lists logs-based metrics.
 
@@ -602,7 +613,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -635,19 +646,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_log_metrics]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_log_metrics]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_log_metrics]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -668,10 +679,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = MetricsServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -694,7 +706,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Gets a logs-based metric.
 
@@ -744,7 +756,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -784,19 +796,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_log_metric]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_log_metric]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -817,10 +829,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = MetricsServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -833,7 +846,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates a logs-based metric.
 
@@ -899,7 +912,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -941,19 +954,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_log_metric]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_log_metric]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -974,10 +987,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = MetricsServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -990,7 +1004,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates or updates a logs-based metric.
 
@@ -1055,7 +1069,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -1097,19 +1111,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_log_metric]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_log_metric]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1130,10 +1144,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = MetricsServiceV2ClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1211,12 +1226,12 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_log_metric]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_log_metric]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -550,6 +550,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListLogMetricsPager:
         r"""Lists logs-based metrics.
 
@@ -601,6 +602,10 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.services.metrics_service_v2.pagers.ListLogMetricsPager:
@@ -630,7 +635,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_log_metrics]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_log_metrics]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_log_metrics]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -650,6 +667,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -672,6 +694,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Gets a logs-based metric.
 
@@ -721,6 +744,10 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogMetric:
@@ -757,7 +784,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_log_metric]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_log_metric]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -778,6 +817,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -789,6 +833,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates a logs-based metric.
 
@@ -854,6 +899,10 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogMetric:
@@ -892,7 +941,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_log_metric]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_log_metric]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -913,6 +974,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -924,6 +990,7 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> logging_metrics.LogMetric:
         r"""Creates or updates a logs-based metric.
 
@@ -988,6 +1055,10 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.logging_v2.types.LogMetric:
@@ -1026,7 +1097,19 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_log_metric]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_log_metric]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1046,6 +1129,11 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1123,7 +1211,12 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_log_metric]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_log_metric]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_log_metric]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 from google.cloud.logging_v2 import gapic_version as package_version
@@ -123,6 +124,84 @@ class MetricsServiceV2Transport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_log_metrics: gapic_v1.method.wrap_method(
+                    self.list_log_metrics,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_log_metric: gapic_v1.method.wrap_method(
+                    self.get_log_metric,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_log_metric: gapic_v1.method.wrap_method(
+                    self.create_log_metric,
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_log_metric: gapic_v1.method.wrap_method(
+                    self.update_log_metric,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.delete_log_metric: gapic_v1.method.wrap_method(
+                    self.delete_log_metric,
+                    default_retry=retries.Retry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.list_log_metrics: gapic_v1.method.wrap_method(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -15,7 +15,7 @@
 #
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
@@ -33,6 +33,18 @@ from google.protobuf import empty_pb2  # type: ignore
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class MetricsServiceV2Transport(abc.ABC):
     """Abstract transport class for MetricsServiceV2."""

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/grpc_asyncio.py
@@ -371,6 +371,67 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_log_metrics: self._wrap_method(
+                    self.list_log_metrics,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_log_metric: self._wrap_method(
+                    self.get_log_metric,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.create_log_metric: self._wrap_method(
+                    self.create_log_metric,
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.update_log_metric: self._wrap_method(
+                    self.update_log_metric,
+                    default_retry=retries.AsyncRetry(
+                        initial=0.1,
+                        maximum=60.0,
+                        multiplier=1.3,
+                        predicate=retries.if_exception_type(
+                            core_exceptions.DeadlineExceeded,
+                            core_exceptions.InternalServerError,
+                            core_exceptions.ServiceUnavailable,
+                        ),
+                        deadline=60.0,
+                    ),
+                    default_timeout=60.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.list_log_metrics: self._wrap_method(
                 self.list_log_metrics,
@@ -461,6 +522,8 @@ class MetricsServiceV2GrpcAsyncIOTransport(MetricsServiceV2Transport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -11611,13 +11611,14 @@ def test_list_buckets_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_buckets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListBucketsPager)
 
 def test_get_bucket_with_metadata_callback_grpc():
@@ -11641,13 +11642,14 @@ def test_get_bucket_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_bucket(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogBucket)
 
 def test_create_bucket_with_metadata_callback_grpc():
@@ -11671,13 +11673,14 @@ def test_create_bucket_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.create_bucket(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogBucket)
 
 def test_update_bucket_with_metadata_callback_grpc():
@@ -11701,13 +11704,14 @@ def test_update_bucket_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_bucket(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogBucket)
 
 def test_list_views_with_metadata_callback_grpc():
@@ -11725,13 +11729,14 @@ def test_list_views_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_views(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListViewsPager)
 
 def test_get_view_with_metadata_callback_grpc():
@@ -11751,13 +11756,14 @@ def test_get_view_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_view(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogView)
 
 def test_create_view_with_metadata_callback_grpc():
@@ -11777,13 +11783,14 @@ def test_create_view_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.create_view(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogView)
 
 def test_update_view_with_metadata_callback_grpc():
@@ -11803,13 +11810,14 @@ def test_update_view_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_view(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogView)
 
 def test_list_sinks_with_metadata_callback_grpc():
@@ -11827,13 +11835,14 @@ def test_list_sinks_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_sinks(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListSinksPager)
 
 def test_get_sink_with_metadata_callback_grpc():
@@ -11858,13 +11867,14 @@ def test_get_sink_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_sink(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogSink)
 
 def test_create_sink_with_metadata_callback_grpc():
@@ -11889,13 +11899,14 @@ def test_create_sink_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.create_sink(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogSink)
 
 def test_update_sink_with_metadata_callback_grpc():
@@ -11920,13 +11931,14 @@ def test_update_sink_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_sink(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogSink)
 
 def test_list_links_with_metadata_callback_grpc():
@@ -11944,13 +11956,14 @@ def test_list_links_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_links(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLinksPager)
 
 def test_get_link_with_metadata_callback_grpc():
@@ -11970,13 +11983,14 @@ def test_get_link_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_link(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.Link)
 
 def test_list_exclusions_with_metadata_callback_grpc():
@@ -11994,13 +12008,14 @@ def test_list_exclusions_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_exclusions(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListExclusionsPager)
 
 def test_get_exclusion_with_metadata_callback_grpc():
@@ -12021,13 +12036,14 @@ def test_get_exclusion_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_exclusion(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogExclusion)
 
 def test_create_exclusion_with_metadata_callback_grpc():
@@ -12048,13 +12064,14 @@ def test_create_exclusion_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.create_exclusion(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogExclusion)
 
 def test_update_exclusion_with_metadata_callback_grpc():
@@ -12075,13 +12092,14 @@ def test_update_exclusion_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_exclusion(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogExclusion)
 
 def test_get_cmek_settings_with_metadata_callback_grpc():
@@ -12102,13 +12120,14 @@ def test_get_cmek_settings_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_cmek_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.CmekSettings)
 
 def test_update_cmek_settings_with_metadata_callback_grpc():
@@ -12129,13 +12148,14 @@ def test_update_cmek_settings_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_cmek_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.CmekSettings)
 
 def test_get_settings_with_metadata_callback_grpc():
@@ -12157,13 +12177,14 @@ def test_get_settings_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.Settings)
 
 def test_update_settings_with_metadata_callback_grpc():
@@ -12185,13 +12206,14 @@ def test_update_settings_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.Settings)
 
 
@@ -13767,13 +13789,14 @@ async def test_list_buckets_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_buckets), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_buckets(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListBucketsAsyncPager)
 
 @pytest.mark.asyncio
@@ -13798,13 +13821,14 @@ async def test_get_bucket_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_bucket), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_bucket(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogBucket)
 
 @pytest.mark.asyncio
@@ -13829,13 +13853,14 @@ async def test_create_bucket_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.create_bucket), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.create_bucket(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogBucket)
 
 @pytest.mark.asyncio
@@ -13860,13 +13885,14 @@ async def test_update_bucket_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_bucket), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_bucket(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogBucket)
 
 @pytest.mark.asyncio
@@ -13885,13 +13911,14 @@ async def test_list_views_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_views), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_views(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListViewsAsyncPager)
 
 @pytest.mark.asyncio
@@ -13912,13 +13939,14 @@ async def test_get_view_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_view), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_view(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogView)
 
 @pytest.mark.asyncio
@@ -13939,13 +13967,14 @@ async def test_create_view_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.create_view), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.create_view(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogView)
 
 @pytest.mark.asyncio
@@ -13966,13 +13995,14 @@ async def test_update_view_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_view), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_view(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogView)
 
 @pytest.mark.asyncio
@@ -13991,13 +14021,14 @@ async def test_list_sinks_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_sinks), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_sinks(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListSinksAsyncPager)
 
 @pytest.mark.asyncio
@@ -14023,13 +14054,14 @@ async def test_get_sink_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_sink), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_sink(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogSink)
 
 @pytest.mark.asyncio
@@ -14055,13 +14087,14 @@ async def test_create_sink_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.create_sink), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.create_sink(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogSink)
 
 @pytest.mark.asyncio
@@ -14087,13 +14120,14 @@ async def test_update_sink_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_sink), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_sink(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogSink)
 
 @pytest.mark.asyncio
@@ -14112,13 +14146,14 @@ async def test_list_links_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_links), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_links(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLinksAsyncPager)
 
 @pytest.mark.asyncio
@@ -14139,13 +14174,14 @@ async def test_get_link_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_link), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_link(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.Link)
 
 @pytest.mark.asyncio
@@ -14164,13 +14200,14 @@ async def test_list_exclusions_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_exclusions), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_exclusions(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListExclusionsAsyncPager)
 
 @pytest.mark.asyncio
@@ -14192,13 +14229,14 @@ async def test_get_exclusion_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_exclusion), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_exclusion(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogExclusion)
 
 @pytest.mark.asyncio
@@ -14220,13 +14258,14 @@ async def test_create_exclusion_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.create_exclusion), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.create_exclusion(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogExclusion)
 
 @pytest.mark.asyncio
@@ -14248,13 +14287,14 @@ async def test_update_exclusion_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_exclusion), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_exclusion(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.LogExclusion)
 
 @pytest.mark.asyncio
@@ -14276,13 +14316,14 @@ async def test_get_cmek_settings_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_cmek_settings), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_cmek_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.CmekSettings)
 
 @pytest.mark.asyncio
@@ -14304,13 +14345,14 @@ async def test_update_cmek_settings_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_cmek_settings), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_cmek_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.CmekSettings)
 
 @pytest.mark.asyncio
@@ -14333,13 +14375,14 @@ async def test_get_settings_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_settings), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.Settings)
 
 @pytest.mark.asyncio
@@ -14362,13 +14405,14 @@ async def test_update_settings_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_settings), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_settings(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_config.Settings)
 
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -11596,6 +11596,1222 @@ def test_copy_log_entries_empty_call_grpc():
         assert args[0] == request_msg
 
 
+def test_list_buckets_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.ListBucketsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_buckets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListBucketsPager)
+
+def test_get_bucket_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogBucket(
+        name='name_value',
+        description='description_value',
+        retention_days=1512,
+        locked=True,
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+        analytics_enabled=True,
+        restricted_fields=['restricted_fields_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_bucket(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogBucket)
+
+def test_create_bucket_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogBucket(
+        name='name_value',
+        description='description_value',
+        retention_days=1512,
+        locked=True,
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+        analytics_enabled=True,
+        restricted_fields=['restricted_fields_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.create_bucket(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogBucket)
+
+def test_update_bucket_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogBucket(
+        name='name_value',
+        description='description_value',
+        retention_days=1512,
+        locked=True,
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+        analytics_enabled=True,
+        restricted_fields=['restricted_fields_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_bucket(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogBucket)
+
+def test_list_views_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.ListViewsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_views(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListViewsPager)
+
+def test_get_view_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogView(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_view(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogView)
+
+def test_create_view_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogView(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.create_view(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogView)
+
+def test_update_view_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogView(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_view(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogView)
+
+def test_list_sinks_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.ListSinksResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_sinks(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListSinksPager)
+
+def test_get_sink_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogSink(
+        name='name_value',
+        destination='destination_value',
+        filter='filter_value',
+        description='description_value',
+        disabled=True,
+        output_version_format=logging_config.LogSink.VersionFormat.V2,
+        writer_identity='writer_identity_value',
+        include_children=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_sink(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogSink)
+
+def test_create_sink_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogSink(
+        name='name_value',
+        destination='destination_value',
+        filter='filter_value',
+        description='description_value',
+        disabled=True,
+        output_version_format=logging_config.LogSink.VersionFormat.V2,
+        writer_identity='writer_identity_value',
+        include_children=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.create_sink(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogSink)
+
+def test_update_sink_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogSink(
+        name='name_value',
+        destination='destination_value',
+        filter='filter_value',
+        description='description_value',
+        disabled=True,
+        output_version_format=logging_config.LogSink.VersionFormat.V2,
+        writer_identity='writer_identity_value',
+        include_children=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_sink(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogSink)
+
+def test_list_links_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.ListLinksResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_links(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLinksPager)
+
+def test_get_link_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.Link(
+        name='name_value',
+        description='description_value',
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_link(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.Link)
+
+def test_list_exclusions_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.ListExclusionsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_exclusions(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListExclusionsPager)
+
+def test_get_exclusion_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogExclusion(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        disabled=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_exclusion(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogExclusion)
+
+def test_create_exclusion_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogExclusion(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        disabled=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.create_exclusion(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogExclusion)
+
+def test_update_exclusion_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.LogExclusion(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        disabled=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_exclusion(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogExclusion)
+
+def test_get_cmek_settings_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.CmekSettings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_key_version_name='kms_key_version_name_value',
+        service_account_id='service_account_id_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_cmek_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.CmekSettings)
+
+def test_update_cmek_settings_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.CmekSettings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_key_version_name='kms_key_version_name_value',
+        service_account_id='service_account_id_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_cmek_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.CmekSettings)
+
+def test_get_settings_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.Settings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_service_account_id='kms_service_account_id_value',
+        storage_location='storage_location_value',
+        disable_default_sink=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.Settings)
+
+def test_update_settings_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_config.Settings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_service_account_id='kms_service_account_id_value',
+        storage_location='storage_location_value',
+        disable_default_sink=True,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.Settings)
+
+
+def test_list_buckets_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.ListBucketsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_buckets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListBucketsPager)
+
+def test_get_bucket_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogBucket()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_bucket(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogBucket)
+
+def test_create_bucket_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogBucket()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_bucket(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogBucket)
+
+def test_update_bucket_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogBucket()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_bucket(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogBucket)
+
+def test_list_views_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.ListViewsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_views(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListViewsPager)
+
+def test_get_view_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogView()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_view(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogView)
+
+def test_create_view_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogView()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_view(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogView)
+
+def test_update_view_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogView()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_view(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogView)
+
+def test_list_sinks_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.ListSinksResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_sinks(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListSinksPager)
+
+def test_get_sink_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogSink()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_sink(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogSink)
+
+def test_create_sink_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogSink()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_sink(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogSink)
+
+def test_update_sink_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogSink()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_sink(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogSink)
+
+def test_list_links_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.ListLinksResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_links(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLinksPager)
+
+def test_get_link_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.Link()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_link(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.Link)
+
+def test_list_exclusions_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.ListExclusionsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_exclusions(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListExclusionsPager)
+
+def test_get_exclusion_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogExclusion()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_exclusion(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogExclusion)
+
+def test_create_exclusion_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogExclusion()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_exclusion(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogExclusion)
+
+def test_update_exclusion_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.LogExclusion()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_exclusion(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogExclusion)
+
+def test_get_cmek_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.CmekSettings()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_cmek_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.CmekSettings)
+
+def test_update_cmek_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.CmekSettings()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_cmek_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.CmekSettings)
+
+def test_get_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.Settings()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.Settings)
+
+def test_update_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_config.Settings()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.Settings)
+
+
 def test_transport_kind_grpc_asyncio():
     transport = ConfigServiceV2AsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
@@ -12535,10 +13751,1293 @@ async def test_copy_log_entries_empty_call_grpc_asyncio():
         assert args[0] == request_msg
 
 
+@pytest.mark.asyncio
+async def test_list_buckets_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.ListBucketsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_buckets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_buckets(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListBucketsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_bucket_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogBucket(
+        name='name_value',
+        description='description_value',
+        retention_days=1512,
+        locked=True,
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+        analytics_enabled=True,
+        restricted_fields=['restricted_fields_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.get_bucket), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_bucket(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogBucket)
+
+@pytest.mark.asyncio
+async def test_create_bucket_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogBucket(
+        name='name_value',
+        description='description_value',
+        retention_days=1512,
+        locked=True,
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+        analytics_enabled=True,
+        restricted_fields=['restricted_fields_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.create_bucket), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.create_bucket(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogBucket)
+
+@pytest.mark.asyncio
+async def test_update_bucket_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogBucket(
+        name='name_value',
+        description='description_value',
+        retention_days=1512,
+        locked=True,
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+        analytics_enabled=True,
+        restricted_fields=['restricted_fields_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.update_bucket), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_bucket(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogBucket)
+
+@pytest.mark.asyncio
+async def test_list_views_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.ListViewsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_views), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_views(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListViewsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_view_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogView(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_view), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_view(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogView)
+
+@pytest.mark.asyncio
+async def test_create_view_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogView(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+    )
+    with mock.patch.object(
+        type(client.transport.create_view), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.create_view(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogView)
+
+@pytest.mark.asyncio
+async def test_update_view_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogView(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+    )
+    with mock.patch.object(
+        type(client.transport.update_view), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_view(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogView)
+
+@pytest.mark.asyncio
+async def test_list_sinks_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.ListSinksResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_sinks), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_sinks(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListSinksAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_sink_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogSink(
+        name='name_value',
+        destination='destination_value',
+        filter='filter_value',
+        description='description_value',
+        disabled=True,
+        output_version_format=logging_config.LogSink.VersionFormat.V2,
+        writer_identity='writer_identity_value',
+        include_children=True,
+    )
+    with mock.patch.object(
+        type(client.transport.get_sink), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_sink(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogSink)
+
+@pytest.mark.asyncio
+async def test_create_sink_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogSink(
+        name='name_value',
+        destination='destination_value',
+        filter='filter_value',
+        description='description_value',
+        disabled=True,
+        output_version_format=logging_config.LogSink.VersionFormat.V2,
+        writer_identity='writer_identity_value',
+        include_children=True,
+    )
+    with mock.patch.object(
+        type(client.transport.create_sink), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.create_sink(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogSink)
+
+@pytest.mark.asyncio
+async def test_update_sink_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogSink(
+        name='name_value',
+        destination='destination_value',
+        filter='filter_value',
+        description='description_value',
+        disabled=True,
+        output_version_format=logging_config.LogSink.VersionFormat.V2,
+        writer_identity='writer_identity_value',
+        include_children=True,
+    )
+    with mock.patch.object(
+        type(client.transport.update_sink), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_sink(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogSink)
+
+@pytest.mark.asyncio
+async def test_list_links_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.ListLinksResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_links), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_links(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLinksAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_link_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.Link(
+        name='name_value',
+        description='description_value',
+        lifecycle_state=logging_config.LifecycleState.ACTIVE,
+    )
+    with mock.patch.object(
+        type(client.transport.get_link), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_link(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.Link)
+
+@pytest.mark.asyncio
+async def test_list_exclusions_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.ListExclusionsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_exclusions), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_exclusions(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListExclusionsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_exclusion_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogExclusion(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        disabled=True,
+    )
+    with mock.patch.object(
+        type(client.transport.get_exclusion), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_exclusion(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogExclusion)
+
+@pytest.mark.asyncio
+async def test_create_exclusion_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogExclusion(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        disabled=True,
+    )
+    with mock.patch.object(
+        type(client.transport.create_exclusion), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.create_exclusion(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogExclusion)
+
+@pytest.mark.asyncio
+async def test_update_exclusion_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.LogExclusion(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        disabled=True,
+    )
+    with mock.patch.object(
+        type(client.transport.update_exclusion), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_exclusion(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.LogExclusion)
+
+@pytest.mark.asyncio
+async def test_get_cmek_settings_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.CmekSettings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_key_version_name='kms_key_version_name_value',
+        service_account_id='service_account_id_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_cmek_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_cmek_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.CmekSettings)
+
+@pytest.mark.asyncio
+async def test_update_cmek_settings_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.CmekSettings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_key_version_name='kms_key_version_name_value',
+        service_account_id='service_account_id_value',
+    )
+    with mock.patch.object(
+        type(client.transport.update_cmek_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_cmek_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.CmekSettings)
+
+@pytest.mark.asyncio
+async def test_get_settings_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.Settings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_service_account_id='kms_service_account_id_value',
+        storage_location='storage_location_value',
+        disable_default_sink=True,
+    )
+    with mock.patch.object(
+        type(client.transport.get_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.Settings)
+
+@pytest.mark.asyncio
+async def test_update_settings_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_config.Settings(
+        name='name_value',
+        kms_key_name='kms_key_name_value',
+        kms_service_account_id='kms_service_account_id_value',
+        storage_location='storage_location_value',
+        disable_default_sink=True,
+    )
+    with mock.patch.object(
+        type(client.transport.update_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_settings(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_config.Settings)
+
+
+@pytest.mark.asyncio
+async def test_list_buckets_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_buckets), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListBucketsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_buckets(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListBucketsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_bucket_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_bucket), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogBucket())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_bucket(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogBucket)
+
+@pytest.mark.asyncio
+async def test_create_bucket_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.create_bucket), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogBucket())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.create_bucket(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogBucket)
+
+@pytest.mark.asyncio
+async def test_update_bucket_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_bucket), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogBucket())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_bucket(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogBucket)
+
+@pytest.mark.asyncio
+async def test_list_views_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_views), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListViewsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_views(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListViewsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_view_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_view), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogView())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_view(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogView)
+
+@pytest.mark.asyncio
+async def test_create_view_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.create_view), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogView())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.create_view(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogView)
+
+@pytest.mark.asyncio
+async def test_update_view_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_view), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogView())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_view(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogView)
+
+@pytest.mark.asyncio
+async def test_list_sinks_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_sinks), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListSinksResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_sinks(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListSinksAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_sink_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_sink), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogSink())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_sink(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogSink)
+
+@pytest.mark.asyncio
+async def test_create_sink_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.create_sink), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogSink())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.create_sink(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogSink)
+
+@pytest.mark.asyncio
+async def test_update_sink_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_sink), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogSink())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_sink(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogSink)
+
+@pytest.mark.asyncio
+async def test_list_links_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_links), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListLinksResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_links(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLinksAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_link_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_link), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.Link())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_link(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.Link)
+
+@pytest.mark.asyncio
+async def test_list_exclusions_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_exclusions), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.ListExclusionsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_exclusions(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListExclusionsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_exclusion_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_exclusion), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogExclusion())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_exclusion(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogExclusion)
+
+@pytest.mark.asyncio
+async def test_create_exclusion_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.create_exclusion), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogExclusion())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.create_exclusion(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogExclusion)
+
+@pytest.mark.asyncio
+async def test_update_exclusion_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_exclusion), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.LogExclusion())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_exclusion(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.LogExclusion)
+
+@pytest.mark.asyncio
+async def test_get_cmek_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_cmek_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.CmekSettings())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_cmek_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.CmekSettings)
+
+@pytest.mark.asyncio
+async def test_update_cmek_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_cmek_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.CmekSettings())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_cmek_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.CmekSettings)
+
+@pytest.mark.asyncio
+async def test_get_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.Settings())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.Settings)
+
+@pytest.mark.asyncio
+async def test_update_settings_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = ConfigServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_settings), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_config.Settings())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_settings(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_config.Settings)
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = ConfigServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -2963,6 +2963,216 @@ def test_list_logs_empty_call_grpc():
         assert args[0] == request_msg
 
 
+def test_write_log_entries_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging.WriteLogEntriesResponse(
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.write_log_entries(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging.WriteLogEntriesResponse)
+
+def test_list_log_entries_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging.ListLogEntriesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_log_entries(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLogEntriesPager)
+
+def test_list_monitored_resource_descriptors_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging.ListMonitoredResourceDescriptorsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_monitored_resource_descriptors(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListMonitoredResourceDescriptorsPager)
+
+def test_list_logs_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging.ListLogsResponse(
+        log_names=['log_names_value'],
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_logs(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLogsPager)
+
+
+def test_write_log_entries_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging.WriteLogEntriesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.write_log_entries(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging.WriteLogEntriesResponse)
+
+def test_list_log_entries_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging.ListLogEntriesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_log_entries(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLogEntriesPager)
+
+def test_list_monitored_resource_descriptors_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging.ListMonitoredResourceDescriptorsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_monitored_resource_descriptors(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListMonitoredResourceDescriptorsPager)
+
+def test_list_logs_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging.ListLogsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_logs(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLogsPager)
+
+
 def test_transport_kind_grpc_asyncio():
     transport = LoggingServiceV2AsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
@@ -3111,10 +3321,233 @@ async def test_list_logs_empty_call_grpc_asyncio():
         assert args[0] == request_msg
 
 
+@pytest.mark.asyncio
+async def test_write_log_entries_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging.WriteLogEntriesResponse(
+    )
+    with mock.patch.object(
+        type(client.transport.write_log_entries), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.write_log_entries(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging.WriteLogEntriesResponse)
+
+@pytest.mark.asyncio
+async def test_list_log_entries_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging.ListLogEntriesResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_log_entries), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_log_entries(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLogEntriesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_list_monitored_resource_descriptors_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging.ListMonitoredResourceDescriptorsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_monitored_resource_descriptors), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_monitored_resource_descriptors(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListMonitoredResourceDescriptorsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_list_logs_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging.ListLogsResponse(
+        log_names=['log_names_value'],
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_logs), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_logs(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLogsAsyncPager)
+
+
+@pytest.mark.asyncio
+async def test_write_log_entries_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.write_log_entries), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging.WriteLogEntriesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.write_log_entries(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging.WriteLogEntriesResponse)
+
+@pytest.mark.asyncio
+async def test_list_log_entries_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_log_entries), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging.ListLogEntriesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_log_entries(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLogEntriesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_list_monitored_resource_descriptors_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_monitored_resource_descriptors), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging.ListMonitoredResourceDescriptorsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_monitored_resource_descriptors(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListMonitoredResourceDescriptorsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_list_logs_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = LoggingServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_logs), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging.ListLogsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_logs(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLogsAsyncPager)
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = LoggingServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -2977,13 +2977,14 @@ def test_write_log_entries_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.write_log_entries(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging.WriteLogEntriesResponse)
 
 def test_list_log_entries_with_metadata_callback_grpc():
@@ -3001,13 +3002,14 @@ def test_list_log_entries_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_log_entries(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLogEntriesPager)
 
 def test_list_monitored_resource_descriptors_with_metadata_callback_grpc():
@@ -3025,13 +3027,14 @@ def test_list_monitored_resource_descriptors_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_monitored_resource_descriptors(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListMonitoredResourceDescriptorsPager)
 
 def test_list_logs_with_metadata_callback_grpc():
@@ -3050,13 +3053,14 @@ def test_list_logs_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_logs(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLogsPager)
 
 
@@ -3336,13 +3340,14 @@ async def test_write_log_entries_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.write_log_entries), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.write_log_entries(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging.WriteLogEntriesResponse)
 
 @pytest.mark.asyncio
@@ -3361,13 +3366,14 @@ async def test_list_log_entries_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_log_entries), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_log_entries(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLogEntriesAsyncPager)
 
 @pytest.mark.asyncio
@@ -3386,13 +3392,14 @@ async def test_list_monitored_resource_descriptors_with_metadata_callback_grpc_a
     with mock.patch.object(
         type(client.transport.list_monitored_resource_descriptors), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_monitored_resource_descriptors(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListMonitoredResourceDescriptorsAsyncPager)
 
 @pytest.mark.asyncio
@@ -3412,13 +3419,14 @@ async def test_list_logs_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_logs), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_logs(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLogsAsyncPager)
 
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2765,13 +2765,14 @@ def test_list_log_metrics_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_log_metrics(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLogMetricsPager)
 
 def test_get_log_metric_with_metadata_callback_grpc():
@@ -2795,13 +2796,14 @@ def test_get_log_metric_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_log_metric(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_metrics.LogMetric)
 
 def test_create_log_metric_with_metadata_callback_grpc():
@@ -2825,13 +2827,14 @@ def test_create_log_metric_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.create_log_metric(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_metrics.LogMetric)
 
 def test_update_log_metric_with_metadata_callback_grpc():
@@ -2855,13 +2858,14 @@ def test_update_log_metric_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.update_log_metric(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_metrics.LogMetric)
 
 
@@ -3160,13 +3164,14 @@ async def test_list_log_metrics_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_log_metrics), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_log_metrics(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListLogMetricsAsyncPager)
 
 @pytest.mark.asyncio
@@ -3191,13 +3196,14 @@ async def test_get_log_metric_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_log_metric), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_log_metric(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_metrics.LogMetric)
 
 @pytest.mark.asyncio
@@ -3222,13 +3228,14 @@ async def test_create_log_metric_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.create_log_metric), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.create_log_metric(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_metrics.LogMetric)
 
 @pytest.mark.asyncio
@@ -3253,13 +3260,14 @@ async def test_update_log_metric_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.update_log_metric), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.update_log_metric(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, logging_metrics.LogMetric)
 
 

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -2750,6 +2750,234 @@ def test_delete_log_metric_empty_call_grpc():
         assert args[0] == request_msg
 
 
+def test_list_log_metrics_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_metrics.ListLogMetricsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_log_metrics(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLogMetricsPager)
+
+def test_get_log_metric_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_metrics.LogMetric(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        bucket_name='bucket_name_value',
+        disabled=True,
+        value_extractor='value_extractor_value',
+        version=logging_metrics.LogMetric.ApiVersion.V1,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_log_metric(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_metrics.LogMetric)
+
+def test_create_log_metric_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_metrics.LogMetric(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        bucket_name='bucket_name_value',
+        disabled=True,
+        value_extractor='value_extractor_value',
+        version=logging_metrics.LogMetric.ApiVersion.V1,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.create_log_metric(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_metrics.LogMetric)
+
+def test_update_log_metric_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = logging_metrics.LogMetric(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        bucket_name='bucket_name_value',
+        disabled=True,
+        value_extractor='value_extractor_value',
+        version=logging_metrics.LogMetric.ApiVersion.V1,
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.update_log_metric(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_metrics.LogMetric)
+
+
+def test_list_log_metrics_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_metrics.ListLogMetricsResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_log_metrics(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLogMetricsPager)
+
+def test_get_log_metric_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_metrics.LogMetric()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_log_metric(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_metrics.LogMetric)
+
+def test_create_log_metric_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_metrics.LogMetric()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.create_log_metric(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_metrics.LogMetric)
+
+def test_update_log_metric_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2Client(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = logging_metrics.LogMetric()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.update_log_metric(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_metrics.LogMetric)
+
+
 def test_transport_kind_grpc_asyncio():
     transport = MetricsServiceV2AsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
@@ -2916,10 +3144,251 @@ async def test_delete_log_metric_empty_call_grpc_asyncio():
         assert args[0] == request_msg
 
 
+@pytest.mark.asyncio
+async def test_list_log_metrics_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_metrics.ListLogMetricsResponse(
+        next_page_token='next_page_token_value',
+    )
+    with mock.patch.object(
+        type(client.transport.list_log_metrics), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_log_metrics(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListLogMetricsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_log_metric_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_metrics.LogMetric(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        bucket_name='bucket_name_value',
+        disabled=True,
+        value_extractor='value_extractor_value',
+        version=logging_metrics.LogMetric.ApiVersion.V1,
+    )
+    with mock.patch.object(
+        type(client.transport.get_log_metric), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_log_metric(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_metrics.LogMetric)
+
+@pytest.mark.asyncio
+async def test_create_log_metric_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_metrics.LogMetric(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        bucket_name='bucket_name_value',
+        disabled=True,
+        value_extractor='value_extractor_value',
+        version=logging_metrics.LogMetric.ApiVersion.V1,
+    )
+    with mock.patch.object(
+        type(client.transport.create_log_metric), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.create_log_metric(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_metrics.LogMetric)
+
+@pytest.mark.asyncio
+async def test_update_log_metric_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = logging_metrics.LogMetric(
+        name='name_value',
+        description='description_value',
+        filter='filter_value',
+        bucket_name='bucket_name_value',
+        disabled=True,
+        value_extractor='value_extractor_value',
+        version=logging_metrics.LogMetric.ApiVersion.V1,
+    )
+    with mock.patch.object(
+        type(client.transport.update_log_metric), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.update_log_metric(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, logging_metrics.LogMetric)
+
+
+@pytest.mark.asyncio
+async def test_list_log_metrics_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_log_metrics), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_metrics.ListLogMetricsResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_log_metrics(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListLogMetricsAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_log_metric_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_log_metric), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_metrics.LogMetric())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_log_metric(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_metrics.LogMetric)
+
+@pytest.mark.asyncio
+async def test_create_log_metric_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.create_log_metric), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_metrics.LogMetric())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.create_log_metric(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_metrics.LogMetric)
+
+@pytest.mark.asyncio
+async def test_update_log_metric_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = MetricsServiceV2AsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.update_log_metric), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(logging_metrics.LogMetric())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.update_log_metric(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, logging_metrics.LogMetric)
+
+
 def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = MetricsServiceV2Client(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -16,6 +16,7 @@
 from collections import OrderedDict
 import re
 from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Optional, Sequence, Tuple, Type, Union
+import warnings
 
 from google.cloud.redis_v1 import gapic_version as package_version
 
@@ -262,6 +263,7 @@ class CloudRedisAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListInstancesAsyncPager:
         r"""Lists all Redis instances owned by a project in either the
         specified location (region) or all locations.
@@ -321,6 +323,10 @@ class CloudRedisAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.redis_v1.services.cloud_redis.pagers.ListInstancesAsyncPager:
@@ -351,7 +357,18 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.list_instances]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_instances]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.list_instances]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -371,6 +388,10 @@ class CloudRedisAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -393,6 +414,7 @@ class CloudRedisAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> cloud_redis.Instance:
         r"""Gets the details of a specific Redis instance.
 
@@ -441,6 +463,10 @@ class CloudRedisAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.redis_v1.types.Instance:
@@ -466,7 +492,18 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_instance]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -486,6 +523,10 @@ class CloudRedisAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -497,6 +538,7 @@ class CloudRedisAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> cloud_redis.InstanceAuthString:
         r"""Gets the AUTH string for a Redis instance. If AUTH is
         not enabled for the instance the response will be empty.
@@ -548,6 +590,10 @@ class CloudRedisAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.aio.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.redis_v1.types.InstanceAuthString:
@@ -573,7 +619,18 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.get_instance_auth_string]
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_instance_auth_string]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.get_instance_auth_string]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -593,6 +650,10 @@ class CloudRedisAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                await raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -732,7 +793,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.create_instance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.create_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -880,7 +945,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.update_instance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.update_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1013,7 +1082,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.upgrade_instance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.upgrade_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.upgrade_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1156,7 +1229,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.import_instance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.import_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.import_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1296,7 +1373,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.export_instance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.export_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.export_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1430,7 +1511,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.failover_instance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.failover_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.failover_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1559,7 +1644,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.delete_instance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_instance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1703,7 +1792,11 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._client._transport._wrapped_methods[self._client._transport.reschedule_maintenance]
+        with_call = False
+        if with_call:  # pragma: NO COVER
+            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.reschedule_maintenance]
+        else:
+            rpc = self._client._transport._wrapped_methods[self._client._transport.reschedule_maintenance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py
@@ -42,9 +42,20 @@ from google.longrunning import operations_pb2 # type: ignore
 from google.protobuf import empty_pb2  # type: ignore
 from google.protobuf import field_mask_pb2  # type: ignore
 from google.protobuf import timestamp_pb2  # type: ignore
+from .transports.base import BaseCallMetadata
 from .transports.base import CloudRedisTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc_asyncio import CloudRedisGrpcAsyncIOTransport
 from .client import CloudRedisClient
+
+
+class CloudRedisAsyncClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata: Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata: Sequence[Tuple[str, Union[str, bytes]]] = []
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class CloudRedisAsyncClient:
@@ -263,7 +274,7 @@ class CloudRedisAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListInstancesAsyncPager:
         r"""Lists all Redis instances owned by a project in either the
         specified location (region) or all locations.
@@ -323,7 +334,7 @@ class CloudRedisAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -357,18 +368,19 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.list_instances]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.list_instances]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.list_instances]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -388,10 +400,16 @@ class CloudRedisAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = CloudRedisAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__aiter__` convenience method.
@@ -414,7 +432,7 @@ class CloudRedisAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> cloud_redis.Instance:
         r"""Gets the details of a specific Redis instance.
 
@@ -463,7 +481,7 @@ class CloudRedisAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -492,18 +510,19 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_instance]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -523,10 +542,16 @@ class CloudRedisAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = CloudRedisAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -538,7 +563,7 @@ class CloudRedisAsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> cloud_redis.InstanceAuthString:
         r"""Gets the AUTH string for a Redis instance. If AUTH is
         not enabled for the instance the response will be empty.
@@ -590,7 +615,7 @@ class CloudRedisAsyncClient:
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.aio.Call, requests.models.Response]`.
@@ -619,18 +644,19 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
+        wrapped_methods = None
+
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._client._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._client._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.get_instance_auth_string]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.get_instance_auth_string]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.get_instance_auth_string]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -650,10 +676,16 @@ class CloudRedisAsyncClient:
             timeout=timeout,
             metadata=metadata,
         )
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                await raw_response_callback(response[1])
-            response = response[0]
+                response_metadata = await transport_call_metadata.trailing_metadata()
+                # Convert grpc.aio._metadata.Metadata to Sequence[Tuple[str, Union[str, bytes]]]
+                response_metadata = [
+                     (k, v) for k, v in response_metadata
+                ]
+                call_metadata = CloudRedisAsyncClientCallMetadata(response_metadata = response_metadata)
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -793,11 +825,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.create_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.create_instance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.create_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -945,11 +978,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.update_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.update_instance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.update_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1082,11 +1116,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.upgrade_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.upgrade_instance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.upgrade_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1229,11 +1264,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.import_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.import_instance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.import_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1373,11 +1409,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.export_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.export_instance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.export_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1511,11 +1548,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.failover_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.failover_instance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.failover_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1644,11 +1682,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.delete_instance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.delete_instance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.delete_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1792,11 +1831,12 @@ class CloudRedisAsyncClient:
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        with_call = False
-        if with_call:  # pragma: NO COVER
-            rpc = self._client._transport._wrapped_methods_with_call[self._client._transport.reschedule_maintenance]
-        else:
-            rpc = self._client._transport._wrapped_methods[self._client._transport.reschedule_maintenance]
+        wrapped_methods = None
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._client._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._client._transport.reschedule_maintenance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -611,6 +611,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> pagers.ListInstancesPager:
         r"""Lists all Redis instances owned by a project in either the
         specified location (region) or all locations.
@@ -670,6 +671,10 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.redis_v1.services.cloud_redis.pagers.ListInstancesPager:
@@ -699,7 +704,19 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.list_instances]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.list_instances]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.list_instances]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -719,6 +736,11 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -741,6 +763,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> cloud_redis.Instance:
         r"""Gets the details of a specific Redis instance.
 
@@ -789,6 +812,10 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.redis_v1.types.Instance:
@@ -813,7 +840,19 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_instance]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -834,6 +873,11 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             metadata=metadata,
         )
 
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
+
         # Done; return the response.
         return response
 
@@ -844,6 +888,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
+            raw_response_callback: Optional[callable] = None,
             ) -> cloud_redis.InstanceAuthString:
         r"""Gets the AUTH string for a Redis instance. If AUTH is
         not enabled for the instance the response will be empty.
@@ -895,6 +940,10 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
+            raw_response_callback (Optional[callable]): Adds a callback that
+                will be called if the request succeeds. The callback will have
+                a `raw_response` argument which is of type
+                `Union[grpc.Call, requests.models.Response]`.
 
         Returns:
             google.cloud.redis_v1.types.InstanceAuthString:
@@ -919,7 +968,19 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.get_instance_auth_string]
+
+        with_call = False
+        if raw_response_callback: # pragma: NO COVER
+            if hasattr(self._transport, "_wrapped_methods_with_call"):
+                with_call = True
+            else:
+                raw_response_callback = None
+                warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
+                    RuntimeWarning)
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.get_instance_auth_string]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.get_instance_auth_string]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -939,6 +1000,11 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             timeout=timeout,
             metadata=metadata,
         )
+
+        if isinstance(response, Tuple): # pragma: NO COVER
+            if raw_response_callback:
+                raw_response_callback(response[1])
+            response = response[0]
 
         # Done; return the response.
         return response
@@ -1077,7 +1143,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.create_instance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.create_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.create_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1224,7 +1295,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.update_instance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.update_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.update_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1356,7 +1432,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.upgrade_instance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.upgrade_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.upgrade_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1498,7 +1579,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.import_instance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.import_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.import_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1637,7 +1723,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.export_instance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.export_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.export_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1770,7 +1861,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.failover_instance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.failover_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.failover_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1898,7 +1994,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.delete_instance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_instance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.delete_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2041,7 +2142,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
-        rpc = self._transport._wrapped_methods[self._transport.reschedule_maintenance]
+
+        with_call = False
+        if with_call: # pragma: NO COVER
+            rpc = self._transport._wrapped_methods_with_call[self._transport.reschedule_maintenance]
+        else:
+            rpc = self._transport._wrapped_methods[self._transport.reschedule_maintenance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -48,6 +48,7 @@ from google.protobuf import timestamp_pb2  # type: ignore
 from .transports.base import CloudRedisTransport, DEFAULT_CLIENT_INFO
 from .transports.grpc import CloudRedisGrpcTransport
 from .transports.grpc_asyncio import CloudRedisGrpcAsyncIOTransport
+from .transports.base import BaseCallMetadata
 from .transports.rest import CloudRedisRestTransport
 try:
     from .transports.rest_asyncio import AsyncCloudRedisRestTransport
@@ -55,6 +56,16 @@ try:
 except ImportError as e: # pragma: NO COVER
     HAS_ASYNC_REST_DEPENDENCIES = False
     ASYNC_REST_EXCEPTION = e
+
+
+class CloudRedisClientCallMetadata(BaseCallMetadata):
+    def __init__(
+            self,
+            request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+            response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        ):
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata) # pragma: NO COVER
 
 
 class CloudRedisClientMeta(type):
@@ -611,7 +622,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> pagers.ListInstancesPager:
         r"""Lists all Redis instances owned by a project in either the
         specified location (region) or all locations.
@@ -671,7 +682,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -704,19 +715,19 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.list_instances]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.list_instances]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.list_instances]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -737,10 +748,11 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = CloudRedisClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # This method is paged; wrap the response in a pager, which provides
         # an `__iter__` convenience method.
@@ -763,7 +775,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> cloud_redis.Instance:
         r"""Gets the details of a specific Redis instance.
 
@@ -812,7 +824,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -840,19 +852,19 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_instance]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -873,10 +885,11 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = CloudRedisClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -888,7 +901,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, Union[str, bytes]]] = (),
-            raw_response_callback: Optional[callable] = None,
+            raw_response_callback: Optional[Callable] = None,
             ) -> cloud_redis.InstanceAuthString:
         r"""Gets the AUTH string for a Redis instance. If AUTH is
         not enabled for the instance the response will be empty.
@@ -940,7 +953,7 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                 sent along with the request as metadata. Normally, each value must be of type `str`,
                 but for metadata keys ending with the suffix `-bin`, the corresponding values must
                 be of type `bytes`.
-            raw_response_callback (Optional[callable]): Adds a callback that
+            raw_response_callback (Optional[Callable]): Adds a callback that
                 will be called if the request succeeds. The callback will have
                 a `raw_response` argument which is of type
                 `Union[grpc.Call, requests.models.Response]`.
@@ -968,19 +981,19 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
         if raw_response_callback: # pragma: NO COVER
-            if hasattr(self._transport, "_wrapped_methods_with_call"):
-                with_call = True
-            else:
+            wrapped_methods = getattr(self._transport, "_wrapped_methods_with_call", None)
+            if not wrapped_methods:
                 raw_response_callback = None
                 warnings.warn("Unable to retrieve response metadata. This feature requires `google-api-core` version 2.x.x",
                     RuntimeWarning)
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.get_instance_auth_string]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.get_instance_auth_string]
+
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.get_instance_auth_string]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1001,10 +1014,11 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
             metadata=metadata,
         )
 
-        if isinstance(response, Tuple): # pragma: NO COVER
+        if isinstance(response, tuple): # pragma: NO COVER
+            response, transport_call_metadata = response
             if raw_response_callback:
-                raw_response_callback(response[1])
-            response = response[0]
+                call_metadata = CloudRedisClientCallMetadata(response_metadata = transport_call_metadata.trailing_metadata())
+                raw_response_callback(call_metadata)
 
         # Done; return the response.
         return response
@@ -1143,12 +1157,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.create_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.create_instance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.create_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1295,12 +1309,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.update_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.update_instance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.update_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1432,12 +1446,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.upgrade_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.upgrade_instance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.upgrade_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1579,12 +1593,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.import_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.import_instance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.import_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1723,12 +1737,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.export_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.export_instance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.export_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1861,12 +1875,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.failover_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.failover_instance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.failover_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -1994,12 +2008,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.delete_instance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.delete_instance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.delete_instance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.
@@ -2142,12 +2156,12 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
 
         # Wrap the RPC method; this adds retry and timeout information,
         # and friendly error handling.
+        wrapped_methods = None
 
-        with_call = False
-        if with_call: # pragma: NO COVER
-            rpc = self._transport._wrapped_methods_with_call[self._transport.reschedule_maintenance]
-        else:
-            rpc = self._transport._wrapped_methods[self._transport.reschedule_maintenance]
+        if not wrapped_methods: # pragma: NO COVER
+            wrapped_methods = self._transport._wrapped_methods
+
+        rpc = wrapped_methods[self._transport.reschedule_maintenance]
 
         # Certain fields should be provided within the metadata header;
         # add these here.

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -15,7 +15,7 @@
 #
 import abc
 import inspect
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple, Union
 
 from google.cloud.redis_v1 import gapic_version as package_version
 
@@ -34,6 +34,18 @@ from google.longrunning import operations_pb2 # type: ignore
 
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(gapic_version=package_version.__version__)
 
+
+class BaseCallMetadata():
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+    def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
 
 class CloudRedisTransport(abc.ABC):
     """Abstract transport class for CloudRedis."""

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import abc
+import inspect
 from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
 
 from google.cloud.redis_v1 import gapic_version as package_version
@@ -120,6 +121,28 @@ class CloudRedisTransport(abc.ABC):
         return self._host
 
     def _prep_wrapped_messages(self, client_info):
+        if "with_call" in inspect.signature(gapic_v1.method.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_instances: gapic_v1.method.wrap_method(
+                    self.list_instances,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_instance: gapic_v1.method.wrap_method(
+                    self.get_instance,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_instance_auth_string: gapic_v1.method.wrap_method(
+                    self.get_instance_auth_string,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         # Precompute the wrapped methods.
         self._wrapped_methods = {
             self.list_instances: gapic_v1.method.wrap_method(

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/grpc_asyncio.py
@@ -613,6 +613,28 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_instances: self._wrap_method(
+                    self.list_instances,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_instance: self._wrap_method(
+                    self.get_instance,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_instance_auth_string: self._wrap_method(
+                    self.get_instance_auth_string,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.list_instances: self._wrap_method(
                 self.list_instances,
@@ -709,6 +731,8 @@ class CloudRedisGrpcAsyncIOTransport(CloudRedisTransport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     def close(self):

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -693,6 +693,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the create instance method over HTTP.
 
@@ -737,7 +738,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _DeleteInstance(_BaseCloudRedisRestTransport._BaseDeleteInstance, CloudRedisRestStub):
         def __hash__(self):
@@ -770,6 +774,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the delete instance method over HTTP.
 
@@ -812,7 +817,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ExportInstance(_BaseCloudRedisRestTransport._BaseExportInstance, CloudRedisRestStub):
         def __hash__(self):
@@ -846,6 +854,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the export instance method over HTTP.
 
@@ -890,7 +899,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _FailoverInstance(_BaseCloudRedisRestTransport._BaseFailoverInstance, CloudRedisRestStub):
         def __hash__(self):
@@ -924,6 +936,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the failover instance method over HTTP.
 
@@ -968,11 +981,16 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_failover_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetInstance(_BaseCloudRedisRestTransport._BaseGetInstance, CloudRedisRestStub):
         def __hash__(self):
             return hash("CloudRedisRestTransport.GetInstance")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1001,6 +1019,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> cloud_redis.Instance:
             r"""Call the get instance method over HTTP.
 
@@ -1042,11 +1061,16 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetInstanceAuthString(_BaseCloudRedisRestTransport._BaseGetInstanceAuthString, CloudRedisRestStub):
         def __hash__(self):
             return hash("CloudRedisRestTransport.GetInstanceAuthString")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1075,6 +1099,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> cloud_redis.InstanceAuthString:
             r"""Call the get instance auth string method over HTTP.
 
@@ -1116,7 +1141,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance_auth_string(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ImportInstance(_BaseCloudRedisRestTransport._BaseImportInstance, CloudRedisRestStub):
         def __hash__(self):
@@ -1150,6 +1178,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the import instance method over HTTP.
 
@@ -1194,11 +1223,16 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_import_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListInstances(_BaseCloudRedisRestTransport._BaseListInstances, CloudRedisRestStub):
         def __hash__(self):
             return hash("CloudRedisRestTransport.ListInstances")
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
 
         @staticmethod
         def _get_response(
@@ -1227,6 +1261,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> cloud_redis.ListInstancesResponse:
             r"""Call the list instances method over HTTP.
 
@@ -1270,7 +1305,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_instances(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _RescheduleMaintenance(_BaseCloudRedisRestTransport._BaseRescheduleMaintenance, CloudRedisRestStub):
         def __hash__(self):
@@ -1304,6 +1342,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the reschedule maintenance method over HTTP.
 
@@ -1348,7 +1387,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_reschedule_maintenance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpdateInstance(_BaseCloudRedisRestTransport._BaseUpdateInstance, CloudRedisRestStub):
         def __hash__(self):
@@ -1382,6 +1424,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the update instance method over HTTP.
 
@@ -1426,7 +1469,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpgradeInstance(_BaseCloudRedisRestTransport._BaseUpgradeInstance, CloudRedisRestStub):
         def __hash__(self):
@@ -1460,6 +1506,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 retry: OptionalRetry=gapic_v1.method.DEFAULT,
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                with_call: bool = False,
                 ) -> operations_pb2.Operation:
             r"""Call the upgrade instance method over HTTP.
 
@@ -1504,7 +1551,10 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_upgrade_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     @property
     def create_instance(self) -> Callable[

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -38,6 +38,7 @@ from google.longrunning import operations_pb2  # type: ignore
 
 
 from .rest_base import _BaseCloudRedisRestTransport
+from .base import BaseCallMetadata
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
 try:
@@ -694,7 +695,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the create instance method over HTTP.
 
             Args:
@@ -739,7 +740,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -775,7 +778,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the delete instance method over HTTP.
 
             Args:
@@ -818,7 +821,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -855,7 +860,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the export instance method over HTTP.
 
             Args:
@@ -900,7 +905,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -937,7 +944,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the failover instance method over HTTP.
 
             Args:
@@ -982,7 +989,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_failover_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1020,7 +1029,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> cloud_redis.Instance:
+                ) -> Union[cloud_redis.Instance, Tuple[cloud_redis.Instance, BaseCallMetadata]]:
             r"""Call the get instance method over HTTP.
 
             Args:
@@ -1062,7 +1071,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1100,7 +1111,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> cloud_redis.InstanceAuthString:
+                ) -> Union[cloud_redis.InstanceAuthString, Tuple[cloud_redis.InstanceAuthString, BaseCallMetadata]]:
             r"""Call the get instance auth string method over HTTP.
 
             Args:
@@ -1142,7 +1153,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance_auth_string(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1179,7 +1192,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the import instance method over HTTP.
 
             Args:
@@ -1224,7 +1237,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_import_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1262,7 +1277,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> cloud_redis.ListInstancesResponse:
+                ) -> Union[cloud_redis.ListInstancesResponse, Tuple[cloud_redis.ListInstancesResponse, BaseCallMetadata]]:
             r"""Call the list instances method over HTTP.
 
             Args:
@@ -1306,7 +1321,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_instances(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1343,7 +1360,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the reschedule maintenance method over HTTP.
 
             Args:
@@ -1388,7 +1405,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_reschedule_maintenance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1425,7 +1444,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the update instance method over HTTP.
 
             Args:
@@ -1470,7 +1489,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1507,7 +1528,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 timeout: Optional[float]=None,
                 metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                 with_call: bool = False,
-                ) -> operations_pb2.Operation:
+                ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the upgrade instance method over HTTP.
 
             Args:
@@ -1552,7 +1573,9 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_upgrade_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = BaseCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -50,6 +50,7 @@ from google.longrunning import operations_pb2  # type: ignore
 
 from .rest_base import _BaseCloudRedisRestTransport
 
+from .base import BaseCallMetadata
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
 try:
@@ -507,6 +508,21 @@ class AsyncCloudRedisRestInterceptor:
         return response
 
 
+class AsyncCallMetadata(BaseCallMetadata):
+    def __init__(
+        self,
+        request_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+        response_metadata : Sequence[Tuple[str, Union[str, bytes]]] = [],
+    ): # pragma: NO COVER
+        self.request_metadata = request_metadata
+        self.response_metadata = response_metadata
+
+        super().__init__(request_metadata=request_metadata, response_metadata=response_metadata)
+
+    async def trailing_metadata(self):
+        return self.response_metadata # pragma: NO COVER
+
+
 @dataclasses.dataclass
 class AsyncCloudRedisRestStub:
     _session: AsyncAuthorizedSession
@@ -747,7 +763,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the create instance method over HTTP.
 
             Args:
@@ -798,7 +814,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_create_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -834,7 +852,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the delete instance method over HTTP.
 
             Args:
@@ -883,7 +901,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_delete_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -920,7 +940,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the export instance method over HTTP.
 
             Args:
@@ -971,7 +991,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_export_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1008,7 +1030,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the failover instance method over HTTP.
 
             Args:
@@ -1059,7 +1081,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_failover_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1097,7 +1121,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> cloud_redis.Instance:
+                    ) -> Union[cloud_redis.Instance, Tuple[cloud_redis.Instance, BaseCallMetadata]]:
             r"""Call the get instance method over HTTP.
 
             Args:
@@ -1143,7 +1167,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1181,7 +1207,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> cloud_redis.InstanceAuthString:
+                    ) -> Union[cloud_redis.InstanceAuthString, Tuple[cloud_redis.InstanceAuthString, BaseCallMetadata]]:
             r"""Call the get instance auth string method over HTTP.
 
             Args:
@@ -1227,7 +1253,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance_auth_string(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1264,7 +1292,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the import instance method over HTTP.
 
             Args:
@@ -1315,7 +1343,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_import_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1353,7 +1383,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> cloud_redis.ListInstancesResponse:
+                    ) -> Union[cloud_redis.ListInstancesResponse, Tuple[cloud_redis.ListInstancesResponse, BaseCallMetadata]]:
             r"""Call the list instances method over HTTP.
 
             Args:
@@ -1401,7 +1431,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_list_instances(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1438,7 +1470,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the reschedule maintenance method over HTTP.
 
             Args:
@@ -1489,7 +1521,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_reschedule_maintenance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1526,7 +1560,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the update instance method over HTTP.
 
             Args:
@@ -1577,7 +1611,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_update_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 
@@ -1614,7 +1650,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
                     with_call: bool = False,
-                    ) -> operations_pb2.Operation:
+                    ) -> Union[operations_pb2.Operation, Tuple[operations_pb2.Operation, BaseCallMetadata]]:
             r"""Call the upgrade instance method over HTTP.
 
             Args:
@@ -1665,7 +1701,9 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_upgrade_instance(resp)
             if with_call: # pragma: NO COVER
-                return (resp, response)
+                call_metadata = AsyncCallMetadata()
+                call_metadata.response_metadata = [(k, v) for k, v in response.headers.items()]
+                return (resp, call_metadata)
             else:
                 return resp
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import inspect
 
 import google.auth
 try:
@@ -591,6 +592,28 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
     def _prep_wrapped_messages(self, client_info):
         """ Precompute the wrapped methods, overriding the base class method to use async wrappers."""
+        if "with_call" in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            self._wrapped_methods_with_call = {
+                self.list_instances: self._wrap_method(
+                    self.list_instances,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_instance: self._wrap_method(
+                    self.get_instance,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+                self.get_instance_auth_string: self._wrap_method(
+                    self.get_instance_auth_string,
+                    default_timeout=600.0,
+                    client_info=client_info,
+                    with_call=True,
+                ),
+            }
+
         self._wrapped_methods = {
             self.list_instances: self._wrap_method(
                 self.list_instances,
@@ -687,6 +710,8 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
     def _wrap_method(self, func, *args, **kwargs):
         if self._wrap_with_kind:  # pragma: NO COVER
             kwargs["kind"] = self.kind
+        if "with_call" not in inspect.signature(gapic_v1.method_async.wrap_method).parameters: # pragma: NO COVER
+            kwargs.pop("with_call", None)
         return gapic_v1.method_async.wrap_method(func, *args, **kwargs)
 
     class _CreateInstance(_BaseCloudRedisRestTransport._BaseCreateInstance, AsyncCloudRedisRestStub):
@@ -721,6 +746,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the create instance method over HTTP.
 
@@ -771,7 +797,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_create_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _DeleteInstance(_BaseCloudRedisRestTransport._BaseDeleteInstance, AsyncCloudRedisRestStub):
         def __hash__(self):
@@ -804,6 +833,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the delete instance method over HTTP.
 
@@ -852,7 +882,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_delete_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ExportInstance(_BaseCloudRedisRestTransport._BaseExportInstance, AsyncCloudRedisRestStub):
         def __hash__(self):
@@ -886,6 +919,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the export instance method over HTTP.
 
@@ -936,7 +970,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_export_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _FailoverInstance(_BaseCloudRedisRestTransport._BaseFailoverInstance, AsyncCloudRedisRestStub):
         def __hash__(self):
@@ -970,6 +1007,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the failover instance method over HTTP.
 
@@ -1020,12 +1058,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_failover_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetInstance(_BaseCloudRedisRestTransport._BaseGetInstance, AsyncCloudRedisRestStub):
         def __hash__(self):
             return hash("AsyncCloudRedisRestTransport.GetInstance")
 
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
         @staticmethod
         async def _get_response(
             host,
@@ -1053,6 +1096,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> cloud_redis.Instance:
             r"""Call the get instance method over HTTP.
 
@@ -1098,12 +1142,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _GetInstanceAuthString(_BaseCloudRedisRestTransport._BaseGetInstanceAuthString, AsyncCloudRedisRestStub):
         def __hash__(self):
             return hash("AsyncCloudRedisRestTransport.GetInstanceAuthString")
 
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
         @staticmethod
         async def _get_response(
             host,
@@ -1131,6 +1180,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> cloud_redis.InstanceAuthString:
             r"""Call the get instance auth string method over HTTP.
 
@@ -1176,7 +1226,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance_auth_string(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ImportInstance(_BaseCloudRedisRestTransport._BaseImportInstance, AsyncCloudRedisRestStub):
         def __hash__(self):
@@ -1210,6 +1263,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the import instance method over HTTP.
 
@@ -1260,12 +1314,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_import_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _ListInstances(_BaseCloudRedisRestTransport._BaseListInstances, AsyncCloudRedisRestStub):
         def __hash__(self):
             return hash("AsyncCloudRedisRestTransport.ListInstances")
 
+        def with_call(self, request=None, retry=None, timeout=None, metadata=None):
+            return self.__call__(request=request, retry=retry, timeout=timeout, metadata=metadata, with_call=True) # pragma: NO COVER
         @staticmethod
         async def _get_response(
             host,
@@ -1293,6 +1352,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> cloud_redis.ListInstancesResponse:
             r"""Call the list instances method over HTTP.
 
@@ -1340,7 +1400,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_list_instances(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _RescheduleMaintenance(_BaseCloudRedisRestTransport._BaseRescheduleMaintenance, AsyncCloudRedisRestStub):
         def __hash__(self):
@@ -1374,6 +1437,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the reschedule maintenance method over HTTP.
 
@@ -1424,7 +1488,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_reschedule_maintenance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpdateInstance(_BaseCloudRedisRestTransport._BaseUpdateInstance, AsyncCloudRedisRestStub):
         def __hash__(self):
@@ -1458,6 +1525,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the update instance method over HTTP.
 
@@ -1508,7 +1576,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_update_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     class _UpgradeInstance(_BaseCloudRedisRestTransport._BaseUpgradeInstance, AsyncCloudRedisRestStub):
         def __hash__(self):
@@ -1542,6 +1613,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     retry: OptionalRetry=gapic_v1.method.DEFAULT,
                     timeout: Optional[float]=None,
                     metadata: Sequence[Tuple[str, Union[str, bytes]]]=(),
+                    with_call: bool = False,
                     ) -> operations_pb2.Operation:
             r"""Call the upgrade instance method over HTTP.
 
@@ -1592,7 +1664,10 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_upgrade_instance(resp)
-            return resp
+            if with_call: # pragma: NO COVER
+                return (resp, response)
+            else:
+                return resp
 
     @property
     def operations_client(self) -> AsyncOperationsRestClient:

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6846,6 +6846,191 @@ def test_reschedule_maintenance_empty_call_grpc():
         assert args[0] == request_msg
 
 
+def test_list_instances_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = cloud_redis.ListInstancesResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.list_instances(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListInstancesPager)
+
+def test_get_instance_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = cloud_redis.Instance(
+        name='name_value',
+        display_name='display_name_value',
+        location_id='location_id_value',
+        alternative_location_id='alternative_location_id_value',
+        redis_version='redis_version_value',
+        reserved_ip_range='reserved_ip_range_value',
+        secondary_ip_range='secondary_ip_range_value',
+        host='host_value',
+        port=453,
+        current_location_id='current_location_id_value',
+        state=cloud_redis.Instance.State.CREATING,
+        status_message='status_message_value',
+        tier=cloud_redis.Instance.Tier.BASIC,
+        memory_size_gb=1499,
+        authorized_network='authorized_network_value',
+        persistence_iam_identity='persistence_iam_identity_value',
+        connect_mode=cloud_redis.Instance.ConnectMode.DIRECT_PEERING,
+        auth_enabled=True,
+        transit_encryption_mode=cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION,
+        replica_count=1384,
+        read_endpoint='read_endpoint_value',
+        read_endpoint_port=1920,
+        read_replicas_mode=cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED,
+        customer_managed_key='customer_managed_key_value',
+        suspension_reasons=[cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE],
+        maintenance_version='maintenance_version_value',
+        available_maintenance_versions=['available_maintenance_versions_value'],
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_instance(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, cloud_redis.Instance)
+
+def test_get_instance_auth_string_with_metadata_callback_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    response_obj = cloud_redis.InstanceAuthString(
+        auth_string='auth_string_value',
+    )
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        mocked_grpc_callable = mock.Mock()
+        call.return_value = (response_obj, mocked_grpc_callable)
+        mocked_callback = mock.Mock()
+        response = client.get_instance_auth_string(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, cloud_redis.InstanceAuthString)
+
+
+def test_list_instances_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = cloud_redis.ListInstancesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_instances(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListInstancesPager)
+
+def test_get_instance_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = cloud_redis.Instance()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_instance(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.Instance)
+
+def test_get_instance_auth_string_with_metadata_callback_raises_warning_if_no_metadata_grpc():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="grpc",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = cloud_redis.InstanceAuthString()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_instance_auth_string(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.InstanceAuthString)
+
+
 def test_transport_kind_grpc_asyncio():
     transport = CloudRedisAsyncClient.get_transport_class("grpc_asyncio")(
         credentials=async_anonymous_credentials()
@@ -7183,6 +7368,200 @@ async def test_reschedule_maintenance_empty_call_grpc_asyncio():
         request_msg = cloud_redis.RescheduleMaintenanceRequest()
 
         assert args[0] == request_msg
+
+
+@pytest.mark.asyncio
+async def test_list_instances_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = cloud_redis.ListInstancesResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.list_instances), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_instances(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, pagers.ListInstancesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_instance_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = cloud_redis.Instance(
+        name='name_value',
+        display_name='display_name_value',
+        location_id='location_id_value',
+        alternative_location_id='alternative_location_id_value',
+        redis_version='redis_version_value',
+        reserved_ip_range='reserved_ip_range_value',
+        secondary_ip_range='secondary_ip_range_value',
+        host='host_value',
+        port=453,
+        current_location_id='current_location_id_value',
+        state=cloud_redis.Instance.State.CREATING,
+        status_message='status_message_value',
+        tier=cloud_redis.Instance.Tier.BASIC,
+        memory_size_gb=1499,
+        authorized_network='authorized_network_value',
+        persistence_iam_identity='persistence_iam_identity_value',
+        connect_mode=cloud_redis.Instance.ConnectMode.DIRECT_PEERING,
+        auth_enabled=True,
+        transit_encryption_mode=cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION,
+        replica_count=1384,
+        read_endpoint='read_endpoint_value',
+        read_endpoint_port=1920,
+        read_replicas_mode=cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED,
+        customer_managed_key='customer_managed_key_value',
+        suspension_reasons=[cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE],
+        maintenance_version='maintenance_version_value',
+        available_maintenance_versions=['available_maintenance_versions_value'],
+    )
+    with mock.patch.object(
+        type(client.transport.get_instance), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_instance(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, cloud_redis.Instance)
+
+@pytest.mark.asyncio
+async def test_get_instance_auth_string_with_metadata_callback_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    response_obj = cloud_redis.InstanceAuthString(
+        auth_string='auth_string_value',
+    )
+    with mock.patch.object(
+        type(client.transport.get_instance_auth_string), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_instance_auth_string(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert isinstance(response, cloud_redis.InstanceAuthString)
+
+
+@pytest.mark.asyncio
+async def test_list_instances_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_instances), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.ListInstancesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_instances(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListInstancesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_instance_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_instance), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.Instance())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_instance(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.Instance)
+
+@pytest.mark.asyncio
+async def test_get_instance_auth_string_with_metadata_callback_raises_warning_if_no_metadata_grpc_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 24):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="grpc_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_instance_auth_string), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.InstanceAuthString())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_instance_auth_string(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.InstanceAuthString)
 
 
 def test_transport_kind_rest():
@@ -9027,6 +9406,242 @@ def test_reschedule_maintenance_empty_call_rest():
         request_msg = cloud_redis.RescheduleMaintenanceRequest()
 
         assert args[0] == request_msg
+
+
+def test_list_instances_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = cloud_redis.ListInstancesResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = cloud_redis.ListInstancesRequest.pb(cloud_redis.ListInstancesRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = cloud_redis.ListInstancesResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.list_instances(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListInstancesPager)
+
+def test_get_instance_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = cloud_redis.Instance(
+        name='name_value',
+        display_name='display_name_value',
+        location_id='location_id_value',
+        alternative_location_id='alternative_location_id_value',
+        redis_version='redis_version_value',
+        reserved_ip_range='reserved_ip_range_value',
+        secondary_ip_range='secondary_ip_range_value',
+        host='host_value',
+        port=453,
+        current_location_id='current_location_id_value',
+        state=cloud_redis.Instance.State.CREATING,
+        status_message='status_message_value',
+        tier=cloud_redis.Instance.Tier.BASIC,
+        memory_size_gb=1499,
+        authorized_network='authorized_network_value',
+        persistence_iam_identity='persistence_iam_identity_value',
+        connect_mode=cloud_redis.Instance.ConnectMode.DIRECT_PEERING,
+        auth_enabled=True,
+        transit_encryption_mode=cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION,
+        replica_count=1384,
+        read_endpoint='read_endpoint_value',
+        read_endpoint_port=1920,
+        read_replicas_mode=cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED,
+        customer_managed_key='customer_managed_key_value',
+        suspension_reasons=[cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE],
+        maintenance_version='maintenance_version_value',
+        available_maintenance_versions=['available_maintenance_versions_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = cloud_redis.GetInstanceRequest.pb(cloud_redis.GetInstanceRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = cloud_redis.Instance.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_instance(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, cloud_redis.Instance)
+
+def test_get_instance_auth_string_with_metadata_callback_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    response_obj = cloud_redis.InstanceAuthString(
+        auth_string='auth_string_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = cloud_redis.GetInstanceAuthStringRequest.pb(cloud_redis.GetInstanceAuthStringRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = cloud_redis.InstanceAuthString.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        call.return_value.content = json_response_obj
+        mocked_callback = mock.Mock()
+        response = client.get_instance_auth_string(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, cloud_redis.InstanceAuthString)
+
+
+def test_list_instances_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = cloud_redis.ListInstancesResponse()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.list_instances(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListInstancesPager)
+
+def test_get_instance_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = cloud_redis.Instance()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_instance(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.Instance)
+
+def test_get_instance_auth_string_with_metadata_callback_raises_warning_if_no_metadata_rest():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisClient(
+        credentials=ga_credentials.AnonymousCredentials(),
+        transport="rest",
+    )
+
+    with mock.patch.object(
+        google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
+        call.return_value = cloud_redis.InstanceAuthString()
+        mocked_callback = mock.Mock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = client.get_instance_auth_string(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.InstanceAuthString)
 
 
 def test_cloud_redis_rest_lro_client():
@@ -11025,6 +11640,263 @@ async def test_reschedule_maintenance_empty_call_rest_asyncio():
         assert args[0] == request_msg
 
 
+@pytest.mark.asyncio
+async def test_list_instances_with_metadata_callback_rest_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    response_obj = cloud_redis.ListInstancesResponse(
+        next_page_token='next_page_token_value',
+        unreachable=['unreachable_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = cloud_redis.ListInstancesRequest.pb(cloud_redis.ListInstancesRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = cloud_redis.ListInstancesResponse.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        response_value.read = mock.AsyncMock(return_value=json_response_obj.encode('UTF-8'))
+        mocked_callback = mock.AsyncMock()
+        response = await client.list_instances(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, pagers.ListInstancesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_instance_with_metadata_callback_rest_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    response_obj = cloud_redis.Instance(
+        name='name_value',
+        display_name='display_name_value',
+        location_id='location_id_value',
+        alternative_location_id='alternative_location_id_value',
+        redis_version='redis_version_value',
+        reserved_ip_range='reserved_ip_range_value',
+        secondary_ip_range='secondary_ip_range_value',
+        host='host_value',
+        port=453,
+        current_location_id='current_location_id_value',
+        state=cloud_redis.Instance.State.CREATING,
+        status_message='status_message_value',
+        tier=cloud_redis.Instance.Tier.BASIC,
+        memory_size_gb=1499,
+        authorized_network='authorized_network_value',
+        persistence_iam_identity='persistence_iam_identity_value',
+        connect_mode=cloud_redis.Instance.ConnectMode.DIRECT_PEERING,
+        auth_enabled=True,
+        transit_encryption_mode=cloud_redis.Instance.TransitEncryptionMode.SERVER_AUTHENTICATION,
+        replica_count=1384,
+        read_endpoint='read_endpoint_value',
+        read_endpoint_port=1920,
+        read_replicas_mode=cloud_redis.Instance.ReadReplicasMode.READ_REPLICAS_DISABLED,
+        customer_managed_key='customer_managed_key_value',
+        suspension_reasons=[cloud_redis.Instance.SuspensionReason.CUSTOMER_MANAGED_KEY_ISSUE],
+        maintenance_version='maintenance_version_value',
+        available_maintenance_versions=['available_maintenance_versions_value'],
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = cloud_redis.GetInstanceRequest.pb(cloud_redis.GetInstanceRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = cloud_redis.Instance.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        response_value.read = mock.AsyncMock(return_value=json_response_obj.encode('UTF-8'))
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_instance(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, cloud_redis.Instance)
+
+@pytest.mark.asyncio
+async def test_get_instance_auth_string_with_metadata_callback_rest_asyncio():
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+        pytest.skip("Skip this test if we're using an older version of `google-api-core` that doesn't support the metadata callback feature")
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    response_obj = cloud_redis.InstanceAuthString(
+        auth_string='auth_string_value',
+    )
+    with mock.patch.object(path_template, "transcode") as transcode, \
+        mock.patch.object(type(client.transport._session), "request") as call:
+
+        pb_request = cloud_redis.GetInstanceAuthStringRequest.pb(cloud_redis.GetInstanceAuthStringRequest())
+        transcode_result = {
+            'uri': 'v1/sample_method',
+            'method': "get",
+            'query_params': pb_request,
+        }
+
+        transcode.return_value = transcode_result
+
+        # Wrap the value into a proper Response obj
+        response_value = mock.Mock()
+        response_value.status_code = 200
+        call.return_value = response_value
+
+        # Convert return value to protobuf type
+        response_obj_pb = cloud_redis.InstanceAuthString.pb(response_obj)
+        json_response_obj = json_format.MessageToJson(response_obj_pb)
+        response_value.read = mock.AsyncMock(return_value=json_response_obj.encode('UTF-8'))
+        mocked_callback = mock.AsyncMock()
+        response = await client.get_instance_auth_string(
+            raw_response_callback=mocked_callback,
+            metadata=(("something", "something_value"),),
+        )
+        mocked_callback.assert_called_with(response_value)
+        assert isinstance(response, cloud_redis.InstanceAuthString)
+
+
+@pytest.mark.asyncio
+async def test_list_instances_with_metadata_callback_raises_warning_if_no_metadata_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.list_instances), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.ListInstancesResponse())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.list_instances(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, pagers.ListInstancesAsyncPager)
+
+@pytest.mark.asyncio
+async def test_get_instance_with_metadata_callback_raises_warning_if_no_metadata_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_instance), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.Instance())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_instance(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.Instance)
+
+@pytest.mark.asyncio
+async def test_get_instance_auth_string_with_metadata_callback_raises_warning_if_no_metadata_rest_asyncio():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    api_core_major, api_core_minor = [int(part) for part in api_core_version.__version__.split(".")[0:2]]
+    if api_core_major > 2 or (api_core_major == 2 and api_core_minor >= 14):
+        pytest.skip("Skip this test if we're already on version of `google-api-core` that supports the metadata callback feature")
+
+    client = CloudRedisAsyncClient(
+        credentials=async_anonymous_credentials(),
+        transport="rest_asyncio",
+    )
+
+    with mock.patch.object(
+        type(client.transport.get_instance_auth_string), '__call__') as call:
+        mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(cloud_redis.InstanceAuthString())
+        call.side_effect = (mocked_grpc_callable, )
+        mocked_callback = mock.AsyncMock()
+        with pytest.warns(
+            RuntimeWarning,
+            match="Unable to retrieve response metadata.",
+        ) as warned:
+            response = await client.get_instance_auth_string(
+                raw_response_callback=mocked_callback,
+                metadata=(("something", "something_value"),),
+            )
+            assert issubclass(warned[0].category, RuntimeWarning)
+            warning_msg = str(warned[0].message)
+            assert "Unable to retrieve response metadata." in warning_msg
+
+            assert isinstance(response, cloud_redis.InstanceAuthString)
+
+
 def test_cloud_redis_rest_asyncio_lro_client():
     if not HAS_ASYNC_REST_EXTRA:
         pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
@@ -11059,6 +11931,7 @@ def test_transport_grpc_default():
     # A client should use the gRPC transport by default.
     client = CloudRedisClient(
         credentials=ga_credentials.AnonymousCredentials(),
+
     )
     assert isinstance(
         client.transport,

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6862,13 +6862,14 @@ def test_list_instances_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.list_instances(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListInstancesPager)
 
 def test_get_instance_with_metadata_callback_grpc():
@@ -6912,13 +6913,14 @@ def test_get_instance_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_instance(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.Instance)
 
 def test_get_instance_auth_string_with_metadata_callback_grpc():
@@ -6936,13 +6938,14 @@ def test_get_instance_auth_string_with_metadata_callback_grpc():
     with mock.patch.object(
         google.api_core.gapic_v1.method._GapicCallable, "__call__") as call:
         mocked_grpc_callable = mock.Mock()
+        mocked_grpc_callable.trailing_metadata=mock.Mock(return_value=[("some_key", "some_value")])
         call.return_value = (response_obj, mocked_grpc_callable)
         mocked_callback = mock.Mock()
         response = client.get_instance_auth_string(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.InstanceAuthString)
 
 
@@ -7387,13 +7390,14 @@ async def test_list_instances_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.list_instances), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.list_instances(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListInstancesAsyncPager)
 
 @pytest.mark.asyncio
@@ -7438,13 +7442,14 @@ async def test_get_instance_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_instance), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_instance(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.Instance)
 
 @pytest.mark.asyncio
@@ -7463,13 +7468,14 @@ async def test_get_instance_auth_string_with_metadata_callback_grpc_asyncio():
     with mock.patch.object(
         type(client.transport.get_instance_auth_string), '__call__') as call:
         mocked_grpc_callable = grpc_helpers_async.FakeUnaryUnaryCall(response_obj)
+        mocked_grpc_callable.trailing_metadata=mock.AsyncMock(return_value=[("some_key", "some_value")])
         call.side_effect = (mocked_grpc_callable, mocked_grpc_callable)
         mocked_callback = mock.AsyncMock()
         response = await client.get_instance_auth_string(
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(mocked_grpc_callable)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.InstanceAuthString)
 
 
@@ -9436,6 +9442,7 @@ def test_list_instances_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -9447,7 +9454,7 @@ def test_list_instances_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListInstancesPager)
 
 def test_get_instance_with_metadata_callback_rest():
@@ -9503,6 +9510,7 @@ def test_get_instance_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -9514,7 +9522,7 @@ def test_get_instance_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.Instance)
 
 def test_get_instance_auth_string_with_metadata_callback_rest():
@@ -9544,6 +9552,7 @@ def test_get_instance_auth_string_with_metadata_callback_rest():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -9555,7 +9564,7 @@ def test_get_instance_auth_string_with_metadata_callback_rest():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.InstanceAuthString)
 
 
@@ -11671,6 +11680,7 @@ async def test_list_instances_with_metadata_callback_rest_asyncio():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -11682,7 +11692,7 @@ async def test_list_instances_with_metadata_callback_rest_asyncio():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, pagers.ListInstancesAsyncPager)
 
 @pytest.mark.asyncio
@@ -11741,6 +11751,7 @@ async def test_get_instance_with_metadata_callback_rest_asyncio():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -11752,7 +11763,7 @@ async def test_get_instance_with_metadata_callback_rest_asyncio():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.Instance)
 
 @pytest.mark.asyncio
@@ -11785,6 +11796,7 @@ async def test_get_instance_auth_string_with_metadata_callback_rest_asyncio():
         # Wrap the value into a proper Response obj
         response_value = mock.Mock()
         response_value.status_code = 200
+        response_value.headers = {"some_key": "some_value"}
         call.return_value = response_value
 
         # Convert return value to protobuf type
@@ -11796,7 +11808,7 @@ async def test_get_instance_auth_string_with_metadata_callback_rest_asyncio():
             raw_response_callback=mocked_callback,
             metadata=(("something", "something_value"),),
         )
-        mocked_callback.assert_called_with(response_value)
+        assert mocked_callback.call_args[0][0].response_metadata == [("some_key", "some_value")]
         assert isinstance(response, cloud_redis.InstanceAuthString)
 
 

--- a/tests/system/test_request_metadata.py
+++ b/tests/system/test_request_metadata.py
@@ -1,4 +1,4 @@
-# Copyright 2018 Google LLC
+# Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,20 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import pytest
 
+import google.api_core
 from google import showcase
-
-
-def test_metadata_string(echo):
-    echo.echo(
-        showcase.EchoRequest(
-            content="The hail in Wales falls mainly on the snails.",
-            request_id="some_value",
-            other_request_id="",
-        ),
-        metadata=[('some-key', 'some_value')]
-    )
 
 
 def test_metadata_binary(echo):
@@ -52,3 +43,88 @@ def test_metadata_binary(echo):
                 ),
                 metadata=[('some-key-bin', 'some_value')]
             )
+
+
+def test_metadata(echo):
+    api_core_major, api_core_minor = [
+        int(part) for part in google.api_core.version.__version__.split(".")[0:2]
+    ]
+    if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 14):
+        pytest.skip(
+            "Skip this test if we're on an older version of google-api-core which doesn't support `with_call`"
+        )
+
+    class MetadataCallback:
+        trailing_metadata = None
+
+        def get_raw_response_callback(self, response):
+            if isinstance(echo.transport, type(echo).get_transport_class("grpc")):
+                self.trailing_metadata = response.trailing_metadata()
+            else:
+                self.headers = response.headers
+
+    metadata_callback = MetadataCallback()
+
+    response = echo.echo(
+        showcase.EchoRequest(
+            content="The hail in Wales falls mainly on the snails."
+        ),
+        raw_response_callback=metadata_callback.get_raw_response_callback,
+        metadata=(("something", "something_value"),),
+    )
+
+    assert response.content == "The hail in Wales falls mainly on the snails."
+    if isinstance(echo.transport, type(echo).get_transport_class("grpc")):
+        response_metadata = [
+            (metadata.key, metadata.value)
+            for metadata in metadata_callback.trailing_metadata
+        ]
+        assert ("something", "something_value") in response_metadata
+    else:
+
+        assert "X-Showcase-Request-Something" in metadata_callback.headers
+        assert metadata_callback.headers["X-Showcase-Request-Something"] == "something_value"
+
+
+if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
+    @pytest.mark.asyncio
+    async def test_metadata_async(async_echo):
+        api_core_major, api_core_minor = [
+            int(part) for part in google.api_core.version.__version__.split(".")[0:2]
+        ]
+        if api_core_major < 2 or (api_core_major == 2 and api_core_minor < 24):
+            pytest.skip(
+                "Skip this test if we're on an older version of google-api-core which doesn't support async `with_call`"
+            )
+
+        class MetadataCallback:
+            trailing_metadata = None
+
+            async def get_raw_response_callback(self, response):
+                if isinstance(async_echo.transport, type(async_echo).get_transport_class("grpc_asyncio")):
+                    self.trailing_metadata = await response.trailing_metadata()
+                else:
+                    self.headers = response.headers
+
+        metadata_callback = MetadataCallback()
+
+        response = await async_echo.echo(
+            showcase.EchoRequest(
+                content="The hail in Wales falls mainly on the snails."
+            ),
+            raw_response_callback=metadata_callback.get_raw_response_callback,
+            metadata=(("something", "something_value"),),
+        )
+
+        assert response.content == "The hail in Wales falls mainly on the snails."
+        if isinstance(async_echo.transport, type(async_echo).get_transport_class("grpc_asyncio")):
+            response_metadata = [
+                (metadata.key, metadata.value)
+                if hasattr(metadata, 'key')
+                else metadata
+                for metadata in metadata_callback.trailing_metadata
+            ]
+            assert ("something", "something_value") in response_metadata
+        else:
+            assert "X-Showcase-Request-Something" in metadata_callback.headers
+            assert metadata_callback.headers["X-Showcase-Request-Something"] == "something_value"

--- a/tests/system/test_request_metadata.py
+++ b/tests/system/test_request_metadata.py
@@ -55,13 +55,10 @@ def test_metadata(echo):
         )
 
     class MetadataCallback:
-        trailing_metadata = None
+        response_metadata = None
 
         def get_raw_response_callback(self, response):
-            if isinstance(echo.transport, type(echo).get_transport_class("grpc")):
-                self.trailing_metadata = response.trailing_metadata()
-            else:
-                self.headers = response.headers
+            self.response_metadata = response.response_metadata
 
     metadata_callback = MetadataCallback()
 
@@ -75,15 +72,11 @@ def test_metadata(echo):
 
     assert response.content == "The hail in Wales falls mainly on the snails."
     if isinstance(echo.transport, type(echo).get_transport_class("grpc")):
-        response_metadata = [
-            (metadata.key, metadata.value)
-            for metadata in metadata_callback.trailing_metadata
-        ]
-        assert ("something", "something_value") in response_metadata
+        key = "something"
     else:
+        key = "X-Showcase-Request-Something"
 
-        assert "X-Showcase-Request-Something" in metadata_callback.headers
-        assert metadata_callback.headers["X-Showcase-Request-Something"] == "something_value"
+    assert (key, "something_value") in metadata_callback.response_metadata
 
 
 if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
@@ -98,13 +91,10 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
             )
 
         class MetadataCallback:
-            trailing_metadata = None
+            response_metadata = None
 
-            async def get_raw_response_callback(self, response):
-                if isinstance(async_echo.transport, type(async_echo).get_transport_class("grpc_asyncio")):
-                    self.trailing_metadata = await response.trailing_metadata()
-                else:
-                    self.headers = response.headers
+            def get_raw_response_callback(self, response):
+                self.response_metadata = response.response_metadata
 
         metadata_callback = MetadataCallback()
 
@@ -118,13 +108,8 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
 
         assert response.content == "The hail in Wales falls mainly on the snails."
         if isinstance(async_echo.transport, type(async_echo).get_transport_class("grpc_asyncio")):
-            response_metadata = [
-                (metadata.key, metadata.value)
-                if hasattr(metadata, 'key')
-                else metadata
-                for metadata in metadata_callback.trailing_metadata
-            ]
-            assert ("something", "something_value") in response_metadata
+            key = "something"
         else:
-            assert "X-Showcase-Request-Something" in metadata_callback.headers
-            assert metadata_callback.headers["X-Showcase-Request-Something"] == "something_value"
+            key = "X-Showcase-Request-Something"
+            assert (key, "something_value") in metadata_callback.response_metadata
+        assert response.content == "The hail in Wales falls mainly on the snails."


### PR DESCRIPTION
Prototype 1: `ResponseMetadata` via a callback , using a conditional `with_call`

Fixes b/347351441