### PR TITLE
fix: only format samples if the directory exists

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -16,10 +16,14 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
 {% if api.naming.module_namespace %}
-LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.py", "setup.py"]
 {% else %}
-LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -26,7 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -26,7 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -26,7 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -26,7 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/logging_internal/noxfile.py
+++ b/tests/integration/goldens/logging_internal/noxfile.py
@@ -26,7 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -26,7 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/redis_selective/noxfile.py
+++ b/tests/integration/goldens/redis_selective/noxfile.py
@@ -26,7 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-LINT_PATHS = ["docs", "google", "samples", "tests", "noxfile.py", "setup.py"]
+LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
+
+# Add samples to the list of directories to format if the directory exists.
+if os.path.isdir("samples"):
+    LINT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",


### PR DESCRIPTION
https://github.com/googleapis/gapic-generator-python/pull/2438 adding formatting for generated samples. This change introduced an issue in 11 libraries which do not contain generated samples. See https://github.com/googleapis/google-cloud-python/pull/14792 which mentions 

```
Generation failed for
google-apps-card
google-apps-script-type
google-cloud-alloydb-connectors
google-cloud-appengine-logging
google-cloud-bigquery-logging
google-cloud-common
google-cloud-iam-logging
google-cloud-source-context
google-geo-type
google-maps-places
google-shopping-type
```

The specific stack trace is

```
Broken 1 paths
nox > black docs google samples tests noxfile.py setup.py
Usage: black [OPTIONS] SRC ...
Try 'black -h' for help.

Error: Invalid value for 'SRC ...': Path 'samples' does not exist.
nox > Command black docs google samples tests noxfile.py setup.py failed with exit code 2
```

The reason that these libraries do not contain samples is that the APIs do not have any RPCs
