### PR TITLE
fix: Temporarily disable `test_<service>_api_version_header_async` which is not marked as async

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -81,7 +81,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -224,7 +224,11 @@ def test__get_api_endpoint():
 
 {% if service.version %}
 {% for method in service.methods.values() %}{% with method_name = method.name|snake_case %}
-{% for mode in ["", "async"] %}
+{# TODO(https://github.com/googleapis/gapic-generator-python/issues/2428): Restore async test `
+ # once it properly runs as an async test with `@pytest.mark.asyncio`
+ # Add "async" to the list below `for mode in ["", "async"]`
+#}
+{% for mode in [""] %}
 {% if mode == "async" %}
 async def test_{{ method_name }}_api_version_header_async(transport_name="grpc"):
     client = {{ service.async_client_name }}(credentials=async_anonymous_credentials(), transport=transport_name)

--- a/noxfile.py
+++ b/noxfile.py
@@ -392,9 +392,9 @@ def showcase(
     """Run the Showcase test suite."""
 
     with showcase_library(session, templates=templates, other_opts=other_opts):
-        # Exclude pytest-asyncio==1.0.0 while we investigate the recent failure described in
+        # Use pytest-asyncio<1.0.0 while we investigate the recent failure described in
         # https://github.com/googleapis/gapic-generator-python/issues/2399
-        session.install("pytest", "pytest-asyncio!=1.0.0")
+        session.install("pytest", "pytest-asyncio<1.0.0")
         test_directory = Path("tests", "system")
         ignore_file = env.get("IGNORE_FILE")
         pytest_command = [
@@ -424,9 +424,9 @@ def showcase_w_rest_async(
     with showcase_library(
         session, templates=templates, other_opts=other_opts, rest_async_io_enabled=True
     ):
-        # Exclude pytest-asyncio==1.0.0 while we investigate the recent failure described in
+        # Use pytest-asyncio<1.0.0 while we investigate the recent failure described in
         # https://github.com/googleapis/gapic-generator-python/issues/2399
-        session.install("pytest", "pytest-asyncio!=1.0.0")
+        session.install("pytest", "pytest-asyncio<1.0.0")
         test_directory = Path("tests", "system")
         ignore_file = env.get("IGNORE_FILE")
         pytest_command = [

--- a/noxfile.py
+++ b/noxfile.py
@@ -589,7 +589,8 @@ def showcase_mypy(
     """Perform typecheck analysis on the generated Showcase library."""
 
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-setuptools",
         "types-protobuf",
         "types-requests",

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -88,7 +88,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -88,7 +88,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -88,7 +88,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -88,7 +88,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )

--- a/tests/integration/goldens/logging_internal/noxfile.py
+++ b/tests/integration/goldens/logging_internal/noxfile.py
@@ -88,7 +88,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -88,7 +88,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )

--- a/tests/integration/goldens/redis_selective/noxfile.py
+++ b/tests/integration/goldens/redis_selective/noxfile.py
@@ -88,7 +88,8 @@ nox.options.error_on_missing_interpreters = True
 def mypy(session):
     """Run the type checker."""
     session.install(
-        "mypy",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2410): Use the latest version of mypy
+        "mypy<1.16.0",
         "types-requests",
         "types-protobuf",
     )


### PR DESCRIPTION
This PR includes 3 fixes to unblock development due to failing presubmits:

- Temporarily disable `test_<service>_api_version_header_async` which is not marked as async. See follow up issue https://github.com/googleapis/google-cloud-python/issues/16218
- Temporarily pin mypy<1.16.0. See follow up issue https://github.com/googleapis/gapic-generator-python/issues/2410
- Temporarily pin pytest-asyncio<1.0.0. See follow up issue https://github.com/googleapis/google-cloud-python/issues/16226

BEGIN_COMMIT_OVERRIDE
fix: Temporarily disable `test_<service>_api_version_header_async` which is not marked as async
test: Temporarily pin mypy<1.16.0
test: Temporarily pin pytest-asyncio<1.0.0 
END_COMMIT_OVERRIDE
