### PR TITLE
feat: check Python and dependency versions in generated GAPICs

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -7,6 +7,17 @@ from {{package_path}} import gapic_version as package_version
 
 __version__ = package_version.__version__
 
+
+import google.api_core
+
+{# How do we get the name of the PyPI path into this template? We
+   want the string arguments below to be something like
+   "google-cloud-foo (google.cloud.foo)", where the name outside the
+   parentheses is the PyPI package name, and the the name inside the
+   parentheses is the qualified Python package name installed. #}
+api_core.check_python_version("{package_path}")
+api_core.check_dependency_versions("{package_path}")
+
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}
 from . import {{ subpackage }}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -10,11 +10,11 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     {# TODO(api_core): remove `type:ignore` below when minimum version of api_core makes the else clause unnecessary. #}
     api_core.check_python_version("{{package_path}}") # type: ignore
     api_core.check_dependency_versions("{{package_path}}") # type: ignore
-else:
+else:   # pragma: no coverage
 {# TODO(api_core): Remove this try-catch when we require api-core at a version that
    supports the changes in https://github.com/googleapis/python-api-core/pull/832
 

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -11,10 +11,11 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("{{package_path}}")
-    api_core.check_dependency_versions("{{package_path}}")
+    {# TODO(api_core): remove `type:ignore` below when minimum version of api_core makes the else clause unnecessary. #}
+    api_core.check_python_version("{{package_path}}") # type: ignore
+    api_core.check_dependency_versions("{{package_path}}") # type: ignore
 else:
-{# TODO: Remove this try-catch when we require api-core at a version that
+{# TODO(api_core): Remove this try-catch when we require api-core at a version that
    supports the changes in https://github.com/googleapis/python-api-core/pull/832
 
     In the meantime, please ensure the functionality here mirrors the

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -53,9 +53,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -63,18 +63,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -15,8 +15,8 @@ import google.api_core as api_core
    "google-cloud-foo (google.cloud.foo)", where the name outside the
    parentheses is the PyPI package name, and the the name inside the
    parentheses is the qualified Python package name installed. #}
-api_core.check_python_version("{package_path}")
-api_core.check_dependency_versions("{package_path}")
+api_core.check_python_version("{{package_path}}")
+api_core.check_dependency_versions("{{package_path}}")
 
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -10,11 +10,11 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     {# TODO(api_core): remove `type:ignore` below when minimum version of api_core makes the else clause unnecessary. #}
     api_core.check_python_version("{{package_path}}") # type: ignore
     api_core.check_dependency_versions("{{package_path}}") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
 {# TODO(api_core): Remove this try-catch when we require api-core at a version that
    supports the changes in https://github.com/googleapis/python-api-core/pull/832
 

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -42,31 +42,43 @@ except AttributeError:
             "least Python 3.10, before then, and " +
             f"then update {_package_label}.")
 
-  import pkg_resources
   from packaging.version import parse as parse_version
 
-  def _get_version(dependency_name):
-    version_string = pkg_resources.get_distribution(dependency_name).version
-    return parse_version(version_string)
-
-  try:
-    _dependency_package = "google.protobuf"
-    _version_used = _get_version(_dependency_package)
-    _next_supported_version = "4.25.8"
-    if _version_used < parse_version(_next_supported_version):
-      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-              f"{_dependency_package}, currently installed at version " +
-              f"{_version_used.__str__}. Future updates to " +
-              f"{_package_label} will require {_dependency_package} at " +
-              f"version {_next_supported_version} or higher. Please ensure " +
-              "that either (a) your Python environment doesn't pin the " +
-              f"version of {_dependency_package}, so that updates to " +
-              f"{_package_label} can require the higher version, or " +
-              "(b) you manually update your Python environment to use at " +
-              f"least version {_next_supported_version} of " +
-              f"{_dependency_package}.")
-  except pkg_resources.DistributionNotFound:
-    pass
+  if sys.version_info < (3, 8):
+    import pkg_resources
+    def _get_version(dependency_name):
+      try:
+        version_string = pkg_resources.get_distribution(dependency_name).version
+        return parse_version(version_string)
+      except pkg_resources.DistributionNotFound:
+        return None
+  else:
+    from importlib import metadata
+  
+    def _get_version(dependency_name):
+      try:
+        version_string = metadata.version("requests")
+        parsed_version = parse_version(version_string)
+        return parsed_version.release
+      except metadata.PackageNotFoundError:
+        return None
+  
+  _dependency_package = "google.protobuf"
+  _next_supported_version = "4.25.8"
+  _next_supported_version_tuple = (4, 25, 8)
+  _version_used = _get_version(_dependency_package)
+  if _version_used and _version_used < _next_supported_version_tuple:
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}.")
   
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -34,14 +34,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -80,7 +82,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -24,7 +24,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -21,71 +21,77 @@ else:   # pragma: NO COVER
     In the meantime, please ensure the functionality here mirrors the
     equivalent functionality in api_core, in those two functions above.
 #}
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "{{package_path}}"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "{{package_path}}"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -19,11 +19,12 @@ except AttributeError:
 
     In the meantime, please ensure the functionality here mirrors the
     equivalent functionality in api_core, in those two functions above.  
--#}
+#}
   # An older version of api_core is installed, which does not define the
   # functions above. We do equivalent checks manually.
 
   import logging
+  import sys
 
   _py_version_str = sys.version.split()[0]
   _package_label = "{{package_path}}"
@@ -39,7 +40,7 @@ except AttributeError:
             "it reaches its end of life (October 2025). Please " +
             "upgrade to the latest Python version, or at " +
             "least Python 3.10, before then, and " +
-            f"then update {_package_label}. "
+            f"then update {_package_label}.")
 
   import pkg_resources
   from packaging.version import parse as parse_version
@@ -48,22 +49,24 @@ except AttributeError:
     version_string = pkg_resources.get_distribution(dependency_name).version
     return parse_version(version_string)
 
-  _dependency_package = "google.protobuf"
-  _version_used = _get_version(_dependency_package)
-  _next_supported_version = "4.25.8"
-  if _version_used < parse_version(_next_supported_version):
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}."
-      
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
   
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -10,76 +10,77 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("{{package_path}}")
-  api_core.check_dependency_versions("{{package_path}}")
-except AttributeError:
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("{{package_path}}")
+    api_core.check_dependency_versions("{{package_path}}")
+else:
 {# TODO: Remove this try-catch when we require api-core at a version that
    supports the changes in https://github.com/googleapis/python-api-core/pull/832
 
     In the meantime, please ensure the functionality here mirrors the
-    equivalent functionality in api_core, in those two functions above.  
+    equivalent functionality in api_core, in those two functions above.
 #}
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "{{package_path}}"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "{{package_path}}"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
-  
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
-  
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
-  
+    if sys.version_info < (3, 8):
+        import pkg_resources
+
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
+
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
+
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}
 from . import {{ subpackage }}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -8,7 +8,7 @@ from {{package_path}} import gapic_version as package_version
 __version__ = package_version.__version__
 
 
-import google.api_core
+import google.api_core as api_core
 
 {# How do we get the name of the PyPI path into this template? We
    want the string arguments below to be something like

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -70,13 +70,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -74,7 +74,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -30,18 +30,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "{{package_path}}"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -70,17 +70,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}

--- a/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/__init__.py.j2
@@ -10,14 +10,61 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-{# How do we get the name of the PyPI path into this template? We
-   want the string arguments below to be something like
-   "google-cloud-foo (google.cloud.foo)", where the name outside the
-   parentheses is the PyPI package name, and the the name inside the
-   parentheses is the qualified Python package name installed. #}
-api_core.check_python_version("{{package_path}}")
-api_core.check_dependency_versions("{{package_path}}")
+try:
+  api_core.check_python_version("{{package_path}}")
+  api_core.check_dependency_versions("{{package_path}}")
+except AttributeError:
+{# TODO: Remove this try-catch when we require api-core at a version that
+   supports the changes in https://github.com/googleapis/python-api-core/pull/832
 
+    In the meantime, please ensure the functionality here mirrors the
+    equivalent functionality in api_core, in those two functions above.  
+-#}
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "{{package_path}}"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}. "
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  _dependency_package = "google.protobuf"
+  _version_used = _get_version(_dependency_package)
+  _next_supported_version = "4.25.8"
+  if _version_used < parse_version(_next_supported_version):
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}."
+      
+  
 {#  Import subpackages. -#}
 {% for subpackage, _ in api.subpackages|dictsort %}
 from . import {{ subpackage }}

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -39,6 +39,7 @@ dependencies = [
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
     "grpcio >= 1.33.2, < 2.0.0",
     "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     {# Explicitly exclude protobuf versions mentioned in https://cloud.google.com/support/bulletins#GCP-2022-019 #}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1486,7 +1486,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1486,7 +1486,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record: # match="client_cert|mtls") as record:
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default|mtls') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -1495,7 +1495,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            # assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -1533,14 +1533,14 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:  # , match="mtls") as record:
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
+            # assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1486,8 +1486,8 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
-                with mock.patch.object(google.auth, 'default') as adc:
+            with pytest.warns(DeprecationWarning) as record: # match="client_cert|mtls") as record:
+                with mock.patch.object(google.auth, 'default|mtls') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
                         host="squid.clam.whelk",
@@ -1533,7 +1533,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning) as record:  # , match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1486,8 +1486,8 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
-                with mock.patch.object(google.auth, 'default|mtls') as adc:
+            with pytest.warns(DeprecationWarning):
+                with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
                         host="squid.clam.whelk",
@@ -1495,7 +1495,6 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            # assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -1533,14 +1532,13 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            # assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1485,7 +1485,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -1517,7 +1517,6 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.{{ service.grpc_transport_name }}, transports.{{ service.grpc_asyncio_transport_name }}])
 def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
     transport_class
@@ -1533,7 +1532,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1485,7 +1485,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -1494,6 +1494,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -1531,13 +1532,14 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1494,7 +1494,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1472,6 +1472,7 @@ def test_{{ service.name|snake_case }}_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.{{ service.grpc_transport_name }}, transports.{{ service.grpc_asyncio_transport_name }}])
 def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1494,7 +1494,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1517,6 +1517,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.{{ service.grpc_transport_name }}, transports.{{ service.grpc_asyncio_transport_name }}])
 def test_{{ service.name|snake_case }}_transport_channel_mtls_with_adc(
     transport_class

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1494,7 +1494,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1494,7 +1494,7 @@ def test_{{ service.name|snake_case }}_transport_channel_mtls_with_client_cert_s
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/noxfile.py
+++ b/noxfile.py
@@ -61,6 +61,8 @@ def unit(session):
         "pyfakefs",
         "grpcio-status",
         "proto-plus",
+        "setuptools",  # TODO: Remove when not needed in __init__.py.j2
+        "packaging",  # TODO: Remove when not needed in __init__.py.j2
     )
     session.install("-e", ".")
     session.run(
@@ -482,6 +484,8 @@ def run_showcase_unit_tests(session, fail_under=100, rest_async_io_enabled=False
         "pytest-xdist",
         "asyncmock; python_version < '3.8'",
         "pytest-asyncio",
+        "setuptools",  # TODO: Remove when not needed in __init__.py.j2
+        "packaging",  # TODO: Remove when not needed in __init__.py.j2
     )
     # Run the tests.
     # NOTE: async rest is not supported against the minimum supported version of google-api-core.
@@ -596,6 +600,8 @@ def showcase_mypy(
         "types-protobuf",
         "types-requests",
         "types-dataclasses",
+        "setuptools",  # TODO: Remove when not needed in __init__.py.j2
+        "packaging",  # TODO: Remove when not needed in __init__.py.j2
     )
 
     with showcase_library(session, templates=templates, other_opts=other_opts) as lib:
@@ -726,6 +732,8 @@ def mypy(session):
         "types-PyYAML",
         "types-dataclasses",
         "click==8.1.3",
+        "setuptools",  # TODO: Remove when not needed in __init__.py.j2
+        "packaging",  # TODO: Remove when not needed in __init__.py.j2
     )
     session.install(".")
     session.run("mypy", "-p", "gapic")

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     api_core.check_python_version("google.cloud.asset_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.asset_v1") # type: ignore
-else:
+else:   # pragma: no coverage
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -24,71 +24,77 @@ if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_depend
     api_core.check_python_version("google.cloud.asset_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.asset_v1") # type: ignore
 else:   # pragma: NO COVER
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.cloud.asset_v1"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "google.cloud.asset_v1"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 
 from .services.asset_service import AssetServiceClient

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -73,13 +73,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -20,69 +20,70 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("google.cloud.asset_v1")
-  api_core.check_dependency_versions("google.cloud.asset_v1")
-except AttributeError:
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("google.cloud.asset_v1")
+    api_core.check_dependency_versions("google.cloud.asset_v1")
+else:
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "google.cloud.asset_v1"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "google.cloud.asset_v1"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
+    if sys.version_info < (3, 8):
+        import pkg_resources
 
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
 
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
 
 
 from .services.asset_service import AssetServiceClient

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     api_core.check_python_version("google.cloud.asset_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.asset_v1") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -46,31 +46,43 @@ except AttributeError:
             "least Python 3.10, before then, and " +
             f"then update {_package_label}.")
 
