### PR TITLE
chore: update generated MANIFEST.in

### DIFF
--- a/gapic/templates/MANIFEST.in.j2
+++ b/gapic/templates/MANIFEST.in.j2
@@ -1,2 +1,15 @@
-recursive-include {{ '/'.join(api.naming.module_namespace + (api.naming.module_name,)) }} *.py
-recursive-include {{ '/'.join(api.naming.module_namespace + (api.naming.versioned_module_name,)) }} *.py
+{% extends "_base.py.j2" %}
+
+{% block content %}
+
+include README.rst LICENSE
+{% if api.naming.module_namespace %}
+recursive-include {{ api.naming.module_namespace[0] }} *.py *.pyi *.json *.proto py.typed
+{% else %}
+recursive-include {{ api.naming.versioned_module_name }} *.py *.pyi *.json *.proto py.typed
+{% endif %}
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__
+
+{% endblock %}

--- a/tests/integration/goldens/asset/MANIFEST.in
+++ b/tests/integration/goldens/asset/MANIFEST.in
@@ -1,2 +1,20 @@
-recursive-include google/cloud/asset *.py
-recursive-include google/cloud/asset_v1 *.py
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include README.rst LICENSE
+recursive-include google *.py *.pyi *.json *.proto py.typed
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/tests/integration/goldens/credentials/MANIFEST.in
+++ b/tests/integration/goldens/credentials/MANIFEST.in
@@ -1,2 +1,20 @@
-recursive-include google/iam/credentials *.py
-recursive-include google/iam/credentials_v1 *.py
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include README.rst LICENSE
+recursive-include google *.py *.pyi *.json *.proto py.typed
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/tests/integration/goldens/eventarc/MANIFEST.in
+++ b/tests/integration/goldens/eventarc/MANIFEST.in
@@ -1,2 +1,20 @@
-recursive-include google/cloud/eventarc *.py
-recursive-include google/cloud/eventarc_v1 *.py
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include README.rst LICENSE
+recursive-include google *.py *.pyi *.json *.proto py.typed
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/tests/integration/goldens/logging/MANIFEST.in
+++ b/tests/integration/goldens/logging/MANIFEST.in
@@ -1,2 +1,20 @@
-recursive-include google/cloud/logging *.py
-recursive-include google/cloud/logging_v2 *.py
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include README.rst LICENSE
+recursive-include google *.py *.pyi *.json *.proto py.typed
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/tests/integration/goldens/logging_internal/MANIFEST.in
+++ b/tests/integration/goldens/logging_internal/MANIFEST.in
@@ -1,2 +1,20 @@
-recursive-include google/cloud/logging *.py
-recursive-include google/cloud/logging_v2 *.py
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include README.rst LICENSE
+recursive-include google *.py *.pyi *.json *.proto py.typed
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/tests/integration/goldens/redis/MANIFEST.in
+++ b/tests/integration/goldens/redis/MANIFEST.in
@@ -1,2 +1,20 @@
-recursive-include google/cloud/redis *.py
-recursive-include google/cloud/redis_v1 *.py
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include README.rst LICENSE
+recursive-include google *.py *.pyi *.json *.proto py.typed
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/tests/integration/goldens/redis_selective/MANIFEST.in
+++ b/tests/integration/goldens/redis_selective/MANIFEST.in
@@ -1,2 +1,21 @@
-recursive-include google/cloud/redis *.py
-recursive-include google/cloud/redis_v1 *.py
+# -*- coding: utf-8 -*-
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+include README.rst LICENSE
+recursive-include google/cloud/redis *.py *.pyi *.json *.proto py.typed
+recursive-include google/cloud/redis_v1 *.py *.pyi *.json *.proto py.typed
+recursive-include tests *
+global-exclude *.py[co]
+global-exclude __pycache__

--- a/tests/integration/goldens/redis_selective/MANIFEST.in
+++ b/tests/integration/goldens/redis_selective/MANIFEST.in
@@ -14,8 +14,7 @@
 # limitations under the License.
 #
 include README.rst LICENSE
-recursive-include google/cloud/redis *.py *.pyi *.json *.proto py.typed
-recursive-include google/cloud/redis_v1 *.py *.pyi *.json *.proto py.typed
+recursive-include google *.py *.pyi *.json *.proto py.typed
 recursive-include tests *
 global-exclude *.py[co]
 global-exclude __pycache__


### PR DESCRIPTION
This PR updates the `MANIFEST.in` file in the generated output to match https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/MANIFEST.in

I also explicitly added `*.py *.pyi` to the list of files in `recursive-include`. You can test the output by running `python3 setup.py sdist` in the root of a given package.