### PR TITLE
chore: update generated docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ rst_epilog = """
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-needs_sphinx = '4.5.0'
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ rst_epilog = """
 
 # If your documentation needs a minimal Sphinx version, state it here.
 #
-# needs_sphinx = '1.0'
+needs_sphinx = '4.5.0'
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/gapic/ads-templates/docs/conf.py.j2
+++ b/gapic/ads-templates/docs/conf.py.j2
@@ -28,7 +28,7 @@ __version__ = "0.1.0"
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/gapic/templates/docs/_static/custom.css.j2
+++ b/gapic/templates/docs/_static/custom.css.j2
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/gapic/templates/docs/_templates/layout.html.j2
+++ b/gapic/templates/docs/_templates/layout.html.j2
@@ -1,0 +1,51 @@
+{% raw %}
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol"> 
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version. 
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}
+{% endraw %}

--- a/gapic/templates/docs/conf.py.j2
+++ b/gapic/templates/docs/conf.py.j2
@@ -23,12 +23,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -38,26 +42,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -68,8 +71,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"{{ api.naming.warehouse_package_name }}"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -85,7 +88,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -95,7 +98,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -135,7 +144,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "{{ api.naming.namespace|join(' ') }} Client Libraries for Python",
+    "description": "{{ api.naming.namespace|join(' ') }} Client Libraries for {{ api.naming.warehouse_package_name }}",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -298,7 +307,7 @@ man_pages = [
     (
         root_doc,
         "{{ api.naming.warehouse_package_name }}",
-        u"{{ api.naming.long_name }} Documentation",
+        "{{ api.naming.warehouse_package_name }} Documentation",
         [author],
         1,
     )
@@ -317,10 +326,10 @@ texinfo_documents = [
     (
         root_doc,
         "{{ api.naming.warehouse_package_name }}",
-        u"{{ api.naming.warehouse_package_name }} Documentation",
+        "{{ api.naming.warehouse_package_name }} Documentation",
         author,
         "{{ api.naming.warehouse_package_name }}",
-        "GAPIC library for {{ api.naming.long_name }} API",
+        "{{ api.naming.warehouse_package_name }} Library",
         "APIs",
     )
 ]
@@ -340,14 +349,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/gapic/templates/docs/conf.py.j2
+++ b/gapic/templates/docs/conf.py.j2
@@ -32,7 +32,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/gapic/templates/docs/index.rst.j2
+++ b/gapic/templates/docs/index.rst.j2
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/gapic/templates/docs/multiprocessing.rst.j2
+++ b/gapic/templates/docs/multiprocessing.rst.j2
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.

--- a/tests/integration/goldens/asset/docs/_static/custom.css
+++ b/tests/integration/goldens/asset/docs/_static/custom.css
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/tests/integration/goldens/asset/docs/_templates/layout.html
+++ b/tests/integration/goldens/asset/docs/_templates/layout.html
@@ -1,0 +1,50 @@
+
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol">
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version.
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}

--- a/tests/integration/goldens/asset/docs/conf.py
+++ b/tests/integration/goldens/asset/docs/conf.py
@@ -43,7 +43,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tests/integration/goldens/asset/docs/conf.py
+++ b/tests/integration/goldens/asset/docs/conf.py
@@ -34,12 +34,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,26 +53,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -79,8 +82,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"google-cloud-asset"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,7 +99,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -106,7 +109,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -146,7 +155,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Cloud Client Libraries for Python",
+    "description": "Google Cloud Client Libraries for google-cloud-asset",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -309,7 +318,7 @@ man_pages = [
     (
         root_doc,
         "google-cloud-asset",
-        u"Google Cloud Asset Documentation",
+        "google-cloud-asset Documentation",
         [author],
         1,
     )
@@ -328,10 +337,10 @@ texinfo_documents = [
     (
         root_doc,
         "google-cloud-asset",
-        u"google-cloud-asset Documentation",
+        "google-cloud-asset Documentation",
         author,
         "google-cloud-asset",
-        "GAPIC library for Google Cloud Asset API",
+        "google-cloud-asset Library",
         "APIs",
     )
 ]
@@ -351,14 +360,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/tests/integration/goldens/asset/docs/index.rst
+++ b/tests/integration/goldens/asset/docs/index.rst
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/tests/integration/goldens/asset/docs/multiprocessing.rst
+++ b/tests/integration/goldens/asset/docs/multiprocessing.rst
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.

--- a/tests/integration/goldens/credentials/docs/_static/custom.css
+++ b/tests/integration/goldens/credentials/docs/_static/custom.css
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/tests/integration/goldens/credentials/docs/_templates/layout.html
+++ b/tests/integration/goldens/credentials/docs/_templates/layout.html
@@ -1,0 +1,50 @@
+
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol">
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version.
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}

