### PR TITLE
fix: resolve issue where rest-numeric-enums=False is not supported

### DIFF
--- a/gapic/utils/options.py
+++ b/gapic/utils/options.py
@@ -167,6 +167,16 @@ class Options:
             "TRUE",
         )
 
+        # `rest-numeric-enums` is False by default. Make sure users can also disable
+        # it by passing `rest-numeric-enums=False`.
+        rest_numeric_enums = opts.pop("rest-numeric-enums", ["False"])[0] in (
+            "True",
+            "true",
+            "T",
+            "t",
+            "TRUE",
+        )
+
         # NOTE: Snippets are not currently correct for the alternative (Ads) templates
         # so always disable snippetgen in that case
         # https://github.com/googleapis/gapic-generator-python/issues/1052
@@ -197,7 +207,7 @@ class Options:
             # transport should include desired transports delimited by '+', e.g. transport='grpc+rest'
             transport=opts.pop("transport", ["grpc"])[0].split("+"),
             service_yaml_config=service_yaml_config,
-            rest_numeric_enums=bool(opts.pop("rest-numeric-enums", False)),
+            rest_numeric_enums=rest_numeric_enums,
             proto_plus_deps=proto_plus_deps,
             gapic_version=opts.pop("gapic-version", ["0.0.0"]).pop(),
         )

--- a/tests/unit/generator/test_options.py
+++ b/tests/unit/generator/test_options.py
@@ -212,6 +212,9 @@ def test_options_bool_flags():
     options = Options.build("autogen-snippets=False")
     assert not options.autogen_snippets
 
+    options = Options.build("rest-numeric-enums=False")
+    assert not options.rest_numeric_enums
+
 
 def test_options_autogen_snippets_false_for_old_naming():
     # NOTE: Snippets are not currently correct for the alternative (Ads) templates


### PR DESCRIPTION
This PR resolves an issue where `rest-numeric-enums=False` was not properly supported. See test case below that fails without the fix.

```
(py392) partheniou@partheniou-vm-3:~/git/gapic-generator-python$ pytest /usr/local/google/home/partheniou/git/gapic-generator-python/tests/unit/generator/test_options.py
================================================================================================================================================= test session starts =================================================================================================================================================
platform linux -- Python 3.9.16, pytest-8.4.2, pluggy-1.5.0
rootdir: /usr/local/google/home/partheniou/git/gapic-generator-python
plugins: asyncio-1.2.0, anyio-4.8.0, mock-3.14.1, localserver-0.8.1, pyfakefs-5.8.0, cov-5.0.0, flaky-3.8.1
asyncio: mode=strict, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 14 items                                                                                                                                                                                                                                                                                                    

tests/unit/generator/test_options.py ...........F..                                                                                                                                                                                                                                                             [100%]

====================================================================================================================================================== FAILURES =======================================================================================================================================================
_______________________________________________________________________________________________________________________________________________ test_options_bool_flags _______________________________________________________________________________________________________________________________________________

    def test_options_bool_flags():
        # Most options are default False.
        # New options should follow the dash-case/snake_case convention.
        opt_str_to_attr_name = {
            name: re.sub(r"-", "_", name)
            for name in [
                "lazy-import",
                "old-naming",
                "add-iam-methods",
                "metadata",
                "warehouse-package-name",
                "rest-numeric-enums",
            ]
        }
    
        for opt, attr in opt_str_to_attr_name.items():
            options = Options.build("")
            assert not getattr(options, attr)
    
            options = Options.build(opt)
            assert getattr(options, attr)
    
        # Check autogen-snippets separately, as it is default True
        options = Options.build("")
        assert options.autogen_snippets
    
        options = Options.build("autogen-snippets=False")
        assert not options.autogen_snippets
    
        options = Options.build("rest-numeric-enums=False")
>       assert not options.rest_numeric_enums
E       AssertionError: assert not True
E        +  where True = Options(name='', namespace=(), warehouse_package_name='', retry=None, sample_configs=(), autogen_snippets=True, templa... 'transport', 'rest-numeric-enums', 'lazy-import', 'add-iam-methods', 'samples', 'autogen-snippets', 'gapic-version'})).rest_numeric_enums

tests/unit/generator/test_options.py:216: AssertionError
=============================================================================================================================================== short test summary info ===============================================================================================================================================
FAILED tests/unit/generator/test_options.py::test_options_bool_flags - AssertionError: assert not True
============================================================================================================================================ 1 failed, 13 passed in 0.84s 
```