### PR TITLE
fix: require grpcio >= 1.75.1 for Python 3.14

### DIFF
--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -34,6 +34,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -34,11 +34,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     {# Explicitly exclude protobuf versions mentioned in https://cloud.google.com/support/bulletins#GCP-2022-019 #}

--- a/gapic/templates/testing/_default_constraints.j2
+++ b/gapic/templates/testing/_default_constraints.j2
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/gapic/templates/testing/_default_constraints.j2
+++ b/gapic/templates/testing/_default_constraints.j2
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/gapic/templates/testing/_default_constraints.j2
+++ b/gapic/templates/testing/_default_constraints.j2
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/gapic/templates/testing/constraints-3.13.txt.j2
+++ b/gapic/templates/testing/constraints-3.13.txt.j2
@@ -8,6 +8,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/gapic/templates/testing/constraints-3.14.txt.j2
+++ b/gapic/templates/testing/constraints-3.14.txt.j2
@@ -8,6 +8,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -7,7 +7,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -6,6 +6,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
+grpcio==1.33.2
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -6,8 +6,8 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
-grpcio==1.33.2
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2
 {% for package_tuple, package_info in pypi_packages.items() %}

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -40,6 +40,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -40,11 +40,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/asset/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.11.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/asset/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.12.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/asset/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.13.txt
@@ -7,6 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6
 google-cloud-access-context-manager>=0

--- a/tests/integration/goldens/asset/testing/constraints-3.14.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.14.txt
@@ -7,6 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6
 google-cloud-access-context-manager>=0

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -6,7 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2
 google-cloud-access-context-manager==0.1.2

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -5,8 +5,8 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
-grpcio==1.33.2
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2
 google-cloud-access-context-manager==0.1.2

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -5,6 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
+grpcio==1.33.2
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/asset/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.8.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/asset/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.9.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 google-cloud-access-context-manager

--- a/tests/integration/goldens/asset/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -40,6 +40,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -40,11 +40,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/credentials/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.10.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.10.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.11.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.11.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.12.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.12.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.13.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/credentials/testing/constraints-3.14.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.14.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/credentials/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.7.txt
@@ -5,7 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
-grpcio==1.33.2
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/credentials/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.7.txt
@@ -6,6 +6,7 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/credentials/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.7.txt
@@ -5,6 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
+grpcio==1.33.2
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/credentials/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.8.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.8.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.9.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.9.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/credentials/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -40,6 +40,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -40,11 +40,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.13.txt
@@ -7,6 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6
 grpc-google-iam-v1>=0

--- a/tests/integration/goldens/eventarc/testing/constraints-3.14.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.14.txt
@@ -7,6 +7,7 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6
 grpc-google-iam-v1>=0

--- a/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
@@ -5,6 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
+grpcio==1.33.2
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
@@ -5,8 +5,8 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
-grpcio==1.33.2
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2
 grpc-google-iam-v1==0.14.0

--- a/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
@@ -6,7 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2
 grpc-google-iam-v1==0.14.0

--- a/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
@@ -3,7 +3,7 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf
 grpc-google-iam-v1

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -40,6 +40,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -40,11 +40,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/logging/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.10.txt
@@ -2,5 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.10.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.11.txt
@@ -2,5 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.11.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.12.txt
@@ -2,5 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.12.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.13.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/logging/testing/constraints-3.14.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.14.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/logging/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.7.txt
@@ -6,5 +6,6 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/logging/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.7.txt
@@ -6,6 +6,7 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/logging/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.8.txt
@@ -2,5 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.8.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.9.txt
@@ -2,5 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.9.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/setup.py
+++ b/tests/integration/goldens/logging_internal/setup.py
@@ -40,6 +40,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/logging_internal/setup.py
+++ b/tests/integration/goldens/logging_internal/setup.py
@@ -40,11 +40,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.13.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.14.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.14.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
@@ -5,7 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
-grpcio==1.33.2
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
@@ -6,6 +6,7 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
@@ -5,6 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
+grpcio==1.33.2
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -40,6 +40,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -40,11 +40,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/redis/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.10.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.10.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.11.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.11.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.12.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.12.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.13.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/redis/testing/constraints-3.14.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.14.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/redis/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.7.txt
@@ -5,7 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
-grpcio==1.33.2
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.7.txt
@@ -6,6 +6,7 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.7.txt
@@ -5,6 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
+grpcio==1.33.2
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.8.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.8.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.9.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.9.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/setup.py
+++ b/tests/integration/goldens/redis_selective/setup.py
@@ -40,6 +40,8 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",

--- a/tests/integration/goldens/redis_selective/setup.py
+++ b/tests/integration/goldens/redis_selective/setup.py
@@ -40,11 +40,11 @@ else:
 
 dependencies = [
     "google-api-core[grpc] >= 1.34.1, <3.0.0,!=2.0.*,!=2.1.*,!=2.2.*,!=2.3.*,!=2.4.*,!=2.5.*,!=2.6.*,!=2.7.*,!=2.8.*,!=2.9.*,!=2.10.*",
-    "grpcio >= 1.33.2, < 2.0.0",
-    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     # Exclude incompatible versions of `google-auth`
     # See https://github.com/googleapis/google-cloud-python/issues/12364
     "google-auth >= 2.14.1, <3.0.0,!=2.24.0,!=2.25.0",
+    "grpcio >= 1.33.2, < 2.0.0",
+    "grpcio >= 1.75.1, < 2.0.0; python_version >= '3.14'",
     "proto-plus >= 1.22.3, <2.0.0",
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.13.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.13.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.14.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.14.txt
@@ -7,5 +7,6 @@
 # Then this file should have google-cloud-foo>=1
 google-api-core>=2
 google-auth>=2
+grpcio>=1
 proto-plus>=1
 protobuf>=6

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
@@ -5,7 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
-grpcio==1.33.2
 google-auth==2.14.1
+grpcio==1.33.2
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
@@ -6,6 +6,7 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
-grpcio==1.33.2
+# TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
+# Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
@@ -5,6 +5,7 @@
 # e.g., if setup.py has "google-cloud-foo >= 1.14.0, < 2.0.0",
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
+grpcio==1.33.2
 google-auth==2.14.1
 proto-plus==1.22.3
 protobuf==3.20.2

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
@@ -2,5 +2,6 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+grpc
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
@@ -3,6 +3,6 @@
 # List all library dependencies and extras in this file.
 google-api-core
 google-auth
-grpc
+grpcio
 proto-plus
 protobuf

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
@@ -2,6 +2,7 @@
 # This constraints file is required for unit tests.
 # List all library dependencies and extras in this file.
 google-api-core
+google-auth
 grpc
 proto-plus
 protobuf


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: require grpcio >=  1.33.2
fix: require grpcio >= 1.75.1 for Python 3.14
END_COMMIT_OVERRIDE

https://github.com/grpc/grpc/releases/tag/v1.75.1
