### PR TITLE
chore: remove unused import in test file

### DIFF
--- a/tests/unit/utils/test_uri_conv.py
+++ b/tests/unit/utils/test_uri_conv.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 
-import pypandoc
-
 from gapic import utils
 
 


### PR DESCRIPTION
Remove import statement for `pypandoc` which is unused