### PR TITLE
test: fix async showcase test

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -17,6 +17,7 @@ import grpc
 from unittest import mock
 import os
 import pytest
+import pytest_asyncio
 
 from typing import Sequence, Tuple
 
@@ -407,7 +408,7 @@ def intercepted_echo_grpc(use_mtls):
     return EchoClient(transport=transport), interceptor
 
 
-@pytest.fixture
+@pytest_asyncio.fixture
 async def intercepted_echo_grpc_async():
     # The interceptor adds 'showcase-trailer' client metadata. Showcase server
     # echoes any metadata with key 'showcase-trailer', so the same metadata

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -314,8 +314,7 @@ class EchoMetadataClientGrpcInterceptor(
     def _read_response_metadata_stream(self):
         # Access the metadata via the original stream object
         if hasattr(self, "_original_stream"):
-            return self._original_stream.trailing_metadata()
-        return []
+            self.response_metadata = self._original_stream.trailing_metadata()
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
         self._read_request_metadata(client_call_details)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -80,7 +80,7 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
     def event_loop():
         return asyncio.get_event_loop()
 
-    @pytest.fixture(params=["grpc_asyncio", "rest_asyncio"])
+    @pytest_asyncio.fixture(params=["grpc_asyncio", "rest_asyncio"])
     def async_echo(use_mtls, request, event_loop):
         transport = request.param
         if transport == "rest_asyncio" and not HAS_ASYNC_REST_ECHO_TRANSPORT:
@@ -95,7 +95,7 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
             credentials=async_anonymous_credentials(),
         )
 
-    @pytest.fixture(params=["grpc_asyncio", "rest_asyncio"])
+    @pytest_asyncio.fixture(params=["grpc_asyncio", "rest_asyncio"])
     def async_identity(use_mtls, request, event_loop):
         transport = request.param
         if transport == "rest_asyncio" and not HAS_ASYNC_REST_IDENTITY_TRANSPORT:
@@ -303,15 +303,12 @@ class EchoMetadataClientGrpcInterceptor(
     grpc.StreamUnaryClientInterceptor,
     grpc.StreamStreamClientInterceptor,
 ):
-    def __init__(self, key, value):
-        self._key = key
-        self._value = value
+    def __init__(self):
         self.request_metadata = []
         self.response_metadata = []
 
     def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
-            client_call_details.metadata.append((self._key, self._value))
             self.request_metadata = client_call_details.metadata
 
     def intercept_unary_unary(self, continuation, client_call_details, request):
@@ -347,15 +344,12 @@ class EchoMetadataClientGrpcAsyncInterceptor(
     grpc.aio.StreamUnaryClientInterceptor,
     grpc.aio.StreamStreamClientInterceptor,
 ):
-    def __init__(self, key, value):
-        self._key = key
-        self._value = value
+    def __init__(self):
         self.request_metadata = []
         self.response_metadata = []
 
     async def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
-            client_call_details.metadata.append((self._key, self._value))
             self.request_metadata = client_call_details.metadata
 
     async def intercept_unary_unary(self, continuation, client_call_details, request):
@@ -390,10 +384,7 @@ def intercepted_echo_grpc(use_mtls):
     # The interceptor adds 'showcase-trailer' client metadata. Showcase server
     # echoes any metadata with key 'showcase-trailer', so the same metadata
     # should appear as trailing metadata in the response.