--- a/tests/integration/goldens/credentials/docs/conf.py
+++ b/tests/integration/goldens/credentials/docs/conf.py
@@ -34,12 +34,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,26 +53,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -79,8 +82,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"google-iam-credentials"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,7 +99,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -106,7 +109,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -146,7 +155,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Iam Client Libraries for Python",
+    "description": "Google Iam Client Libraries for google-iam-credentials",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -309,7 +318,7 @@ man_pages = [
     (
         root_doc,
         "google-iam-credentials",
-        u"Google Iam Credentials Documentation",
+        "google-iam-credentials Documentation",
         [author],
         1,
     )
@@ -328,10 +337,10 @@ texinfo_documents = [
     (
         root_doc,
         "google-iam-credentials",
-        u"google-iam-credentials Documentation",
+        "google-iam-credentials Documentation",
         author,
         "google-iam-credentials",
-        "GAPIC library for Google Iam Credentials API",
+        "google-iam-credentials Library",
         "APIs",
     )
 ]
@@ -351,14 +360,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/tests/integration/goldens/credentials/docs/conf.py
+++ b/tests/integration/goldens/credentials/docs/conf.py
@@ -43,7 +43,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tests/integration/goldens/credentials/docs/index.rst
+++ b/tests/integration/goldens/credentials/docs/index.rst
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/tests/integration/goldens/credentials/docs/multiprocessing.rst
+++ b/tests/integration/goldens/credentials/docs/multiprocessing.rst
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.

--- a/tests/integration/goldens/eventarc/docs/_static/custom.css
+++ b/tests/integration/goldens/eventarc/docs/_static/custom.css
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/tests/integration/goldens/eventarc/docs/_templates/layout.html
+++ b/tests/integration/goldens/eventarc/docs/_templates/layout.html
@@ -1,0 +1,50 @@
+
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol">
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version.
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}

--- a/tests/integration/goldens/eventarc/docs/conf.py
+++ b/tests/integration/goldens/eventarc/docs/conf.py
@@ -34,12 +34,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,26 +53,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -79,8 +82,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"google-cloud-eventarc"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,7 +99,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -106,7 +109,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -146,7 +155,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Cloud Client Libraries for Python",
+    "description": "Google Cloud Client Libraries for google-cloud-eventarc",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -309,7 +318,7 @@ man_pages = [
     (
         root_doc,
         "google-cloud-eventarc",
-        u"Google Cloud Eventarc Documentation",
+        "google-cloud-eventarc Documentation",
         [author],
         1,
     )
@@ -328,10 +337,10 @@ texinfo_documents = [
     (
         root_doc,
         "google-cloud-eventarc",
-        u"google-cloud-eventarc Documentation",
+        "google-cloud-eventarc Documentation",
         author,
         "google-cloud-eventarc",
-        "GAPIC library for Google Cloud Eventarc API",
+        "google-cloud-eventarc Library",
         "APIs",
     )
 ]
@@ -351,14 +360,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/tests/integration/goldens/eventarc/docs/conf.py
+++ b/tests/integration/goldens/eventarc/docs/conf.py
@@ -43,7 +43,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tests/integration/goldens/eventarc/docs/index.rst
+++ b/tests/integration/goldens/eventarc/docs/index.rst
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/tests/integration/goldens/eventarc/docs/multiprocessing.rst
+++ b/tests/integration/goldens/eventarc/docs/multiprocessing.rst
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.

--- a/tests/integration/goldens/logging/docs/_static/custom.css
+++ b/tests/integration/goldens/logging/docs/_static/custom.css
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/tests/integration/goldens/logging/docs/_templates/layout.html
+++ b/tests/integration/goldens/logging/docs/_templates/layout.html
@@ -1,0 +1,50 @@
+
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol">
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version.
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}