-  import pkg_resources
   from packaging.version import parse as parse_version
 
-  def _get_version(dependency_name):
-    version_string = pkg_resources.get_distribution(dependency_name).version
-    return parse_version(version_string)
+  if sys.version_info < (3, 8):
+    import pkg_resources
+    def _get_version(dependency_name):
+      try:
+        version_string = pkg_resources.get_distribution(dependency_name).version
+        return parse_version(version_string)
+      except pkg_resources.DistributionNotFound:
+        return None
+  else:
+    from importlib import metadata
 
-  try:
-    _dependency_package = "google.protobuf"
-    _version_used = _get_version(_dependency_package)
-    _next_supported_version = "4.25.8"
-    if _version_used < parse_version(_next_supported_version):
-      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-              f"{_dependency_package}, currently installed at version " +
-              f"{_version_used.__str__}. Future updates to " +
-              f"{_package_label} will require {_dependency_package} at " +
-              f"version {_next_supported_version} or higher. Please ensure " +
-              "that either (a) your Python environment doesn't pin the " +
-              f"version of {_dependency_package}, so that updates to " +
-              f"{_package_label} can require the higher version, or " +
-              "(b) you manually update your Python environment to use at " +
-              f"least version {_next_supported_version} of " +
-              f"{_dependency_package}.")
-  except pkg_resources.DistributionNotFound:
-    pass
+    def _get_version(dependency_name):
+      try:
+        version_string = metadata.version("requests")
+        parsed_version = parse_version(version_string)
+        return parsed_version.release
+      except metadata.PackageNotFoundError:
+        return None
+
+  _dependency_package = "google.protobuf"
+  _next_supported_version = "4.25.8"
+  _next_supported_version_tuple = (4, 25, 8)
+  _version_used = _get_version(_dependency_package)
+  if _version_used and _version_used < _next_supported_version_tuple:
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}.")
 
 
 from .services.asset_service import AssetServiceClient

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -27,7 +27,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -20,8 +20,57 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-api_core.check_python_version("google.cloud.asset_v1")
-api_core.check_dependency_versions("google.cloud.asset_v1")
+try:
+  api_core.check_python_version("google.cloud.asset_v1")
+  api_core.check_dependency_versions("google.cloud.asset_v1")
+except AttributeError:
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+  import sys
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "google.cloud.asset_v1"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}.")
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
 
 
 from .services.asset_service import AssetServiceClient

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -37,14 +37,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -83,7 +85,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 
 from .services.asset_service import AssetServiceClient

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -80,7 +80,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -18,6 +18,12 @@ from google.cloud.asset_v1 import gapic_version as package_version
 __version__ = package_version.__version__
 
 
+import google.api_core as api_core
+
+api_core.check_python_version("google.cloud.asset_v1")
+api_core.check_dependency_versions("google.cloud.asset_v1")
+
+
 from .services.asset_service import AssetServiceClient
 from .services.asset_service import AssetServiceAsyncClient
 

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -33,18 +33,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "google.cloud.asset_v1"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -73,17 +73,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 
 from .services.asset_service import AssetServiceClient

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -56,9 +56,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -66,18 +66,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/__init__.py
@@ -21,8 +21,8 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("google.cloud.asset_v1")
-    api_core.check_dependency_versions("google.cloud.asset_v1")
+    api_core.check_python_version("google.cloud.asset_v1") # type: ignore
+    api_core.check_dependency_versions("google.cloud.asset_v1") # type: ignore
 else:
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -43,6 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -43,8 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17757,6 +17757,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.AssetServiceGrpcTransport, transports.AssetServiceGrpcAsyncIOTransport])
 def test_asset_service_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17712,6 +17712,7 @@ def test_asset_service_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.AssetServiceGrpcTransport, transports.AssetServiceGrpcAsyncIOTransport])
 def test_asset_service_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17734,7 +17734,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17726,7 +17726,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17726,7 +17726,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -17758,7 +17758,6 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.AssetServiceGrpcTransport, transports.AssetServiceGrpcAsyncIOTransport])
 def test_asset_service_transport_channel_mtls_with_adc(
     transport_class
@@ -17774,7 +17773,7 @@ def test_asset_service_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17734,7 +17734,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17734,7 +17734,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17726,7 +17726,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -17735,7 +17735,6 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -17773,14 +17772,13 @@ def test_asset_service_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17725,7 +17725,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -17734,6 +17734,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -17771,13 +17772,14 @@ def test_asset_service_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
+++ b/tests/integration/goldens/asset/tests/unit/gapic/asset_v1/test_asset_service.py
@@ -17734,7 +17734,7 @@ def test_asset_service_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -20,8 +20,57 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-api_core.check_python_version("google.iam.credentials_v1")
-api_core.check_dependency_versions("google.iam.credentials_v1")
+try:
+  api_core.check_python_version("google.iam.credentials_v1")
+  api_core.check_dependency_versions("google.iam.credentials_v1")
+except AttributeError:
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+  import sys
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "google.iam.credentials_v1"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}.")
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
 
 
 from .services.iam_credentials import IAMCredentialsClient

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -21,8 +21,8 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("google.iam.credentials_v1")
-    api_core.check_dependency_versions("google.iam.credentials_v1")
+    api_core.check_python_version("google.iam.credentials_v1") # type: ignore
+    api_core.check_dependency_versions("google.iam.credentials_v1") # type: ignore
 else:
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -73,13 +73,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -20,69 +20,70 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("google.iam.credentials_v1")
-  api_core.check_dependency_versions("google.iam.credentials_v1")
-except AttributeError:
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("google.iam.credentials_v1")
+    api_core.check_dependency_versions("google.iam.credentials_v1")
+else:
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "google.iam.credentials_v1"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "google.iam.credentials_v1"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
+    if sys.version_info < (3, 8):
+        import pkg_resources
 
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
 
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
 
 
 from .services.iam_credentials import IAMCredentialsClient

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -24,71 +24,77 @@ if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_depend
     api_core.check_python_version("google.iam.credentials_v1") # type: ignore
     api_core.check_dependency_versions("google.iam.credentials_v1") # type: ignore
 else:   # pragma: NO COVER
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.iam.credentials_v1"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "google.iam.credentials_v1"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 
 from .services.iam_credentials import IAMCredentialsClient

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -18,6 +18,12 @@ from google.iam.credentials_v1 import gapic_version as package_version
 __version__ = package_version.__version__
 
 
