### PR TITLE
feat: add debug log when sending requests via REST

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -197,7 +197,8 @@ def _get_http_options():
         method_name (str): The method name.
         service_name (str): The service name.
         is_async (bool): Used to determine the code path i.e. whether for sync or async call. #}
-{% macro rest_call_method_common(body_spec, method_name, service_name, is_async=False) %}
+{% macro rest_call_method_common(body_spec, method_name, service, is_async=False) %}
+{% set service_name = service.name %}
 {% set await_prefix = "await " if is_async else "" %}
 {% set async_class_prefix = "Async" if is_async else "" %}
 
@@ -434,7 +435,7 @@ class _{{ name }}(_Base{{ service.name }}RestTransport._Base{{name}}, {{ async_m
             {{ sig.response_type }}: Response from {{ name }} method.
         {% endif %}
         """
-        {{ rest_call_method_common(body_spec, name, service.name, is_async)|indent(4) }}
+        {{ rest_call_method_common(body_spec, name, service, is_async)|indent(4) }}
         
         {% if sig.response_type == "None" %}
         return {{ await_prefix }}self._interceptor.post_{{ name|snake_case }}(None)
@@ -447,6 +448,17 @@ class _{{ name }}(_Base{{ service.name }}RestTransport._Base{{name}}, {{ async_m
         resp = {{ sig.response_type }}()
         resp = json_format.Parse(content, resp)
         resp = {{ await_prefix }}self._interceptor.post_{{ name|snake_case }}(resp)
+        if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+            _LOGGER.debug(
+                "Received response for {{ service.meta.address.proto_package_versioned }}.{{ service.async_client_name }}.{{ name }}",
+                extra = {
+                    "serviceName": "{{ service.meta.address.proto }}",
+                    "rpcName": "{{ name }}",
+                    "retryAttempt": 1,
+                    "response": json_format.MessageToJson(response),
+                    "metadata": str(dict(response.headers)),
+                },
+            )
         return resp
         {% endif %}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -468,14 +468,19 @@ class _{{ name }}(_Base{{ service.name }}RestTransport._Base{{name}}, {{ async_m
         resp = json_format.Parse(content, resp)
         resp = {{ await_prefix }}self._interceptor.post_{{ name|snake_case }}(resp)
         if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+            http_response = {
+                "payload": json_format.MessageToJson(response),
+                "headers":  dict(response.headers),
+                "status": response.status_code,
+            }        
             _LOGGER.debug(
                 "Received response for {{ service.meta.address.proto_package_versioned }}.{{ service.async_client_name }}.{{ name }}",
                 extra = {
                     "serviceName": "{{ service.meta.address.proto }}",
                     "rpcName": "{{ name }}",
-                    "retryAttempt": 1,
-                    "response": json_format.MessageToJson(response),
-                    "metadata": str(dict(response.headers)),
+                    {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2275): logging `metadata` seems repetitive and may need to be cleaned up #}
+                    "metadata": http_response["headers"],
+                    "httpResponse": http_response,
                 },
             )
         return resp

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -203,6 +203,7 @@ def _get_http_options():
 {% set async_class_prefix = "Async" if is_async else "" %}
 
     http_options = _Base{{ service_name }}RestTransport._Base{{method_name}}._get_http_options()
+    {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2274): Add debug log before intercepting a request #} 
     request, metadata = {{ await_prefix }}self._interceptor.pre_{{ method_name|snake_case }}(request, metadata)
     transcoded_request = _Base{{ service_name }}RestTransport._Base{{method_name}}._get_transcoded_request(http_options, request)
 
@@ -218,7 +219,7 @@ def _get_http_options():
         method = transcoded_request['method']
         http_request = {
           "payload":   type(request).to_json(request),
-          "requestmethod": method,
+          "requestMethod": method,
           "requestUrl": request_url,
         }
         _LOGGER.debug(

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -214,12 +214,16 @@ def _get_http_options():
     query_params = _Base{{ service_name }}RestTransport._Base{{method_name}}._get_query_params_json(transcoded_request)
 
     if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+        request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+        method = transcoded_request['method']
         _LOGGER.debug(
             f"Sending request via {{ service.meta.address.proto_package_versioned }}.{{ service.client_name }}.{{ method_name }}",
             extra = {
                 "serviceName": "{{ service.meta.address.proto }}",
                 "rpcName": "{{ method_name }}",
-                "request": type(request).to_json(request),
+                "httpRequest": type(request).to_json(request),
+                "httpRequestMethod": method,
+                "httpRequestUrl": request_url,
                 "metadata": str(dict(metadata)),
             },
         )

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -213,6 +213,18 @@ def _get_http_options():
     # Jsonify the query params
     query_params = _Base{{ service_name }}RestTransport._Base{{method_name}}._get_query_params_json(transcoded_request)
 
+    if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+        _LOGGER.debug(
+            f"Sending request via {{ service.meta.address.proto_package_versioned }}.{{ service.client_name }}.{{ method_name }}",
+            extra = {
+                "serviceName": "{{ service.meta.address.proto }}",
+                "rpcName": "{{ method_name }}",
+                "retryAttempt": 1,
+                "request": type(request).to_json(request),
+                "metadata": str(dict(metadata)),
+            },
+        )
+
     # Send the request
     response = {{ await_prefix }}{{ async_class_prefix }}{{ service_name }}RestTransport._{{method_name}}._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request{% if body_spec %}, body{% endif %})
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -219,7 +219,6 @@ def _get_http_options():
             extra = {
                 "serviceName": "{{ service.meta.address.proto }}",
                 "rpcName": "{{ method_name }}",
-                "retryAttempt": 1,
                 "request": type(request).to_json(request),
                 "metadata": str(dict(metadata)),
             },

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -195,7 +195,7 @@ def _get_http_options():
     Args:
         body_spec (str): The http options body i.e. method.http_options[0].body
         method_name (str): The method name.
-        service_name (str): The service name.
+        service: The service.
         is_async (bool): Used to determine the code path i.e. whether for sync or async call. #}
 {% macro rest_call_method_common(body_spec, method_name, service, is_async=False) %}
 {% set service_name = service.name %}
@@ -216,15 +216,18 @@ def _get_http_options():
     if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
         request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
         method = transcoded_request['method']
+        http_request = {
+          "payload":   type(request).to_json(request),
+          "requestmethod": method,
+          "requestUrl": request_url,
+        }
         _LOGGER.debug(
-            f"Sending request via {{ service.meta.address.proto_package_versioned }}.{{ service.client_name }}.{{ method_name }}",
+            f"Sending request for  {{ service.meta.address.proto_package_versioned }}.{{ service.client_name }}.{{ method_name }}",
             extra = {
                 "serviceName": "{{ service.meta.address.proto }}",
                 "rpcName": "{{ method_name }}",
-                "httpRequest": type(request).to_json(request),
-                "httpRequestMethod": method,
-                "httpRequestUrl": request_url,
                 "metadata": str(dict(metadata)),
+                "httpRequest": http_request,
             },
         )
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/client.py.j2
@@ -617,8 +617,8 @@ class {{ service.client_name }}(metaclass={{ service.client_name }}Meta):
                     extra = {
                         "serviceName": "{{ service.meta.address.proto }}",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -258,6 +258,7 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -265,7 +266,7 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                     extra = {
                         "serviceName": "{{ service.meta.address.proto }}",
                         "rpcName": "{{ method.name }}",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -254,11 +254,12 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             {% endif %}{# method.lro #}
+            {#- TODO(https://github.com/googleapis/gapic-generator-python/issues/2274): Add debug log before intercepting a request #} 
             resp = self._interceptor.post_{{ method.name|snake_case }}(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -41,6 +41,16 @@ except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
 
 
+import logging
+
+try:  # pragma: NO COVER
+    from google.api_core import client_logging  # type: ignore
+    CLIENT_LOGGING_SUPPORTED = True
+except ImportError:
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
     grpc_version=None,
@@ -227,7 +237,7 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             {% endif %}
             """
 
-            {{ shared_macros.rest_call_method_common(body_spec, method.name, service.name)|indent(8) }}
+            {{ shared_macros.rest_call_method_common(body_spec, method.name, service)|indent(8) }}
 
             {% if not method.void %}
             # Return the response
@@ -247,6 +257,17 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             {% endif %}{# method.lro #}
             resp = self._interceptor.post_{{ method.name|snake_case }}(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for {{ service.meta.address.proto_package_versioned }}.{{ service.client_name }}.{{ method.transport_safe_name|snake_case }}",
+                    extra = {
+                        "serviceName": "{{ service.meta.address.proto }}",
+                        "rpcName": "{{ method.name }}",
+                        "retryAttempt": 1,
+                        "response": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
             {% endif %}{# method.void #}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -256,13 +256,17 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             {% endif %}{# method.lro #}
             resp = self._interceptor.post_{{ method.name|snake_case }}(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for {{ service.meta.address.proto_package_versioned }}.{{ service.client_name }}.{{ method.transport_safe_name|snake_case }}",
                     extra = {
                         "serviceName": "{{ service.meta.address.proto }}",
                         "rpcName": "{{ method.name }}",
-                        "response": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -259,13 +259,14 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                 http_response = {
                 "payload": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for {{ service.meta.address.proto_package_versioned }}.{{ service.client_name }}.{{ method.transport_safe_name|snake_case }}",
                     extra = {
                         "serviceName": "{{ service.meta.address.proto }}",
                         "rpcName": "{{ method.name }}",
+                        {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2275): logging `metadata` seems repetitive and may need to be cleaned up #}
                         "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -3,9 +3,10 @@
 
 {% block content %}
 
+import logging
+import json  # type: ignore
 
 from google.auth.transport.requests import AuthorizedSession  # type: ignore
-import json  # type: ignore
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import retry as retries
@@ -39,9 +40,6 @@ try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
-
-
-import logging
 
 try:  # pragma: NO COVER
     from google.api_core import client_logging  # type: ignore
@@ -263,7 +261,6 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                     extra = {
                         "serviceName": "{{ service.meta.address.proto }}",
                         "rpcName": "{{ method.name }}",
-                        "retryAttempt": 1,
                         "response": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
                         "metadata": str(dict(response.headers)),
                     },

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -58,6 +58,17 @@ from .rest_base import _Base{{ service.name }}RestTransport
 
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
+
+import logging
+
+try:  # pragma: NO COVER
+    from google.api_core import client_logging  # type: ignore
+    CLIENT_LOGGING_SUPPORTED = True
+except ImportError:
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
 try:
     OptionalRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
@@ -188,7 +199,7 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             {% endif %}
             """
 
-            {{ shared_macros.rest_call_method_common(body_spec, method.name, service.name, is_async=True)|indent(8) }}
+            {{ shared_macros.rest_call_method_common(body_spec, method.name, service, is_async=True)|indent(8) }}
 
             {% if not method.void %}
             # Return the response
@@ -206,6 +217,18 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             {% endif %}{# if method.server_streaming #}
             resp = await self._interceptor.post_{{ method.name|snake_case }}(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for {{ service.meta.address.proto_package_versioned }}.{{ service.async_client_name }}.{{ method.transport_safe_name|snake_case }}",
+                    extra = {
+                        "serviceName": "{{ service.meta.address.proto }}",
+                        "rpcName": "{{ method.name }}",
+                        "retryAttempt": 1,
+                        "response": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(response){% else %}json_format.MessageToJson(response){% endif %},
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
             {% endif %}{# method.void #}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -218,17 +218,21 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             {% endif %}{# if method.server_streaming #}
             resp = await self._interceptor.post_{{ method.name|snake_case }}(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(response){% else %}json_format.MessageToJson(response){% endif %},
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for {{ service.meta.address.proto_package_versioned }}.{{ service.async_client_name }}.{{ method.transport_safe_name|snake_case }}",
                     extra = {
                         "serviceName": "{{ service.meta.address.proto }}",
                         "rpcName": "{{ method.name }}",
-                        "retryAttempt": 1,
-                        "response": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(response){% else %}json_format.MessageToJson(response){% endif %},
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
-
+            
             return resp
 
             {% endif %}{# method.void #}

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -638,8 +638,8 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -869,7 +869,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.AnalyzeIamPolicyResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_iam_policy",
@@ -982,7 +982,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_iam_policy_longrunning",
@@ -1092,7 +1092,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.AnalyzeMoveResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_move",
@@ -1202,7 +1202,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPoliciesResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policies",
@@ -1313,7 +1313,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policy_governed_assets",
@@ -1424,7 +1424,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPolicyGovernedContainersResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policy_governed_containers",
@@ -1531,7 +1531,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.BatchGetAssetsHistoryResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.batch_get_assets_history",
@@ -1642,7 +1642,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.BatchGetEffectiveIamPoliciesResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.batch_get_effective_iam_policies",
@@ -1760,7 +1760,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.create_feed",
@@ -1872,7 +1872,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.create_saved_query",
@@ -2143,7 +2143,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.export_assets",
@@ -2258,7 +2258,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.get_feed",
@@ -2367,7 +2367,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.get_saved_query",
@@ -2474,7 +2474,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.ListAssetsResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.list_assets",
@@ -2581,7 +2581,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.ListFeedsResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.list_feeds",
@@ -2688,7 +2688,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.ListSavedQueriesResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.list_saved_queries",
@@ -2798,7 +2798,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.QueryAssetsResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.query_assets",
@@ -2905,7 +2905,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.SearchAllIamPoliciesResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.search_all_iam_policies",
@@ -3012,7 +3012,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.SearchAllResourcesResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.search_all_resources",
@@ -3130,7 +3130,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.update_feed",
@@ -3242,7 +3242,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.update_saved_query",

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -867,6 +867,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeIamPolicyResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -874,7 +875,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeIamPolicy",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -978,6 +979,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -985,7 +987,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeIamPolicyLongrunning",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1086,6 +1088,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeMoveResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1093,7 +1096,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeMove",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1194,6 +1197,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPoliciesResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1201,7 +1205,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicies",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1303,6 +1307,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1310,7 +1315,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicyGovernedAssets",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1412,6 +1417,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPolicyGovernedContainersResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1419,7 +1425,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicyGovernedContainers",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1517,6 +1523,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.BatchGetAssetsHistoryResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1524,7 +1531,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "BatchGetAssetsHistory",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1626,6 +1633,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.BatchGetEffectiveIamPoliciesResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1633,7 +1641,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "BatchGetEffectiveIamPolicies",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1742,6 +1750,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1749,7 +1758,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "CreateFeed",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1852,6 +1861,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1859,7 +1869,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "CreateSavedQuery",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2119,6 +2129,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2126,7 +2137,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ExportAssets",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2232,6 +2243,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2239,7 +2251,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetFeed",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2339,6 +2351,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2346,7 +2359,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetSavedQuery",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2444,6 +2457,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.ListAssetsResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2451,7 +2465,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListAssets",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2549,6 +2563,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.ListFeedsResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2556,7 +2571,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListFeeds",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2654,6 +2669,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.ListSavedQueriesResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2661,7 +2677,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListSavedQueries",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2762,6 +2778,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.QueryAssetsResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2769,7 +2786,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "QueryAssets",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2867,6 +2884,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SearchAllIamPoliciesResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2874,7 +2892,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "SearchAllIamPolicies",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2972,6 +2990,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SearchAllResourcesResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2979,7 +2998,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "SearchAllResources",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -3088,6 +3107,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -3095,7 +3115,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "UpdateFeed",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -3198,6 +3218,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -3205,7 +3226,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "UpdateSavedQuery",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -834,6 +834,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicy._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeIamPolicy",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeIamPolicy",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._AnalyzeIamPolicy._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -926,6 +938,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicyLongrunning._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeIamPolicyLongrunning",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeIamPolicyLongrunning",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._AnalyzeIamPolicyLongrunning._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1010,6 +1034,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeMove._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeMove",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeMove",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._AnalyzeMove._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1097,6 +1133,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicies._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicies",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeOrgPolicies",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._AnalyzeOrgPolicies._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1186,6 +1234,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedAssets._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicyGovernedAssets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeOrgPolicyGovernedAssets",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._AnalyzeOrgPolicyGovernedAssets._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1274,6 +1334,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedContainers._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicyGovernedContainers",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeOrgPolicyGovernedContainers",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._AnalyzeOrgPolicyGovernedContainers._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1357,6 +1429,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseBatchGetAssetsHistory._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.BatchGetAssetsHistory",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "BatchGetAssetsHistory",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._BatchGetAssetsHistory._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1445,6 +1529,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseBatchGetEffectiveIamPolicies._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.BatchGetEffectiveIamPolicies",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "BatchGetEffectiveIamPolicies",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._BatchGetEffectiveIamPolicies._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1541,6 +1637,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseCreateFeed._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.CreateFeed",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "CreateFeed",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._CreateFeed._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1630,6 +1738,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseCreateSavedQuery._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.CreateSavedQuery",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "CreateSavedQuery",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._CreateSavedQuery._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1710,6 +1830,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseDeleteFeed._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.DeleteFeed",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "DeleteFeed",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._DeleteFeed._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1770,6 +1902,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseDeleteSavedQuery._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.DeleteSavedQuery",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "DeleteSavedQuery",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._DeleteSavedQuery._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1841,6 +1985,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseExportAssets._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ExportAssets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ExportAssets",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._ExportAssets._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -1932,6 +2088,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseGetFeed._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.GetFeed",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "GetFeed",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._GetFeed._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2018,6 +2186,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseGetSavedQuery._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.GetSavedQuery",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "GetSavedQuery",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._GetSavedQuery._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2101,6 +2281,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseListAssets._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ListAssets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ListAssets",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._ListAssets._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2186,6 +2378,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseListFeeds._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ListFeeds",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ListFeeds",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._ListFeeds._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2269,6 +2473,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseListSavedQueries._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ListSavedQueries",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ListSavedQueries",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._ListSavedQueries._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2357,6 +2573,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseQueryAssets._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.QueryAssets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "QueryAssets",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._QueryAssets._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -2441,6 +2669,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseSearchAllIamPolicies._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.SearchAllIamPolicies",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "SearchAllIamPolicies",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._SearchAllIamPolicies._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2524,6 +2764,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseSearchAllResources._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.SearchAllResources",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "SearchAllResources",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._SearchAllResources._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2620,6 +2872,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseUpdateFeed._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.UpdateFeed",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "UpdateFeed",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = AssetServiceRestTransport._UpdateFeed._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -2708,6 +2972,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseUpdateSavedQuery._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.UpdateSavedQuery",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "UpdateSavedQuery",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._UpdateSavedQuery._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -2980,6 +3256,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             # Jsonify the query params
             query_params = _BaseAssetServiceRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = AssetServiceRestTransport._GetOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import logging
+import json  # type: ignore
 
 from google.auth.transport.requests import AuthorizedSession  # type: ignore
-import json  # type: ignore
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import retry as retries
@@ -44,9 +45,6 @@ try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
-
-
-import logging
 
 try:  # pragma: NO COVER
     from google.api_core import client_logging  # type: ignore
@@ -835,14 +833,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicy._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeIamPolicy",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.AnalyzeIamPolicy",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeIamPolicy",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -861,14 +865,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.AnalyzeIamPolicyResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_iam_policy",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeIamPolicy",
-                        "retryAttempt": 1,
-                        "response": asset_service.AnalyzeIamPolicyResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -939,14 +946,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicyLongrunning._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeIamPolicyLongrunning",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.AnalyzeIamPolicyLongrunning",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeIamPolicyLongrunning",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -963,14 +976,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy_longrunning(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_iam_policy_longrunning",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeIamPolicyLongrunning",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1036,14 +1052,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeMove._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeMove",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.AnalyzeMove",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeMove",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1062,14 +1084,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_move(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.AnalyzeMoveResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_move",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeMove",
-                        "retryAttempt": 1,
-                        "response": asset_service.AnalyzeMoveResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1135,14 +1160,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicies._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicies",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicies",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicies",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1161,14 +1192,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policies(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.AnalyzeOrgPoliciesResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policies",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicies",
-                        "retryAttempt": 1,
-                        "response": asset_service.AnalyzeOrgPoliciesResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1235,14 +1269,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedAssets._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicyGovernedAssets",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicyGovernedAssets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicyGovernedAssets",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1261,14 +1301,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policy_governed_assets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicyGovernedAssets",
-                        "retryAttempt": 1,
-                        "response": asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1335,14 +1378,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedContainers._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicyGovernedContainers",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.AnalyzeOrgPolicyGovernedContainers",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicyGovernedContainers",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1361,14 +1410,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_containers(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.AnalyzeOrgPolicyGovernedContainersResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policy_governed_containers",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "AnalyzeOrgPolicyGovernedContainers",
-                        "retryAttempt": 1,
-                        "response": asset_service.AnalyzeOrgPolicyGovernedContainersResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1431,14 +1483,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseBatchGetAssetsHistory._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.BatchGetAssetsHistory",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.BatchGetAssetsHistory",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "BatchGetAssetsHistory",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1457,14 +1515,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_assets_history(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.BatchGetAssetsHistoryResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.batch_get_assets_history",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "BatchGetAssetsHistory",
-                        "retryAttempt": 1,
-                        "response": asset_service.BatchGetAssetsHistoryResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1531,14 +1592,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseBatchGetEffectiveIamPolicies._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.BatchGetEffectiveIamPolicies",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.BatchGetEffectiveIamPolicies",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "BatchGetEffectiveIamPolicies",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1557,14 +1624,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_effective_iam_policies(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.BatchGetEffectiveIamPoliciesResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.batch_get_effective_iam_policies",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "BatchGetEffectiveIamPolicies",
-                        "retryAttempt": 1,
-                        "response": asset_service.BatchGetEffectiveIamPoliciesResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1638,14 +1708,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseCreateFeed._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.CreateFeed",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.CreateFeed",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "CreateFeed",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1664,14 +1740,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_feed(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.Feed.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.create_feed",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "CreateFeed",
-                        "retryAttempt": 1,
-                        "response": asset_service.Feed.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1739,14 +1818,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseCreateSavedQuery._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.CreateSavedQuery",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.CreateSavedQuery",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "CreateSavedQuery",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1765,14 +1850,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_saved_query(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.SavedQuery.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.create_saved_query",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "CreateSavedQuery",
-                        "retryAttempt": 1,
-                        "response": asset_service.SavedQuery.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1831,14 +1919,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseDeleteFeed._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.DeleteFeed",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.DeleteFeed",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "DeleteFeed",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1904,14 +1998,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseDeleteSavedQuery._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.DeleteSavedQuery",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.DeleteSavedQuery",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "DeleteSavedQuery",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1987,14 +2087,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseExportAssets._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ExportAssets",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.ExportAssets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ExportAssets",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2011,14 +2117,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.export_assets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ExportAssets",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2089,14 +2198,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseGetFeed._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.GetFeed",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.GetFeed",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetFeed",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2115,14 +2230,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_feed(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.Feed.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.get_feed",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetFeed",
-                        "retryAttempt": 1,
-                        "response": asset_service.Feed.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2187,14 +2305,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseGetSavedQuery._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.GetSavedQuery",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.GetSavedQuery",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetSavedQuery",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2213,14 +2337,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_saved_query(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.SavedQuery.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.get_saved_query",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetSavedQuery",
-                        "retryAttempt": 1,
-                        "response": asset_service.SavedQuery.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2283,14 +2410,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseListAssets._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ListAssets",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.ListAssets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListAssets",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2309,14 +2442,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.ListAssetsResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.list_assets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListAssets",
-                        "retryAttempt": 1,
-                        "response": asset_service.ListAssetsResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2379,14 +2515,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseListFeeds._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ListFeeds",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.ListFeeds",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListFeeds",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2405,14 +2547,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_feeds(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.ListFeedsResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.list_feeds",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListFeeds",
-                        "retryAttempt": 1,
-                        "response": asset_service.ListFeedsResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2475,14 +2620,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseListSavedQueries._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.ListSavedQueries",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.ListSavedQueries",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListSavedQueries",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2501,14 +2652,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_saved_queries(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.ListSavedQueriesResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.list_saved_queries",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "ListSavedQueries",
-                        "retryAttempt": 1,
-                        "response": asset_service.ListSavedQueriesResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2574,14 +2728,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseQueryAssets._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.QueryAssets",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.QueryAssets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "QueryAssets",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2600,14 +2760,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_query_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.QueryAssetsResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.query_assets",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "QueryAssets",
-                        "retryAttempt": 1,
-                        "response": asset_service.QueryAssetsResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2670,14 +2833,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseSearchAllIamPolicies._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.SearchAllIamPolicies",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.SearchAllIamPolicies",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "SearchAllIamPolicies",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2696,14 +2865,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_iam_policies(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.SearchAllIamPoliciesResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.search_all_iam_policies",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "SearchAllIamPolicies",
-                        "retryAttempt": 1,
-                        "response": asset_service.SearchAllIamPoliciesResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2766,14 +2938,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseSearchAllResources._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.SearchAllResources",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.SearchAllResources",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "SearchAllResources",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2792,14 +2970,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_resources(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.SearchAllResourcesResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.search_all_resources",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "SearchAllResources",
-                        "retryAttempt": 1,
-                        "response": asset_service.SearchAllResourcesResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2873,14 +3054,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseUpdateFeed._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.UpdateFeed",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.UpdateFeed",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "UpdateFeed",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2899,14 +3086,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_feed(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.Feed.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.update_feed",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "UpdateFeed",
-                        "retryAttempt": 1,
-                        "response": asset_service.Feed.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2974,14 +3164,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseUpdateSavedQuery._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.UpdateSavedQuery",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.UpdateSavedQuery",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "UpdateSavedQuery",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3000,14 +3196,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_saved_query(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": asset_service.SavedQuery.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceClient.update_saved_query",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "UpdateSavedQuery",
-                        "retryAttempt": 1,
-                        "response": asset_service.SavedQuery.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -3258,14 +3457,20 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             query_params = _BaseAssetServiceRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.asset_v1.AssetServiceClient.GetOperation",
+                    f"Sending request for  google.cloud.asset_v1.AssetServiceClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -864,11 +864,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.AnalyzeIamPolicyResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_analyze_iam_policy(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeIamPolicyResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -977,11 +978,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_analyze_iam_policy_longrunning(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1087,11 +1089,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.AnalyzeMoveResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_analyze_move(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeMoveResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1197,11 +1200,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.AnalyzeOrgPoliciesResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_analyze_org_policies(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPoliciesResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1308,11 +1312,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_analyze_org_policy_governed_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1419,11 +1424,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.AnalyzeOrgPolicyGovernedContainersResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_analyze_org_policy_governed_containers(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.AnalyzeOrgPolicyGovernedContainersResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1526,11 +1532,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.BatchGetAssetsHistoryResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_batch_get_assets_history(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.BatchGetAssetsHistoryResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1637,11 +1644,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.BatchGetEffectiveIamPoliciesResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_batch_get_effective_iam_policies(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.BatchGetEffectiveIamPoliciesResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1755,11 +1763,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.Feed.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_create_feed(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1867,11 +1876,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.SavedQuery.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_create_saved_query(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2138,11 +2148,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_export_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2253,11 +2264,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.Feed.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_feed(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2362,11 +2374,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.SavedQuery.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_saved_query(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2469,11 +2482,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.ListAssetsResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.ListAssetsResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2576,11 +2590,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.ListFeedsResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_feeds(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.ListFeedsResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2683,11 +2698,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.ListSavedQueriesResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_saved_queries(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.ListSavedQueriesResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2793,11 +2809,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.QueryAssetsResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_query_assets(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.QueryAssetsResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2900,11 +2917,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.SearchAllIamPoliciesResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_search_all_iam_policies(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SearchAllIamPoliciesResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -3007,11 +3025,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.SearchAllResourcesResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_search_all_resources(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SearchAllResourcesResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -3125,11 +3144,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.Feed.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_update_feed(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.Feed.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -3237,11 +3257,12 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             pb_resp = asset_service.SavedQuery.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_update_saved_query(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": asset_service.SavedQuery.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -3532,14 +3553,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_operation(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.asset_v1.AssetServiceAsyncClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.asset.v1.AssetService",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -826,6 +826,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicy._get_http_options()
+
             request, metadata = self._interceptor.pre_analyze_iam_policy(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicy._get_transcoded_request(http_options, request)
 
@@ -837,7 +838,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -938,6 +939,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicyLongrunning._get_http_options()
+
             request, metadata = self._interceptor.pre_analyze_iam_policy_longrunning(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseAnalyzeIamPolicyLongrunning._get_transcoded_request(http_options, request)
 
@@ -951,7 +953,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1047,6 +1049,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseAnalyzeMove._get_http_options()
+
             request, metadata = self._interceptor.pre_analyze_move(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseAnalyzeMove._get_transcoded_request(http_options, request)
 
@@ -1058,7 +1061,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1156,6 +1159,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicies._get_http_options()
+
             request, metadata = self._interceptor.pre_analyze_org_policies(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicies._get_transcoded_request(http_options, request)
 
@@ -1167,7 +1171,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1266,6 +1270,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedAssets._get_http_options()
+
             request, metadata = self._interceptor.pre_analyze_org_policy_governed_assets(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedAssets._get_transcoded_request(http_options, request)
 
@@ -1277,7 +1282,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1376,6 +1381,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedContainers._get_http_options()
+
             request, metadata = self._interceptor.pre_analyze_org_policy_governed_containers(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedContainers._get_transcoded_request(http_options, request)
 
@@ -1387,7 +1393,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1482,6 +1488,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseBatchGetAssetsHistory._get_http_options()
+
             request, metadata = self._interceptor.pre_batch_get_assets_history(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseBatchGetAssetsHistory._get_transcoded_request(http_options, request)
 
@@ -1493,7 +1500,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1592,6 +1599,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseBatchGetEffectiveIamPolicies._get_http_options()
+
             request, metadata = self._interceptor.pre_batch_get_effective_iam_policies(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseBatchGetEffectiveIamPolicies._get_transcoded_request(http_options, request)
 
@@ -1603,7 +1611,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1707,6 +1715,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseCreateFeed._get_http_options()
+
             request, metadata = self._interceptor.pre_create_feed(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseCreateFeed._get_transcoded_request(http_options, request)
 
@@ -1720,7 +1729,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1818,6 +1827,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseCreateSavedQuery._get_http_options()
+
             request, metadata = self._interceptor.pre_create_saved_query(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseCreateSavedQuery._get_transcoded_request(http_options, request)
 
@@ -1831,7 +1841,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1922,6 +1932,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseDeleteFeed._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_feed(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseDeleteFeed._get_transcoded_request(http_options, request)
 
@@ -1933,7 +1944,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2001,6 +2012,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseDeleteSavedQuery._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_saved_query(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseDeleteSavedQuery._get_transcoded_request(http_options, request)
 
@@ -2012,7 +2024,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2088,6 +2100,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseExportAssets._get_http_options()
+
             request, metadata = self._interceptor.pre_export_assets(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseExportAssets._get_transcoded_request(http_options, request)
 
@@ -2101,7 +2114,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2202,6 +2215,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseGetFeed._get_http_options()
+
             request, metadata = self._interceptor.pre_get_feed(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseGetFeed._get_transcoded_request(http_options, request)
 
@@ -2213,7 +2227,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2310,6 +2324,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseGetSavedQuery._get_http_options()
+
             request, metadata = self._interceptor.pre_get_saved_query(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseGetSavedQuery._get_transcoded_request(http_options, request)
 
@@ -2321,7 +2336,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2416,6 +2431,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseListAssets._get_http_options()
+
             request, metadata = self._interceptor.pre_list_assets(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseListAssets._get_transcoded_request(http_options, request)
 
@@ -2427,7 +2443,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2522,6 +2538,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseListFeeds._get_http_options()
+
             request, metadata = self._interceptor.pre_list_feeds(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseListFeeds._get_transcoded_request(http_options, request)
 
@@ -2533,7 +2550,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2628,6 +2645,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseListSavedQueries._get_http_options()
+
             request, metadata = self._interceptor.pre_list_saved_queries(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseListSavedQueries._get_transcoded_request(http_options, request)
 
@@ -2639,7 +2657,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2735,6 +2753,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseQueryAssets._get_http_options()
+
             request, metadata = self._interceptor.pre_query_assets(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseQueryAssets._get_transcoded_request(http_options, request)
 
@@ -2748,7 +2767,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2843,6 +2862,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseSearchAllIamPolicies._get_http_options()
+
             request, metadata = self._interceptor.pre_search_all_iam_policies(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseSearchAllIamPolicies._get_transcoded_request(http_options, request)
 
@@ -2854,7 +2874,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2949,6 +2969,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseSearchAllResources._get_http_options()
+
             request, metadata = self._interceptor.pre_search_all_resources(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseSearchAllResources._get_transcoded_request(http_options, request)
 
@@ -2960,7 +2981,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3064,6 +3085,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseUpdateFeed._get_http_options()
+
             request, metadata = self._interceptor.pre_update_feed(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseUpdateFeed._get_transcoded_request(http_options, request)
 
@@ -3077,7 +3099,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3175,6 +3197,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseUpdateSavedQuery._get_http_options()
+
             request, metadata = self._interceptor.pre_update_saved_query(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseUpdateSavedQuery._get_transcoded_request(http_options, request)
 
@@ -3188,7 +3211,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3471,6 +3494,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             """
 
             http_options = _BaseAssetServiceRestTransport._BaseGetOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_get_operation(request, metadata)
             transcoded_request = _BaseAssetServiceRestTransport._BaseGetOperation._get_transcoded_request(http_options, request)
 
@@ -3482,7 +3506,7 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -46,6 +46,16 @@ except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
 
 
+import logging
+
+try:  # pragma: NO COVER
+    from google.api_core import client_logging  # type: ignore
+    CLIENT_LOGGING_SUPPORTED = True
+except ImportError:
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
     grpc_version=None,
@@ -838,6 +848,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_iam_policy",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeIamPolicy",
+                        "retryAttempt": 1,
+                        "response": asset_service.AnalyzeIamPolicyResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _AnalyzeIamPolicyLongrunning(_BaseAssetServiceRestTransport._BaseAnalyzeIamPolicyLongrunning, AssetServiceRestStub):
@@ -917,6 +938,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_iam_policy_longrunning(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_iam_policy_longrunning",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeIamPolicyLongrunning",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _AnalyzeMove(_BaseAssetServiceRestTransport._BaseAnalyzeMove, AssetServiceRestStub):
@@ -993,6 +1025,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_move(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_move",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeMove",
+                        "retryAttempt": 1,
+                        "response": asset_service.AnalyzeMoveResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _AnalyzeOrgPolicies(_BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicies, AssetServiceRestStub):
@@ -1069,6 +1112,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policies(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policies",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeOrgPolicies",
+                        "retryAttempt": 1,
+                        "response": asset_service.AnalyzeOrgPoliciesResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _AnalyzeOrgPolicyGovernedAssets(_BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedAssets, AssetServiceRestStub):
@@ -1146,6 +1200,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_assets(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policy_governed_assets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeOrgPolicyGovernedAssets",
+                        "retryAttempt": 1,
+                        "response": asset_service.AnalyzeOrgPolicyGovernedAssetsResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _AnalyzeOrgPolicyGovernedContainers(_BaseAssetServiceRestTransport._BaseAnalyzeOrgPolicyGovernedContainers, AssetServiceRestStub):
@@ -1223,6 +1288,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_analyze_org_policy_governed_containers(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.analyze_org_policy_governed_containers",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "AnalyzeOrgPolicyGovernedContainers",
+                        "retryAttempt": 1,
+                        "response": asset_service.AnalyzeOrgPolicyGovernedContainersResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _BatchGetAssetsHistory(_BaseAssetServiceRestTransport._BaseBatchGetAssetsHistory, AssetServiceRestStub):
@@ -1296,6 +1372,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_assets_history(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.batch_get_assets_history",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "BatchGetAssetsHistory",
+                        "retryAttempt": 1,
+                        "response": asset_service.BatchGetAssetsHistoryResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _BatchGetEffectiveIamPolicies(_BaseAssetServiceRestTransport._BaseBatchGetEffectiveIamPolicies, AssetServiceRestStub):
@@ -1373,6 +1460,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_batch_get_effective_iam_policies(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.batch_get_effective_iam_policies",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "BatchGetEffectiveIamPolicies",
+                        "retryAttempt": 1,
+                        "response": asset_service.BatchGetEffectiveIamPoliciesResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _CreateFeed(_BaseAssetServiceRestTransport._BaseCreateFeed, AssetServiceRestStub):
@@ -1457,6 +1555,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_feed(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.create_feed",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "CreateFeed",
+                        "retryAttempt": 1,
+                        "response": asset_service.Feed.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _CreateSavedQuery(_BaseAssetServiceRestTransport._BaseCreateSavedQuery, AssetServiceRestStub):
@@ -1535,6 +1644,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_saved_query(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.create_saved_query",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "CreateSavedQuery",
+                        "retryAttempt": 1,
+                        "response": asset_service.SavedQuery.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _DeleteFeed(_BaseAssetServiceRestTransport._BaseDeleteFeed, AssetServiceRestStub):
@@ -1734,6 +1854,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_assets(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.export_assets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ExportAssets",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetFeed(_BaseAssetServiceRestTransport._BaseGetFeed, AssetServiceRestStub):
@@ -1815,6 +1946,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_feed(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.get_feed",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "GetFeed",
+                        "retryAttempt": 1,
+                        "response": asset_service.Feed.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetSavedQuery(_BaseAssetServiceRestTransport._BaseGetSavedQuery, AssetServiceRestStub):
@@ -1890,6 +2032,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_saved_query(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.get_saved_query",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "GetSavedQuery",
+                        "retryAttempt": 1,
+                        "response": asset_service.SavedQuery.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListAssets(_BaseAssetServiceRestTransport._BaseListAssets, AssetServiceRestStub):
@@ -1963,6 +2116,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_assets(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.list_assets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ListAssets",
+                        "retryAttempt": 1,
+                        "response": asset_service.ListAssetsResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListFeeds(_BaseAssetServiceRestTransport._BaseListFeeds, AssetServiceRestStub):
@@ -2036,6 +2200,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_feeds(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.list_feeds",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ListFeeds",
+                        "retryAttempt": 1,
+                        "response": asset_service.ListFeedsResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListSavedQueries(_BaseAssetServiceRestTransport._BaseListSavedQueries, AssetServiceRestStub):
@@ -2109,6 +2284,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_saved_queries(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.list_saved_queries",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "ListSavedQueries",
+                        "retryAttempt": 1,
+                        "response": asset_service.ListSavedQueriesResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _QueryAssets(_BaseAssetServiceRestTransport._BaseQueryAssets, AssetServiceRestStub):
@@ -2185,6 +2371,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_query_assets(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.query_assets",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "QueryAssets",
+                        "retryAttempt": 1,
+                        "response": asset_service.QueryAssetsResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _SearchAllIamPolicies(_BaseAssetServiceRestTransport._BaseSearchAllIamPolicies, AssetServiceRestStub):
@@ -2258,6 +2455,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_iam_policies(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.search_all_iam_policies",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "SearchAllIamPolicies",
+                        "retryAttempt": 1,
+                        "response": asset_service.SearchAllIamPoliciesResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _SearchAllResources(_BaseAssetServiceRestTransport._BaseSearchAllResources, AssetServiceRestStub):
@@ -2331,6 +2539,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_search_all_resources(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.search_all_resources",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "SearchAllResources",
+                        "retryAttempt": 1,
+                        "response": asset_service.SearchAllResourcesResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _UpdateFeed(_BaseAssetServiceRestTransport._BaseUpdateFeed, AssetServiceRestStub):
@@ -2415,6 +2634,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_feed(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.update_feed",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "UpdateFeed",
+                        "retryAttempt": 1,
+                        "response": asset_service.Feed.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _UpdateSavedQuery(_BaseAssetServiceRestTransport._BaseUpdateSavedQuery, AssetServiceRestStub):
@@ -2493,6 +2723,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_saved_query(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceClient.update_saved_query",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "UpdateSavedQuery",
+                        "retryAttempt": 1,
+                        "response": asset_service.SavedQuery.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2752,6 +2993,17 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             resp = operations_pb2.Operation()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_operation(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.asset_v1.AssetServiceAsyncClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.asset.v1.AssetService",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -575,8 +575,8 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -328,6 +328,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             """
 
             http_options = _BaseIAMCredentialsRestTransport._BaseGenerateAccessToken._get_http_options()
+
             request, metadata = self._interceptor.pre_generate_access_token(request, metadata)
             transcoded_request = _BaseIAMCredentialsRestTransport._BaseGenerateAccessToken._get_transcoded_request(http_options, request)
 
@@ -341,7 +342,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -437,6 +438,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             """
 
             http_options = _BaseIAMCredentialsRestTransport._BaseGenerateIdToken._get_http_options()
+
             request, metadata = self._interceptor.pre_generate_id_token(request, metadata)
             transcoded_request = _BaseIAMCredentialsRestTransport._BaseGenerateIdToken._get_transcoded_request(http_options, request)
 
@@ -450,7 +452,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -546,6 +548,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             """
 
             http_options = _BaseIAMCredentialsRestTransport._BaseSignBlob._get_http_options()
+
             request, metadata = self._interceptor.pre_sign_blob(request, metadata)
             transcoded_request = _BaseIAMCredentialsRestTransport._BaseSignBlob._get_transcoded_request(http_options, request)
 
@@ -559,7 +562,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -655,6 +658,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             """
 
             http_options = _BaseIAMCredentialsRestTransport._BaseSignJwt._get_http_options()
+
             request, metadata = self._interceptor.pre_sign_jwt(request, metadata)
             transcoded_request = _BaseIAMCredentialsRestTransport._BaseSignJwt._get_transcoded_request(http_options, request)
 
@@ -668,7 +672,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -368,11 +368,12 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             pb_resp = common.GenerateAccessTokenResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_generate_access_token(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.GenerateAccessTokenResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -478,11 +479,12 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             pb_resp = common.GenerateIdTokenResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_generate_id_token(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.GenerateIdTokenResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -588,11 +590,12 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             pb_resp = common.SignBlobResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_sign_blob(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.SignBlobResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -698,11 +701,12 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             pb_resp = common.SignJwtResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_sign_jwt(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.SignJwtResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import logging
+import json  # type: ignore
 
 from google.auth.transport.requests import AuthorizedSession  # type: ignore
-import json  # type: ignore
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import retry as retries
@@ -41,9 +42,6 @@ try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
-
-
-import logging
 
 try:  # pragma: NO COVER
     from google.api_core import client_logging  # type: ignore
@@ -339,14 +337,20 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             query_params = _BaseIAMCredentialsRestTransport._BaseGenerateAccessToken._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.GenerateAccessToken",
+                    f"Sending request for  google.iam.credentials_v1.IAMCredentialsClient.GenerateAccessToken",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "GenerateAccessToken",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -365,14 +369,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_access_token(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": common.GenerateAccessTokenResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.generate_access_token",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "GenerateAccessToken",
-                        "retryAttempt": 1,
-                        "response": common.GenerateAccessTokenResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -438,14 +445,20 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             query_params = _BaseIAMCredentialsRestTransport._BaseGenerateIdToken._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.GenerateIdToken",
+                    f"Sending request for  google.iam.credentials_v1.IAMCredentialsClient.GenerateIdToken",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "GenerateIdToken",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -464,14 +477,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_id_token(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": common.GenerateIdTokenResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.generate_id_token",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "GenerateIdToken",
-                        "retryAttempt": 1,
-                        "response": common.GenerateIdTokenResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -537,14 +553,20 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             query_params = _BaseIAMCredentialsRestTransport._BaseSignBlob._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.SignBlob",
+                    f"Sending request for  google.iam.credentials_v1.IAMCredentialsClient.SignBlob",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "SignBlob",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -563,14 +585,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_blob(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": common.SignBlobResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.sign_blob",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "SignBlob",
-                        "retryAttempt": 1,
-                        "response": common.SignBlobResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -636,14 +661,20 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             query_params = _BaseIAMCredentialsRestTransport._BaseSignJwt._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.SignJwt",
+                    f"Sending request for  google.iam.credentials_v1.IAMCredentialsClient.SignJwt",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "SignJwt",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -662,14 +693,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_jwt(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": common.SignJwtResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.sign_jwt",
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "SignJwt",
-                        "retryAttempt": 1,
-                        "response": common.SignJwtResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -371,6 +371,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.GenerateAccessTokenResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -378,7 +379,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "GenerateAccessToken",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -479,6 +480,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.GenerateIdTokenResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -486,7 +488,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "GenerateIdToken",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -587,6 +589,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.SignBlobResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -594,7 +597,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "SignBlob",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -695,6 +698,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": common.SignJwtResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -702,7 +706,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                     extra = {
                         "serviceName": "google.iam.credentials.v1.IAMCredentials",
                         "rpcName": "SignJwt",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -338,6 +338,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             # Jsonify the query params
             query_params = _BaseIAMCredentialsRestTransport._BaseGenerateAccessToken._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.GenerateAccessToken",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "GenerateAccessToken",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = IAMCredentialsRestTransport._GenerateAccessToken._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -424,6 +436,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             # Jsonify the query params
             query_params = _BaseIAMCredentialsRestTransport._BaseGenerateIdToken._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.GenerateIdToken",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "GenerateIdToken",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = IAMCredentialsRestTransport._GenerateIdToken._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -512,6 +536,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             # Jsonify the query params
             query_params = _BaseIAMCredentialsRestTransport._BaseSignBlob._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.SignBlob",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "SignBlob",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = IAMCredentialsRestTransport._SignBlob._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -598,6 +634,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             # Jsonify the query params
             query_params = _BaseIAMCredentialsRestTransport._BaseSignJwt._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.iam.credentials_v1.IAMCredentialsClient.SignJwt",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "SignJwt",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = IAMCredentialsRestTransport._SignJwt._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -43,6 +43,16 @@ except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
 
 
+import logging
+
+try:  # pragma: NO COVER
+    from google.api_core import client_logging  # type: ignore
+    CLIENT_LOGGING_SUPPORTED = True
+except ImportError:
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
     grpc_version=None,
@@ -342,6 +352,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_access_token(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.iam.credentials_v1.IAMCredentialsClient.generate_access_token",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "GenerateAccessToken",
+                        "retryAttempt": 1,
+                        "response": common.GenerateAccessTokenResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GenerateIdToken(_BaseIAMCredentialsRestTransport._BaseGenerateIdToken, IAMCredentialsRestStub):
@@ -418,6 +439,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_generate_id_token(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.iam.credentials_v1.IAMCredentialsClient.generate_id_token",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "GenerateIdToken",
+                        "retryAttempt": 1,
+                        "response": common.GenerateIdTokenResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _SignBlob(_BaseIAMCredentialsRestTransport._BaseSignBlob, IAMCredentialsRestStub):
@@ -494,6 +526,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_blob(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.iam.credentials_v1.IAMCredentialsClient.sign_blob",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "SignBlob",
+                        "retryAttempt": 1,
+                        "response": common.SignBlobResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _SignJwt(_BaseIAMCredentialsRestTransport._BaseSignJwt, IAMCredentialsRestStub):
@@ -570,6 +613,17 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_sign_jwt(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.iam.credentials_v1.IAMCredentialsClient.sign_jwt",
+                    extra = {
+                        "serviceName": "google.iam.credentials.v1.IAMCredentials",
+                        "rpcName": "SignJwt",
+                        "retryAttempt": 1,
+                        "response": common.SignJwtResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -373,7 +373,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 http_response = {
                 "payload": common.GenerateAccessTokenResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.generate_access_token",
@@ -483,7 +483,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 http_response = {
                 "payload": common.GenerateIdTokenResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.generate_id_token",
@@ -593,7 +593,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 http_response = {
                 "payload": common.SignBlobResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.sign_blob",
@@ -703,7 +703,7 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
                 http_response = {
                 "payload": common.SignJwtResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.iam.credentials_v1.IAMCredentialsClient.sign_jwt",

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/client.py
@@ -683,8 +683,8 @@ class EventarcClient(metaclass=EventarcClientMeta):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -969,7 +969,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.create_channel_",
@@ -1081,7 +1081,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.create_channel_connection",
@@ -1193,7 +1193,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.create_trigger",
@@ -1302,7 +1302,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.delete_channel",
@@ -1411,7 +1411,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.delete_channel_connection",
@@ -1520,7 +1520,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.delete_trigger",
@@ -1636,7 +1636,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": channel.Channel.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_channel",
@@ -1751,7 +1751,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": channel_connection.ChannelConnection.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_channel_connection",
@@ -1867,7 +1867,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": google_channel_config.GoogleChannelConfig.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_google_channel_config",
@@ -1977,7 +1977,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": discovery.Provider.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_provider",
@@ -2087,7 +2087,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": trigger.Trigger.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_trigger",
@@ -2197,7 +2197,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": eventarc.ListChannelConnectionsResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_channel_connections",
@@ -2305,7 +2305,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": eventarc.ListChannelsResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_channels",
@@ -2413,7 +2413,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": eventarc.ListProvidersResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_providers",
@@ -2521,7 +2521,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": eventarc.ListTriggersResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_triggers",
@@ -2633,7 +2633,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.update_channel",
@@ -2753,7 +2753,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": gce_google_channel_config.GoogleChannelConfig.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.update_google_channel_config",
@@ -2865,7 +2865,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.update_trigger",

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import logging
+import json  # type: ignore
 
 from google.auth.transport.requests import AuthorizedSession  # type: ignore
-import json  # type: ignore
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import retry as retries
@@ -52,9 +53,6 @@ try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
-
-
-import logging
 
 try:  # pragma: NO COVER
     from google.api_core import client_logging  # type: ignore
@@ -937,14 +935,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseCreateChannel._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CreateChannel",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.CreateChannel",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateChannel",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -961,14 +965,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.create_channel_",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateChannel",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1038,14 +1045,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseCreateChannelConnection._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CreateChannelConnection",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.CreateChannelConnection",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateChannelConnection",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1062,14 +1075,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel_connection(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.create_channel_connection",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateChannelConnection",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1139,14 +1155,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseCreateTrigger._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CreateTrigger",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.CreateTrigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateTrigger",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1163,14 +1185,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.create_trigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateTrigger",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1237,14 +1262,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseDeleteChannel._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteChannel",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.DeleteChannel",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteChannel",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1261,14 +1292,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.delete_channel",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteChannel",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1335,14 +1369,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseDeleteChannelConnection._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteChannelConnection",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.DeleteChannelConnection",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteChannelConnection",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1359,14 +1399,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel_connection(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.delete_channel_connection",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteChannelConnection",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1433,14 +1476,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseDeleteTrigger._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteTrigger",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.DeleteTrigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteTrigger",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1457,14 +1506,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.delete_trigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteTrigger",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1536,14 +1588,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetChannel._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetChannel",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetChannel",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetChannel",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1562,14 +1620,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": channel.Channel.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_channel",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetChannel",
-                        "retryAttempt": 1,
-                        "response": channel.Channel.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1640,14 +1701,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetChannelConnection._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetChannelConnection",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetChannelConnection",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetChannelConnection",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1666,14 +1733,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel_connection(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": channel_connection.ChannelConnection.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_channel_connection",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetChannelConnection",
-                        "retryAttempt": 1,
-                        "response": channel_connection.ChannelConnection.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1745,14 +1815,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetGoogleChannelConfig._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetGoogleChannelConfig",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetGoogleChannelConfig",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetGoogleChannelConfig",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1771,14 +1847,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_google_channel_config(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": google_channel_config.GoogleChannelConfig.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_google_channel_config",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetGoogleChannelConfig",
-                        "retryAttempt": 1,
-                        "response": google_channel_config.GoogleChannelConfig.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1844,14 +1923,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetProvider._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetProvider",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetProvider",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetProvider",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1870,14 +1955,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_provider(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": discovery.Provider.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_provider",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetProvider",
-                        "retryAttempt": 1,
-                        "response": discovery.Provider.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1943,14 +2031,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetTrigger._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetTrigger",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetTrigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetTrigger",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1969,14 +2063,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": trigger.Trigger.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.get_trigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetTrigger",
-                        "retryAttempt": 1,
-                        "response": trigger.Trigger.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2042,14 +2139,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseListChannelConnections._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListChannelConnections",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.ListChannelConnections",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListChannelConnections",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2068,14 +2171,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channel_connections(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": eventarc.ListChannelConnectionsResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_channel_connections",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListChannelConnections",
-                        "retryAttempt": 1,
-                        "response": eventarc.ListChannelConnectionsResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2139,14 +2245,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseListChannels._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListChannels",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.ListChannels",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListChannels",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2165,14 +2277,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channels(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": eventarc.ListChannelsResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_channels",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListChannels",
-                        "retryAttempt": 1,
-                        "response": eventarc.ListChannelsResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2236,14 +2351,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseListProviders._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListProviders",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.ListProviders",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListProviders",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2262,14 +2383,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_providers(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": eventarc.ListProvidersResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_providers",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListProviders",
-                        "retryAttempt": 1,
-                        "response": eventarc.ListProvidersResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2333,14 +2457,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseListTriggers._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListTriggers",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.ListTriggers",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListTriggers",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2359,14 +2489,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_triggers(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": eventarc.ListTriggersResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.list_triggers",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListTriggers",
-                        "retryAttempt": 1,
-                        "response": eventarc.ListTriggersResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2436,14 +2569,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseUpdateChannel._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.UpdateChannel",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.UpdateChannel",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateChannel",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2460,14 +2599,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.update_channel",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateChannel",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2543,14 +2685,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseUpdateGoogleChannelConfig._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.UpdateGoogleChannelConfig",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.UpdateGoogleChannelConfig",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateGoogleChannelConfig",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2569,14 +2717,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_google_channel_config(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": gce_google_channel_config.GoogleChannelConfig.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.update_google_channel_config",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateGoogleChannelConfig",
-                        "retryAttempt": 1,
-                        "response": gce_google_channel_config.GoogleChannelConfig.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2646,14 +2797,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseUpdateTrigger._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.UpdateTrigger",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.UpdateTrigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateTrigger",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2670,14 +2827,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcClient.update_trigger",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateTrigger",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2888,14 +3048,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetLocation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetLocation",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetLocation",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetLocation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2986,14 +3152,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseListLocations._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListLocations",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.ListLocations",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListLocations",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3084,14 +3256,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetIamPolicy._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetIamPolicy",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetIamPolicy",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetIamPolicy",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3185,14 +3363,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseSetIamPolicy._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.SetIamPolicy",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.SetIamPolicy",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "SetIamPolicy",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3286,14 +3470,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseTestIamPermissions._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.TestIamPermissions",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.TestIamPermissions",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "TestIamPermissions",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3384,14 +3574,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseCancelOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CancelOperation",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.CancelOperation",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CancelOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3464,14 +3660,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseDeleteOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteOperation",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.DeleteOperation",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3547,14 +3749,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetOperation",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -3645,14 +3853,20 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             query_params = _BaseEventarcRestTransport._BaseListOperations._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListOperations",
+                    f"Sending request for  google.cloud.eventarc_v1.EventarcClient.ListOperations",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListOperations",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -967,6 +967,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -974,7 +975,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateChannel",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1077,6 +1078,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1084,7 +1086,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateChannelConnection",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1187,6 +1189,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1194,7 +1197,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "CreateTrigger",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1294,6 +1297,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1301,7 +1305,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteChannel",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1401,6 +1405,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1408,7 +1413,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteChannelConnection",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1508,6 +1513,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1515,7 +1521,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "DeleteTrigger",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1622,6 +1628,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": channel.Channel.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1629,7 +1636,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetChannel",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1735,6 +1742,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": channel_connection.ChannelConnection.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1742,7 +1750,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetChannelConnection",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1849,6 +1857,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": google_channel_config.GoogleChannelConfig.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1856,7 +1865,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetGoogleChannelConfig",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1957,6 +1966,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": discovery.Provider.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1964,7 +1974,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetProvider",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2065,6 +2075,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": trigger.Trigger.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2072,7 +2083,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetTrigger",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2173,6 +2184,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListChannelConnectionsResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2180,7 +2192,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListChannelConnections",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2279,6 +2291,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListChannelsResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2286,7 +2299,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListChannels",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2385,6 +2398,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListProvidersResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2392,7 +2406,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListProviders",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2491,6 +2505,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListTriggersResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2498,7 +2513,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListTriggers",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2601,6 +2616,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2608,7 +2624,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateChannel",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2719,6 +2735,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": gce_google_channel_config.GoogleChannelConfig.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2726,7 +2743,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateGoogleChannelConfig",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -2829,6 +2846,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -2836,7 +2854,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "UpdateTrigger",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -936,6 +936,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseCreateChannel._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CreateChannel",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "CreateChannel",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._CreateChannel._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1024,6 +1036,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseCreateChannelConnection._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CreateChannelConnection",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "CreateChannelConnection",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._CreateChannelConnection._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -1114,6 +1138,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseCreateTrigger._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CreateTrigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "CreateTrigger",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._CreateTrigger._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1199,6 +1235,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseDeleteChannel._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteChannel",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "DeleteChannel",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._DeleteChannel._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1286,6 +1334,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseDeleteChannelConnection._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteChannelConnection",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "DeleteChannelConnection",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._DeleteChannelConnection._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1371,6 +1431,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseDeleteTrigger._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteTrigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "DeleteTrigger",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._DeleteTrigger._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1463,6 +1535,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetChannel._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetChannel",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetChannel",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._GetChannel._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1554,6 +1638,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetChannelConnection._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetChannelConnection",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetChannelConnection",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._GetChannelConnection._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1648,6 +1744,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetGoogleChannelConfig._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetGoogleChannelConfig",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetGoogleChannelConfig",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._GetGoogleChannelConfig._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1734,6 +1842,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetProvider._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetProvider",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetProvider",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._GetProvider._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1822,6 +1942,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetTrigger._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetTrigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetTrigger",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._GetTrigger._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1909,6 +2041,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseListChannelConnections._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListChannelConnections",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListChannelConnections",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._ListChannelConnections._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1993,6 +2137,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseListChannels._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListChannels",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListChannels",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._ListChannels._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2079,6 +2235,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseListProviders._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListProviders",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListProviders",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._ListProviders._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2163,6 +2331,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseListTriggers._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListTriggers",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListTriggers",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._ListTriggers._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2254,6 +2434,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseUpdateChannel._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.UpdateChannel",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "UpdateChannel",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._UpdateChannel._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -2350,6 +2542,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseUpdateGoogleChannelConfig._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.UpdateGoogleChannelConfig",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "UpdateGoogleChannelConfig",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._UpdateGoogleChannelConfig._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -2440,6 +2644,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseUpdateTrigger._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.UpdateTrigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "UpdateTrigger",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._UpdateTrigger._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -2671,6 +2887,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetLocation._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetLocation",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetLocation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._GetLocation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2757,6 +2985,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseListLocations._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListLocations",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListLocations",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._ListLocations._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2842,6 +3082,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetIamPolicy._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetIamPolicy",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetIamPolicy",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._GetIamPolicy._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2932,6 +3184,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseSetIamPolicy._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.SetIamPolicy",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "SetIamPolicy",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._SetIamPolicy._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -3021,6 +3285,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseTestIamPermissions._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.TestIamPermissions",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "TestIamPermissions",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._TestIamPermissions._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -3107,6 +3383,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseCancelOperation._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.CancelOperation",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "CancelOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = EventarcRestTransport._CancelOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -3174,6 +3462,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseDeleteOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.DeleteOperation",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "DeleteOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._DeleteOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -3245,6 +3545,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._GetOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -3331,6 +3643,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             # Jsonify the query params
             query_params = _BaseEventarcRestTransport._BaseListOperations._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.eventarc_v1.EventarcClient.ListOperations",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListOperations",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = EventarcRestTransport._ListOperations._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -54,6 +54,16 @@ except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
 
 
+import logging
+
+try:  # pragma: NO COVER
+    from google.api_core import client_logging  # type: ignore
+    CLIENT_LOGGING_SUPPORTED = True
+except ImportError:
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
     grpc_version=None,
@@ -938,6 +948,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.create_channel_",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "CreateChannel",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _CreateChannelConnection(_BaseEventarcRestTransport._BaseCreateChannelConnection, EventarcRestStub):
@@ -1016,6 +1037,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_channel_connection(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.create_channel_connection",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "CreateChannelConnection",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _CreateTrigger(_BaseEventarcRestTransport._BaseCreateTrigger, EventarcRestStub):
@@ -1094,6 +1126,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_trigger(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.create_trigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "CreateTrigger",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _DeleteChannel(_BaseEventarcRestTransport._BaseDeleteChannel, EventarcRestStub):
@@ -1169,6 +1212,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.delete_channel",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "DeleteChannel",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _DeleteChannelConnection(_BaseEventarcRestTransport._BaseDeleteChannelConnection, EventarcRestStub):
@@ -1244,6 +1298,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_channel_connection(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.delete_channel_connection",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "DeleteChannelConnection",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _DeleteTrigger(_BaseEventarcRestTransport._BaseDeleteTrigger, EventarcRestStub):
@@ -1319,6 +1384,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_trigger(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.delete_trigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "DeleteTrigger",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetChannel(_BaseEventarcRestTransport._BaseGetChannel, EventarcRestStub):
@@ -1401,6 +1477,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.get_channel",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetChannel",
+                        "retryAttempt": 1,
+                        "response": channel.Channel.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetChannelConnection(_BaseEventarcRestTransport._BaseGetChannelConnection, EventarcRestStub):
@@ -1482,6 +1569,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_channel_connection(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.get_channel_connection",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetChannelConnection",
+                        "retryAttempt": 1,
+                        "response": channel_connection.ChannelConnection.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetGoogleChannelConfig(_BaseEventarcRestTransport._BaseGetGoogleChannelConfig, EventarcRestStub):
@@ -1564,6 +1662,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_google_channel_config(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.get_google_channel_config",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetGoogleChannelConfig",
+                        "retryAttempt": 1,
+                        "response": google_channel_config.GoogleChannelConfig.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetProvider(_BaseEventarcRestTransport._BaseGetProvider, EventarcRestStub):
@@ -1640,6 +1749,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_provider(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.get_provider",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetProvider",
+                        "retryAttempt": 1,
+                        "response": discovery.Provider.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetTrigger(_BaseEventarcRestTransport._BaseGetTrigger, EventarcRestStub):
@@ -1716,6 +1836,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_trigger(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.get_trigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetTrigger",
+                        "retryAttempt": 1,
+                        "response": trigger.Trigger.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListChannelConnections(_BaseEventarcRestTransport._BaseListChannelConnections, EventarcRestStub):
@@ -1792,6 +1923,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channel_connections(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.list_channel_connections",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListChannelConnections",
+                        "retryAttempt": 1,
+                        "response": eventarc.ListChannelConnectionsResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListChannels(_BaseEventarcRestTransport._BaseListChannels, EventarcRestStub):
@@ -1866,6 +2008,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_channels(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.list_channels",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListChannels",
+                        "retryAttempt": 1,
+                        "response": eventarc.ListChannelsResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListProviders(_BaseEventarcRestTransport._BaseListProviders, EventarcRestStub):
@@ -1940,6 +2093,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_providers(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.list_providers",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListProviders",
+                        "retryAttempt": 1,
+                        "response": eventarc.ListProvidersResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListTriggers(_BaseEventarcRestTransport._BaseListTriggers, EventarcRestStub):
@@ -2014,6 +2178,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_triggers(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.list_triggers",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListTriggers",
+                        "retryAttempt": 1,
+                        "response": eventarc.ListTriggersResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _UpdateChannel(_BaseEventarcRestTransport._BaseUpdateChannel, EventarcRestStub):
@@ -2092,6 +2267,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_channel(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.update_channel",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "UpdateChannel",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _UpdateGoogleChannelConfig(_BaseEventarcRestTransport._BaseUpdateGoogleChannelConfig, EventarcRestStub):
@@ -2178,6 +2364,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_google_channel_config(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.update_google_channel_config",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "UpdateGoogleChannelConfig",
+                        "retryAttempt": 1,
+                        "response": gce_google_channel_config.GoogleChannelConfig.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _UpdateTrigger(_BaseEventarcRestTransport._BaseUpdateTrigger, EventarcRestStub):
@@ -2256,6 +2453,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_trigger(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcClient.update_trigger",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "UpdateTrigger",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2475,6 +2683,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = locations_pb2.Location()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_location(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.GetLocation",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetLocation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2550,6 +2769,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = locations_pb2.ListLocationsResponse()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_locations(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.ListLocations",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListLocations",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2625,6 +2855,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = policy_pb2.Policy()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_iam_policy(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.GetIamPolicy",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetIamPolicy",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2703,6 +2944,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = policy_pb2.Policy()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_set_iam_policy(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.SetIamPolicy",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "SetIamPolicy",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2781,6 +3033,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = iam_policy_pb2.TestIamPermissionsResponse()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_test_iam_permissions(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.TestIamPermissions",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "TestIamPermissions",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2995,6 +3258,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.Operation()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_operation(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -3070,6 +3344,17 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = operations_pb2.ListOperationsResponse()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_operations(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.ListOperations",
+                    extra = {
+                        "serviceName": "google.cloud.eventarc.v1.Eventarc",
+                        "rpcName": "ListOperations",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -964,11 +964,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_create_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1076,11 +1077,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_create_channel_connection(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1188,11 +1190,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_create_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1297,11 +1300,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_delete_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1406,11 +1410,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_delete_channel_connection(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1515,11 +1520,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_delete_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1631,11 +1637,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = channel.Channel.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": channel.Channel.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1746,11 +1753,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = channel_connection.ChannelConnection.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_channel_connection(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": channel_connection.ChannelConnection.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1862,11 +1870,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = google_channel_config.GoogleChannelConfig.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_google_channel_config(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": google_channel_config.GoogleChannelConfig.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1972,11 +1981,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = discovery.Provider.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_provider(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": discovery.Provider.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2082,11 +2092,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = trigger.Trigger.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": trigger.Trigger.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2192,11 +2203,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = eventarc.ListChannelConnectionsResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_channel_connections(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListChannelConnectionsResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2300,11 +2312,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = eventarc.ListChannelsResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_channels(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListChannelsResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2408,11 +2421,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = eventarc.ListProvidersResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_providers(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListProvidersResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2516,11 +2530,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = eventarc.ListTriggersResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_triggers(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": eventarc.ListTriggersResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2628,11 +2643,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_update_channel(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2748,11 +2764,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             pb_resp = gce_google_channel_config.GoogleChannelConfig.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_update_google_channel_config(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": gce_google_channel_config.GoogleChannelConfig.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2860,11 +2877,12 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_update_trigger(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -3115,14 +3133,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_location(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.GetLocation",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetLocation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -3220,14 +3242,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_locations(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.ListLocations",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListLocations",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -3325,14 +3351,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_iam_policy(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.GetIamPolicy",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetIamPolicy",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -3433,14 +3463,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_set_iam_policy(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.SetIamPolicy",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "SetIamPolicy",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -3541,14 +3575,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_test_iam_permissions(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.TestIamPermissions",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "TestIamPermissions",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -3823,14 +3861,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_operation(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -3928,14 +3970,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_operations(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.eventarc_v1.EventarcAsyncClient.ListOperations",
                     extra = {
                         "serviceName": "google.cloud.eventarc.v1.Eventarc",
                         "rpcName": "ListOperations",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -926,6 +926,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseCreateChannel._get_http_options()
+
             request, metadata = self._interceptor.pre_create_channel(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseCreateChannel._get_transcoded_request(http_options, request)
 
@@ -939,7 +940,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1037,6 +1038,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseCreateChannelConnection._get_http_options()
+
             request, metadata = self._interceptor.pre_create_channel_connection(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseCreateChannelConnection._get_transcoded_request(http_options, request)
 
@@ -1050,7 +1052,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1148,6 +1150,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseCreateTrigger._get_http_options()
+
             request, metadata = self._interceptor.pre_create_trigger(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseCreateTrigger._get_transcoded_request(http_options, request)
 
@@ -1161,7 +1164,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1258,6 +1261,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseDeleteChannel._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_channel(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseDeleteChannel._get_transcoded_request(http_options, request)
 
@@ -1269,7 +1273,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1366,6 +1370,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseDeleteChannelConnection._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_channel_connection(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseDeleteChannelConnection._get_transcoded_request(http_options, request)
 
@@ -1377,7 +1382,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1474,6 +1479,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseDeleteTrigger._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_trigger(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseDeleteTrigger._get_transcoded_request(http_options, request)
 
@@ -1485,7 +1491,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1587,6 +1593,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetChannel._get_http_options()
+
             request, metadata = self._interceptor.pre_get_channel(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetChannel._get_transcoded_request(http_options, request)
 
@@ -1598,7 +1605,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1701,6 +1708,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetChannelConnection._get_http_options()
+
             request, metadata = self._interceptor.pre_get_channel_connection(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetChannelConnection._get_transcoded_request(http_options, request)
 
@@ -1712,7 +1720,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1816,6 +1824,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetGoogleChannelConfig._get_http_options()
+
             request, metadata = self._interceptor.pre_get_google_channel_config(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetGoogleChannelConfig._get_transcoded_request(http_options, request)
 
@@ -1827,7 +1836,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1925,6 +1934,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetProvider._get_http_options()
+
             request, metadata = self._interceptor.pre_get_provider(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetProvider._get_transcoded_request(http_options, request)
 
@@ -1936,7 +1946,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2034,6 +2044,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetTrigger._get_http_options()
+
             request, metadata = self._interceptor.pre_get_trigger(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetTrigger._get_transcoded_request(http_options, request)
 
@@ -2045,7 +2056,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2143,6 +2154,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseListChannelConnections._get_http_options()
+
             request, metadata = self._interceptor.pre_list_channel_connections(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseListChannelConnections._get_transcoded_request(http_options, request)
 
@@ -2154,7 +2166,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2250,6 +2262,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseListChannels._get_http_options()
+
             request, metadata = self._interceptor.pre_list_channels(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseListChannels._get_transcoded_request(http_options, request)
 
@@ -2261,7 +2274,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2357,6 +2370,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseListProviders._get_http_options()
+
             request, metadata = self._interceptor.pre_list_providers(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseListProviders._get_transcoded_request(http_options, request)
 
@@ -2368,7 +2382,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2464,6 +2478,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseListTriggers._get_http_options()
+
             request, metadata = self._interceptor.pre_list_triggers(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseListTriggers._get_transcoded_request(http_options, request)
 
@@ -2475,7 +2490,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2575,6 +2590,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseUpdateChannel._get_http_options()
+
             request, metadata = self._interceptor.pre_update_channel(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseUpdateChannel._get_transcoded_request(http_options, request)
 
@@ -2588,7 +2604,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2692,6 +2708,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseUpdateGoogleChannelConfig._get_http_options()
+
             request, metadata = self._interceptor.pre_update_google_channel_config(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseUpdateGoogleChannelConfig._get_transcoded_request(http_options, request)
 
@@ -2705,7 +2722,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2805,6 +2822,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseUpdateTrigger._get_http_options()
+
             request, metadata = self._interceptor.pre_update_trigger(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseUpdateTrigger._get_transcoded_request(http_options, request)
 
@@ -2818,7 +2836,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3059,6 +3077,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetLocation._get_http_options()
+
             request, metadata = self._interceptor.pre_get_location(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetLocation._get_transcoded_request(http_options, request)
 
@@ -3070,7 +3089,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3163,6 +3182,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseListLocations._get_http_options()
+
             request, metadata = self._interceptor.pre_list_locations(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseListLocations._get_transcoded_request(http_options, request)
 
@@ -3174,7 +3194,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3267,6 +3287,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetIamPolicy._get_http_options()
+
             request, metadata = self._interceptor.pre_get_iam_policy(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetIamPolicy._get_transcoded_request(http_options, request)
 
@@ -3278,7 +3299,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3372,6 +3393,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseSetIamPolicy._get_http_options()
+
             request, metadata = self._interceptor.pre_set_iam_policy(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseSetIamPolicy._get_transcoded_request(http_options, request)
 
@@ -3385,7 +3407,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3479,6 +3501,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseTestIamPermissions._get_http_options()
+
             request, metadata = self._interceptor.pre_test_iam_permissions(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseTestIamPermissions._get_transcoded_request(http_options, request)
 
@@ -3492,7 +3515,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3583,6 +3606,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseCancelOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_cancel_operation(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseCancelOperation._get_transcoded_request(http_options, request)
 
@@ -3596,7 +3620,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3671,6 +3695,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseDeleteOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_operation(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseDeleteOperation._get_transcoded_request(http_options, request)
 
@@ -3682,7 +3707,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3760,6 +3785,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseGetOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_get_operation(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseGetOperation._get_transcoded_request(http_options, request)
 
@@ -3771,7 +3797,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -3864,6 +3890,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             """
 
             http_options = _BaseEventarcRestTransport._BaseListOperations._get_http_options()
+
             request, metadata = self._interceptor.pre_list_operations(request, metadata)
             transcoded_request = _BaseEventarcRestTransport._BaseListOperations._get_transcoded_request(http_options, request)
 
@@ -3875,7 +3902,7 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/client.py
@@ -631,8 +631,8 @@ class ConfigServiceV2Client(metaclass=ConfigServiceV2ClientMeta):
                     extra = {
                         "serviceName": "google.logging.v2.ConfigServiceV2",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -562,8 +562,8 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                     extra = {
                         "serviceName": "google.logging.v2.LoggingServiceV2",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/client.py
@@ -563,8 +563,8 @@ class MetricsServiceV2Client(metaclass=MetricsServiceV2ClientMeta):
                     extra = {
                         "serviceName": "google.logging.v2.MetricsServiceV2",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py
@@ -624,8 +624,8 @@ class CloudRedisClient(metaclass=CloudRedisClientMeta):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "universeDomain": getattr(self._transport._credentials, "universe_domain", ""),
-                        "credentialType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
-                        "credentialInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
+                        "credentialsType": f"{type(self._transport._credentials).__module__}.{type(self._transport._credentials).__qualname__}",
+                        "credentialsInfo": getattr(self.transport._credentials, "get_cred_info", lambda: None)(),
                     },
                 )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -768,7 +768,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.create_instance",
@@ -877,7 +877,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.delete_instance",
@@ -989,7 +989,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.export_instance",
@@ -1101,7 +1101,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.failover_instance",
@@ -1209,7 +1209,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": cloud_redis.Instance.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.get_instance",
@@ -1317,7 +1317,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": cloud_redis.InstanceAuthString.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.get_instance_auth_string",
@@ -1429,7 +1429,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.import_instance",
@@ -1539,7 +1539,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": cloud_redis.ListInstancesResponse.to_json(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.list_instances",
@@ -1651,7 +1651,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.reschedule_maintenance",
@@ -1763,7 +1763,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.update_instance",
@@ -1875,7 +1875,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
                 "headers":  str(dict(response.headers)),
-                "status": "OK", # need to obtain this properly
+                "status": response.status_code,
                 }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.upgrade_instance",

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -725,6 +725,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseCreateInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_create_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseCreateInstance._get_transcoded_request(http_options, request)
 
@@ -738,7 +739,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -835,6 +836,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_transcoded_request(http_options, request)
 
@@ -846,7 +848,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -944,6 +946,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseExportInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_export_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseExportInstance._get_transcoded_request(http_options, request)
 
@@ -957,7 +960,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1055,6 +1058,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_failover_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_transcoded_request(http_options, request)
 
@@ -1068,7 +1072,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1162,6 +1166,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_get_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetInstance._get_transcoded_request(http_options, request)
 
@@ -1173,7 +1178,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1269,6 +1274,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_http_options()
+
             request, metadata = self._interceptor.pre_get_instance_auth_string(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_transcoded_request(http_options, request)
 
@@ -1280,7 +1286,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1380,6 +1386,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseImportInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_import_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseImportInstance._get_transcoded_request(http_options, request)
 
@@ -1393,7 +1400,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1489,6 +1496,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseListInstances._get_http_options()
+
             request, metadata = self._interceptor.pre_list_instances(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseListInstances._get_transcoded_request(http_options, request)
 
@@ -1500,7 +1508,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1600,6 +1608,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_http_options()
+
             request, metadata = self._interceptor.pre_reschedule_maintenance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_transcoded_request(http_options, request)
 
@@ -1613,7 +1622,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1711,6 +1720,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_update_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_transcoded_request(http_options, request)
 
@@ -1724,7 +1734,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1822,6 +1832,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_http_options()
+
             request, metadata = self._interceptor.pre_upgrade_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_transcoded_request(http_options, request)
 
@@ -1835,7 +1846,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2020,6 +2031,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetLocation._get_http_options()
+
             request, metadata = self._interceptor.pre_get_location(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetLocation._get_transcoded_request(http_options, request)
 
@@ -2031,7 +2043,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2124,6 +2136,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseListLocations._get_http_options()
+
             request, metadata = self._interceptor.pre_list_locations(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseListLocations._get_transcoded_request(http_options, request)
 
@@ -2135,7 +2148,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2225,6 +2238,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseCancelOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_cancel_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseCancelOperation._get_transcoded_request(http_options, request)
 
@@ -2236,7 +2250,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2311,6 +2325,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_delete_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_transcoded_request(http_options, request)
 
@@ -2322,7 +2337,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2400,6 +2415,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_get_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetOperation._get_transcoded_request(http_options, request)
 
@@ -2411,7 +2427,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2504,6 +2520,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseListOperations._get_http_options()
+
             request, metadata = self._interceptor.pre_list_operations(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseListOperations._get_transcoded_request(http_options, request)
 
@@ -2515,7 +2532,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2609,6 +2626,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseWaitOperation._get_http_options()
+
             request, metadata = self._interceptor.pre_wait_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseWaitOperation._get_transcoded_request(http_options, request)
 
@@ -2622,7 +2640,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -763,11 +763,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_create_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -872,11 +873,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_delete_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -984,11 +986,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_export_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1096,11 +1099,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_failover_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1204,11 +1208,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             pb_resp = cloud_redis.Instance.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": cloud_redis.Instance.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1312,11 +1317,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             pb_resp = cloud_redis.InstanceAuthString.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_get_instance_auth_string(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": cloud_redis.InstanceAuthString.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1424,11 +1430,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_import_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1534,11 +1541,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             pb_resp = cloud_redis.ListInstancesResponse.pb(resp)
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_list_instances(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": cloud_redis.ListInstancesResponse.to_json(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1646,11 +1654,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_reschedule_maintenance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1758,11 +1767,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_update_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -1870,11 +1880,12 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Return the response
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
+
             resp = self._interceptor.post_upgrade_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
-                "headers":  str(dict(response.headers)),
+                "headers":  dict(response.headers),
                 "status": response.status_code,
                 }
                 _LOGGER.debug(
@@ -2069,14 +2080,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_location(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetLocation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetLocation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2174,14 +2189,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_locations(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListLocations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListLocations",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2453,14 +2472,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_operation(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2558,14 +2581,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_operations(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListOperations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListOperations",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2666,14 +2693,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_wait_operation(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.WaitOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "WaitOperation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -735,6 +735,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseCreateInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CreateInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "CreateInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._CreateInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -820,6 +832,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "DeleteInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._DeleteInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -910,6 +934,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseExportInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ExportInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ExportInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._ExportInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -999,6 +1035,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.FailoverInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "FailoverInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._FailoverInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1081,6 +1129,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetInstance._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._GetInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1166,6 +1226,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstanceAuthString",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstanceAuthString",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._GetInstanceAuthString._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1258,6 +1330,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseImportInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ImportInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ImportInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._ImportInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1342,6 +1426,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseListInstances._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListInstances",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListInstances",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._ListInstances._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1434,6 +1530,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.RescheduleMaintenance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "RescheduleMaintenance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._RescheduleMaintenance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1523,6 +1631,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpdateInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpdateInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._UpdateInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1611,6 +1731,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpgradeInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpgradeInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._UpgradeInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -1786,6 +1918,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetLocation._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetLocation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetLocation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._GetLocation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1872,6 +2016,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseListLocations._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListLocations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListLocations",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._ListLocations._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1955,6 +2111,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseCancelOperation._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CancelOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "CancelOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = CloudRedisRestTransport._CancelOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2022,6 +2190,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "DeleteOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._DeleteOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2093,6 +2273,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._GetOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2179,6 +2371,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseListOperations._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListOperations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListOperations",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._ListOperations._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2268,6 +2472,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseWaitOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.WaitOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "WaitOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = CloudRedisRestTransport._WaitOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -766,6 +766,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -773,7 +774,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "CreateInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -873,6 +874,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -880,7 +882,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "DeleteInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -983,6 +985,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -990,7 +993,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ExportInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1093,6 +1096,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1100,7 +1104,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "FailoverInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1199,6 +1203,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": cloud_redis.Instance.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1206,7 +1211,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1305,6 +1310,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": cloud_redis.InstanceAuthString.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1312,7 +1318,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstanceAuthString",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1415,6 +1421,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1422,7 +1429,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ImportInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1523,6 +1530,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": cloud_redis.ListInstancesResponse.to_json(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1530,7 +1538,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListInstances",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1633,6 +1641,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1640,7 +1649,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "RescheduleMaintenance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1743,6 +1752,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1750,7 +1760,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpdateInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )
@@ -1853,6 +1863,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": json_format.MessageToJson(resp),
+                "headers":  str(dict(response.headers)),
                 "status": "OK", # need to obtain this properly
                 }
                 _LOGGER.debug(
@@ -1860,7 +1871,7 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpgradeInstance",
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
                         "httpResponse": http_response,
                     },
                 )

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -46,6 +46,16 @@ except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
 
 
+import logging
+
+try:  # pragma: NO COVER
+    from google.api_core import client_logging  # type: ignore
+    CLIENT_LOGGING_SUPPORTED = True
+except ImportError:
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
 DEFAULT_CLIENT_INFO = gapic_v1.client_info.ClientInfo(
     gapic_version=BASE_DEFAULT_CLIENT_INFO.gapic_version,
     grpc_version=None,
@@ -737,6 +747,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.create_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "CreateInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _DeleteInstance(_BaseCloudRedisRestTransport._BaseDeleteInstance, CloudRedisRestStub):
@@ -812,6 +833,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.delete_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "DeleteInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ExportInstance(_BaseCloudRedisRestTransport._BaseExportInstance, CloudRedisRestStub):
@@ -890,6 +922,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.export_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ExportInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _FailoverInstance(_BaseCloudRedisRestTransport._BaseFailoverInstance, CloudRedisRestStub):
@@ -968,6 +1011,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_failover_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.failover_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "FailoverInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetInstance(_BaseCloudRedisRestTransport._BaseGetInstance, CloudRedisRestStub):
@@ -1042,6 +1096,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.get_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstance",
+                        "retryAttempt": 1,
+                        "response": cloud_redis.Instance.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _GetInstanceAuthString(_BaseCloudRedisRestTransport._BaseGetInstanceAuthString, CloudRedisRestStub):
@@ -1116,6 +1181,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance_auth_string(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.get_instance_auth_string",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstanceAuthString",
+                        "retryAttempt": 1,
+                        "response": cloud_redis.InstanceAuthString.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ImportInstance(_BaseCloudRedisRestTransport._BaseImportInstance, CloudRedisRestStub):
@@ -1194,6 +1270,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_import_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.import_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ImportInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _ListInstances(_BaseCloudRedisRestTransport._BaseListInstances, CloudRedisRestStub):
@@ -1270,6 +1357,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_instances(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.list_instances",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListInstances",
+                        "retryAttempt": 1,
+                        "response": cloud_redis.ListInstancesResponse.to_json(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _RescheduleMaintenance(_BaseCloudRedisRestTransport._BaseRescheduleMaintenance, CloudRedisRestStub):
@@ -1348,6 +1446,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_reschedule_maintenance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.reschedule_maintenance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "RescheduleMaintenance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _UpdateInstance(_BaseCloudRedisRestTransport._BaseUpdateInstance, CloudRedisRestStub):
@@ -1426,6 +1535,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.update_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpdateInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     class _UpgradeInstance(_BaseCloudRedisRestTransport._BaseUpgradeInstance, CloudRedisRestStub):
@@ -1504,6 +1624,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_upgrade_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisClient.upgrade_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpgradeInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(resp),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -1667,6 +1798,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = locations_pb2.Location()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_location(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetLocation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetLocation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -1742,6 +1884,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = locations_pb2.ListLocationsResponse()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_locations(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListLocations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListLocations",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -1953,6 +2106,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_get_operation(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2028,6 +2192,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.ListOperationsResponse()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_list_operations(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListOperations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListOperations",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2106,6 +2281,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             resp = json_format.Parse(content, resp)
             resp = self._interceptor.post_wait_operation(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.WaitOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "WaitOperation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import logging
+import json  # type: ignore
 
 from google.auth.transport.requests import AuthorizedSession  # type: ignore
-import json  # type: ignore
 from google.auth import credentials as ga_credentials  # type: ignore
 from google.api_core import exceptions as core_exceptions
 from google.api_core import retry as retries
@@ -44,9 +45,6 @@ try:
     OptionalRetry = Union[retries.Retry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
     OptionalRetry = Union[retries.Retry, object, None]  # type: ignore
-
-
-import logging
 
 try:  # pragma: NO COVER
     from google.api_core import client_logging  # type: ignore
@@ -736,14 +734,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseCreateInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CreateInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.CreateInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "CreateInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -760,14 +764,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_create_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.create_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "CreateInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -834,14 +841,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.DeleteInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "DeleteInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -858,14 +871,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_delete_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.delete_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "DeleteInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -935,14 +951,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseExportInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ExportInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ExportInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ExportInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -959,14 +981,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_export_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.export_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ExportInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1036,14 +1061,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.FailoverInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.FailoverInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "FailoverInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1060,14 +1091,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_failover_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.failover_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "FailoverInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1131,14 +1165,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1157,14 +1197,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": cloud_redis.Instance.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.get_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstance",
-                        "retryAttempt": 1,
-                        "response": cloud_redis.Instance.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1228,14 +1271,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstanceAuthString",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetInstanceAuthString",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstanceAuthString",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1254,14 +1303,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_get_instance_auth_string(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": cloud_redis.InstanceAuthString.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.get_instance_auth_string",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstanceAuthString",
-                        "retryAttempt": 1,
-                        "response": cloud_redis.InstanceAuthString.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1331,14 +1383,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseImportInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ImportInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ImportInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ImportInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1355,14 +1413,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_import_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.import_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ImportInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1428,14 +1489,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseListInstances._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListInstances",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ListInstances",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListInstances",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1454,14 +1521,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, pb_resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_list_instances(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": cloud_redis.ListInstancesResponse.to_json(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.list_instances",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListInstances",
-                        "retryAttempt": 1,
-                        "response": cloud_redis.ListInstancesResponse.to_json(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1531,14 +1601,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.RescheduleMaintenance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.RescheduleMaintenance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "RescheduleMaintenance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1555,14 +1631,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_reschedule_maintenance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.reschedule_maintenance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "RescheduleMaintenance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1632,14 +1711,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpdateInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.UpdateInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpdateInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1656,14 +1741,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_update_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.update_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpdateInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1733,14 +1821,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpgradeInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.UpgradeInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpgradeInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1757,14 +1851,17 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(response.content, resp, ignore_unknown_fields=True)
             resp = self._interceptor.post_upgrade_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                "payload": json_format.MessageToJson(resp),
+                "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisClient.upgrade_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpgradeInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(resp),
                         "metadata": str(dict(response.headers)),
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -1919,14 +2016,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetLocation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetLocation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetLocation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetLocation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2017,14 +2120,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseListLocations._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListLocations",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ListLocations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListLocations",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2112,14 +2221,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseCancelOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CancelOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.CancelOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "CancelOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2192,14 +2307,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.DeleteOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "DeleteOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2275,14 +2396,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2373,14 +2500,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseListOperations._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListOperations",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ListOperations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListOperations",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2474,14 +2607,20 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseWaitOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.WaitOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.WaitOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "WaitOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -764,6 +764,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseCreateInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CreateInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "CreateInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._CreateInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -856,6 +868,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "DeleteInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._DeleteInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -953,6 +977,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseExportInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ExportInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ExportInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._ExportInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1049,6 +1085,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.FailoverInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "FailoverInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._FailoverInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1139,6 +1187,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._GetInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -1228,6 +1288,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstanceAuthString",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstanceAuthString",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._GetInstanceAuthString._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1325,6 +1397,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseImportInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ImportInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ImportInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._ImportInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1416,6 +1500,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseListInstances._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListInstances",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListInstances",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._ListInstances._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -1513,6 +1609,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.RescheduleMaintenance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "RescheduleMaintenance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._RescheduleMaintenance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1609,6 +1717,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpdateInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpdateInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._UpdateInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
 
@@ -1704,6 +1824,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpgradeInstance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpgradeInstance",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._UpgradeInstance._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)
@@ -1920,6 +2052,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetLocation._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetLocation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetLocation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._GetLocation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2010,6 +2154,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseListLocations._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListLocations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListLocations",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._ListLocations._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2097,6 +2253,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseCancelOperation._get_query_params_json(transcoded_request)
 
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CancelOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "CancelOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
+
             # Send the request
             response = await AsyncCloudRedisRestTransport._CancelOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
 
@@ -2168,6 +2336,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "DeleteOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._DeleteOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2243,6 +2423,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._GetOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2333,6 +2525,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseListOperations._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListOperations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListOperations",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._ListOperations._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request)
@@ -2426,6 +2630,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
 
             # Jsonify the query params
             query_params = _BaseCloudRedisRestTransport._BaseWaitOperation._get_query_params_json(transcoded_request)
+
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.WaitOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "WaitOperation",
+                        "retryAttempt": 1,
+                        "request": type(request).to_json(request),
+                        "metadata": str(dict(metadata)),
+                    },
+                )
 
             # Send the request
             response = await AsyncCloudRedisRestTransport._WaitOperation._get_response(self._host, metadata, query_params, self._session, timeout, transcoded_request, body)

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -765,14 +765,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseCreateInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CreateInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.CreateInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "CreateInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -795,14 +801,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_create_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.create_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "CreateInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -870,14 +880,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.DeleteInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "DeleteInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -900,14 +916,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_delete_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.delete_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "DeleteInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -978,14 +998,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseExportInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ExportInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ExportInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ExportInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1008,14 +1034,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_export_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.export_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ExportInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1086,14 +1116,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.FailoverInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.FailoverInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "FailoverInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1116,14 +1152,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_failover_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.failover_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "FailoverInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1188,14 +1228,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1218,14 +1264,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": cloud_redis.Instance.to_json(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.get_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstance",
-                        "retryAttempt": 1,
-                        "response": cloud_redis.Instance.to_json(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1290,14 +1340,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetInstanceAuthString",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetInstanceAuthString",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstanceAuthString",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1320,14 +1376,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance_auth_string(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": cloud_redis.InstanceAuthString.to_json(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.get_instance_auth_string",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetInstanceAuthString",
-                        "retryAttempt": 1,
-                        "response": cloud_redis.InstanceAuthString.to_json(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1398,14 +1458,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseImportInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ImportInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ImportInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ImportInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1428,14 +1494,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_import_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.import_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ImportInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1502,14 +1572,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseListInstances._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListInstances",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ListInstances",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListInstances",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1532,14 +1608,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_list_instances(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": cloud_redis.ListInstancesResponse.to_json(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.list_instances",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListInstances",
-                        "retryAttempt": 1,
-                        "response": cloud_redis.ListInstancesResponse.to_json(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1610,14 +1690,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.RescheduleMaintenance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.RescheduleMaintenance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "RescheduleMaintenance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1640,14 +1726,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_reschedule_maintenance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.reschedule_maintenance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "RescheduleMaintenance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1718,14 +1808,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpdateInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.UpdateInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpdateInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1748,14 +1844,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_update_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.update_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpdateInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -1826,14 +1926,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.UpgradeInstance",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.UpgradeInstance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpgradeInstance",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -1856,14 +1962,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_upgrade_instance(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  str(dict(response.headers)),
+                    "status": "OK", # need to obtain this properly
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.upgrade_instance",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "UpgradeInstance",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
 
@@ -2053,14 +2163,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetLocation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetLocation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetLocation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetLocation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2155,14 +2271,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseListLocations._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListLocations",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ListLocations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListLocations",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2254,14 +2376,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseCancelOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.CancelOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.CancelOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "CancelOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2338,14 +2466,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.DeleteOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.DeleteOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "DeleteOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2425,14 +2559,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseGetOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.GetOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2527,14 +2667,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseListOperations._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.ListOperations",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.ListOperations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListOperations",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 
@@ -2632,14 +2778,20 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             query_params = _BaseCloudRedisRestTransport._BaseWaitOperation._get_query_params_json(transcoded_request)
 
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                request_url = "{host}{uri}".format(host=self._host, uri=transcoded_request['uri'])
+                method = transcoded_request['method']
+                http_request = {
+                  "payload":   type(request).to_json(request),
+                  "requestmethod": method,
+                  "requestUrl": request_url,
+                }
                 _LOGGER.debug(
-                    f"Sending request via google.cloud.redis_v1.CloudRedisClient.WaitOperation",
+                    f"Sending request for  google.cloud.redis_v1.CloudRedisClient.WaitOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "WaitOperation",
-                        "retryAttempt": 1,
-                        "request": type(request).to_json(request),
                         "metadata": str(dict(metadata)),
+                        "httpRequest": http_request,
                     },
                 )
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -51,6 +51,17 @@ from .rest_base import _BaseCloudRedisRestTransport
 
 from .base import DEFAULT_CLIENT_INFO as BASE_DEFAULT_CLIENT_INFO
 
+
+import logging
+
+try:  # pragma: NO COVER
+    from google.api_core import client_logging  # type: ignore
+    CLIENT_LOGGING_SUPPORTED = True
+except ImportError:
+    CLIENT_LOGGING_SUPPORTED = False
+
+_LOGGER = logging.getLogger(__name__)
+
 try:
     OptionalRetry = Union[retries.AsyncRetry, gapic_v1.method._MethodDefault, None]
 except AttributeError:  # pragma: NO COVER
@@ -771,6 +782,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_create_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.create_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "CreateInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _DeleteInstance(_BaseCloudRedisRestTransport._BaseDeleteInstance, AsyncCloudRedisRestStub):
@@ -852,6 +875,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_delete_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.delete_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "DeleteInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _ExportInstance(_BaseCloudRedisRestTransport._BaseExportInstance, AsyncCloudRedisRestStub):
@@ -936,6 +971,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_export_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.export_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ExportInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _FailoverInstance(_BaseCloudRedisRestTransport._BaseFailoverInstance, AsyncCloudRedisRestStub):
@@ -1020,6 +1067,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_failover_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.failover_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "FailoverInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _GetInstance(_BaseCloudRedisRestTransport._BaseGetInstance, AsyncCloudRedisRestStub):
@@ -1098,6 +1157,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.get_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstance",
+                        "retryAttempt": 1,
+                        "response": cloud_redis.Instance.to_json(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _GetInstanceAuthString(_BaseCloudRedisRestTransport._BaseGetInstanceAuthString, AsyncCloudRedisRestStub):
@@ -1176,6 +1247,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_get_instance_auth_string(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.get_instance_auth_string",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetInstanceAuthString",
+                        "retryAttempt": 1,
+                        "response": cloud_redis.InstanceAuthString.to_json(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _ImportInstance(_BaseCloudRedisRestTransport._BaseImportInstance, AsyncCloudRedisRestStub):
@@ -1260,6 +1343,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_import_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.import_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ImportInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _ListInstances(_BaseCloudRedisRestTransport._BaseListInstances, AsyncCloudRedisRestStub):
@@ -1340,6 +1435,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_list_instances(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.list_instances",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListInstances",
+                        "retryAttempt": 1,
+                        "response": cloud_redis.ListInstancesResponse.to_json(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _RescheduleMaintenance(_BaseCloudRedisRestTransport._BaseRescheduleMaintenance, AsyncCloudRedisRestStub):
@@ -1424,6 +1531,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_reschedule_maintenance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.reschedule_maintenance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "RescheduleMaintenance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _UpdateInstance(_BaseCloudRedisRestTransport._BaseUpdateInstance, AsyncCloudRedisRestStub):
@@ -1508,6 +1627,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_update_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.update_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpdateInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     class _UpgradeInstance(_BaseCloudRedisRestTransport._BaseUpgradeInstance, AsyncCloudRedisRestStub):
@@ -1592,6 +1723,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             content = await response.read()
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             resp = await self._interceptor.post_upgrade_instance(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.upgrade_instance",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "UpgradeInstance",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
+
             return resp
 
     @property
@@ -1793,6 +1936,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = locations_pb2.Location()
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_get_location(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetLocation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetLocation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -1872,6 +2026,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = locations_pb2.ListLocationsResponse()
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_list_locations(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListLocations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListLocations",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2095,6 +2260,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_get_operation(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "GetOperation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2174,6 +2350,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.ListOperationsResponse()
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_list_operations(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListOperations",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "ListOperations",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property
@@ -2256,6 +2443,17 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = operations_pb2.Operation()
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_wait_operation(resp)
+            if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                _LOGGER.debug(
+                    "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.WaitOperation",
+                    extra = {
+                        "serviceName": "google.cloud.redis.v1.CloudRedis",
+                        "rpcName": "WaitOperation",
+                        "retryAttempt": 1,
+                        "response": json_format.MessageToJson(response),
+                        "metadata": str(dict(response.headers)),
+                    },
+                )
             return resp
 
     @property

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -2209,14 +2209,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_get_location(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetLocation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetLocation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2318,14 +2322,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_list_locations(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListLocations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListLocations",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2609,14 +2617,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_get_operation(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.GetOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "GetOperation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2718,14 +2730,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_list_operations(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.ListOperations",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "ListOperations",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp
@@ -2830,14 +2846,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             resp = json_format.Parse(content, resp)
             resp = await self._interceptor.post_wait_operation(resp)
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
+                http_response = {
+                    "payload": json_format.MessageToJson(response),
+                    "headers":  dict(response.headers),
+                    "status": response.status_code,
+                }
                 _LOGGER.debug(
                     "Received response for google.cloud.redis_v1.CloudRedisAsyncClient.WaitOperation",
                     extra = {
                         "serviceName": "google.cloud.redis.v1.CloudRedis",
                         "rpcName": "WaitOperation",
-                        "retryAttempt": 1,
-                        "response": json_format.MessageToJson(response),
-                        "metadata": str(dict(response.headers)),
+                        "metadata": http_response["headers"],
+                        "httpResponse": http_response,
                     },
                 )
             return resp

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -756,6 +756,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseCreateInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_create_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseCreateInstance._get_transcoded_request(http_options, request)
 
@@ -769,7 +770,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -873,6 +874,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_delete_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseDeleteInstance._get_transcoded_request(http_options, request)
 
@@ -884,7 +886,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -989,6 +991,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseExportInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_export_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseExportInstance._get_transcoded_request(http_options, request)
 
@@ -1002,7 +1005,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1107,6 +1110,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_failover_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseFailoverInstance._get_transcoded_request(http_options, request)
 
@@ -1120,7 +1124,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1221,6 +1225,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_get_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetInstance._get_transcoded_request(http_options, request)
 
@@ -1232,7 +1237,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1333,6 +1338,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_http_options()
+
             request, metadata = await self._interceptor.pre_get_instance_auth_string(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetInstanceAuthString._get_transcoded_request(http_options, request)
 
@@ -1344,7 +1350,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1449,6 +1455,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseImportInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_import_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseImportInstance._get_transcoded_request(http_options, request)
 
@@ -1462,7 +1469,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1565,6 +1572,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseListInstances._get_http_options()
+
             request, metadata = await self._interceptor.pre_list_instances(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseListInstances._get_transcoded_request(http_options, request)
 
@@ -1576,7 +1584,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1681,6 +1689,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_http_options()
+
             request, metadata = await self._interceptor.pre_reschedule_maintenance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseRescheduleMaintenance._get_transcoded_request(http_options, request)
 
@@ -1694,7 +1703,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1799,6 +1808,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_update_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseUpdateInstance._get_transcoded_request(http_options, request)
 
@@ -1812,7 +1822,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -1917,6 +1927,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_http_options()
+
             request, metadata = await self._interceptor.pre_upgrade_instance(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseUpgradeInstance._get_transcoded_request(http_options, request)
 
@@ -1930,7 +1941,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2156,6 +2167,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetLocation._get_http_options()
+
             request, metadata = await self._interceptor.pre_get_location(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetLocation._get_transcoded_request(http_options, request)
 
@@ -2167,7 +2179,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2264,6 +2276,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseListLocations._get_http_options()
+
             request, metadata = await self._interceptor.pre_list_locations(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseListLocations._get_transcoded_request(http_options, request)
 
@@ -2275,7 +2288,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2369,6 +2382,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseCancelOperation._get_http_options()
+
             request, metadata = await self._interceptor.pre_cancel_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseCancelOperation._get_transcoded_request(http_options, request)
 
@@ -2380,7 +2394,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2459,6 +2473,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_http_options()
+
             request, metadata = await self._interceptor.pre_delete_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseDeleteOperation._get_transcoded_request(http_options, request)
 
@@ -2470,7 +2485,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2552,6 +2567,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseGetOperation._get_http_options()
+
             request, metadata = await self._interceptor.pre_get_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseGetOperation._get_transcoded_request(http_options, request)
 
@@ -2563,7 +2579,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2660,6 +2676,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseListOperations._get_http_options()
+
             request, metadata = await self._interceptor.pre_list_operations(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseListOperations._get_transcoded_request(http_options, request)
 
@@ -2671,7 +2688,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(
@@ -2769,6 +2786,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             """
 
             http_options = _BaseCloudRedisRestTransport._BaseWaitOperation._get_http_options()
+
             request, metadata = await self._interceptor.pre_wait_operation(request, metadata)
             transcoded_request = _BaseCloudRedisRestTransport._BaseWaitOperation._get_transcoded_request(http_options, request)
 
@@ -2782,7 +2800,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                 method = transcoded_request['method']
                 http_request = {
                   "payload":   type(request).to_json(request),
-                  "requestmethod": method,
+                  "requestMethod": method,
                   "requestUrl": request_url,
                 }
                 _LOGGER.debug(


### PR DESCRIPTION
Fixes b/381100800

The work in https://github.com/googleapis/gapic-generator-python/pull/2266#discussion_r1866737408 is still outstanding.

When running tests for async REST, I see the following stack trace. If this is expected, we should file a follow up issue in case one doesn't already exist.
```
Traceback (most recent call last):
  File "/usr/local/google/home/partheniou/git/gapic-generator-python/check.py", line 24, in <module>
    asyncio.run(list_instances())
  File "/usr/local/google/home/partheniou/.pyenv/versions/3.9.16/lib/python3.9/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/usr/local/google/home/partheniou/.pyenv/versions/3.9.16/lib/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/usr/local/google/home/partheniou/git/gapic-generator-python/check.py", line 17, in list_instances
    redis = CloudRedisAsyncClient(transport="rest_asyncio")
  File "/usr/local/google/home/partheniou/git/gapic-generator-python/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/async_client.py", line 258, in __init__
    self._client = CloudRedisClient(
  File "/usr/local/google/home/partheniou/git/gapic-generator-python/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/client.py", line 595, in __init__
    self._transport = transport_init(
  File "/usr/local/google/home/partheniou/git/gapic-generator-python/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py", line 597, in __init__
    self._session = AsyncAuthorizedSession(self._credentials)  # type: ignore
  File "/usr/local/google/home/partheniou/git/google-auth-library-python/google/auth/aio/transport/sessions.py", line 120, in __init__
    raise exceptions.InvalidType(
google.auth.exceptions.InvalidType: The configured credentials of type <class 'google.oauth2.credentials.Credentials'> are invalid and must be of type `google.auth.aio.credentials.Credentials`
```

using this code
```
from google.cloud.redis_v1 import CloudRedisAsyncClient
import asyncio
async def list_instances():
    redis = CloudRedisAsyncClient(transport="rest_asyncio")
    response = await redis.list_instances(parent="projects/partheniou-303520/locations/us-central1", metadata=[('some-key-bin', b'some_value')])
    print(response)

asyncio.run(list_instances())
```