### PR TITLE
build: remove showcase integration tests ads

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -15,14 +15,11 @@ branchProtectionRules:
     - 'mypy (3.13)'
     - 'showcase (3.7, showcase)'
     - 'showcase (3.13, showcase)'
-    - 'showcase (3.7, showcase_alternative_templates)'
-    - 'showcase (3.13, showcase_alternative_templates)'
     - 'showcase (3.7, showcase_w_rest_async)'
     - 'showcase (3.13, showcase_w_rest_async)'
     # TODO(dovs): reenable these when the mtls tests have been debugged and fixed
     # See #1218 for details
     # - 'showcase-mtls (showcase_mtls)'
-    # - 'showcase-mtls (showcase_mtls_alternative_templates)'
     - 'showcase-mypy'
     - 'showcase-mypy (_alternative_templates)'
     - 'showcase-unit (3.7)'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -57,7 +57,7 @@ jobs:
       matrix:
         # TODO(https://github.com/googleapis/gapic-generator-python/issues/2121) Remove `showcase_w_rest_async` target when async rest is GA.
         python: ["3.7", "3.13"]
-        target: [showcase, showcase_alternative_templates, showcase_w_rest_async]
+        target: [showcase, showcase_w_rest_async]
         logging_scope: ["", "google"]
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2303): use `ubuntu-latest` once this bug is fixed.
@@ -102,7 +102,7 @@ jobs:
     if: ${{ false }}            # TODO(dovs): reenable when #1218 is fixed
     strategy:
       matrix:
-        target: [showcase_mtls, showcase_mtls_alternative_templates]
+        target: [showcase_mtls]
       max-parallel: 1
     runs-on: ubuntu-latest
     steps:

--- a/noxfile.py
+++ b/noxfile.py
@@ -461,28 +461,6 @@ def showcase_mtls(
         )
 
 
-@nox.session(python=ALL_PYTHON)
-def showcase_alternative_templates(session):
-    templates = path.join(path.dirname(__file__), "gapic", "ads-templates")
-    showcase(
-        session,
-        templates=templates,
-        other_opts=("old-naming",),
-        env={"GAPIC_PYTHON_ASYNC": "False", "IGNORE_FILE": "test_universe_domain.py"},
-    )
-
-
-@nox.session(python=NEWEST_PYTHON)
-def showcase_mtls_alternative_templates(session):
-    templates = path.join(path.dirname(__file__), "gapic", "ads-templates")
-    showcase_mtls(
-        session,
-        templates=templates,
-        other_opts=("old-naming",),
-        env={"GAPIC_PYTHON_ASYNC": "False", "IGNORE_FILE": "test_universe_domain.py"},
-    )
-
-
 def run_showcase_unit_tests(session, fail_under=100, rest_async_io_enabled=False):
     session.install(
         "coverage",


### PR DESCRIPTION
`googleads/ads` is no longer using the Ads templates. There is still 1 remaining [usage](https://github.com/search?q=repo%3Agoogleapis%2Fgoogleapis%20%22ads-templates%22&type=code) in `google/ads/searchads360/v0` and there is an active plan to remove usage. We still need to keep the Ads templates but we can turn off showcase integration testing for Ads to reduce toil since the showcase integration tests are handwritten.