+import google.api_core as api_core
+
+api_core.check_python_version("google.iam.credentials_v1")
+api_core.check_dependency_versions("google.iam.credentials_v1")
+
+
 from .services.iam_credentials import IAMCredentialsClient
 from .services.iam_credentials import IAMCredentialsAsyncClient
 

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -37,14 +37,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -83,7 +85,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 
 from .services.iam_credentials import IAMCredentialsClient

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -27,7 +27,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -80,7 +80,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -33,18 +33,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "google.iam.credentials_v1"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -73,17 +73,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 
 from .services.iam_credentials import IAMCredentialsClient

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     api_core.check_python_version("google.iam.credentials_v1") # type: ignore
     api_core.check_dependency_versions("google.iam.credentials_v1") # type: ignore
-else:
+else:   # pragma: no coverage
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -46,31 +46,43 @@ except AttributeError:
             "least Python 3.10, before then, and " +
             f"then update {_package_label}.")
 
-  import pkg_resources
   from packaging.version import parse as parse_version
 
-  def _get_version(dependency_name):
-    version_string = pkg_resources.get_distribution(dependency_name).version
-    return parse_version(version_string)
+  if sys.version_info < (3, 8):
+    import pkg_resources
+    def _get_version(dependency_name):
+      try:
+        version_string = pkg_resources.get_distribution(dependency_name).version
+        return parse_version(version_string)
+      except pkg_resources.DistributionNotFound:
+        return None
+  else:
+    from importlib import metadata
 
-  try:
-    _dependency_package = "google.protobuf"
-    _version_used = _get_version(_dependency_package)
-    _next_supported_version = "4.25.8"
-    if _version_used < parse_version(_next_supported_version):
-      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-              f"{_dependency_package}, currently installed at version " +
-              f"{_version_used.__str__}. Future updates to " +
-              f"{_package_label} will require {_dependency_package} at " +
-              f"version {_next_supported_version} or higher. Please ensure " +
-              "that either (a) your Python environment doesn't pin the " +
-              f"version of {_dependency_package}, so that updates to " +
-              f"{_package_label} can require the higher version, or " +
-              "(b) you manually update your Python environment to use at " +
-              f"least version {_next_supported_version} of " +
-              f"{_dependency_package}.")
-  except pkg_resources.DistributionNotFound:
-    pass
+    def _get_version(dependency_name):
+      try:
+        version_string = metadata.version("requests")
+        parsed_version = parse_version(version_string)
+        return parsed_version.release
+      except metadata.PackageNotFoundError:
+        return None
+
+  _dependency_package = "google.protobuf"
+  _next_supported_version = "4.25.8"
+  _next_supported_version_tuple = (4, 25, 8)
+  _version_used = _get_version(_dependency_package)
+  if _version_used and _version_used < _next_supported_version_tuple:
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}.")
 
 
 from .services.iam_credentials import IAMCredentialsClient

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -56,9 +56,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -66,18 +66,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     api_core.check_python_version("google.iam.credentials_v1") # type: ignore
     api_core.check_dependency_versions("google.iam.credentials_v1") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -43,6 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -43,8 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3994,7 +3994,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3972,6 +3972,7 @@ def test_iam_credentials_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.IAMCredentialsGrpcTransport, transports.IAMCredentialsGrpcAsyncIOTransport])
 def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -4017,6 +4017,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.IAMCredentialsGrpcTransport, transports.IAMCredentialsGrpcAsyncIOTransport])
 def test_iam_credentials_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3994,7 +3994,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3986,7 +3986,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -4018,7 +4018,6 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.IAMCredentialsGrpcTransport, transports.IAMCredentialsGrpcAsyncIOTransport])
 def test_iam_credentials_transport_channel_mtls_with_adc(
     transport_class
@@ -4034,7 +4033,7 @@ def test_iam_credentials_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3985,7 +3985,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3994,6 +3994,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -4031,13 +4032,14 @@ def test_iam_credentials_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3994,7 +3994,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3994,7 +3994,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3986,7 +3986,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
+++ b/tests/integration/goldens/credentials/tests/unit/gapic/credentials_v1/test_iam_credentials.py
@@ -3986,7 +3986,7 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3995,7 +3995,6 @@ def test_iam_credentials_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -4033,14 +4032,13 @@ def test_iam_credentials_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -24,71 +24,77 @@ if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_depend
     api_core.check_python_version("google.cloud.eventarc_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.eventarc_v1") # type: ignore
 else:   # pragma: NO COVER
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.cloud.eventarc_v1"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "google.cloud.eventarc_v1"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 
 from .services.eventarc import EventarcClient

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -73,13 +73,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -33,18 +33,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "google.cloud.eventarc_v1"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -73,17 +73,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 
 from .services.eventarc import EventarcClient

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     api_core.check_python_version("google.cloud.eventarc_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.eventarc_v1") # type: ignore
-else:
+else:   # pragma: no coverage
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     api_core.check_python_version("google.cloud.eventarc_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.eventarc_v1") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -21,8 +21,8 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("google.cloud.eventarc_v1")
-    api_core.check_dependency_versions("google.cloud.eventarc_v1")
+    api_core.check_python_version("google.cloud.eventarc_v1") # type: ignore
+    api_core.check_dependency_versions("google.cloud.eventarc_v1") # type: ignore
 else:
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -27,7 +27,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -18,6 +18,12 @@ from google.cloud.eventarc_v1 import gapic_version as package_version
 __version__ = package_version.__version__
 
 
+import google.api_core as api_core
+
+api_core.check_python_version("google.cloud.eventarc_v1")
+api_core.check_dependency_versions("google.cloud.eventarc_v1")
+
+
 from .services.eventarc import EventarcClient
 from .services.eventarc import EventarcAsyncClient
 

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -20,8 +20,57 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-api_core.check_python_version("google.cloud.eventarc_v1")
-api_core.check_dependency_versions("google.cloud.eventarc_v1")
+try:
+  api_core.check_python_version("google.cloud.eventarc_v1")
+  api_core.check_dependency_versions("google.cloud.eventarc_v1")
+except AttributeError:
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+  import sys
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "google.cloud.eventarc_v1"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}.")
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
 
 
 from .services.eventarc import EventarcClient

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -20,69 +20,70 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("google.cloud.eventarc_v1")
-  api_core.check_dependency_versions("google.cloud.eventarc_v1")
-except AttributeError:
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("google.cloud.eventarc_v1")
+    api_core.check_dependency_versions("google.cloud.eventarc_v1")
+else:
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "google.cloud.eventarc_v1"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "google.cloud.eventarc_v1"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
+    if sys.version_info < (3, 8):
+        import pkg_resources
 
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
 
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
 
 
 from .services.eventarc import EventarcClient

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -37,14 +37,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -83,7 +85,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 
 from .services.eventarc import EventarcClient

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -80,7 +80,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -46,31 +46,43 @@ except AttributeError:
             "least Python 3.10, before then, and " +
             f"then update {_package_label}.")
 
-  import pkg_resources
   from packaging.version import parse as parse_version
 
-  def _get_version(dependency_name):
-    version_string = pkg_resources.get_distribution(dependency_name).version
-    return parse_version(version_string)
+  if sys.version_info < (3, 8):
+    import pkg_resources
+    def _get_version(dependency_name):
+      try:
+        version_string = pkg_resources.get_distribution(dependency_name).version
+        return parse_version(version_string)
+      except pkg_resources.DistributionNotFound:
+        return None
+  else:
+    from importlib import metadata
 
