### PR TITLE
chore: skip logging for streaming rest RPCs

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -256,6 +256,8 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             {% endif %}{# method.lro #}
             {#- TODO(https://github.com/googleapis/gapic-generator-python/issues/2274): Add debug log before intercepting a request #} 
             resp = self._interceptor.post_{{ method.name|snake_case }}(resp)
+            {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2279): Add logging support for rest streaming. #}
+            {% if not method.server_streaming %}
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                 "payload": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(resp){% else %}json_format.MessageToJson(resp){% endif %},
@@ -272,6 +274,7 @@ class {{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                         "httpResponse": http_response,
                     },
                 )
+            {% endif %}{# if not method.server_streaming #}
             return resp
 
             {% endif %}{# method.void #}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -234,6 +234,7 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             {% endif %}{# if not method.server_streaming #}
             return resp
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -217,6 +217,8 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
             json_format.Parse(content, pb_resp, ignore_unknown_fields=True)
             {% endif %}{# if method.server_streaming #}
             resp = await self._interceptor.post_{{ method.name|snake_case }}(resp)
+            {# TODO(https://github.com/googleapis/gapic-generator-python/issues/2279): Add logging support for rest streaming. #}
+            {% if not method.server_streaming %}
             if CLIENT_LOGGING_SUPPORTED and _LOGGER.isEnabledFor(logging.DEBUG):  # pragma: NO COVER
                 http_response = {
                     "payload": {% if method.output.ident.is_proto_plus_type %}{{ method.output.ident }}.to_json(response){% else %}json_format.MessageToJson(response){% endif %},
@@ -232,7 +234,7 @@ class Async{{service.name}}RestTransport(_Base{{ service.name }}RestTransport):
                         "httpResponse": http_response,
                     },
                 )
-            
+            {% endif %}{# if not method.server_streaming #}
             return resp
 
             {% endif %}{# method.void #}

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -817,7 +817,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _DeleteInstance(_BaseCloudRedisRestTransport._BaseDeleteInstance, AsyncCloudRedisRestStub):
@@ -934,7 +933,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _ExportInstance(_BaseCloudRedisRestTransport._BaseExportInstance, AsyncCloudRedisRestStub):
@@ -1054,7 +1052,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _FailoverInstance(_BaseCloudRedisRestTransport._BaseFailoverInstance, AsyncCloudRedisRestStub):
@@ -1174,7 +1171,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _GetInstance(_BaseCloudRedisRestTransport._BaseGetInstance, AsyncCloudRedisRestStub):
@@ -1288,7 +1284,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _GetInstanceAuthString(_BaseCloudRedisRestTransport._BaseGetInstanceAuthString, AsyncCloudRedisRestStub):
@@ -1402,7 +1397,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _ImportInstance(_BaseCloudRedisRestTransport._BaseImportInstance, AsyncCloudRedisRestStub):
@@ -1522,7 +1516,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _ListInstances(_BaseCloudRedisRestTransport._BaseListInstances, AsyncCloudRedisRestStub):
@@ -1638,7 +1631,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _RescheduleMaintenance(_BaseCloudRedisRestTransport._BaseRescheduleMaintenance, AsyncCloudRedisRestStub):
@@ -1758,7 +1750,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _UpdateInstance(_BaseCloudRedisRestTransport._BaseUpdateInstance, AsyncCloudRedisRestStub):
@@ -1878,7 +1869,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     class _UpgradeInstance(_BaseCloudRedisRestTransport._BaseUpgradeInstance, AsyncCloudRedisRestStub):
@@ -1998,7 +1988,6 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
-
             return resp
 
     @property

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -817,6 +817,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _DeleteInstance(_BaseCloudRedisRestTransport._BaseDeleteInstance, AsyncCloudRedisRestStub):
@@ -933,6 +934,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _ExportInstance(_BaseCloudRedisRestTransport._BaseExportInstance, AsyncCloudRedisRestStub):
@@ -1052,6 +1054,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _FailoverInstance(_BaseCloudRedisRestTransport._BaseFailoverInstance, AsyncCloudRedisRestStub):
@@ -1171,6 +1174,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _GetInstance(_BaseCloudRedisRestTransport._BaseGetInstance, AsyncCloudRedisRestStub):
@@ -1284,6 +1288,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _GetInstanceAuthString(_BaseCloudRedisRestTransport._BaseGetInstanceAuthString, AsyncCloudRedisRestStub):
@@ -1397,6 +1402,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _ImportInstance(_BaseCloudRedisRestTransport._BaseImportInstance, AsyncCloudRedisRestStub):
@@ -1516,6 +1522,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _ListInstances(_BaseCloudRedisRestTransport._BaseListInstances, AsyncCloudRedisRestStub):
@@ -1631,6 +1638,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _RescheduleMaintenance(_BaseCloudRedisRestTransport._BaseRescheduleMaintenance, AsyncCloudRedisRestStub):
@@ -1750,6 +1758,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _UpdateInstance(_BaseCloudRedisRestTransport._BaseUpdateInstance, AsyncCloudRedisRestStub):
@@ -1869,6 +1878,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     class _UpgradeInstance(_BaseCloudRedisRestTransport._BaseUpgradeInstance, AsyncCloudRedisRestStub):
@@ -1988,6 +1998,7 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
                         "httpResponse": http_response,
                     },
                 )
+
             return resp
 
     @property


### PR DESCRIPTION
Logging for streaming rest RPCs will be supported when we get to https://github.com/googleapis/gapic-generator-python/issues/2279.