### PR TITLE
chore: librarian release pull request: 20251113T154231Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:4e3486fee9eba44b75a18c67f0c60fa0c4af675132305e3ff3fae2e9b94f94bb
 libraries:
   - id: gapic-generator
-    version: 1.29.0
+    version: 1.30.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.30.0](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.29.0...gapic-generator-v1.30.0) (2025-11-13)
+
+
+### Features
+
+* auto-enable mTLS when supported certificates are detected (#2472) ([4748760fe6d489d80cb17306157edb43d25f72b3](https://github.com/googleapis/google-cloud-python/commit/4748760fe6d489d80cb17306157edb43d25f72b3))
+
+
+### Bug Fixes
+
+* add api_version to gapic_metadata.json (#2476) ([c424e33d5e9cfd75b383b4b0c7b77211f3604b79](https://github.com/googleapis/google-cloud-python/commit/c424e33d5e9cfd75b383b4b0c7b77211f3604b79))
+
 
 ## [1.29.0](https://github.com/googleapis/gapic-generator-python/compare/v1.28.3...v1.29.0) (2025-10-23)
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/gapic-generator-python"
-version = "1.29.0"
+version = "1.30.0"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:4e3486fee9eba44b75a18c67f0c60fa0c4af675132305e3ff3fae2e9b94f94bb
<details><summary>gapic-generator: 1.30.0</summary>

## [1.30.0](https://github.com/googleapis/gapic-generator-python/compare/v1.29.0...v1.30.0) (2025-11-13)

### Features

* auto-enable mTLS when supported certificates are detected (#2472) ([4748760f](https://github.com/googleapis/gapic-generator-python/commit/4748760f))

### Bug Fixes

* add api_version to gapic_metadata.json (#2476) ([c424e33d](https://github.com/googleapis/gapic-generator-python/commit/c424e33d))

</details>