-  try:
-    _dependency_package = "google.protobuf"
-    _version_used = _get_version(_dependency_package)
-    _next_supported_version = "4.25.8"
-    if _version_used < parse_version(_next_supported_version):
-      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-              f"{_dependency_package}, currently installed at version " +
-              f"{_version_used.__str__}. Future updates to " +
-              f"{_package_label} will require {_dependency_package} at " +
-              f"version {_next_supported_version} or higher. Please ensure " +
-              "that either (a) your Python environment doesn't pin the " +
-              f"version of {_dependency_package}, so that updates to " +
-              f"{_package_label} can require the higher version, or " +
-              "(b) you manually update your Python environment to use at " +
-              f"least version {_next_supported_version} of " +
-              f"{_dependency_package}.")
-  except pkg_resources.DistributionNotFound:
-    pass
+    def _get_version(dependency_name):
+      try:
+        version_string = metadata.version("requests")
+        parsed_version = parse_version(version_string)
+        return parsed_version.release
+      except metadata.PackageNotFoundError:
+        return None
+
+  _dependency_package = "google.protobuf"
+  _next_supported_version = "4.25.8"
+  _next_supported_version_tuple = (4, 25, 8)
+  _version_used = _get_version(_dependency_package)
+  if _version_used and _version_used < _next_supported_version_tuple:
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}.")
 
 
 from .services.eventarc import EventarcClient

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/__init__.py
@@ -56,9 +56,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -66,18 +66,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -43,6 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -43,8 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15392,7 +15392,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -15424,7 +15424,6 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.EventarcGrpcTransport, transports.EventarcGrpcAsyncIOTransport])
 def test_eventarc_transport_channel_mtls_with_adc(
     transport_class
@@ -15440,7 +15439,7 @@ def test_eventarc_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15392,7 +15392,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -15401,7 +15401,6 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -15439,14 +15438,13 @@ def test_eventarc_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15392,7 +15392,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15423,6 +15423,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.EventarcGrpcTransport, transports.EventarcGrpcAsyncIOTransport])
 def test_eventarc_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15400,7 +15400,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15400,7 +15400,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15400,7 +15400,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15391,7 +15391,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -15400,6 +15400,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -15437,13 +15438,14 @@ def test_eventarc_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15400,7 +15400,7 @@ def test_eventarc_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -15378,6 +15378,7 @@ def test_eventarc_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.EventarcGrpcTransport, transports.EventarcGrpcAsyncIOTransport])
 def test_eventarc_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -73,13 +73,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -20,69 +20,70 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("google.cloud.logging_v2")
-  api_core.check_dependency_versions("google.cloud.logging_v2")
-except AttributeError:
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("google.cloud.logging_v2")
+    api_core.check_dependency_versions("google.cloud.logging_v2")
+else:
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "google.cloud.logging_v2"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "google.cloud.logging_v2"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
+    if sys.version_info < (3, 8):
+        import pkg_resources
 
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
 
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
 
 
 from .services.config_service_v2 import ConfigServiceV2Client

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     api_core.check_python_version("google.cloud.logging_v2") # type: ignore
     api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
-else:
+else:   # pragma: no coverage
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -21,8 +21,8 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("google.cloud.logging_v2")
-    api_core.check_dependency_versions("google.cloud.logging_v2")
+    api_core.check_python_version("google.cloud.logging_v2") # type: ignore
+    api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
 else:
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -37,14 +37,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -83,7 +85,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 
 from .services.config_service_v2 import ConfigServiceV2Client

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -20,8 +20,57 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-api_core.check_python_version("google.cloud.logging_v2")
-api_core.check_dependency_versions("google.cloud.logging_v2")
+try:
+  api_core.check_python_version("google.cloud.logging_v2")
+  api_core.check_dependency_versions("google.cloud.logging_v2")
+except AttributeError:
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+  import sys
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "google.cloud.logging_v2"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}.")
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
 
 
 from .services.config_service_v2 import ConfigServiceV2Client

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -27,7 +27,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     api_core.check_python_version("google.cloud.logging_v2") # type: ignore
     api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -46,31 +46,43 @@ except AttributeError:
             "least Python 3.10, before then, and " +
             f"then update {_package_label}.")
 
-  import pkg_resources
   from packaging.version import parse as parse_version
 
-  def _get_version(dependency_name):
-    version_string = pkg_resources.get_distribution(dependency_name).version
-    return parse_version(version_string)
+  if sys.version_info < (3, 8):
+    import pkg_resources
+    def _get_version(dependency_name):
+      try:
+        version_string = pkg_resources.get_distribution(dependency_name).version
+        return parse_version(version_string)
+      except pkg_resources.DistributionNotFound:
+        return None
+  else:
+    from importlib import metadata
 
-  try:
-    _dependency_package = "google.protobuf"
-    _version_used = _get_version(_dependency_package)
-    _next_supported_version = "4.25.8"
-    if _version_used < parse_version(_next_supported_version):
-      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-              f"{_dependency_package}, currently installed at version " +
-              f"{_version_used.__str__}. Future updates to " +
-              f"{_package_label} will require {_dependency_package} at " +
-              f"version {_next_supported_version} or higher. Please ensure " +
-              "that either (a) your Python environment doesn't pin the " +
-              f"version of {_dependency_package}, so that updates to " +
-              f"{_package_label} can require the higher version, or " +
-              "(b) you manually update your Python environment to use at " +
-              f"least version {_next_supported_version} of " +
-              f"{_dependency_package}.")
-  except pkg_resources.DistributionNotFound:
-    pass
+    def _get_version(dependency_name):
+      try:
+        version_string = metadata.version("requests")
+        parsed_version = parse_version(version_string)
+        return parsed_version.release
+      except metadata.PackageNotFoundError:
+        return None
+
+  _dependency_package = "google.protobuf"
+  _next_supported_version = "4.25.8"
+  _next_supported_version_tuple = (4, 25, 8)
+  _version_used = _get_version(_dependency_package)
+  if _version_used and _version_used < _next_supported_version_tuple:
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}.")
 
 
 from .services.config_service_v2 import ConfigServiceV2Client

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -80,7 +80,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -24,71 +24,77 @@ if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_depend
     api_core.check_python_version("google.cloud.logging_v2") # type: ignore
     api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
 else:   # pragma: NO COVER
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.cloud.logging_v2"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "google.cloud.logging_v2"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 
 from .services.config_service_v2 import ConfigServiceV2Client

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -56,9 +56,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -66,18 +66,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -33,18 +33,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "google.cloud.logging_v2"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -73,17 +73,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 
 from .services.config_service_v2 import ConfigServiceV2Client

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/__init__.py
@@ -18,6 +18,12 @@ from google.cloud.logging_v2 import gapic_version as package_version
 __version__ = package_version.__version__
 
 
+import google.api_core as api_core
+
+api_core.check_python_version("google.cloud.logging_v2")
+api_core.check_dependency_versions("google.cloud.logging_v2")
+
+
 from .services.config_service_v2 import ConfigServiceV2Client
 from .services.config_service_v2 import ConfigServiceV2AsyncClient
 from .services.logging_service_v2 import LoggingServiceV2Client

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -43,6 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -43,8 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12942,6 +12942,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.ConfigServiceV2GrpcTransport, transports.ConfigServiceV2GrpcAsyncIOTransport])
 def test_config_service_v2_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12911,7 +12911,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -12920,7 +12920,6 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -12958,14 +12957,13 @@ def test_config_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12911,7 +12911,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12897,6 +12897,7 @@ def test_config_service_v2_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.ConfigServiceV2GrpcTransport, transports.ConfigServiceV2GrpcAsyncIOTransport])
 def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12911,7 +12911,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -12943,7 +12943,6 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.ConfigServiceV2GrpcTransport, transports.ConfigServiceV2GrpcAsyncIOTransport])
 def test_config_service_v2_transport_channel_mtls_with_adc(
     transport_class
@@ -12959,7 +12958,7 @@ def test_config_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12910,7 +12910,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -12919,6 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -12956,13 +12957,14 @@ def test_config_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3459,7 +3459,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3459,7 +3459,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3491,7 +3491,6 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.LoggingServiceV2GrpcTransport, transports.LoggingServiceV2GrpcAsyncIOTransport])
 def test_logging_service_v2_transport_channel_mtls_with_adc(
     transport_class
@@ -3507,7 +3506,7 @@ def test_logging_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3490,6 +3490,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.LoggingServiceV2GrpcTransport, transports.LoggingServiceV2GrpcAsyncIOTransport])
 def test_logging_service_v2_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3459,7 +3459,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3468,7 +3468,6 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3506,14 +3505,13 @@ def test_logging_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3458,7 +3458,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3467,6 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3504,13 +3505,14 @@ def test_logging_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3445,6 +3445,7 @@ def test_logging_service_v2_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.LoggingServiceV2GrpcTransport, transports.LoggingServiceV2GrpcAsyncIOTransport])
 def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3263,7 +3263,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3272,7 +3272,6 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3310,14 +3309,13 @@ def test_metrics_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3294,6 +3294,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.MetricsServiceV2GrpcTransport, transports.MetricsServiceV2GrpcAsyncIOTransport])
 def test_metrics_service_v2_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3263,7 +3263,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3295,7 +3295,6 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.MetricsServiceV2GrpcTransport, transports.MetricsServiceV2GrpcAsyncIOTransport])
 def test_metrics_service_v2_transport_channel_mtls_with_adc(
     transport_class
@@ -3311,7 +3310,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3263,7 +3263,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3262,7 +3262,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3271,6 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3308,13 +3309,14 @@ def test_metrics_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3249,6 +3249,7 @@ def test_metrics_service_v2_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.MetricsServiceV2GrpcTransport, transports.MetricsServiceV2GrpcAsyncIOTransport])
 def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -18,6 +18,12 @@ from google.cloud.logging_v2 import gapic_version as package_version
 __version__ = package_version.__version__
 
 
+import google.api_core as api_core
+
+api_core.check_python_version("google.cloud.logging_v2")
+api_core.check_dependency_versions("google.cloud.logging_v2")
+
+
 from .services.config_service_v2 import BaseConfigServiceV2Client
 from .services.config_service_v2 import BaseConfigServiceV2AsyncClient
 from .services.logging_service_v2 import LoggingServiceV2Client

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -73,13 +73,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -37,14 +37,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -83,7 +85,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 
 from .services.config_service_v2 import BaseConfigServiceV2Client

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     api_core.check_python_version("google.cloud.logging_v2") # type: ignore
     api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
