### PR TITLE
chore: remove code formatting for docs/conf.py

### DIFF
--- a/gapic/templates/docs/conf.py.j2
+++ b/gapic/templates/docs/conf.py.j2
@@ -70,9 +70,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"{{ api.naming.warehouse_package_name }}"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "{{ api.naming.warehouse_package_name }}"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -272,7 +272,7 @@ latex_documents = [
     (
         root_doc,
         "{{ api.naming.warehouse_package_name }}.tex",
-        u"{{ api.naming.warehouse_package_name }} Documentation",
+        "{{ api.naming.warehouse_package_name }} Documentation",
         author,
         "manual",
     )

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -16,10 +16,10 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
 {% if api.naming.module_namespace %}
-FORMAT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests"]
+FORMAT_PATHS = ["{{ api.naming.module_namespace[0] }}", "tests"]
 LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.py", "setup.py"]
 {% else %}
-FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests"]
+FORMAT_PATHS = ["{{ api.naming.versioned_module_name }}", "tests"]
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
 

--- a/tests/integration/goldens/asset/docs/conf.py
+++ b/tests/integration/goldens/asset/docs/conf.py
@@ -81,9 +81,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-asset"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "google-cloud-asset"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -283,7 +283,7 @@ latex_documents = [
     (
         root_doc,
         "google-cloud-asset.tex",
-        u"google-cloud-asset Documentation",
+        "google-cloud-asset Documentation",
         author,
         "manual",
     )

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests"]
+FORMAT_PATHS = ["google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/credentials/docs/conf.py
+++ b/tests/integration/goldens/credentials/docs/conf.py
@@ -81,9 +81,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"google-iam-credentials"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "google-iam-credentials"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -283,7 +283,7 @@ latex_documents = [
     (
         root_doc,
         "google-iam-credentials.tex",
-        u"google-iam-credentials Documentation",
+        "google-iam-credentials Documentation",
         author,
         "manual",
     )

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests"]
+FORMAT_PATHS = ["google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/eventarc/docs/conf.py
+++ b/tests/integration/goldens/eventarc/docs/conf.py
@@ -81,9 +81,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-eventarc"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "google-cloud-eventarc"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -283,7 +283,7 @@ latex_documents = [
     (
         root_doc,
         "google-cloud-eventarc.tex",
-        u"google-cloud-eventarc Documentation",
+        "google-cloud-eventarc Documentation",
         author,
         "manual",
     )

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests"]
+FORMAT_PATHS = ["google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/logging/docs/conf.py
+++ b/tests/integration/goldens/logging/docs/conf.py
@@ -81,9 +81,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-logging"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "google-cloud-logging"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -283,7 +283,7 @@ latex_documents = [
     (
         root_doc,
         "google-cloud-logging.tex",
-        u"google-cloud-logging Documentation",
+        "google-cloud-logging Documentation",
         author,
         "manual",
     )

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests"]
+FORMAT_PATHS = ["google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/logging_internal/docs/conf.py
+++ b/tests/integration/goldens/logging_internal/docs/conf.py
@@ -81,9 +81,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-logging"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "google-cloud-logging"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -283,7 +283,7 @@ latex_documents = [
     (
         root_doc,
         "google-cloud-logging.tex",
-        u"google-cloud-logging Documentation",
+        "google-cloud-logging Documentation",
         author,
         "manual",
     )

--- a/tests/integration/goldens/logging_internal/noxfile.py
+++ b/tests/integration/goldens/logging_internal/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests"]
+FORMAT_PATHS = ["google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/redis/docs/conf.py
+++ b/tests/integration/goldens/redis/docs/conf.py
@@ -81,9 +81,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-redis"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "google-cloud-redis"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -283,7 +283,7 @@ latex_documents = [
     (
         root_doc,
         "google-cloud-redis.tex",
-        u"google-cloud-redis Documentation",
+        "google-cloud-redis Documentation",
         author,
         "manual",
     )

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests"]
+FORMAT_PATHS = ["google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly

--- a/tests/integration/goldens/redis_selective/docs/conf.py
+++ b/tests/integration/goldens/redis_selective/docs/conf.py
@@ -81,9 +81,9 @@ source_suffix = [".rst", ".md"]
 root_doc = "index"
 
 # General information about the project.
-project = u"google-cloud-redis"
-copyright = u"2025, Google, LLC"
-author = u"Google APIs"
+project = "google-cloud-redis"
+copyright = "2025, Google, LLC"
+author = "Google APIs"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -283,7 +283,7 @@ latex_documents = [
     (
         root_doc,
         "google-cloud-redis.tex",
-        u"google-cloud-redis Documentation",
+        "google-cloud-redis Documentation",
         author,
         "manual",
     )

--- a/tests/integration/goldens/redis_selective/noxfile.py
+++ b/tests/integration/goldens/redis_selective/noxfile.py
@@ -26,7 +26,7 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests"]
+FORMAT_PATHS = ["google", "tests"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 
 # We're most interested in ensuring that code is formatted properly


### PR DESCRIPTION
This PR depends on https://github.com/googleapis/gapic-generator-python/pull/2492. Similar to https://github.com/googleapis/gapic-generator-python/pull/2492, we're removing code formatting for `docs/conf.py` while keeping the code formatting verification via the `lint` session.