### PR TITLE
chore: remove code formatting for setup.py

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -16,10 +16,10 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
 {% if api.naming.module_namespace %}
-FORMAT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests"]
 LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.py", "setup.py"]
 {% else %}
-FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests"]
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
 

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -16,14 +16,17 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
 {% if api.naming.module_namespace %}
+FORMAT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "setup.py"]
 LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.py", "setup.py"]
 {% else %}
+FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "setup.py"]
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
+    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -167,7 +170,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *LINT_PATHS,
+        *FORMAT_PATHS,
     )
 
 
@@ -183,11 +186,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *LINT_PATHS,
+        *FORMAT_PATHS,
     )
     session.run(
         "black",
-        *LINT_PATHS,
+        *FORMAT_PATHS,
     )
 
 

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -23,6 +23,10 @@ FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "setu
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
 
+# We're most interested in ensuring that code is formatted properly
+# and less concerned about the line length.
+LINT_LINE_LENGTH = 150
+
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
@@ -155,6 +159,7 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
+        f"--line-length={LINT_LINE_LENGTH}",
     )
 
 {% if api.naming.module_namespace %}
@@ -171,6 +176,7 @@ def blacken(session):
     session.run(
         "black",
         *FORMAT_PATHS,
+        f"--line-length={LINT_LINE_LENGTH}",
     )
 
 
@@ -191,6 +197,7 @@ def format(session):
     session.run(
         "black",
         *FORMAT_PATHS,
+        f"--line-length={LINT_LINE_LENGTH}",
     )
 
 
@@ -207,8 +214,7 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please "
-            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -239,12 +245,15 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
-    )
+    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -307,9 +316,7 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(
-        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
-    )
+    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,8 +393,10 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  "html",  # builder
-        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
+        "-b",  # builder
+        "html",
+        "-d",  # cache directory
+        os.path.join("docs", "_build", "doctrees", ""),
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -455,7 +464,12 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
+    if protobuf_implementation == "cpp" and session.python in (
+        "3.11",
+        "3.12",
+        "3.13",
+        "3.14",
+    ):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -466,11 +480,7 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
+    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -482,13 +492,8 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading whitespace and comment lines.
-    constraints_deps = [
-        match.group(1)
-        for match in re.finditer(
-            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
-        )
-    ]
+    # Ignore leading spaces and comment lines.
+    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -559,11 +564,7 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = (
-        SYSTEM_TEST_STANDARD_DEPENDENCIES
-        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
-        + SYSTEM_TEST_EXTRAS
-    )
+    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -575,13 +576,8 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading whitespace and comment lines.
-    constraints_deps = [
-        match.group(1)
-        for match in re.finditer(
-            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
-        )
-    ]
+    # Ignore leading spaces and comment lines.
+    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/gapic/templates/setup.py.j2
+++ b/gapic/templates/setup.py.j2
@@ -9,11 +9,11 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = '{{ api.naming.warehouse_package_name }}'
+name = "{{ api.naming.warehouse_package_name }}"
 
 {% set warehouse_description = api.naming.warehouse_package_name.replace('-',' ')|title %}
 
@@ -22,9 +22,9 @@ description = "{{ warehouse_description }} API client library"
 
 version = None
 