-else:
+else:   # pragma: no coverage
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -21,8 +21,8 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("google.cloud.logging_v2")
-    api_core.check_dependency_versions("google.cloud.logging_v2")
+    api_core.check_python_version("google.cloud.logging_v2") # type: ignore
+    api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
 else:
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -27,7 +27,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     api_core.check_python_version("google.cloud.logging_v2") # type: ignore
     api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -80,7 +80,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -20,8 +20,57 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-api_core.check_python_version("google.cloud.logging_v2")
-api_core.check_dependency_versions("google.cloud.logging_v2")
+try:
+  api_core.check_python_version("google.cloud.logging_v2")
+  api_core.check_dependency_versions("google.cloud.logging_v2")
+except AttributeError:
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+  import sys
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "google.cloud.logging_v2"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}.")
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
 
 
 from .services.config_service_v2 import BaseConfigServiceV2Client

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -24,71 +24,77 @@ if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_depend
     api_core.check_python_version("google.cloud.logging_v2") # type: ignore
     api_core.check_dependency_versions("google.cloud.logging_v2") # type: ignore
 else:   # pragma: NO COVER
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.cloud.logging_v2"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "google.cloud.logging_v2"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 
 from .services.config_service_v2 import BaseConfigServiceV2Client

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -20,69 +20,70 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("google.cloud.logging_v2")
-  api_core.check_dependency_versions("google.cloud.logging_v2")
-except AttributeError:
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("google.cloud.logging_v2")
+    api_core.check_dependency_versions("google.cloud.logging_v2")
+else:
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "google.cloud.logging_v2"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "google.cloud.logging_v2"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
+    if sys.version_info < (3, 8):
+        import pkg_resources
 
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
 
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
 
 
 from .services.config_service_v2 import BaseConfigServiceV2Client

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -33,18 +33,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "google.cloud.logging_v2"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -73,17 +73,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 
 from .services.config_service_v2 import BaseConfigServiceV2Client

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/__init__.py
@@ -56,9 +56,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -66,18 +66,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/logging_internal/setup.py
+++ b/tests/integration/goldens/logging_internal/setup.py
@@ -43,6 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/tests/integration/goldens/logging_internal/setup.py
+++ b/tests/integration/goldens/logging_internal/setup.py
@@ -43,8 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12942,6 +12942,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.ConfigServiceV2GrpcTransport, transports.ConfigServiceV2GrpcAsyncIOTransport])
 def test_config_service_v2_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12911,7 +12911,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -12920,7 +12920,6 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -12958,14 +12957,13 @@ def test_config_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12911,7 +12911,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12897,6 +12897,7 @@ def test_config_service_v2_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.ConfigServiceV2GrpcTransport, transports.ConfigServiceV2GrpcAsyncIOTransport])
 def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12919,7 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12911,7 +12911,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -12943,7 +12943,6 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.ConfigServiceV2GrpcTransport, transports.ConfigServiceV2GrpcAsyncIOTransport])
 def test_config_service_v2_transport_channel_mtls_with_adc(
     transport_class
@@ -12959,7 +12958,7 @@ def test_config_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -12910,7 +12910,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -12919,6 +12919,7 @@ def test_config_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -12956,13 +12957,14 @@ def test_config_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3459,7 +3459,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3459,7 +3459,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3491,7 +3491,6 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.LoggingServiceV2GrpcTransport, transports.LoggingServiceV2GrpcAsyncIOTransport])
 def test_logging_service_v2_transport_channel_mtls_with_adc(
     transport_class
@@ -3507,7 +3506,7 @@ def test_logging_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3490,6 +3490,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.LoggingServiceV2GrpcTransport, transports.LoggingServiceV2GrpcAsyncIOTransport])
 def test_logging_service_v2_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3459,7 +3459,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3468,7 +3468,6 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3506,14 +3505,13 @@ def test_logging_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3458,7 +3458,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3467,6 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3504,13 +3505,14 @@ def test_logging_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3445,6 +3445,7 @@ def test_logging_service_v2_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.LoggingServiceV2GrpcTransport, transports.LoggingServiceV2GrpcAsyncIOTransport])
 def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -3467,7 +3467,7 @@ def test_logging_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3263,7 +3263,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3272,7 +3272,6 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3310,14 +3309,13 @@ def test_metrics_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3294,6 +3294,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.MetricsServiceV2GrpcTransport, transports.MetricsServiceV2GrpcAsyncIOTransport])
 def test_metrics_service_v2_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3263,7 +3263,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3295,7 +3295,6 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.MetricsServiceV2GrpcTransport, transports.MetricsServiceV2GrpcAsyncIOTransport])
 def test_metrics_service_v2_transport_channel_mtls_with_adc(
     transport_class
@@ -3311,7 +3310,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3263,7 +3263,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3262,7 +3262,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -3271,6 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -3308,13 +3309,14 @@ def test_metrics_service_v2_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3249,6 +3249,7 @@ def test_metrics_service_v2_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.MetricsServiceV2GrpcTransport, transports.MetricsServiceV2GrpcAsyncIOTransport])
 def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -3271,7 +3271,7 @@ def test_metrics_service_v2_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     api_core.check_python_version("google.cloud.redis_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -73,13 +73,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -24,71 +24,77 @@ if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_depend
     api_core.check_python_version("google.cloud.redis_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
 else:   # pragma: NO COVER
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.cloud.redis_v1"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "google.cloud.redis_v1"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -21,8 +21,8 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("google.cloud.redis_v1")
-    api_core.check_dependency_versions("google.cloud.redis_v1")
+    api_core.check_python_version("google.cloud.redis_v1") # type: ignore
+    api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
 else:
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -33,18 +33,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "google.cloud.redis_v1"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -73,17 +73,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -37,14 +37,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -83,7 +85,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -18,6 +18,12 @@ from google.cloud.redis_v1 import gapic_version as package_version
 __version__ = package_version.__version__
 
 
+import google.api_core as api_core
+
+api_core.check_python_version("google.cloud.redis_v1")
+api_core.check_dependency_versions("google.cloud.redis_v1")
+
+
 from .services.cloud_redis import CloudRedisClient
 from .services.cloud_redis import CloudRedisAsyncClient
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -20,8 +20,57 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-api_core.check_python_version("google.cloud.redis_v1")
-api_core.check_dependency_versions("google.cloud.redis_v1")
+try:
+  api_core.check_python_version("google.cloud.redis_v1")
+  api_core.check_dependency_versions("google.cloud.redis_v1")
+except AttributeError:
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+  import sys
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "google.cloud.redis_v1"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}.")
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -27,7 +27,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -80,7 +80,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -46,31 +46,43 @@ except AttributeError:
             "least Python 3.10, before then, and " +
             f"then update {_package_label}.")
 
-  import pkg_resources
   from packaging.version import parse as parse_version
 
-  def _get_version(dependency_name):
-    version_string = pkg_resources.get_distribution(dependency_name).version
-    return parse_version(version_string)
+  if sys.version_info < (3, 8):
+    import pkg_resources
+    def _get_version(dependency_name):
+      try:
+        version_string = pkg_resources.get_distribution(dependency_name).version
+        return parse_version(version_string)
+      except pkg_resources.DistributionNotFound:
+        return None
+  else:
+    from importlib import metadata
 
