### PR TITLE
chore: remove code formatting for noxfile.py

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -16,14 +16,17 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
 {% if api.naming.module_namespace %}
+FORMAT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "setup.py"]
 LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.py", "setup.py"]
 {% else %}
+FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "setup.py"]
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
+    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -167,7 +170,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *LINT_PATHS,
+        *FORMAT_PATHS,
     )
 
 
@@ -183,11 +186,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *LINT_PATHS,
+        *FORMAT_PATHS,
     )
     session.run(
         "black",
-        *LINT_PATHS,
+        *FORMAT_PATHS,
     )
 
 

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -23,6 +23,10 @@ FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "setu
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
 
+# We're most interested in ensuring that code is formatted properly
+# and less concerned about the line length.
+LINT_LINE_LENGTH = 150
+
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
@@ -155,6 +159,7 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
+        f"--line-length={LINT_LINE_LENGTH}",
     )
 
 {% if api.naming.module_namespace %}
@@ -171,6 +176,7 @@ def blacken(session):
     session.run(
         "black",
         *FORMAT_PATHS,
+        f"--line-length={LINT_LINE_LENGTH}",
     )
 
 
@@ -191,6 +197,7 @@ def format(session):
     session.run(
         "black",
         *FORMAT_PATHS,
+        f"--line-length={LINT_LINE_LENGTH}",
     )
 
 
@@ -207,8 +214,7 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please "
-            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -239,12 +245,15 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
-    )
+    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -307,9 +316,7 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
-    )
+    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,8 +393,10 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  "html",  # builder
-        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
+        "-b",  # builder
+        "html",
+        "-d",  # cache directory
+        os.path.join("docs", "_build", "doctrees", ""),
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -455,7 +464,12 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -466,11 +480,7 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
+    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -482,13 +492,8 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading whitespace and comment lines.
-    constraints_deps = [
-        match.group(1)
-        for match in re.finditer(
-            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
-        )
-    ]
+    # Ignore leading spaces and comment lines.
+    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -559,11 +564,7 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
+    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -575,13 +576,8 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading whitespace and comment lines.
-    constraints_deps = [
-        match.group(1)
-        for match in re.finditer(
-            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
-        )
-    ]
+    # Ignore leading spaces and comment lines.
+    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)


### PR DESCRIPTION
We should ensure that generated code is formatted correctly, rather than relying on external code formatting which increases the overall generation time.

This PR removes code formatting as a separate step for `noxfile.py`. There were only 3 changes in the file needed to address formatting issues. 

We already have a `goldens-lint` check which checks that the code is formatted properly. This PR avoid the extra step of formatting `noxfile.py` prior to running the lint check.

IOW, the `blacken` nox session no longer touches `noxfile.py`

https://github.com/googleapis/gapic-generator-python/blob/f93a0eb9bc88bb20c7a1540a33cf9f2fc12764f6/.github/workflows/tests.yaml#L409-L414