--- a/tests/integration/goldens/logging/docs/conf.py
+++ b/tests/integration/goldens/logging/docs/conf.py
@@ -34,12 +34,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,26 +53,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -79,8 +82,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"google-cloud-logging"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,7 +99,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -106,7 +109,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -146,7 +155,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Cloud Client Libraries for Python",
+    "description": "Google Cloud Client Libraries for google-cloud-logging",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -309,7 +318,7 @@ man_pages = [
     (
         root_doc,
         "google-cloud-logging",
-        u"Google Cloud Logging Documentation",
+        "google-cloud-logging Documentation",
         [author],
         1,
     )
@@ -328,10 +337,10 @@ texinfo_documents = [
     (
         root_doc,
         "google-cloud-logging",
-        u"google-cloud-logging Documentation",
+        "google-cloud-logging Documentation",
         author,
         "google-cloud-logging",
-        "GAPIC library for Google Cloud Logging API",
+        "google-cloud-logging Library",
         "APIs",
     )
 ]
@@ -351,14 +360,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/tests/integration/goldens/logging/docs/conf.py
+++ b/tests/integration/goldens/logging/docs/conf.py
@@ -43,7 +43,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tests/integration/goldens/logging/docs/index.rst
+++ b/tests/integration/goldens/logging/docs/index.rst
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/tests/integration/goldens/logging/docs/multiprocessing.rst
+++ b/tests/integration/goldens/logging/docs/multiprocessing.rst
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.

--- a/tests/integration/goldens/logging_internal/docs/_static/custom.css
+++ b/tests/integration/goldens/logging_internal/docs/_static/custom.css
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/tests/integration/goldens/logging_internal/docs/_templates/layout.html
+++ b/tests/integration/goldens/logging_internal/docs/_templates/layout.html
@@ -1,0 +1,50 @@
+
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol">
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version.
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}

--- a/tests/integration/goldens/logging_internal/docs/conf.py
+++ b/tests/integration/goldens/logging_internal/docs/conf.py
@@ -34,12 +34,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,26 +53,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -79,8 +82,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"google-cloud-logging"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,7 +99,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -106,7 +109,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -146,7 +155,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Cloud Client Libraries for Python",
+    "description": "Google Cloud Client Libraries for google-cloud-logging",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -309,7 +318,7 @@ man_pages = [
     (
         root_doc,
         "google-cloud-logging",
-        u"Google Cloud Logging Documentation",
+        "google-cloud-logging Documentation",
         [author],
         1,
     )
@@ -328,10 +337,10 @@ texinfo_documents = [
     (
         root_doc,
         "google-cloud-logging",
-        u"google-cloud-logging Documentation",
+        "google-cloud-logging Documentation",
         author,
         "google-cloud-logging",
-        "GAPIC library for Google Cloud Logging API",
+        "google-cloud-logging Library",
         "APIs",
     )
 ]
@@ -351,14 +360,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/tests/integration/goldens/logging_internal/docs/conf.py
+++ b/tests/integration/goldens/logging_internal/docs/conf.py
@@ -43,7 +43,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tests/integration/goldens/logging_internal/docs/index.rst
+++ b/tests/integration/goldens/logging_internal/docs/index.rst
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/tests/integration/goldens/logging_internal/docs/multiprocessing.rst
+++ b/tests/integration/goldens/logging_internal/docs/multiprocessing.rst
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.

--- a/tests/integration/goldens/redis/docs/_static/custom.css
+++ b/tests/integration/goldens/redis/docs/_static/custom.css
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/tests/integration/goldens/redis/docs/_templates/layout.html
+++ b/tests/integration/goldens/redis/docs/_templates/layout.html
@@ -1,0 +1,50 @@
+
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol">
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version.
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}