-with open(os.path.join(package_root, '{{ package_path }}/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "{{ package_path }}/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -52,14 +52,16 @@ dependencies = [
     {% endif %}
     {% endfor %}
 ]
-extras = {
 {% if rest_async_io_enabled %}
+extras = {
     "async_rest": [
         "google-api-core[grpc] >= 2.21.0, < 3.0.0",
-        "google-auth[aiohttp] >= 2.35.0, <3.0.0"
+        "google-auth[aiohttp] >= 2.35.0, <3.0.0",
     ],
-{% endif %}
 }
+{% else %}
+extras = {}
+{% endif %}
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/{{ api.naming.warehouse_package_name }}"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -68,11 +70,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("{{ api.naming.namespace_packages|first }}")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("{{ api.naming.namespace_packages|first }}")]
 
 setuptools.setup(
     name=name,

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/asset/setup.py
+++ b/tests/integration/goldens/asset/setup.py
@@ -17,20 +17,20 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = 'google-cloud-asset'
+name = "google-cloud-asset"
 
 
 description = "Google Cloud Asset API client library"
 
 version = None
 
-with open(os.path.join(package_root, 'google/cloud/asset/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "google/cloud/asset/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -52,8 +52,7 @@ dependencies = [
     "google-cloud-os-config >= 1.0.0, <2.0.0",
     "grpc-google-iam-v1 >= 0.14.0, <1.0.0",
 ]
-extras = {
-}
+extras = {}
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-asset"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -62,11 +61,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("google")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("google")]
 
 setuptools.setup(
     name=name,

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/credentials/setup.py
+++ b/tests/integration/goldens/credentials/setup.py
@@ -17,20 +17,20 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = 'google-iam-credentials'
+name = "google-iam-credentials"
 
 
 description = "Google Iam Credentials API client library"
 
 version = None
 
-with open(os.path.join(package_root, 'google/iam/credentials/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "google/iam/credentials/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -49,8 +49,7 @@ dependencies = [
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
-extras = {
-}
+extras = {}
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-iam-credentials"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -59,11 +58,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("google")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("google")]
 
 setuptools.setup(
     name=name,

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/eventarc/setup.py
+++ b/tests/integration/goldens/eventarc/setup.py
@@ -17,20 +17,20 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = 'google-cloud-eventarc'
+name = "google-cloud-eventarc"
 
 
 description = "Google Cloud Eventarc API client library"
 
 version = None
 
-with open(os.path.join(package_root, 'google/cloud/eventarc_v1/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "google/cloud/eventarc_v1/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -50,8 +50,7 @@ dependencies = [
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
     "grpc-google-iam-v1 >= 0.14.0, <1.0.0",
 ]
-extras = {
-}
+extras = {}
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-eventarc"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -60,11 +59,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("google")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("google")]
 
 setuptools.setup(
     name=name,

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/logging/setup.py
+++ b/tests/integration/goldens/logging/setup.py
@@ -17,20 +17,20 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = 'google-cloud-logging'
+name = "google-cloud-logging"
 
 
 description = "Google Cloud Logging API client library"
 
 version = None
 
-with open(os.path.join(package_root, 'google/cloud/logging/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "google/cloud/logging/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -49,8 +49,7 @@ dependencies = [
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
-extras = {
-}
+extras = {}
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-logging"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -59,11 +58,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("google")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("google")]
 
 setuptools.setup(
     name=name,

--- a/tests/integration/goldens/logging_internal/noxfile.py
+++ b/tests/integration/goldens/logging_internal/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/logging_internal/setup.py
+++ b/tests/integration/goldens/logging_internal/setup.py
@@ -17,20 +17,20 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = 'google-cloud-logging'
+name = "google-cloud-logging"
 
 
 description = "Google Cloud Logging API client library"
 
 version = None
 
-with open(os.path.join(package_root, 'google/cloud/logging/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "google/cloud/logging/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -49,8 +49,7 @@ dependencies = [
     "proto-plus >= 1.25.0, <2.0.0; python_version >= '3.13'",
     "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
-extras = {
-}
+extras = {}
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-logging"
 
 package_root = os.path.abspath(os.path.dirname(__file__))
@@ -59,11 +58,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("google")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("google")]
 
 setuptools.setup(
     name=name,

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/redis/setup.py
+++ b/tests/integration/goldens/redis/setup.py
@@ -17,20 +17,20 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = 'google-cloud-redis'
+name = "google-cloud-redis"
 
 
 description = "Google Cloud Redis API client library"
 
 version = None
 
-with open(os.path.join(package_root, 'google/cloud/redis/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "google/cloud/redis/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -52,7 +52,7 @@ dependencies = [
 extras = {
     "async_rest": [
         "google-api-core[grpc] >= 2.21.0, < 3.0.0",
-        "google-auth[aiohttp] >= 2.35.0, <3.0.0"
+        "google-auth[aiohttp] >= 2.35.0, <3.0.0",
     ],
 }
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-redis"
@@ -63,11 +63,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("google")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("google")]
 
 setuptools.setup(
     name=name,

--- a/tests/integration/goldens/redis_selective/noxfile.py
+++ b/tests/integration/goldens/redis_selective/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
+FORMAT_PATHS = ["docs", "google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/redis_selective/setup.py
+++ b/tests/integration/goldens/redis_selective/setup.py
@@ -17,20 +17,20 @@ import io
 import os
 import re
 
-import setuptools # type: ignore
+import setuptools  # type: ignore
 
 package_root = os.path.abspath(os.path.dirname(__file__))
 
-name = 'google-cloud-redis'
+name = "google-cloud-redis"
 
 
 description = "Google Cloud Redis API client library"
 
 version = None
 
-with open(os.path.join(package_root, 'google/cloud/redis/gapic_version.py')) as fp:
+with open(os.path.join(package_root, "google/cloud/redis/gapic_version.py")) as fp:
     version_candidates = re.findall(r"(?<=\")\d+.\d+.\d+(?=\")", fp.read())
-    assert (len(version_candidates) == 1)
+    assert len(version_candidates) == 1
     version = version_candidates[0]
 
 if version[0] == "0":
@@ -52,7 +52,7 @@ dependencies = [
 extras = {
     "async_rest": [
         "google-api-core[grpc] >= 2.21.0, < 3.0.0",
-        "google-auth[aiohttp] >= 2.35.0, <3.0.0"
+        "google-auth[aiohttp] >= 2.35.0, <3.0.0",
     ],
 }
 url = "https://github.com/googleapis/google-cloud-python/tree/main/packages/google-cloud-redis"
@@ -63,11 +63,7 @@ readme_filename = os.path.join(package_root, "README.rst")
 with io.open(readme_filename, encoding="utf-8") as readme_file:
     readme = readme_file.read()
 
-packages = [
-    package
-    for package in setuptools.find_namespace_packages()
-    if package.startswith("google")
-]
+packages = [package for package in setuptools.find_namespace_packages() if package.startswith("google")]
 
 setuptools.setup(
     name=name,


### PR DESCRIPTION
This PR depends on https://github.com/googleapis/gapic-generator-python/pull/2491. Similar to https://github.com/googleapis/gapic-generator-python/pull/2491, we're removing code formatting for `setup.py` while keeping the code formatting verification via the `lint` session.