### PR TITLE
build: update constraints file to test latest major versions

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -42,7 +42,7 @@ dependencies = [
     {# Explicitly exclude protobuf versions mentioned in https://cloud.google.com/support/bulletins#GCP-2022-019 #}
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     {% for package_tuple, package_info in pypi_packages.items() %}
-    {# Quick check to make sure `package_info.package_name` is not the package being generated. #}
+    {# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
     {% if api.naming.warehouse_package_name != package_info.package_name %}
     {% if api.requires_package(package_tuple) %}
     "{{ package_info.package_name }} >= {{ package_info.lower_bound }}, <{{ package_info.upper_bound }}",

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -42,7 +42,7 @@ dependencies = [
     {# Explicitly exclude protobuf versions mentioned in https://cloud.google.com/support/bulletins#GCP-2022-019 #}
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     {% for package_tuple, package_info in pypi_packages.items() %}
-    {# Quick check to make sure the package is different from this setup.py #}
+    {# Quick check to make sure `package_info.package_name` is not the package being generated. #}
     {% if api.naming.warehouse_package_name != package_info.package_name %}
     {% if api.requires_package(package_tuple) %}
     "{{ package_info.package_name }} >= {{ package_info.lower_bound }}, <{{ package_info.upper_bound }}",

--- a/gapic/templates/testing/_default_constraints.j2
+++ b/gapic/templates/testing/_default_constraints.j2
@@ -5,7 +5,7 @@ google-api-core
 proto-plus
 protobuf
 {% for package_tuple, package_info in pypi_packages.items() %}
-{# Quick check to make sure the package is different from this setup.py #}
+{# Quick check to make sure `package_info.package_name` is not the package being generated. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}
 {% if api.requires_package(package_tuple) %}
 {{ package_info.package_name }}

--- a/gapic/templates/testing/_default_constraints.j2
+++ b/gapic/templates/testing/_default_constraints.j2
@@ -5,7 +5,7 @@ google-api-core
 proto-plus
 protobuf
 {% for package_tuple, package_info in pypi_packages.items() %}
-{# Quick check to make sure `package_info.package_name` is not the package being generated. #}
+{# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}
 {% if api.requires_package(package_tuple) %}
 {{ package_info.package_name }}

--- a/gapic/templates/testing/constraints-3.13.txt.j2
+++ b/gapic/templates/testing/constraints-3.13.txt.j2
@@ -1,5 +1,6 @@
 {% from '_pypi_packages.j2' import pypi_packages %}
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/gapic/templates/testing/constraints-3.13.txt.j2
+++ b/gapic/templates/testing/constraints-3.13.txt.j2
@@ -1,4 +1,19 @@
-# -*- coding: utf-8 -*-
-{% block constraints %}
-{% include "testing/_default_constraints.j2" %}
-{% endblock %}
+{% from '_pypi_packages.j2' import pypi_packages %}
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
+# List all library dependencies and extras in this file.
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6
+{% for package_tuple, package_info in pypi_packages.items() %}
+{# Quick check to make sure the package is different from this setup.py #}
+{% if api.naming.warehouse_package_name != package_info.package_name %}
+{% if api.requires_package(package_tuple) %}
+{{ package_info.package_name }}>={{ (package_info.upper_bound.split(".")[0] | int) - 1 }}
+{% endif %}
+{% endif %}
+{% endfor %}

--- a/gapic/templates/testing/constraints-3.13.txt.j2
+++ b/gapic/templates/testing/constraints-3.13.txt.j2
@@ -10,7 +10,7 @@ google-auth>=2
 proto-plus>=1
 protobuf>=6
 {% for package_tuple, package_info in pypi_packages.items() %}
-{# Quick check to make sure the package is different from this setup.py #}
+{# Quick check to make sure `package_info.package_name` is not the package being generated. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}
 {% if api.requires_package(package_tuple) %}
 {{ package_info.package_name }}>={{ (package_info.upper_bound.split(".")[0] | int) - 1 }}

--- a/gapic/templates/testing/constraints-3.13.txt.j2
+++ b/gapic/templates/testing/constraints-3.13.txt.j2
@@ -10,7 +10,7 @@ google-auth>=2
 proto-plus>=1
 protobuf>=6
 {% for package_tuple, package_info in pypi_packages.items() %}
-{# Quick check to make sure `package_info.package_name` is not the package being generated. #}
+{# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}
 {% if api.requires_package(package_tuple) %}
 {{ package_info.package_name }}>={{ (package_info.upper_bound.split(".")[0] | int) - 1 }}

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -10,7 +10,7 @@ google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2
 {% for package_tuple, package_info in pypi_packages.items() %}
-{# Quick check to make sure the package is different from this setup.py #}
+{# Quick check to make sure `package_info.package_name` is not the package being generated. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}
 {% if api.requires_package(package_tuple) %}
 {{ package_info.package_name }}=={{ package_info.lower_bound }}

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -10,7 +10,7 @@ google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2
 {% for package_tuple, package_info in pypi_packages.items() %}
-{# Quick check to make sure `package_info.package_name` is not the package being generated. #}
+{# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}
 {% if api.requires_package(package_tuple) %}
 {{ package_info.package_name }}=={{ package_info.lower_bound }}

--- a/tests/integration/goldens/asset/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.13.txt
@@ -1,4 +1,5 @@
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/tests/integration/goldens/asset/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.13.txt
@@ -1,9 +1,13 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
-google-cloud-access-context-manager
-google-cloud-os-config
-grpc-google-iam-v1
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6
+google-cloud-access-context-manager>=0
+google-cloud-os-config>=1
+grpc-google-iam-v1>=0

--- a/tests/integration/goldens/credentials/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.13.txt
@@ -1,4 +1,5 @@
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/tests/integration/goldens/credentials/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.13.txt
@@ -1,6 +1,10 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6

--- a/tests/integration/goldens/eventarc/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.13.txt
@@ -1,4 +1,5 @@
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/tests/integration/goldens/eventarc/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.13.txt
@@ -1,7 +1,11 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
-grpc-google-iam-v1
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6
+grpc-google-iam-v1>=0

--- a/tests/integration/goldens/logging/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.13.txt
@@ -1,4 +1,5 @@
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/tests/integration/goldens/logging/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.13.txt
@@ -1,6 +1,10 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.13.txt
@@ -1,4 +1,5 @@
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.13.txt
@@ -1,6 +1,10 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6

--- a/tests/integration/goldens/redis/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.13.txt
@@ -1,4 +1,5 @@
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/tests/integration/goldens/redis/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.13.txt
@@ -1,6 +1,10 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.13.txt
@@ -1,4 +1,5 @@
-# This constraints file is used to check that the latest
+# We use the constraints file for the latest Python version
+# (currently this file) to check that the latest
 # major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
 # Require the latest major version be installed for each dependency.

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.13.txt
@@ -1,6 +1,10 @@
-# -*- coding: utf-8 -*-
-# This constraints file is required for unit tests.
+# This constraints file is used to check that the latest
+# major versions of dependencies are supported in setup.py.
 # List all library dependencies and extras in this file.
-google-api-core
-proto-plus
-protobuf
+# Require the latest major version be installed for each dependency.
+# e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
+# Then this file should have google-cloud-foo>=1
+google-api-core>=2
+google-auth>=2
+proto-plus>=1
+protobuf>=6


### PR DESCRIPTION
Updates constraints file to ensure that the latest major versions of dependencies are tested.

This fixes a testing gap where presubmits could pass without testing the latest major version. For example, see build log [here](https://github.com/googleapis/gapic-generator-python/actions/runs/13872559057/job/38820975597?pr=2362) which failed using the changes in this PR prior to releasing protobuf 6.x support in  `googleapis-common-protos`.