--- a/tests/integration/goldens/redis/docs/conf.py
+++ b/tests/integration/goldens/redis/docs/conf.py
@@ -34,12 +34,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,26 +53,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -79,8 +82,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"google-cloud-redis"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,7 +99,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -106,7 +109,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -146,7 +155,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Cloud Client Libraries for Python",
+    "description": "Google Cloud Client Libraries for google-cloud-redis",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -309,7 +318,7 @@ man_pages = [
     (
         root_doc,
         "google-cloud-redis",
-        u"Google Cloud Redis Documentation",
+        "google-cloud-redis Documentation",
         [author],
         1,
     )
@@ -328,10 +337,10 @@ texinfo_documents = [
     (
         root_doc,
         "google-cloud-redis",
-        u"google-cloud-redis Documentation",
+        "google-cloud-redis Documentation",
         author,
         "google-cloud-redis",
-        "GAPIC library for Google Cloud Redis API",
+        "google-cloud-redis Library",
         "APIs",
     )
 ]
@@ -351,14 +360,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/tests/integration/goldens/redis/docs/conf.py
+++ b/tests/integration/goldens/redis/docs/conf.py
@@ -43,7 +43,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tests/integration/goldens/redis/docs/index.rst
+++ b/tests/integration/goldens/redis/docs/index.rst
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/tests/integration/goldens/redis/docs/multiprocessing.rst
+++ b/tests/integration/goldens/redis/docs/multiprocessing.rst
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.

--- a/tests/integration/goldens/redis_selective/docs/_static/custom.css
+++ b/tests/integration/goldens/redis_selective/docs/_static/custom.css
@@ -1,3 +1,20 @@
+div#python2-eol {
+	border-color: red;
+	border-width: medium;
+}
+
+/* Ensure minimum width for 'Parameters' / 'Returns' column */
 dl.field-list > dt {
     min-width: 100px
+}
+
+/* Insert space between methods for readability */
+dl.method {
+	padding-top: 10px;
+	padding-bottom: 10px
+}
+
+/* Insert empty space between classes */
+dl.class {
+	padding-bottom: 50px
 }

--- a/tests/integration/goldens/redis_selective/docs/_templates/layout.html
+++ b/tests/integration/goldens/redis_selective/docs/_templates/layout.html
@@ -1,0 +1,50 @@
+
+{% extends "!layout.html" %}
+{%- block content %}
+{%- if theme_fixed_sidebar|lower == 'true' %}
+  <div class="document">
+    {{ sidebar() }}
+    {%- block document %}
+      <div class="documentwrapper">
+      {%- if render_sidebar %}
+        <div class="bodywrapper">
+      {%- endif %}
+
+          {%- block relbar_top %}
+            {%- if theme_show_relbar_top|tobool %}
+              <div class="related top">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+          <div class="body" role="main">
+          	<div class="admonition" id="python2-eol">
+          	 As of January 1, 2020 this library no longer supports Python 2 on the latest released version.
+          	 Library versions released prior to that date will continue to be available. For more information please
+          	 visit <a href="https://cloud.google.com/python/docs/python2-sunset/">Python 2 support on Google Cloud</a>.
+          	</div>
+            {% block body %} {% endblock %}
+          </div>
+
+          {%- block relbar_bottom %}
+            {%- if theme_show_relbar_bottom|tobool %}
+              <div class="related bottom">
+                &nbsp;
+                {{- rellink_markup () }}
+              </div>
+            {%- endif %}
+          {% endblock %}
+
+      {%- if render_sidebar %}
+        </div>
+      {%- endif %}
+      </div>
+    {%- endblock %}
+    <div class="clearer"></div>
+  </div>
+{%- else %}
+{{ super() }}
+{%- endif %}
+{%- endblock %}

--- a/tests/integration/goldens/redis_selective/docs/conf.py
+++ b/tests/integration/goldens/redis_selective/docs/conf.py
@@ -34,12 +34,16 @@ import shlex
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath(".."))
 
-__version__ = "0.1.0"
+# For plugins that can not read conf.py.
+# See also: https://github.com/docascode/sphinx-docfx-yaml/issues/85
+sys.path.insert(0, os.path.abspath("."))
+
+__version__ = ""
 
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "4.0.1"
+needs_sphinx = "1.5.5"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
@@ -49,26 +53,25 @@ extensions = [
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.doctest",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
     "sphinx.ext.viewcode",
+    "recommonmark",
 ]
 
 # autodoc/autosummary flags
 autoclass_content = "both"
-autodoc_default_flags = ["members"]
+autodoc_default_options = {"members": True}
 autosummary_generate = True
 
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 
-# Allow markdown includes (so releases.md can include CHANGLEOG.md)
-# http://www.sphinx-doc.org/en/master/markdown.html
-source_parsers = {".md": "recommonmark.parser.CommonMarkParser"}
-
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
+# source_suffix = ['.rst', '.md']
 source_suffix = [".rst", ".md"]
 
 # The encoding of source files.
@@ -79,8 +82,8 @@ root_doc = "index"
 
 # General information about the project.
 project = u"google-cloud-redis"
