### PR TITLE
tests: temporarily pin coverage to 7.11.0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -54,7 +54,10 @@ NEWEST_PYTHON = ALL_PYTHON[-1]
 def unit(session):
     """Run the unit test suite."""
     session.install(
-        "coverage",
+        # TODO(https://github.com/googleapis/gapic-generator-python/issues/2478):
+        # Temporarily exclude coverage 7.11.1
+        # See https://github.com/nedbat/coveragepy/issues/2077
+        "coverage!=7.11.1",
         "pytest-cov",
         "pytest",
         "pytest-xdist",

--- a/noxfile.py
+++ b/noxfile.py
@@ -57,7 +57,7 @@ def unit(session):
         # TODO(https://github.com/googleapis/gapic-generator-python/issues/2478):
         # Temporarily pin coverage to 7.11.0
         # See https://github.com/nedbat/coveragepy/issues/2077
-        "coverage==7.11.0",
+        "coverage<=7.11.0",
         "pytest-cov",
         "pytest",
         "pytest-xdist",

--- a/noxfile.py
+++ b/noxfile.py
@@ -55,9 +55,9 @@ def unit(session):
     """Run the unit test suite."""
     session.install(
         # TODO(https://github.com/googleapis/gapic-generator-python/issues/2478):
-        # Temporarily exclude coverage 7.11.1
+        # Temporarily pin coverage to 7.11.0
         # See https://github.com/nedbat/coveragepy/issues/2077
-        "coverage!=7.11.1",
+        "coverage==7.11.0",
         "pytest-cov",
         "pytest",
         "pytest-xdist",


### PR DESCRIPTION
Towards https://github.com/googleapis/gapic-generator-python/issues/2478