### PR TITLE
tests: add more tests for LRO

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -385,6 +385,14 @@ def showcase(
 
     with showcase_library(session, templates=templates, other_opts=other_opts):
         session.install("pytest", "pytest-asyncio")
+
+        # For prototyping purposes only.
+        # Remove once https://github.com/googleapis/python-api-core/pull/810 is released
+        session.install(
+            "google-api-core @ git+https://github.com/googleapis/python-api-core.git@fix-lro-no-result",
+            "--ignore-installed",
+        )
+
         test_directory = Path("tests", "system")
         ignore_file = env.get("IGNORE_FILE")
         pytest_command = [
@@ -415,6 +423,12 @@ def showcase_w_rest_async(
         session, templates=templates, other_opts=other_opts, rest_async_io_enabled=True
     ):
         session.install("pytest", "pytest-asyncio")
+        # For prototyping purposes only.
+        # Remove once https://github.com/googleapis/python-api-core/pull/810 is released
+        session.install(
+            "google-api-core @ git+https://github.com/googleapis/python-api-core.git@fix-lro-no-result",
+            "--ignore-installed",
+        )
         test_directory = Path("tests", "system")
         ignore_file = env.get("IGNORE_FILE")
         pytest_command = [

--- a/tests/system/test_lro.py
+++ b/tests/system/test_lro.py
@@ -17,9 +17,11 @@ import pytest
 from datetime import datetime, timedelta, timezone
 
 from google import showcase
+from google.api_core import exceptions
+from google.rpc import code_pb2
 
 
-def test_lro(echo):
+def test_lro_success(echo):
     future = echo.wait(
         {
             "end_time": datetime.now(tz=timezone.utc) + timedelta(seconds=1),
@@ -33,10 +35,40 @@ def test_lro(echo):
     assert response.content.endswith("the snails...eventually.")
 
 
+def test_lro_error(echo):
+    with pytest.raises(
+        exceptions.GoogleAPICallError,
+        match="(?i)This took longer than you said it should",
+    ):
+        future = echo.wait(
+            {
+                "end_time": datetime.now(tz=timezone.utc) + timedelta(seconds=1),
+                "error": {
+                    "code": code_pb2.Code.Value("DEADLINE_EXCEEDED"),
+                    "message": "This took longer than you said it should.",
+                },
+            }
+        )
+        future.result()
+
+
+def test_lro_no_result(echo):
+    # As per the link below, `Some services might not provide a result`.
+    # Neither `error` or `response`.
+    # See https://github.com/googleapis/googleapis/blob/a6c9ed2d33105cb3dc9a0867a0a5d761b049b932/google/longrunning/operations.proto#L141
+    future = echo.wait(
+        {
+            "end_time": datetime.now(tz=timezone.utc) + timedelta(seconds=1),
+        }
+    )
+    response = future.result()
+    assert response is None
+
+
 if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
 
     @pytest.mark.asyncio
-    async def test_lro_async(async_echo):
+    async def test_lro_async_success(async_echo):
 
         future = await async_echo.wait(
             {
@@ -49,3 +81,34 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
         response = await future.result()
         assert isinstance(response, showcase.WaitResponse)
         assert response.content.endswith("the snails...eventually.")
+
+    @pytest.mark.asyncio
+    async def test_lro_async_error(async_echo):
+
+        with pytest.raises(
+            exceptions.GoogleAPICallError,
+            match="(?i)This took longer than you said it should",
+        ):
+            future = await async_echo.wait(
+                {
+                    "end_time": datetime.now(tz=timezone.utc) + timedelta(seconds=1),
+                    "error": {
+                        "code": code_pb2.Code.Value("DEADLINE_EXCEEDED"),
+                        "message": "This took longer than you said it should.",
+                    },
+                }
+            )
+            await future.result(timeout=600)
+
+    @pytest.mark.asyncio
+    async def test_lro_async_no_result(async_echo):
+        # As per the link below, `Some services might not provide a result`.
+        # Neither `error` or `response`.
+        # See https://github.com/googleapis/googleapis/blob/a6c9ed2d33105cb3dc9a0867a0a5d761b049b932/google/longrunning/operations.proto#L141
+        future = await async_echo.wait(
+            {
+                "end_time": datetime.now(tz=timezone.utc) + timedelta(seconds=1),
+            }
+        )
+        response = await future.result()
+        assert response is None


### PR DESCRIPTION
This PR adds more showcase integration tests for LRO:

- Test LRO result with `error` populated
- Test LRO with [no result as per documentation](https://github.com/googleapis/googleapis/blob/a6c9ed2d33105cb3dc9a0867a0a5d761b049b932/google/longrunning/operations.proto#L141)

Towards https://github.com/googleapis/python-api-core/issues/809
Towards b/403274054

