### PR TITLE
tests: use older google-api-core when running tools with older runtimes

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -175,6 +175,13 @@ def fragment(session, use_ads_templates=False):
     )
     session.install("-e", ".")
 
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2473):
+    # Warnings emitted from google-api-core starting in 2.28
+    # appear to cause issues when running protoc.
+    # The specific failure is `Plugin output is unparseable`
+    if session.python in ("3.7", "3.8", "3.9", "3.10"):
+        session.install("google-api-core<2.28")
+
     frag_files = (
         [Path(f) for f in session.posargs] if session.posargs else FRAGMENT_FILES
     )
@@ -237,6 +244,13 @@ def showcase_library(
 
     # Install grpcio-tools for protoc
     session.install("grpcio-tools")
+
+    # TODO(https://github.com/googleapis/gapic-generator-python/issues/2473):
+    # Warnings emitted from google-api-core starting in 2.28
+    # appear to cause issues when running protoc.
+    # The specific failure is `Plugin output is unparseable`
+    if session.python in ("3.7", "3.8", "3.9", "3.10"):
+        session.install("google-api-core<2.28")
 
     # Install a client library for Showcase.
     with tempfile.TemporaryDirectory() as tmp_dir:


### PR DESCRIPTION
Warnings emitted from google-api-core starting in `2.28.0` appear to cause issues when running `protoc`. The specific failure is `Plugin output is unparseable`

This PR adds a temporary workaround to use older version of `google-api-core` to unblock development while we identify a long term fix for https://github.com/googleapis/google-cloud-python/issues/16212