-  try:
-    _dependency_package = "google.protobuf"
-    _version_used = _get_version(_dependency_package)
-    _next_supported_version = "4.25.8"
-    if _version_used < parse_version(_next_supported_version):
-      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-              f"{_dependency_package}, currently installed at version " +
-              f"{_version_used.__str__}. Future updates to " +
-              f"{_package_label} will require {_dependency_package} at " +
-              f"version {_next_supported_version} or higher. Please ensure " +
-              "that either (a) your Python environment doesn't pin the " +
-              f"version of {_dependency_package}, so that updates to " +
-              f"{_package_label} can require the higher version, or " +
-              "(b) you manually update your Python environment to use at " +
-              f"least version {_next_supported_version} of " +
-              f"{_dependency_package}.")
-  except pkg_resources.DistributionNotFound:
-    pass
+    def _get_version(dependency_name):
+      try:
+        version_string = metadata.version("requests")
+        parsed_version = parse_version(version_string)
+        return parsed_version.release
+      except metadata.PackageNotFoundError:
+        return None
+
+  _dependency_package = "google.protobuf"
+  _next_supported_version = "4.25.8"
+  _next_supported_version_tuple = (4, 25, 8)
+  _version_used = _get_version(_dependency_package)
+  if _version_used and _version_used < _next_supported_version_tuple:
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}.")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     api_core.check_python_version("google.cloud.redis_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
-else:
+else:   # pragma: no coverage
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -56,9 +56,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -66,18 +66,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/__init__.py
@@ -20,69 +20,70 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("google.cloud.redis_v1")
-  api_core.check_dependency_versions("google.cloud.redis_v1")
-except AttributeError:
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("google.cloud.redis_v1")
+    api_core.check_dependency_versions("google.cloud.redis_v1")
+else:
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "google.cloud.redis_v1"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "google.cloud.redis_v1"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
+    if sys.version_info < (3, 8):
+        import pkg_resources
 
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
 
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -43,6 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -43,8 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11679,7 +11679,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11657,6 +11657,7 @@ def test_cloud_redis_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.CloudRedisGrpcTransport, transports.CloudRedisGrpcAsyncIOTransport])
 def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11671,7 +11671,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -11680,7 +11680,6 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -11718,14 +11717,13 @@ def test_cloud_redis_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11679,7 +11679,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11679,7 +11679,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11679,7 +11679,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11670,7 +11670,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -11679,6 +11679,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -11716,13 +11717,14 @@ def test_cloud_redis_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11702,6 +11702,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.CloudRedisGrpcTransport, transports.CloudRedisGrpcAsyncIOTransport])
 def test_cloud_redis_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11671,7 +11671,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -11703,7 +11703,6 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.CloudRedisGrpcTransport, transports.CloudRedisGrpcAsyncIOTransport])
 def test_cloud_redis_transport_channel_mtls_with_adc(
     transport_class
@@ -11719,7 +11718,7 @@ def test_cloud_redis_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -11671,7 +11671,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: NO COVER
     api_core.check_python_version("google.cloud.redis_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
-else:   # pragma: no coverage
+else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -73,13 +73,15 @@ else:   # pragma: NO COVER
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
+    _recommendation = " (we recommend 6.x)"
     (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher. Please ensure " +
+                      f"version {_next_supported_version} or higher{recommendation}." +
+                      " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +
                       f"{_package_label} can require the higher version, or " +

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -24,71 +24,77 @@ if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_depend
     api_core.check_python_version("google.cloud.redis_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
 else:   # pragma: NO COVER
-    # An older version of api_core is installed, which does not define the
+    # An older version of api_core is installed which does not define the
     # functions above. We do equivalent checks manually.
+    try:
+        import warnings
+        import sys
 
-    import warnings
-    import sys
+        _py_version_str = sys.version.split()[0]
+        _package_label = "google.cloud.redis_v1"
+        if sys.version_info < (3, 9):
+            warnings.warn("You are using a non-supported Python version " +
+                          f"({_py_version_str}).  Google will not post any further " +
+                          f"updates to {_package_label} supporting this Python version. " +
+                          "Please upgrade to the latest Python version, or at " +
+                          f"least to Python 3.9, and then update {_package_label}.",
+                          FutureWarning)
+        if sys.version_info[:2] == (3, 9):
+            warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                          f"which Google will stop supporting in {_package_label} in " +
+                          "January 2026. Please " +
+                          "upgrade to the latest Python version, or at " +
+                          "least to Python 3.10, before then, and " +
+                          f"then update {_package_label}.",
+                          FutureWarning)
 
-    _py_version_str = sys.version.split()[0]
-    _package_label = "google.cloud.redis_v1"
-    if sys.version_info < (3, 9):
-        warnings.warn("You are using a non-supported Python version " +
-                      f"({_py_version_str}).  Google will not post any further " +
-                      f"updates to {_package_label} supporting this Python version. " +
-                      "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.",
-                      FutureWarning)
-    if sys.version_info[:2] == (3, 9):
-        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
-                      f"which Google will stop supporting in {_package_label} when " +
-                      "it reaches its end of life (October 2025). Please " +
-                      "upgrade to the latest Python version, or at " +
-                      "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.",
-                      FutureWarning)
+        from packaging.version import parse as parse_version
 
-    from packaging.version import parse as parse_version
+        if sys.version_info < (3, 8):
+            import pkg_resources
 
-    if sys.version_info < (3, 8):
-        import pkg_resources
-
-        def _get_version(dependency_name):
-          try:
-            version_string = pkg_resources.get_distribution(dependency_name).version
-            return (parse_version(version_string), version_string)
-          except pkg_resources.DistributionNotFound:
-            return (None, "--")
-    else:
-        from importlib import metadata
-
-        def _get_version(dependency_name):
-            try:
-                version_string = metadata.version("requests")
-                parsed_version = parse_version(version_string)
-                return (parsed_version.release, version_string)
-            except metadata.PackageNotFoundError:
+            def _get_version(dependency_name):
+              try:
+                version_string = pkg_resources.get_distribution(dependency_name).version
+                return (parse_version(version_string), version_string)
+              except pkg_resources.DistributionNotFound:
                 return (None, "--")
+        else:
+            from importlib import metadata
 
-    _dependency_package = "google.protobuf"
-    _next_supported_version = "4.25.8"
-    _next_supported_version_tuple = (4, 25, 8)
-    _recommendation = " (we recommend 6.x)"
-    (_version_used, _version_used_string) = _get_version(_dependency_package)
-    if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"Package {_package_label} depends on " +
-                      f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used_string}. Future updates to " +
-                      f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{_recommendation}." +
-                      " Please ensure " +
-                      "that either (a) your Python environment doesn't pin the " +
-                      f"version of {_dependency_package}, so that updates to " +
-                      f"{_package_label} can require the higher version, or " +
-                      "(b) you manually update your Python environment to use at " +
-                      f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.",
-                      FutureWarning)
+            def _get_version(dependency_name):
+                try:
+                    version_string = metadata.version("requests")
+                    parsed_version = parse_version(version_string)
+                    return (parsed_version.release, version_string)
+                except metadata.PackageNotFoundError:
+                    return (None, "--")
+
+        _dependency_package = "google.protobuf"
+        _next_supported_version = "4.25.8"
+        _next_supported_version_tuple = (4, 25, 8)
+        _recommendation = " (we recommend 6.x)"
+        (_version_used, _version_used_string) = _get_version(_dependency_package)
+        if _version_used and _version_used < _next_supported_version_tuple:
+            warnings.warn(f"Package {_package_label} depends on " +
+                          f"{_dependency_package}, currently installed at version " +
+                          f"{_version_used_string}. Future updates to " +
+                          f"{_package_label} will require {_dependency_package} at " +
+                          f"version {_next_supported_version} or higher{_recommendation}." +
+                          " Please ensure " +
+                          "that either (a) your Python environment doesn't pin the " +
+                          f"version of {_dependency_package}, so that updates to " +
+                          f"{_package_label} can require the higher version, or " +
+                          "(b) you manually update your Python environment to use at " +
+                          f"least version {_next_supported_version} of " +
+                          f"{_dependency_package}.",
+                          FutureWarning)
+    except Exception:
+            warnings.warn("Could not determine the version of Python " +
+                          "currently being used. To continue receiving " +
+                          "updates for {_package_label}, ensure you are " +
+                          "using a supported version of Python; see " +
+                          "https://devguide.python.org/versions/")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -77,7 +77,7 @@ else:   # pragma: NO COVER
     if _version_used and _version_used < _next_supported_version_tuple:
         warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_version_used.__str__()}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -21,8 +21,8 @@ __version__ = package_version.__version__
 import google.api_core as api_core
 
 if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
-    api_core.check_python_version("google.cloud.redis_v1")
-    api_core.check_dependency_versions("google.cloud.redis_v1")
+    api_core.check_python_version("google.cloud.redis_v1") # type: ignore
+    api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
 else:
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -33,18 +33,18 @@ else:   # pragma: NO COVER
     _py_version_str = sys.version.split()[0]
     _package_label = "google.cloud.redis_v1"
     if sys.version_info < (3, 9):
-        logging.warning("You are using a non-supported Python version " +
-                f"({_py_version_str}).  Google will not post any further " +
-                f"updates to {_package_label} supporting this Python version. " +
-                "Please upgrade to the latest Python version, or at " +
-                f"least to Python 3.9, and then update {_package_label}.")
+        warnings.warn("You are using a non-supported Python version " +
+                      f"({_py_version_str}).  Google will not post any further " +
+                      f"updates to {_package_label} supporting this Python version. " +
+                      "Please upgrade to the latest Python version, or at " +
+                      f"least to Python 3.9, and then update {_package_label}.")
     if sys.version_info[:2] == (3, 9):
-        logging.warning(f"You are using a Python version ({_py_version_str}) " +
-                f"which Google will stop supporting in {_package_label} when " +
-                "it reaches its end of life (October 2025). Please " +
-                "upgrade to the latest Python version, or at " +
-                "least Python 3.10, before then, and " +
-                f"then update {_package_label}.")
+        warnings.warn(f"You are using a Python version ({_py_version_str}) " +
+                      f"which Google will stop supporting in {_package_label} when " +
+                      "it reaches its end of life (October 2025). Please " +
+                      "upgrade to the latest Python version, or at " +
+                      "least Python 3.10, before then, and " +
+                      f"then update {_package_label}.")
 
     from packaging.version import parse as parse_version
 
@@ -73,17 +73,17 @@ else:   # pragma: NO COVER
     _next_supported_version_tuple = (4, 25, 8)
     _version_used = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-                  f"{_dependency_package}, currently installed at version " +
-                  f"{_version_used.__str__}. Future updates to " +
-                  f"{_package_label} will require {_dependency_package} at " +
-                  f"version {_next_supported_version} or higher. Please ensure " +
-                  "that either (a) your Python environment doesn't pin the " +
-                  f"version of {_dependency_package}, so that updates to " +
-                  f"{_package_label} can require the higher version, or " +
-                  "(b) you manually update your Python environment to use at " +
-                  f"least version {_next_supported_version} of " +
-                  f"{_dependency_package}.")
+        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+                      f"{_dependency_package}, currently installed at version " +
+                      f"{_version_used.__str__}. Future updates to " +
+                      f"{_package_label} will require {_dependency_package} at " +
+                      f"version {_next_supported_version} or higher. Please ensure " +
+                      "that either (a) your Python environment doesn't pin the " +
+                      f"version of {_dependency_package}, so that updates to " +
+                      f"{_package_label} can require the higher version, or " +
+                      "(b) you manually update your Python environment to use at " +
+                      f"least version {_next_supported_version} of " +
+                      f"{_dependency_package}.")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -37,14 +37,16 @@ else:   # pragma: NO COVER
                       f"({_py_version_str}).  Google will not post any further " +
                       f"updates to {_package_label} supporting this Python version. " +
                       "Please upgrade to the latest Python version, or at " +
