### PR TITLE
fix: fix gapic-version generator option for selective gapic generation

### DIFF
--- a/gapic/schema/api.py
+++ b/gapic/schema/api.py
@@ -559,6 +559,7 @@ class API:
                     naming=naming,
                     all_protos=new_all_protos,
                     service_yaml_config=service_yaml_config,
+                    gapic_version=gapic_version,
                 )
 
         return api

--- a/tests/integration/BUILD.bazel
+++ b/tests/integration/BUILD.bazel
@@ -178,6 +178,7 @@ py_gapic_library(
     grpc_service_config = "redis_grpc_service_config.json",
     opt_args = [
         "autogen-snippets",
+        "gapic-version=1.2.99",
     ],
     service_yaml = "redis_selective_v1.yaml",
     transport = "grpc+rest",

--- a/tests/integration/goldens/redis_selective/google/cloud/redis/gapic_version.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "1.2.99"  # {x-release-please-version}

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/gapic_version.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/gapic_version.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "0.0.0"  # {x-release-please-version}
+__version__ = "1.2.99"  # {x-release-please-version}

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
@@ -8,7 +8,7 @@
     ],
     "language": "PYTHON",
     "name": "google-cloud-redis",
-    "version": "0.0.0"
+    "version": "1.2.99"
   },
   "snippets": [
     {


### PR DESCRIPTION
This PR fixes an issue where the `gapic-version` generator option was not working when [selective_gapic_generation](https://github.com/googleapis/googleapis/blob/63281f4aefb15e92e95109e84ff7542cc5ed7483/google/api/client.proto#L129) was set.

Fixes https://github.com/googleapis/librarian/issues/2486