### PR TITLE
chore: update generated noxfile.py to cater for grafeas

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -143,7 +143,11 @@ def lint(session):
         *LINT_PATHS,
     )
 
-    session.run("flake8", "google", "tests")
+{% if api.naming.module_namespace %}
+    session.run("flake8", "{{ api.naming.module_namespace[0] }}", "tests")
+{% else %}
+    session.run("flake8", "{{ api.naming.versioned_module_name }}, "tests")
+{% endif %}
 
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -15,7 +15,12 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+{% if api.naming.module_namespace %}
+LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.py", "setup.py"]
+{% else %}
+LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
+{% endif %}
+
 
 ALL_PYTHON = [
     "3.7",

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -21,7 +21,6 @@ LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
 
-
 ALL_PYTHON = [
     "3.7",
     "3.8",


### PR DESCRIPTION
Remove hardcoded namespace `google` which is not compatible with `grafeas` which isn't under the `google` namespace. This is needed to unblock https://github.com/googleapis/google-cloud-python/pull/13773