-                      f"least to Python 3.9, and then update {_package_label}.")
+                      f"least to Python 3.9, and then update {_package_label}.",
+                      FutureWarning)
     if sys.version_info[:2] == (3, 9):
         warnings.warn(f"You are using a Python version ({_py_version_str}) " +
                       f"which Google will stop supporting in {_package_label} when " +
                       "it reaches its end of life (October 2025). Please " +
                       "upgrade to the latest Python version, or at " +
                       "least Python 3.10, before then, and " +
-                      f"then update {_package_label}.")
+                      f"then update {_package_label}.",
+                      FutureWarning)
 
     from packaging.version import parse as parse_version
 
@@ -83,7 +85,8 @@ else:   # pragma: NO COVER
                       f"{_package_label} can require the higher version, or " +
                       "(b) you manually update your Python environment to use at " +
                       f"least version {_next_supported_version} of " +
-                      f"{_dependency_package}.")
+                      f"{_dependency_package}.",
+                      FutureWarning)
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -18,6 +18,12 @@ from google.cloud.redis_v1 import gapic_version as package_version
 __version__ = package_version.__version__
 
 
+import google.api_core as api_core
+
+api_core.check_python_version("google.cloud.redis_v1")
+api_core.check_dependency_versions("google.cloud.redis_v1")
+
+
 from .services.cloud_redis import CloudRedisClient
 from .services.cloud_redis import CloudRedisAsyncClient
 

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -20,8 +20,57 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-api_core.check_python_version("google.cloud.redis_v1")
-api_core.check_dependency_versions("google.cloud.redis_v1")
+try:
+  api_core.check_python_version("google.cloud.redis_v1")
+  api_core.check_dependency_versions("google.cloud.redis_v1")
+except AttributeError:
+  # An older version of api_core is installed, which does not define the
+  # functions above. We do equivalent checks manually.
+
+  import logging
+  import sys
+
+  _py_version_str = sys.version.split()[0]
+  _package_label = "google.cloud.redis_v1"
+  if sys.version_info < (3, 9):
+    logging.warning("You are using a non-supported Python version " +
+            f"({_py_version_str}).  Google will not post any further " +
+            f"updates to {_package_label} supporting this Python version. " +
+            "Please upgrade to the latest Python version, or at " +
+            f"least to Python 3.9, and then update {_package_label}.")
+  if sys.version_info[:2] == (3, 9):
+    logging.warning(f"You are using a Python version ({_py_version_str}) " +
+            f"which Google will stop supporting in {_package_label} when " +
+            "it reaches its end of life (October 2025). Please " +
+            "upgrade to the latest Python version, or at " +
+            "least Python 3.10, before then, and " +
+            f"then update {_package_label}.")
+
+  import pkg_resources
+  from packaging.version import parse as parse_version
+
+  def _get_version(dependency_name):
+    version_string = pkg_resources.get_distribution(dependency_name).version
+    return parse_version(version_string)
+
+  try:
+    _dependency_package = "google.protobuf"
+    _version_used = _get_version(_dependency_package)
+    _next_supported_version = "4.25.8"
+    if _version_used < parse_version(_next_supported_version):
+      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+              f"{_dependency_package}, currently installed at version " +
+              f"{_version_used.__str__}. Future updates to " +
+              f"{_package_label} will require {_dependency_package} at " +
+              f"version {_next_supported_version} or higher. Please ensure " +
+              "that either (a) your Python environment doesn't pin the " +
+              f"version of {_dependency_package}, so that updates to " +
+              f"{_package_label} can require the higher version, or " +
+              "(b) you manually update your Python environment to use at " +
+              f"least version {_next_supported_version} of " +
+              f"{_dependency_package}.")
+  except pkg_resources.DistributionNotFound:
+    pass
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -27,7 +27,7 @@ else:   # pragma: NO COVER
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 
-    import logging
+    import warnings
     import sys
 
     _py_version_str = sys.version.split()[0]

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -80,7 +80,7 @@ else:   # pragma: NO COVER
                       f"{_dependency_package}, currently installed at version " +
                       f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
-                      f"version {_next_supported_version} or higher{recommendation}." +
+                      f"version {_next_supported_version} or higher{_recommendation}." +
                       " Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +
                       f"version of {_dependency_package}, so that updates to " +

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -46,31 +46,43 @@ except AttributeError:
             "least Python 3.10, before then, and " +
             f"then update {_package_label}.")
 
-  import pkg_resources
   from packaging.version import parse as parse_version
 
-  def _get_version(dependency_name):
-    version_string = pkg_resources.get_distribution(dependency_name).version
-    return parse_version(version_string)
+  if sys.version_info < (3, 8):
+    import pkg_resources
+    def _get_version(dependency_name):
+      try:
+        version_string = pkg_resources.get_distribution(dependency_name).version
+        return parse_version(version_string)
+      except pkg_resources.DistributionNotFound:
+        return None
+  else:
+    from importlib import metadata
 
-  try:
-    _dependency_package = "google.protobuf"
-    _version_used = _get_version(_dependency_package)
-    _next_supported_version = "4.25.8"
-    if _version_used < parse_version(_next_supported_version):
-      logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-              f"{_dependency_package}, currently installed at version " +
-              f"{_version_used.__str__}. Future updates to " +
-              f"{_package_label} will require {_dependency_package} at " +
-              f"version {_next_supported_version} or higher. Please ensure " +
-              "that either (a) your Python environment doesn't pin the " +
-              f"version of {_dependency_package}, so that updates to " +
-              f"{_package_label} can require the higher version, or " +
-              "(b) you manually update your Python environment to use at " +
-              f"least version {_next_supported_version} of " +
-              f"{_dependency_package}.")
-  except pkg_resources.DistributionNotFound:
-    pass
+    def _get_version(dependency_name):
+      try:
+        version_string = metadata.version("requests")
+        parsed_version = parse_version(version_string)
+        return parsed_version.release
+      except metadata.PackageNotFoundError:
+        return None
+
+  _dependency_package = "google.protobuf"
+  _next_supported_version = "4.25.8"
+  _next_supported_version_tuple = (4, 25, 8)
+  _version_used = _get_version(_dependency_package)
+  if _version_used and _version_used < _next_supported_version_tuple:
+    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+            f"{_dependency_package}, currently installed at version " +
+            f"{_version_used.__str__}. Future updates to " +
+            f"{_package_label} will require {_dependency_package} at " +
+            f"version {_next_supported_version} or higher. Please ensure " +
+            "that either (a) your Python environment doesn't pin the " +
+            f"version of {_dependency_package}, so that updates to " +
+            f"{_package_label} can require the higher version, or " +
+            "(b) you manually update your Python environment to use at " +
+            f"least version {_next_supported_version} of " +
+            f"{_dependency_package}.")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -20,10 +20,10 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):   # pragma: no coverage
     api_core.check_python_version("google.cloud.redis_v1") # type: ignore
     api_core.check_dependency_versions("google.cloud.redis_v1") # type: ignore
-else:
+else:   # pragma: no coverage
     # An older version of api_core is installed, which does not define the
     # functions above. We do equivalent checks manually.
 

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -56,9 +56,9 @@ else:   # pragma: NO COVER
         def _get_version(dependency_name):
           try:
             version_string = pkg_resources.get_distribution(dependency_name).version
-            return parse_version(version_string)
+            return (parse_version(version_string), version_string)
           except pkg_resources.DistributionNotFound:
-            return None
+            return (None, "--")
     else:
         from importlib import metadata
 
@@ -66,18 +66,18 @@ else:   # pragma: NO COVER
             try:
                 version_string = metadata.version("requests")
                 parsed_version = parse_version(version_string)
-                return parsed_version.release
+                return (parsed_version.release, version_string)
             except metadata.PackageNotFoundError:
-                return None
+                return (None, "--")
 
     _dependency_package = "google.protobuf"
     _next_supported_version = "4.25.8"
     _next_supported_version_tuple = (4, 25, 8)
-    _version_used = _get_version(_dependency_package)
+    (_version_used, _version_used_string) = _get_version(_dependency_package)
     if _version_used and _version_used < _next_supported_version_tuple:
