### PR TITLE
fix: update return annotation for streaming calls

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_client_macros.j2
@@ -36,7 +36,7 @@
             {% elif not method.server_streaming %}
             ) -> {{ method.client_output.ident }}:
             {% else %}
-            ) -> Iterable[{{ method.client_output.ident }}]:
+            ) -> Union[Iterable[{{ method.client_output.ident }}], GrpcStream[{{ method.client_output.ident }}]]:
             {% endif %}
         r"""{{ method.meta.doc|rst(width=72, indent=8)|trim }}
 
@@ -75,7 +75,7 @@
             {% if not method.server_streaming %}
             {{ method.client_output.ident.sphinx }}:
             {% else %}
-            Iterable[{{ method.client_output.ident.sphinx }}]:
+            Union[Iterable[{{ method.client_output.ident }}], GrpcStream[{{ method.client_output.ident }}]]:
             {% endif %}
                 {{ method.client_output.meta.doc|rst(width=72, indent=16, source_format="rst") }}
         {% endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/async_client.py.j2
@@ -17,6 +17,13 @@ import warnings
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}} import gapic_version as package_version
 
+{% set import_ns = namespace(has_streaming_methods=false) %}
+{%- for method in service.methods.values() if method.server_streaming %}
+{% set import_ns.has_streaming_methods = True %}
+{% endfor -%}
+{% if import_ns.has_streaming_methods == True %}
+from google.api_core.grpc_helpers_async import GrpcAsyncStream
+{% endif %}
 from google.api_core.client_options import ClientOptions
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
@@ -263,7 +270,7 @@ class {{ service.async_client_name }}:
             {% if not method.server_streaming %}
             ) -> {{ method.client_output_async.ident }}:
             {% else %}
-            ) -> Awaitable[AsyncIterable[{{ method.client_output_async.ident }}]]:
+            ) -> Union[Awaitable[AsyncIterable[{{ method.client_output_async.ident }}]], Awaitable[GrpcAsyncStream[{{ method.client_output_async.ident }}]]]:
             {% endif %}
         r"""{{ method.meta.doc|rst(width=72, indent=8)|trim }}
 
@@ -302,7 +309,7 @@ class {{ service.async_client_name }}:
             {% if not method.server_streaming %}
             {{ method.client_output_async.ident.sphinx }}:
             {% else %}
-            AsyncIterable[{{ method.client_output_async.ident.sphinx }}]:
+            Union[AsyncIterable[{{ method.client_output_async.ident.sphinx }}], GrpcAsyncStream[{{ method.client_output_async.ident.sphinx }}]]:
             {% endif %}
                 {{ method.client_output_async.meta.doc|rst(width=72, indent=16, source_format='rst') }}
         {% endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -21,6 +21,13 @@ import warnings
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}} import gapic_version as package_version
 
+{% set import_ns = namespace(has_streaming_methods=false) %}
+{%- for method in service.methods.values() if method.server_streaming %}
+{% set import_ns.has_streaming_methods = True %}
+{% endfor -%}
+{% if import_ns.has_streaming_methods == True %}
+from google.api_core.grpc_helpers import GrpcStream
+{% endif %}
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 {% if service.any_extended_operations_methods %}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -32,7 +32,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
+    "google-api-core[grpc] >= 2.17.1, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -32,7 +32,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -5,7 +5,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==1.34.1
+google-api-core==2.15.0
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -5,7 +5,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==2.15.0
+google-api-core==2.17.1
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the
     # templated setup.py.j2: https://github.com/googleapis/gapic-generator-python/blob/main/gapic/templates/setup.py.j2
     "click >= 6.7",
-    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
+    "google-api-core[grpc] >= 2.17.1, <3.0.0dev",
     "googleapis-common-protos >= 1.55.0",
     "grpcio >= 1.24.3",
     # 2.11.0 is required which adds the `default` argument to `jinja-filters.map()`

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the
     # templated setup.py.j2: https://github.com/googleapis/gapic-generator-python/blob/main/gapic/templates/setup.py.j2
     "click >= 6.7",