-copyright = u"2023, Google, LLC"
-author = u"Google APIs"         # TODO: autogenerate this bit
+copyright = u"2025, Google, LLC"
+author = u"Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -96,7 +99,7 @@ version = ".".join(release.split(".")[0:2])
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = 'en'
+language = None
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -106,7 +109,13 @@ language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ["_build"]
+exclude_patterns = [
+    "_build",
+    "**/.nox/**/*",
+    "samples/AUTHORING_GUIDE.md",
+    "samples/CONTRIBUTING.md",
+    "samples/snippets/README.rst",
+]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
@@ -146,7 +155,7 @@ html_theme = "alabaster"
 # further.  For a list of options available for each theme, see the
 # documentation.
 html_theme_options = {
-    "description": "Google Cloud Client Libraries for Python",
+    "description": "Google Cloud Client Libraries for google-cloud-redis",
     "github_user": "googleapis",
     "github_repo": "google-cloud-python",
     "github_banner": True,
@@ -309,7 +318,7 @@ man_pages = [
     (
         root_doc,
         "google-cloud-redis",
-        u"Google Cloud Redis Documentation",
+        "google-cloud-redis Documentation",
         [author],
         1,
     )
@@ -328,10 +337,10 @@ texinfo_documents = [
     (
         root_doc,
         "google-cloud-redis",
-        u"google-cloud-redis Documentation",
+        "google-cloud-redis Documentation",
         author,
         "google-cloud-redis",
-        "GAPIC library for Google Cloud Redis API",
+        "google-cloud-redis Library",
         "APIs",
     )
 ]
@@ -351,14 +360,14 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("http://python.readthedocs.org/en/latest/", None),
-    "gax": ("https://gax-python.readthedocs.org/en/latest/", None),
-    "google-auth": ("https://google-auth.readthedocs.io/en/stable", None),
-    "google-gax": ("https://gax-python.readthedocs.io/en/latest/", None),
-    "google.api_core": ("https://googleapis.dev/python/google-api-core/latest/", None),
-    "grpc": ("https://grpc.io/grpc/python/", None),
-    "requests": ("http://requests.kennethreitz.org/en/stable/", None),
-    "proto": ("https://proto-plus-python.readthedocs.io/en/stable", None),
+    "python": ("https://python.readthedocs.org/en/latest/", None),
+    "google-auth": ("https://googleapis.dev/python/google-auth/latest/", None),
+    "google.api_core": (
+        "https://googleapis.dev/python/google-api-core/latest/",
+        None,
+    ),
+    "grpc": ("https://grpc.github.io/grpc/python/", None),
+    "proto-plus": ("https://proto-plus-python.readthedocs.io/en/latest/", None),
     "protobuf": ("https://googleapis.dev/python/protobuf/latest/", None),
 }
 

--- a/tests/integration/goldens/redis_selective/docs/conf.py
+++ b/tests/integration/goldens/redis_selective/docs/conf.py
@@ -43,7 +43,7 @@ __version__ = ""
 # -- General configuration ------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = "1.5.5"
+needs_sphinx = "4.5.0"
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom

--- a/tests/integration/goldens/redis_selective/docs/index.rst
+++ b/tests/integration/goldens/redis_selective/docs/index.rst
@@ -1,3 +1,6 @@
+.. include:: multiprocessing.rst
+
+
 API Reference
 -------------
 .. toctree::

--- a/tests/integration/goldens/redis_selective/docs/multiprocessing.rst
+++ b/tests/integration/goldens/redis_selective/docs/multiprocessing.rst
@@ -1,0 +1,7 @@
+.. note::
+
+   Because this client uses :mod:`grpc` library, it is safe to
+   share instances across threads. In multiprocessing scenarios, the best
+   practice is to create client instances *after* the invocation of
+   :func:`os.fork` by :class:`multiprocessing.pool.Pool` or
+   :class:`multiprocessing.Process`.


### PR DESCRIPTION
This PR updates the generated `docs/**` output to match https://github.com/googleapis/synthtool/blob/master/synthtool/gcp/templates/python_library/docs


`docs/index.rst` and `docs/summary_overview.md` will be updated in a future PR.

BEGIN_COMMIT_OVERRIDE
fix: update generated docs to match synthtool templates
END_COMMIT_OVERRIDE