### PR TITLE
build: remove unused argument

### DIFF
--- a/tests/unit/schema/test_api.py
+++ b/tests/unit/schema/test_api.py
@@ -1993,7 +1993,7 @@ def test_gapic_metadata():
     assert expected == actual
 
 
-def test_http_options(fs):
+def test_http_options():
     fd = (
         make_file_pb2(
             name='example.proto',


### PR DESCRIPTION
The test `test_http_options` has an unused argument. This causes the following error to appear

```
==================================== ERRORS ====================================
_____________________ ERROR at setup of test_http_options ______________________
file ...gapic/tests/unit/schema/test_api.py, line 1982
  def test_http_options(fs):
E       fixture 'fs' not found
>       available fixtures: ...
>       use 'pytest --fixtures [testpath]' for help on them.
```