-    "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
     "googleapis-common-protos >= 1.55.0",
     "grpcio >= 1.24.3",
     # 2.11.0 is required which adds the `default` argument to `jinja-filters.map()`

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
+    "google-api-core[grpc] >= 2.17.1, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==2.15.0
+google-api-core==2.17.1
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==1.34.1
+google-api-core==2.15.0
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
+    "google-api-core[grpc] >= 2.17.1, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/credentials/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==2.15.0
+google-api-core==2.17.1
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/credentials/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==1.34.1
+google-api-core==2.15.0
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
+    "google-api-core[grpc] >= 2.17.1, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==2.15.0
+google-api-core==2.17.1
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==1.34.1
+google-api-core==2.15.0
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -19,6 +19,7 @@ from typing import Dict, Callable, Mapping, MutableMapping, MutableSequence, Opt
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
+from google.api_core.grpc_helpers_async import GrpcAsyncStream
 from google.api_core.client_options import ClientOptions
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
@@ -898,7 +899,7 @@ class LoggingServiceV2AsyncClient:
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> Awaitable[AsyncIterable[logging.TailLogEntriesResponse]]:
+            ) -> Union[Awaitable[AsyncIterable[logging.TailLogEntriesResponse]], Awaitable[GrpcAsyncStream[logging.TailLogEntriesResponse]]]:
         r"""Streaming read of log entries as they are ingested.
         Until the stream is terminated, it will continue reading
         logs.
@@ -950,7 +951,7 @@ class LoggingServiceV2AsyncClient:
                 sent along with the request as metadata.
 
         Returns:
-            AsyncIterable[google.cloud.logging_v2.types.TailLogEntriesResponse]:
+            Union[AsyncIterable[google.cloud.logging_v2.types.TailLogEntriesResponse], GrpcAsyncStream[google.cloud.logging_v2.types.TailLogEntriesResponse]]:
                 Result returned from TailLogEntries.
         """
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -21,6 +21,7 @@ import warnings
 
 from google.cloud.logging_v2 import gapic_version as package_version
 
+from google.api_core.grpc_helpers import GrpcStream
 from google.api_core import client_options as client_options_lib
 from google.api_core import exceptions as core_exceptions
 from google.api_core import gapic_v1
@@ -1208,7 +1209,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
             retry: OptionalRetry = gapic_v1.method.DEFAULT,
             timeout: Union[float, object] = gapic_v1.method.DEFAULT,
             metadata: Sequence[Tuple[str, str]] = (),
-            ) -> Iterable[logging.TailLogEntriesResponse]:
+            ) -> Union[Iterable[logging.TailLogEntriesResponse], GrpcStream[logging.TailLogEntriesResponse]]:
         r"""Streaming read of log entries as they are ingested.
         Until the stream is terminated, it will continue reading
         logs.
@@ -1260,7 +1261,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 sent along with the request as metadata.
 
         Returns:
-            Iterable[google.cloud.logging_v2.types.TailLogEntriesResponse]:
+            Union[Iterable[logging.TailLogEntriesResponse], GrpcStream[logging.TailLogEntriesResponse]]:
                 Result returned from TailLogEntries.
         """
 

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
+    "google-api-core[grpc] >= 2.17.1, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/logging/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==2.15.0
+google-api-core==2.17.1
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/logging/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==1.34.1
+google-api-core==2.15.0
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 1.34.1, <3.0.0dev,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -39,7 +39,7 @@ else:
     release_status = "Development Status :: 5 - Production/Stable"
 
 dependencies = [
-    "google-api-core[grpc] >= 2.15.0, <3.0.0dev",
+    "google-api-core[grpc] >= 2.17.1, <3.0.0dev",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0dev,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/redis/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==2.15.0
+google-api-core==2.17.1
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.7.txt
@@ -4,7 +4,7 @@
 # Pin the version to the lower bound.
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0dev",
 # Then this file should have google-cloud-foo==1.14.0
-google-api-core==1.34.1
+google-api-core==2.15.0
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2


### PR DESCRIPTION
Towards b/347351441

 `GrpcStream[Response]` exposes the underlying `grpc.Call` for streaming calls, there is currently no way to use these `grpc.Call` methods without mypy errors, because of the restrictive return type annotation used. See https://github.com/googleapis/python-api-core/pull/554#issue-1998080923 for context.

Adding the `GrpcStream[Response]` and `Awaitable[AsyncIterable[Response]]` response types for streaming calls will satisfy type checkers. 

BEGIN_COMMIT_OVERRIDE
fix(deps): require google-api-core >= 2.17.1
END_COMMIT_OVERRIDE

`google-api-core>=2.15.0` is the minimum version which supports types `GrpcAsyncStream` and `GrpcStream`
`google-api-core>=2.17.1` is needed which fixes an issue with REST Streaming which can be seen in this [build log](https://github.com/googleapis/gapic-generator-python/actions/runs/11922672625/job/33229457759)