-        warnings.warn(f"DEPRECATION: Package {_package_label} depends on " +
+        warnings.warn(f"Package {_package_label} depends on " +
                       f"{_dependency_package}, currently installed at version " +
-                      f"{_version_used.__str__()}. Future updates to " +
+                      f"{_version_used_string}. Future updates to " +
                       f"{_package_label} will require {_dependency_package} at " +
                       f"version {_next_supported_version} or higher. Please ensure " +
                       "that either (a) your Python environment doesn't pin the " +

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/__init__.py
@@ -20,69 +20,70 @@ __version__ = package_version.__version__
 
 import google.api_core as api_core
 
-try:
-  api_core.check_python_version("google.cloud.redis_v1")
-  api_core.check_dependency_versions("google.cloud.redis_v1")
-except AttributeError:
-  # An older version of api_core is installed, which does not define the
-  # functions above. We do equivalent checks manually.
+if hasattr(api_core, "check_python_version") and hasattr(api_core, "check_dependency_versions"):
+    api_core.check_python_version("google.cloud.redis_v1")
+    api_core.check_dependency_versions("google.cloud.redis_v1")
+else:
+    # An older version of api_core is installed, which does not define the
+    # functions above. We do equivalent checks manually.
 
-  import logging
-  import sys
+    import logging
+    import sys
 
-  _py_version_str = sys.version.split()[0]
-  _package_label = "google.cloud.redis_v1"
-  if sys.version_info < (3, 9):
-    logging.warning("You are using a non-supported Python version " +
-            f"({_py_version_str}).  Google will not post any further " +
-            f"updates to {_package_label} supporting this Python version. " +
-            "Please upgrade to the latest Python version, or at " +
-            f"least to Python 3.9, and then update {_package_label}.")
-  if sys.version_info[:2] == (3, 9):
-    logging.warning(f"You are using a Python version ({_py_version_str}) " +
-            f"which Google will stop supporting in {_package_label} when " +
-            "it reaches its end of life (October 2025). Please " +
-            "upgrade to the latest Python version, or at " +
-            "least Python 3.10, before then, and " +
-            f"then update {_package_label}.")
+    _py_version_str = sys.version.split()[0]
+    _package_label = "google.cloud.redis_v1"
+    if sys.version_info < (3, 9):
+        logging.warning("You are using a non-supported Python version " +
+                f"({_py_version_str}).  Google will not post any further " +
+                f"updates to {_package_label} supporting this Python version. " +
+                "Please upgrade to the latest Python version, or at " +
+                f"least to Python 3.9, and then update {_package_label}.")
+    if sys.version_info[:2] == (3, 9):
+        logging.warning(f"You are using a Python version ({_py_version_str}) " +
+                f"which Google will stop supporting in {_package_label} when " +
+                "it reaches its end of life (October 2025). Please " +
+                "upgrade to the latest Python version, or at " +
+                "least Python 3.10, before then, and " +
+                f"then update {_package_label}.")
 
-  from packaging.version import parse as parse_version
+    from packaging.version import parse as parse_version
 
-  if sys.version_info < (3, 8):
-    import pkg_resources
-    def _get_version(dependency_name):
-      try:
-        version_string = pkg_resources.get_distribution(dependency_name).version
-        return parse_version(version_string)
-      except pkg_resources.DistributionNotFound:
-        return None
-  else:
-    from importlib import metadata
+    if sys.version_info < (3, 8):
+        import pkg_resources
 
-    def _get_version(dependency_name):
-      try:
-        version_string = metadata.version("requests")
-        parsed_version = parse_version(version_string)
-        return parsed_version.release
-      except metadata.PackageNotFoundError:
-        return None
+        def _get_version(dependency_name):
+          try:
+            version_string = pkg_resources.get_distribution(dependency_name).version
+            return parse_version(version_string)
+          except pkg_resources.DistributionNotFound:
+            return None
+    else:
+        from importlib import metadata
 
-  _dependency_package = "google.protobuf"
-  _next_supported_version = "4.25.8"
-  _next_supported_version_tuple = (4, 25, 8)
-  _version_used = _get_version(_dependency_package)
-  if _version_used and _version_used < _next_supported_version_tuple:
-    logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
-            f"{_dependency_package}, currently installed at version " +
-            f"{_version_used.__str__}. Future updates to " +
-            f"{_package_label} will require {_dependency_package} at " +
-            f"version {_next_supported_version} or higher. Please ensure " +
-            "that either (a) your Python environment doesn't pin the " +
-            f"version of {_dependency_package}, so that updates to " +
-            f"{_package_label} can require the higher version, or " +
-            "(b) you manually update your Python environment to use at " +
-            f"least version {_next_supported_version} of " +
-            f"{_dependency_package}.")
+        def _get_version(dependency_name):
+            try:
+                version_string = metadata.version("requests")
+                parsed_version = parse_version(version_string)
+                return parsed_version.release
+            except metadata.PackageNotFoundError:
+                return None
+
+    _dependency_package = "google.protobuf"
+    _next_supported_version = "4.25.8"
+    _next_supported_version_tuple = (4, 25, 8)
+    _version_used = _get_version(_dependency_package)
+    if _version_used and _version_used < _next_supported_version_tuple:
+        logging.warning(f"DEPRECATION: Package {_package_label} depends on " +
+                  f"{_dependency_package}, currently installed at version " +
+                  f"{_version_used.__str__}. Future updates to " +
+                  f"{_package_label} will require {_dependency_package} at " +
+                  f"version {_next_supported_version} or higher. Please ensure " +
+                  "that either (a) your Python environment doesn't pin the " +
+                  f"version of {_dependency_package}, so that updates to " +
+                  f"{_package_label} can require the higher version, or " +
+                  "(b) you manually update your Python environment to use at " +
+                  f"least version {_next_supported_version} of " +
+                  f"{_dependency_package}.")
 
 
 from .services.cloud_redis import CloudRedisClient

--- a/tests/integration/goldens/redis_selective/setup.py
+++ b/tests/integration/goldens/redis_selective/setup.py
@@ -43,6 +43,8 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",

--- a/tests/integration/goldens/redis_selective/setup.py
+++ b/tests/integration/goldens/redis_selective/setup.py
@@ -43,8 +43,7 @@ dependencies = [
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
+    "packaging", # TODO: Remove once we require versions of api core that include this
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6837,7 +6837,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -6869,7 +6869,6 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
-@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.CloudRedisGrpcTransport, transports.CloudRedisGrpcAsyncIOTransport])
 def test_cloud_redis_transport_channel_mtls_with_adc(
     transport_class
@@ -6885,7 +6884,7 @@ def test_cloud_redis_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning) as record:
+            with pytest.warns(DeprecationWarning, match="mtls") as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6837,7 +6837,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="client_cert") as record:
+            with pytest.warns(DeprecationWarning):
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -6846,7 +6846,6 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -6884,14 +6883,13 @@ def test_cloud_redis_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning):
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
-            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6836,7 +6836,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(
@@ -6845,6 +6845,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"
@@ -6882,13 +6883,14 @@ def test_cloud_redis_transport_channel_mtls_with_adc(
             grpc_create_channel.return_value = mock_grpc_channel
             mock_cred = mock.Mock()
 
-            with pytest.warns(DeprecationWarning):
+            with pytest.warns(DeprecationWarning) as record:
                 transport = transport_class(
                     host="squid.clam.whelk",
                     credentials=mock_cred,
                     api_mtls_endpoint="mtls.squid.clam.whelk",
                     client_cert_source=None,
                 )
+            assert len(record) == 1
 
             grpc_create_channel.assert_called_once_with(
                 "mtls.squid.clam.whelk:443",

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6845,7 +6845,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == 7
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6845,7 +6845,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == record # 2 just for debugging; REMOVE
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6845,7 +6845,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 2
+            assert len(record) == record # 2 just for debugging; REMOVE
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6837,7 +6837,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
             grpc_create_channel.return_value = mock_grpc_channel
 
             cred = ga_credentials.AnonymousCredentials()
-            with pytest.warns(DeprecationWarning, match="mtls") as record:
+            with pytest.warns(DeprecationWarning, match="client_cert") as record:
                 with mock.patch.object(google.auth, 'default') as adc:
                     adc.return_value = (cred, None)
                     transport = transport_class(

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6823,6 +6823,7 @@ def test_cloud_redis_grpc_asyncio_transport_channel():
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.CloudRedisGrpcTransport, transports.CloudRedisGrpcAsyncIOTransport])
 def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
     transport_class

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6868,6 +6868,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
 
 # Remove this test when deprecated arguments (api_mtls_endpoint, client_cert_source) are
 # removed from grpc/grpc_asyncio transport constructor.
+@pytest.mark.filterwarnings("ignore::FutureWarning")
 @pytest.mark.parametrize("transport_class", [transports.CloudRedisGrpcTransport, transports.CloudRedisGrpcAsyncIOTransport])
 def test_cloud_redis_transport_channel_mtls_with_adc(
     transport_class

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -6845,7 +6845,7 @@ def test_cloud_redis_transport_channel_mtls_with_client_cert_source(
                         client_cert_source=client_cert_source_callback,
                     )
                     adc.assert_called_once()
-            assert len(record) == 7
+            assert len(record) == 2
 
             grpc_ssl_channel_cred.assert_called_once_with(
                 certificate_chain=b"cert bytes", private_key=b"key bytes"

--- a/tests/system/test_response_metadata.py
+++ b/tests/system/test_response_metadata.py
@@ -84,6 +84,7 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
             ("rest_asyncio", ("X-Showcase-Request-Something3", "something_value3")),
         ],
     )
+    @pytest.mark.filterwarnings("ignore::FutureWarning")
     @pytest.mark.asyncio
     async def test_metadata_response_unary_async(
         intercepted_echo_grpc_async,


### PR DESCRIPTION
Add a check to generated GAPICs to emit the appropriate usage warnings (most prominently, deprecation messages) for unsupported Python runtime versions and dependency versions.

The intent is that before we stop allowing some old versions of a package dependency, we'll have at least one release that adds a warning saying those versions of the dependency are deprecated, before we actually disallow those versions of the dependency in future versions of the GAPICs.

For Python run-times, once we depend on `google.api_core` after the run-time checks have been implemented (in https://github.com/googleapis/python-api-core/pull/832), these usage/deprecation warnings will be automatic. All we need to do is update the dates for (future) Python versions hard-coded therein. 

This PR also contains some fall-back warning code for users who can't upgrade `google.api.core` but can upgrade their GAPICs, so they, too, get the deprecation messages.