-    interceptor = EchoMetadataClientGrpcInterceptor(
-        "showcase-trailer",
-        "intercepted",
-    )
+    interceptor = EchoMetadataClientGrpcInterceptor()
     host = "localhost:7469"
     channel = (
         grpc.secure_channel(host, ssl_credentials)
@@ -413,10 +404,7 @@ async def intercepted_echo_grpc_async():
     # The interceptor adds 'showcase-trailer' client metadata. Showcase server
     # echoes any metadata with key 'showcase-trailer', so the same metadata
     # should appear as trailing metadata in the response.
-    interceptor = EchoMetadataClientGrpcAsyncInterceptor(
-        "showcase-trailer",
-        "intercepted",
-    )
+    interceptor = EchoMetadataClientGrpcAsyncInterceptor()
     host = "localhost:7469"
     channel = grpc.aio.insecure_channel(host, interceptors=[interceptor])
     # intercept_channel = grpc.aio.intercept_channel(channel, interceptor)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -311,6 +311,10 @@ class EchoMetadataClientGrpcInterceptor(
 
     def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
+            # https://grpc.github.io/grpc/python/glossary.html#term-metadata.
+            # For sync, `ClientCallDetails.metadata` is a list.
+            # Whereas for async, `ClientCallDetails.metadata` is a mapping.
+            # https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.Metadata
             client_call_details.metadata.append((self._key, self._value))
             self.request_metadata = client_call_details.metadata
 
@@ -362,6 +366,10 @@ class EchoMetadataClientGrpcAsyncInterceptor(
 
     async def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
+            # https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.Metadata
+            # Note that for async, `ClientCallDetails.metadata` is a mapping.
+            # Whereas for sync, `ClientCallDetails.metadata` is a list.
+            # https://grpc.github.io/grpc/python/glossary.html#term-metadata.
             client_call_details.metadata[self._key] = self._value
             self.request_metadata = list(client_call_details.metadata)
 

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -311,7 +311,7 @@ class EchoMetadataClientGrpcInterceptor(
 
     def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
-            client_call_details.metadata[self._key] = self._value
+            client_call_details.metadata.append((self._key, self._value))
             self.request_metadata = client_call_details.metadata
 
     def _read_response_metadata_stream(self):
@@ -363,7 +363,7 @@ class EchoMetadataClientGrpcAsyncInterceptor(
     async def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
             client_call_details.metadata[self._key] = self._value
-            self.request_metadata = client_call_details.metadata
+            self.request_metadata = list(client_call_details.metadata)
 
     async def intercept_unary_unary(self, continuation, client_call_details, request):
         await self._add_request_metadata(client_call_details)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -381,9 +381,8 @@ class EchoMetadataClientGrpcAsyncInterceptor(
 
 @pytest.fixture
 def intercepted_echo_grpc(use_mtls):
-    # The interceptor adds 'showcase-trailer' client metadata. Showcase server
-    # echoes any metadata with key 'showcase-trailer', so the same metadata
-    # should appear as trailing metadata in the response.
+    # The interceptor reads request
+    # and response metadata.
     interceptor = EchoMetadataClientGrpcInterceptor()
     host = "localhost:7469"
     channel = (
@@ -401,9 +400,8 @@ def intercepted_echo_grpc(use_mtls):
 
 @pytest_asyncio.fixture
 async def intercepted_echo_grpc_async():
-    # The interceptor adds 'showcase-trailer' client metadata. Showcase server
-    # echoes any metadata with key 'showcase-trailer', so the same metadata
-    # should appear as trailing metadata in the response.
+    # The interceptor reads request
+    # and response metadata.
     interceptor = EchoMetadataClientGrpcAsyncInterceptor()
     host = "localhost:7469"
     channel = grpc.aio.insecure_channel(host, interceptors=[interceptor])

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -362,7 +362,7 @@ class EchoMetadataClientGrpcAsyncInterceptor(
 
     async def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
-            client_call_details.metadata[self._key] = self.value
+            client_call_details.metadata[self._key] = self._value
             self.request_metadata = client_call_details.metadata
 
     async def intercept_unary_unary(self, continuation, client_call_details, request):

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -350,7 +350,7 @@ class EchoMetadataClientGrpcAsyncInterceptor(
 
     async def _add_request_metadata(self, client_call_details):
         if client_call_details.metadata is not None:
-            self.request_metadata = client_call_details.metadata
+            self.request_metadata = list(client_call_details.metadata)
 
     async def intercept_unary_unary(self, continuation, client_call_details, request):
         await self._add_request_metadata(client_call_details)

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -408,7 +408,7 @@ def intercepted_echo_grpc(use_mtls):
 
 
 @pytest.fixture
-def intercepted_echo_grpc_async():
+async def intercepted_echo_grpc_async():
     # The interceptor adds 'showcase-trailer' client metadata. Showcase server
     # echoes any metadata with key 'showcase-trailer', so the same metadata
     # should appear as trailing metadata in the response.

--- a/tests/system/test_grpc_interceptor_streams.py
+++ b/tests/system/test_grpc_interceptor_streams.py
@@ -15,10 +15,10 @@
 from google import showcase
 
 
-# intercetped_metadata will be added by the interceptor automatically, and
+# `_METADATA` will be sent as part of the request, and the
 # showcase server will echo it (since it has key 'showcase-trailer') as trailing
 # metadata.
-intercepted_metadata = (("showcase-trailer", "intercepted"),)
+_METADATA = (("showcase-trailer", "intercepted"),)
 
 
 def test_unary_stream(intercepted_echo_grpc):
@@ -28,7 +28,7 @@ def test_unary_stream(intercepted_echo_grpc):
         {
             "content": content,
         },
-        metadata=intercepted_metadata,
+        metadata=_METADATA,
     )
 
     for ground_truth, response in zip(content.split(" "), responses):
@@ -38,7 +38,7 @@ def test_unary_stream(intercepted_echo_grpc):
     response_metadata = [
         (metadata.key, metadata.value) for metadata in responses.trailing_metadata()
     ]
-    assert intercepted_metadata[0] in response_metadata
+    assert _METADATA[0] in response_metadata
     interceptor.response_metadata = response_metadata
 
 
@@ -47,7 +47,7 @@ def test_stream_stream(intercepted_echo_grpc):
     requests = []
     requests.append(showcase.EchoRequest(content="hello"))
     requests.append(showcase.EchoRequest(content="world!"))
-    responses = client.chat(iter(requests), metadata=intercepted_metadata)
+    responses = client.chat(iter(requests), metadata=_METADATA)
 
     contents = [response.content for response in responses]
     assert contents == ["hello", "world!"]
@@ -55,5 +55,5 @@ def test_stream_stream(intercepted_echo_grpc):
     response_metadata = [
         (metadata.key, metadata.value) for metadata in responses.trailing_metadata()
     ]
-    assert intercepted_metadata[0] in response_metadata
+    assert _METADATA[0] in response_metadata
     interceptor.response_metadata = response_metadata

--- a/tests/system/test_grpc_interceptor_streams.py
+++ b/tests/system/test_grpc_interceptor_streams.py
@@ -27,8 +27,7 @@ def test_unary_stream(intercepted_echo_grpc):
     responses = client.expand(
         {
             "content": content,
-        },
-        metadata=_METADATA,
+        }
     )
 
     for ground_truth, response in zip(content.split(" "), responses):
@@ -38,10 +37,10 @@ def test_unary_stream(intercepted_echo_grpc):
     response_metadata = [
         (metadata.key, metadata.value) for metadata in responses.trailing_metadata()
     ]
-    assert _METADATA[0] in interceptor.request_metadata
-    assert _METADATA[0] in response_metadata
+    assert intercepted_metadata[0] in interceptor.request_metadata
+    assert intercepted_metadata[0] in response_metadata
     interceptor._read_response_metadata_stream()
-    assert _METADATA[0] in interceptor.response_metadata
+    assert intercepted_metadata[0] in interceptor.response_metadata
 
 
 def test_stream_stream(intercepted_echo_grpc):
@@ -49,7 +48,7 @@ def test_stream_stream(intercepted_echo_grpc):
     requests = []
     requests.append(showcase.EchoRequest(content="hello"))
     requests.append(showcase.EchoRequest(content="world!"))
-    responses = client.chat(iter(requests), metadata=_METADATA)
+    responses = client.chat(iter(requests))
 
     contents = [response.content for response in responses]
     assert contents == ["hello", "world!"]
@@ -57,7 +56,7 @@ def test_stream_stream(intercepted_echo_grpc):
     response_metadata = [
         (metadata.key, metadata.value) for metadata in responses.trailing_metadata()
     ]
-    assert _METADATA[0] in interceptor.request_metadata
-    assert _METADATA[0] in response_metadata
+    assert intercepted_metadata[0] in interceptor.request_metadata
+    assert intercepted_metadata[0] in response_metadata
     interceptor._read_response_metadata_stream()
-    assert _METADATA[0] in interceptor.response_metadata
+    assert intercepted_metadata[0] in interceptor.response_metadata

--- a/tests/system/test_grpc_interceptor_streams.py
+++ b/tests/system/test_grpc_interceptor_streams.py
@@ -27,7 +27,8 @@ def test_unary_stream(intercepted_echo_grpc):
     responses = client.expand(
         {
             "content": content,
-        }
+        },
+        metadata=intercepted_metadata,
     )
 
     for ground_truth, response in zip(content.split(" "), responses):
@@ -46,7 +47,7 @@ def test_stream_stream(intercepted_echo_grpc):
     requests = []
     requests.append(showcase.EchoRequest(content="hello"))
     requests.append(showcase.EchoRequest(content="world!"))
-    responses = client.chat(iter(requests))
+    responses = client.chat(iter(requests), metadata=intercepted_metadata)
 
     contents = [response.content for response in responses]
     assert contents == ["hello", "world!"]

--- a/tests/system/test_grpc_interceptor_streams.py
+++ b/tests/system/test_grpc_interceptor_streams.py
@@ -15,10 +15,10 @@
 from google import showcase
 
 
-# `_METADATA` will be sent as part of the request, and the
+# intercetped_metadata will be added by the interceptor automatically, and
 # showcase server will echo it (since it has key 'showcase-trailer') as trailing
 # metadata.
-_METADATA = (("showcase-trailer", "intercepted"),)
+intercepted_metadata = (("showcase-trailer", "intercepted"),)
 
 
 def test_unary_stream(intercepted_echo_grpc):

--- a/tests/system/test_grpc_interceptor_streams.py
+++ b/tests/system/test_grpc_interceptor_streams.py
@@ -40,7 +40,8 @@ def test_unary_stream(intercepted_echo_grpc):
     ]
     assert _METADATA[0] in interceptor.request_metadata
     assert _METADATA[0] in response_metadata
-    assert _METADATA[0] in interceptor._read_response_metadata_stream()
+    interceptor._read_response_metadata_stream()
+    assert _METADATA[0] in interceptor.response_metadata
 
 
 def test_stream_stream(intercepted_echo_grpc):
@@ -58,4 +59,5 @@ def test_stream_stream(intercepted_echo_grpc):
     ]
     assert _METADATA[0] in interceptor.request_metadata
     assert _METADATA[0] in response_metadata
-    assert _METADATA[0] in interceptor._read_response_metadata_stream()
+    interceptor._read_response_metadata_stream()
+    assert _METADATA[0] in interceptor.response_metadata

--- a/tests/system/test_grpc_interceptor_streams.py
+++ b/tests/system/test_grpc_interceptor_streams.py
@@ -38,8 +38,9 @@ def test_unary_stream(intercepted_echo_grpc):
     response_metadata = [
         (metadata.key, metadata.value) for metadata in responses.trailing_metadata()
     ]
+    assert _METADATA[0] in interceptor.request_metadata
     assert _METADATA[0] in response_metadata
-    interceptor.response_metadata = response_metadata
+    assert _METADATA[0] in interceptor._read_response_metadata_stream()
 
 
 def test_stream_stream(intercepted_echo_grpc):
@@ -55,5 +56,6 @@ def test_stream_stream(intercepted_echo_grpc):
     response_metadata = [
         (metadata.key, metadata.value) for metadata in responses.trailing_metadata()
     ]
+    assert _METADATA[0] in interceptor.request_metadata
     assert _METADATA[0] in response_metadata
-    interceptor.response_metadata = response_metadata
+    assert _METADATA[0] in interceptor._read_response_metadata_stream()

--- a/tests/system/test_response_metadata.py
+++ b/tests/system/test_response_metadata.py
@@ -95,7 +95,7 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
         request_metadata = ("something3", "something_value3")
 
         if transport == "grpc_asyncio":
-            client, interceptor = await intercepted_echo_grpc_async
+            client, interceptor = intercepted_echo_grpc_async
         else:
             client, interceptor = intercepted_echo_rest_async
         response = await client.echo(

--- a/tests/system/test_response_metadata.py
+++ b/tests/system/test_response_metadata.py
@@ -95,7 +95,7 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
         request_metadata = ("something3", "something_value3")
 
         if transport == "grpc_asyncio":
-            client, interceptor = intercepted_echo_grpc_async
+            client, interceptor = await intercepted_echo_grpc_async
         else:
             client, interceptor = intercepted_echo_rest_async
         response = await client.echo(

--- a/tests/system/test_response_metadata.py
+++ b/tests/system/test_response_metadata.py
@@ -103,5 +103,5 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
             metadata=(request_metadata,),
         )
         assert response.content == request_content
-        #assert request_metadata in interceptor.request_metadata
+        assert request_metadata in interceptor.request_metadata
         assert response_metadata in interceptor.response_metadata

--- a/tests/system/test_response_metadata.py
+++ b/tests/system/test_response_metadata.py
@@ -103,5 +103,5 @@ if os.environ.get("GAPIC_PYTHON_ASYNC", "true") == "true":
             metadata=(request_metadata,),
         )
         assert response.content == request_content
-        assert request_metadata in interceptor.request_metadata
+        #assert request_metadata in interceptor.request_metadata
         assert response_metadata in interceptor.response_metadata

--- a/tests/system/test_streams.py
+++ b/tests/system/test_streams.py
@@ -19,6 +19,9 @@ import threading
 from google import showcase
 
 
+# `_METADATA` will be sent as part of the request, and the
+# showcase server will echo it (since it has key 'showcase-trailer') as trailing
+# metadata.
 _METADATA = (("showcase-trailer", "hello world"),)
 
 

--- a/tests/system/test_streams.py
+++ b/tests/system/test_streams.py
@@ -80,7 +80,7 @@ def test_stream_stream(echo):
     requests = []
     requests.append(showcase.EchoRequest(content="hello"))
     requests.append(showcase.EchoRequest(content="world!"))
-    responses = echo.chat(iter(requests))
+    responses = echo.chat(iter(requests), metadata=_METADATA)
 
     contents = []
     for response in responses:

--- a/tests/system/test_streams.py
+++ b/tests/system/test_streams.py
@@ -80,7 +80,7 @@ def test_stream_stream(echo):
     requests = []
     requests.append(showcase.EchoRequest(content="hello"))
     requests.append(showcase.EchoRequest(content="world!"))
-    responses = echo.chat(iter(requests), metadata=_METADATA)
+    responses = echo.chat(iter(requests))
 
     contents = []
     for response in responses:


### PR DESCRIPTION
This fixes the presubmit failures at HEAD which were caused by a breaking change in gRPC 1.75.0. The breaking change was considered a bug fix because https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc-metadata mentions that a map is expected rather than a list.

Prior to `grpc==1.75.0`, `client_call_details.metadata.append((key, value))` worked for both sync and async. With `grpc==1.75.0`, `client_call_details.metadata.append((self._key, self._value))` only works for sync. For async, we need `client_call_details.metadata[self._key] = self._value`

This type of breaking change is challenging because we have test code that runs against both new and old versions of gRPC to check compatibility.  Here is the error that we get with older gRPC code after making the necessary change to support gRPC 1.75.0:

```
    async def _add_request_metadata(self, client_call_details):
        if client_call_details.metadata is not None:
            # https://grpc.github.io/grpc/python/grpc_asyncio.html#grpc.aio.Metadata
            # Note that for async, `ClientCallDetails.metadata` is a mapping.
            # Whereas for sync, `ClientCallDetails.metadata` is a list.
            # https://grpc.github.io/grpc/python/glossary.html#term-metadata.
>           client_call_details.metadata[self._key] = self._value
E           TypeError: list indices must be integers or slices, not str
```

We need to have special logic to handle this breaking change in 1.75.0. 