### PR TITLE
chore: remove code formatting for samples dir

### DIFF
--- a/gapic/samplegen/samplegen.py
+++ b/gapic/samplegen/samplegen.py
@@ -416,7 +416,7 @@ class Validator:
                 )
             del request["field"]
 
-        if isinstance(request["value"], str):
+        if isinstance(request["value"], str) or isinstance(request["value"], list):
             # Passing value through json is a safe and simple way of
             # making sure strings are properly wrapped and quotes escaped.
             # This statement both wraps enums in quotes and escapes quotes
@@ -426,6 +426,9 @@ class Validator:
             # This is preferable to adding the necessary import statement
             # and requires less munging of the assigned value
             request["value"] = json.dumps(request["value"])
+        elif isinstance(request["value"], bytes):
+            # Use double quotes for bytes literals for consistency.
+            request["value"] = f'b"{request["value"].decode("utf-8")}"'
 
         # Mypy isn't smart enough to handle dictionary unpacking,
         # so disable it for the AttributeRequestSetup ctor call.

--- a/gapic/templates/examples/feature_fragments.j2
+++ b/gapic/templates/examples/feature_fragments.j2
@@ -174,11 +174,15 @@ client = {{ module_name }}.{{ client_name }}()
 {% endif %}
 {% endfor %}
 {% if not full_request.flattenable %}
+{% if full_request.request_list|length > 0 %}
 request = {{ module_name }}.{{ request_type.ident.name }}(
 {% for parameter in full_request.request_list %}
     {{ parameter.base }}={{ parameter.base if parameter.body else parameter.single.value }},
 {% endfor %}
 )
+{% else %}
+request = {{ module_name }}.{{ request_type.ident.name }}()
+{% endif %}
 {# Note: This template assumes only one request needs to be sent. When samples accept
 configs the client streaming logic should be modified to allow 2+ request objects. #}
 {# If client streaming, wrap the single request in a generator that produces 'requests' #}
@@ -256,8 +260,8 @@ operation
 # Make the request
 {% if calling_form in [calling_form_enum.Request, calling_form_enum.RequestStreamingClient] %}
 {% if response_statements %}response = {% endif %}{{ method_invocation_text|trim }}
-
 {% if response_statements %}
+
 # Handle the response
 {% for statement in response_statements %}
 {{ dispatch_statement(statement)|trim }}

--- a/gapic/templates/examples/sample.py.j2
+++ b/gapic/templates/examples/sample.py.j2
@@ -39,6 +39,7 @@
     {{ frags.render_calling_form(method_call, calling_form, calling_form_enum, sample.transport, sample.response)|indent -}}
     {% endwith %}
 
+
 # [END {{ sample.id }}]
 {# TODO: Enable main block (or decide to remove main block from python sample) #}
 {# {{ frags.render_main_block(sample, sample.request) }} #}

--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -27,10 +27,9 @@ LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfil
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/async_client.py
@@ -2439,8 +2439,7 @@ class AssetServiceAsyncClient:
                 client = asset_v1.AssetServiceAsyncClient()
 
                 # Initialize request argument(s)
-                request = asset_v1.UpdateSavedQueryRequest(
-                )
+                request = asset_v1.UpdateSavedQueryRequest()
 
                 # Make the request
                 response = await client.update_saved_query(request=request)
@@ -2660,7 +2659,7 @@ class AssetServiceAsyncClient:
                 # Initialize request argument(s)
                 request = asset_v1.BatchGetEffectiveIamPoliciesRequest(
                     scope="scope_value",
-                    names=['names_value1', 'names_value2'],
+                    names=["names_value1", "names_value2"],
                 )
 
                 # Make the request

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/client.py
@@ -2939,8 +2939,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 client = asset_v1.AssetServiceClient()
 
                 # Initialize request argument(s)
-                request = asset_v1.UpdateSavedQueryRequest(
-                )
+                request = asset_v1.UpdateSavedQueryRequest()
 
                 # Make the request
                 response = client.update_saved_query(request=request)
@@ -3158,7 +3157,7 @@ class AssetServiceClient(metaclass=AssetServiceClientMeta):
                 # Initialize request argument(s)
                 request = asset_v1.BatchGetEffectiveIamPoliciesRequest(
                     scope="scope_value",
-                    names=['names_value1', 'names_value2'],
+                    names=["names_value1", "names_value2"],
                 )
 
                 # Make the request

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -33,10 +33,9 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_async.py
@@ -52,4 +52,5 @@ async def sample_analyze_iam_policy():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeIamPolicy_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_async.py
@@ -60,4 +60,5 @@ async def sample_analyze_iam_policy_longrunning():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeIamPolicyLongrunning_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_longrunning_sync.py
@@ -60,4 +60,5 @@ def sample_analyze_iam_policy_longrunning():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeIamPolicyLongrunning_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_iam_policy_sync.py
@@ -52,4 +52,5 @@ def sample_analyze_iam_policy():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeIamPolicy_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_async.py
@@ -50,4 +50,5 @@ async def sample_analyze_move():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeMove_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_move_sync.py
@@ -50,4 +50,5 @@ def sample_analyze_move():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeMove_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_async.py
@@ -51,4 +51,5 @@ async def sample_analyze_org_policies():
     async for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeOrgPolicies_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policies_sync.py
@@ -51,4 +51,5 @@ def sample_analyze_org_policies():
     for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeOrgPolicies_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_async.py
@@ -51,4 +51,5 @@ async def sample_analyze_org_policy_governed_assets():
     async for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedAssets_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_assets_sync.py
@@ -51,4 +51,5 @@ def sample_analyze_org_policy_governed_assets():
     for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedAssets_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_async.py
@@ -51,4 +51,5 @@ async def sample_analyze_org_policy_governed_containers():
     async for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedContainers_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_analyze_org_policy_governed_containers_sync.py
@@ -51,4 +51,5 @@ def sample_analyze_org_policy_governed_containers():
     for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedContainers_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_async.py
@@ -49,4 +49,5 @@ async def sample_batch_get_assets_history():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_BatchGetAssetsHistory_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_assets_history_sync.py
@@ -49,4 +49,5 @@ def sample_batch_get_assets_history():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_BatchGetAssetsHistory_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_async.py
@@ -41,7 +41,7 @@ async def sample_batch_get_effective_iam_policies():
     # Initialize request argument(s)
     request = asset_v1.BatchGetEffectiveIamPoliciesRequest(
         scope="scope_value",
-        names=['names_value1', 'names_value2'],
+        names=["names_value1", "names_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ async def sample_batch_get_effective_iam_policies():
 
     # Handle the response
     print(response)
+
 
 # [END cloudasset_v1_generated_AssetService_BatchGetEffectiveIamPolicies_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_batch_get_effective_iam_policies_sync.py
@@ -41,7 +41,7 @@ def sample_batch_get_effective_iam_policies():
     # Initialize request argument(s)
     request = asset_v1.BatchGetEffectiveIamPoliciesRequest(
         scope="scope_value",
-        names=['names_value1', 'names_value2'],
+        names=["names_value1", "names_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ def sample_batch_get_effective_iam_policies():
 
     # Handle the response
     print(response)
+
 
 # [END cloudasset_v1_generated_AssetService_BatchGetEffectiveIamPolicies_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_async.py
@@ -54,4 +54,5 @@ async def sample_create_feed():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_CreateFeed_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_feed_sync.py
@@ -54,4 +54,5 @@ def sample_create_feed():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_CreateFeed_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_async.py
@@ -50,4 +50,5 @@ async def sample_create_saved_query():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_CreateSavedQuery_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_create_saved_query_sync.py
@@ -50,4 +50,5 @@ def sample_create_saved_query():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_CreateSavedQuery_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_async.py
@@ -57,4 +57,5 @@ async def sample_export_assets():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ExportAssets_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_export_assets_sync.py
@@ -57,4 +57,5 @@ def sample_export_assets():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ExportAssets_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_async.py
@@ -49,4 +49,5 @@ async def sample_get_feed():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_GetFeed_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_feed_sync.py
@@ -49,4 +49,5 @@ def sample_get_feed():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_GetFeed_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_async.py
@@ -49,4 +49,5 @@ async def sample_get_saved_query():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_GetSavedQuery_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_get_saved_query_sync.py
@@ -49,4 +49,5 @@ def sample_get_saved_query():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_GetSavedQuery_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_async.py
@@ -50,4 +50,5 @@ async def sample_list_assets():
     async for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ListAssets_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_assets_sync.py
@@ -50,4 +50,5 @@ def sample_list_assets():
     for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ListAssets_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_async.py
@@ -49,4 +49,5 @@ async def sample_list_feeds():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ListFeeds_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_feeds_sync.py
@@ -49,4 +49,5 @@ def sample_list_feeds():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ListFeeds_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_async.py
@@ -50,4 +50,5 @@ async def sample_list_saved_queries():
     async for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ListSavedQueries_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_list_saved_queries_sync.py
@@ -50,4 +50,5 @@ def sample_list_saved_queries():
     for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_ListSavedQueries_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_async.py
@@ -50,4 +50,5 @@ async def sample_query_assets():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_QueryAssets_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_query_assets_sync.py
@@ -50,4 +50,5 @@ def sample_query_assets():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_QueryAssets_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_async.py
@@ -50,4 +50,5 @@ async def sample_search_all_iam_policies():
     async for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_SearchAllIamPolicies_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_iam_policies_sync.py
@@ -50,4 +50,5 @@ def sample_search_all_iam_policies():
     for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_SearchAllIamPolicies_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_async.py
@@ -50,4 +50,5 @@ async def sample_search_all_resources():
     async for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_SearchAllResources_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_search_all_resources_sync.py
@@ -50,4 +50,5 @@ def sample_search_all_resources():
     for response in page_result:
         print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_SearchAllResources_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_async.py
@@ -52,4 +52,5 @@ async def sample_update_feed():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_UpdateFeed_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_feed_sync.py
@@ -52,4 +52,5 @@ def sample_update_feed():
     # Handle the response
     print(response)
 
+
 # [END cloudasset_v1_generated_AssetService_UpdateFeed_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_async.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_async.py
@@ -39,13 +39,13 @@ async def sample_update_saved_query():
     client = asset_v1.AssetServiceAsyncClient()
 
     # Initialize request argument(s)
-    request = asset_v1.UpdateSavedQueryRequest(
-    )
+    request = asset_v1.UpdateSavedQueryRequest()
 
     # Make the request
     response = await client.update_saved_query(request=request)
 
     # Handle the response
     print(response)
+
 
 # [END cloudasset_v1_generated_AssetService_UpdateSavedQuery_async]

--- a/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_sync.py
+++ b/tests/integration/goldens/asset/samples/generated_samples/cloudasset_v1_generated_asset_service_update_saved_query_sync.py
@@ -39,13 +39,13 @@ def sample_update_saved_query():
     client = asset_v1.AssetServiceClient()
 
     # Initialize request argument(s)
-    request = asset_v1.UpdateSavedQueryRequest(
-    )
+    request = asset_v1.UpdateSavedQueryRequest()
 
     # Make the request
     response = client.update_saved_query(request=request)
 
     # Handle the response
     print(response)
+
 
 # [END cloudasset_v1_generated_AssetService_UpdateSavedQuery_sync]

--- a/tests/integration/goldens/asset/samples/generated_samples/snippet_metadata_google.cloud.asset.v1.json
+++ b/tests/integration/goldens/asset/samples/generated_samples/snippet_metadata_google.cloud.asset.v1.json
@@ -56,12 +56,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeIamPolicyLongrunning_async",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -81,7 +81,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -132,12 +132,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeIamPolicyLongrunning_sync",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -157,7 +157,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -209,12 +209,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeIamPolicy_async",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -234,7 +234,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -285,12 +285,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeIamPolicy_sync",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -310,7 +310,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -362,12 +362,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeMove_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -387,7 +387,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -438,12 +438,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeMove_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -463,7 +463,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -527,12 +527,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeOrgPolicies_async",
       "segments": [
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "SHORT"
         },
@@ -552,7 +552,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -615,12 +615,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeOrgPolicies_sync",
       "segments": [
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "SHORT"
         },
@@ -640,7 +640,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -704,12 +704,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedAssets_async",
       "segments": [
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "SHORT"
         },
@@ -729,7 +729,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -792,12 +792,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedAssets_sync",
       "segments": [
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "SHORT"
         },
@@ -817,7 +817,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -881,12 +881,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedContainers_async",
       "segments": [
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "SHORT"
         },
@@ -906,7 +906,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -969,12 +969,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_AnalyzeOrgPolicyGovernedContainers_sync",
       "segments": [
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 27,
           "type": "SHORT"
         },
@@ -994,7 +994,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1046,12 +1046,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_BatchGetAssetsHistory_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1071,7 +1071,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1122,12 +1122,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_BatchGetAssetsHistory_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1147,7 +1147,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1199,12 +1199,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_BatchGetEffectiveIamPolicies_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1224,7 +1224,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1275,12 +1275,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_BatchGetEffectiveIamPolicies_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1300,7 +1300,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1356,12 +1356,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_CreateFeed_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -1381,7 +1381,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1436,12 +1436,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_CreateFeed_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -1461,7 +1461,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1525,12 +1525,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_CreateSavedQuery_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1550,7 +1550,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1613,12 +1613,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_CreateSavedQuery_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1638,7 +1638,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -2000,12 +2000,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ExportAssets_async",
       "segments": [
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "SHORT"
         },
@@ -2025,7 +2025,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 57,
           "type": "RESPONSE_HANDLING"
         }
@@ -2076,12 +2076,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ExportAssets_sync",
       "segments": [
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "SHORT"
         },
@@ -2101,7 +2101,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 57,
           "type": "RESPONSE_HANDLING"
         }
@@ -2157,12 +2157,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_GetFeed_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2182,7 +2182,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2237,12 +2237,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_GetFeed_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2262,7 +2262,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2318,12 +2318,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_GetSavedQuery_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2343,7 +2343,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2398,12 +2398,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_GetSavedQuery_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2423,7 +2423,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2479,12 +2479,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ListAssets_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2504,7 +2504,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2559,12 +2559,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ListAssets_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2584,7 +2584,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2640,12 +2640,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ListFeeds_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2665,7 +2665,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2720,12 +2720,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ListFeeds_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2745,7 +2745,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2801,12 +2801,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ListSavedQueries_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2826,7 +2826,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2881,12 +2881,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_ListSavedQueries_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2906,7 +2906,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2958,12 +2958,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_QueryAssets_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2983,7 +2983,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -3034,12 +3034,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_QueryAssets_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3059,7 +3059,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -3119,12 +3119,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_SearchAllIamPolicies_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3144,7 +3144,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3203,12 +3203,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_SearchAllIamPolicies_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3228,7 +3228,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3292,12 +3292,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_SearchAllResources_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3317,7 +3317,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3380,12 +3380,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_SearchAllResources_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3405,7 +3405,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3461,12 +3461,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_UpdateFeed_async",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -3486,7 +3486,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -3541,12 +3541,12 @@
       "regionTag": "cloudasset_v1_generated_AssetService_UpdateFeed_sync",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -3566,7 +3566,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -3641,18 +3641,18 @@
           "type": "CLIENT_INITIALIZATION"
         },
         {
-          "end": 44,
+          "end": 43,
           "start": 41,
           "type": "REQUEST_INITIALIZATION"
         },
         {
-          "end": 47,
-          "start": 45,
+          "end": 46,
+          "start": 44,
           "type": "REQUEST_EXECUTION"
         },
         {
           "end": 51,
-          "start": 48,
+          "start": 47,
           "type": "RESPONSE_HANDLING"
         }
       ],
@@ -3725,18 +3725,18 @@
           "type": "CLIENT_INITIALIZATION"
         },
         {
-          "end": 44,
+          "end": 43,
           "start": 41,
           "type": "REQUEST_INITIALIZATION"
         },
         {
-          "end": 47,
-          "start": 45,
+          "end": 46,
+          "start": 44,
           "type": "REQUEST_EXECUTION"
         },
         {
           "end": 51,
-          "start": 48,
+          "start": 47,
           "type": "RESPONSE_HANDLING"
         }
       ],

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/async_client.py
@@ -310,7 +310,7 @@ class IAMCredentialsAsyncClient:
                 # Initialize request argument(s)
                 request = credentials_v1.GenerateAccessTokenRequest(
                     name="name_value",
-                    scope=['scope_value1', 'scope_value2'],
+                    scope=["scope_value1", "scope_value2"],
                 )
 
                 # Make the request
@@ -623,7 +623,7 @@ class IAMCredentialsAsyncClient:
                 # Initialize request argument(s)
                 request = credentials_v1.SignBlobRequest(
                     name="name_value",
-                    payload=b'payload_blob',
+                    payload=b"payload_blob",
                 )
 
                 # Make the request

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/client.py
@@ -725,7 +725,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 # Initialize request argument(s)
                 request = credentials_v1.GenerateAccessTokenRequest(
                     name="name_value",
-                    scope=['scope_value1', 'scope_value2'],
+                    scope=["scope_value1", "scope_value2"],
                 )
 
                 # Make the request
@@ -1036,7 +1036,7 @@ class IAMCredentialsClient(metaclass=IAMCredentialsClientMeta):
                 # Initialize request argument(s)
                 request = credentials_v1.SignBlobRequest(
                     name="name_value",
-                    payload=b'payload_blob',
+                    payload=b"payload_blob",
                 )
 
                 # Make the request

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -33,10 +33,9 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_async.py
@@ -41,7 +41,7 @@ async def sample_generate_access_token():
     # Initialize request argument(s)
     request = credentials_v1.GenerateAccessTokenRequest(
         name="name_value",
-        scope=['scope_value1', 'scope_value2'],
+        scope=["scope_value1", "scope_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ async def sample_generate_access_token():
 
     # Handle the response
     print(response)
+
 
 # [END iamcredentials_v1_generated_IAMCredentials_GenerateAccessToken_async]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_access_token_sync.py
@@ -41,7 +41,7 @@ def sample_generate_access_token():
     # Initialize request argument(s)
     request = credentials_v1.GenerateAccessTokenRequest(
         name="name_value",
-        scope=['scope_value1', 'scope_value2'],
+        scope=["scope_value1", "scope_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ def sample_generate_access_token():
 
     # Handle the response
     print(response)
+
 
 # [END iamcredentials_v1_generated_IAMCredentials_GenerateAccessToken_sync]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_async.py
@@ -50,4 +50,5 @@ async def sample_generate_id_token():
     # Handle the response
     print(response)
 
+
 # [END iamcredentials_v1_generated_IAMCredentials_GenerateIdToken_async]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_generate_id_token_sync.py
@@ -50,4 +50,5 @@ def sample_generate_id_token():
     # Handle the response
     print(response)
 
+
 # [END iamcredentials_v1_generated_IAMCredentials_GenerateIdToken_sync]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_async.py
@@ -41,7 +41,7 @@ async def sample_sign_blob():
     # Initialize request argument(s)
     request = credentials_v1.SignBlobRequest(
         name="name_value",
-        payload=b'payload_blob',
+        payload=b"payload_blob",
     )
 
     # Make the request
@@ -49,5 +49,6 @@ async def sample_sign_blob():
 
     # Handle the response
     print(response)
+
 
 # [END iamcredentials_v1_generated_IAMCredentials_SignBlob_async]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_blob_sync.py
@@ -41,7 +41,7 @@ def sample_sign_blob():
     # Initialize request argument(s)
     request = credentials_v1.SignBlobRequest(
         name="name_value",
-        payload=b'payload_blob',
+        payload=b"payload_blob",
     )
 
     # Make the request
@@ -49,5 +49,6 @@ def sample_sign_blob():
 
     # Handle the response
     print(response)
+
 
 # [END iamcredentials_v1_generated_IAMCredentials_SignBlob_sync]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_async.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_async.py
@@ -50,4 +50,5 @@ async def sample_sign_jwt():
     # Handle the response
     print(response)
 
+
 # [END iamcredentials_v1_generated_IAMCredentials_SignJwt_async]

--- a/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_sync.py
+++ b/tests/integration/goldens/credentials/samples/generated_samples/iamcredentials_v1_generated_iam_credentials_sign_jwt_sync.py
@@ -50,4 +50,5 @@ def sample_sign_jwt():
     # Handle the response
     print(response)
 
+
 # [END iamcredentials_v1_generated_IAMCredentials_SignJwt_sync]

--- a/tests/integration/goldens/credentials/samples/generated_samples/snippet_metadata_google.iam.credentials.v1.json
+++ b/tests/integration/goldens/credentials/samples/generated_samples/snippet_metadata_google.iam.credentials.v1.json
@@ -72,12 +72,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_GenerateAccessToken_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -97,7 +97,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -164,12 +164,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_GenerateAccessToken_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -189,7 +189,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -257,12 +257,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_GenerateIdToken_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -282,7 +282,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -349,12 +349,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_GenerateIdToken_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -374,7 +374,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -438,12 +438,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_SignBlob_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -463,7 +463,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -526,12 +526,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_SignBlob_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -551,7 +551,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -615,12 +615,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_SignJwt_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -640,7 +640,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -703,12 +703,12 @@
       "regionTag": "iamcredentials_v1_generated_IAMCredentials_SignJwt_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -728,7 +728,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -33,10 +33,9 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_async.py
@@ -60,4 +60,5 @@ async def sample_create_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_CreateChannel_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_async.py
@@ -59,4 +59,5 @@ async def sample_create_channel_connection():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_CreateChannelConnection_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_connection_sync.py
@@ -59,4 +59,5 @@ def sample_create_channel_connection():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_CreateChannelConnection_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_channel_sync.py
@@ -60,4 +60,5 @@ def sample_create_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_CreateChannel_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_async.py
@@ -63,4 +63,5 @@ async def sample_create_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_CreateTrigger_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_create_trigger_sync.py
@@ -63,4 +63,5 @@ def sample_create_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_CreateTrigger_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_async.py
@@ -54,4 +54,5 @@ async def sample_delete_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_DeleteChannel_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_async.py
@@ -53,4 +53,5 @@ async def sample_delete_channel_connection():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_DeleteChannelConnection_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_connection_sync.py
@@ -53,4 +53,5 @@ def sample_delete_channel_connection():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_DeleteChannelConnection_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_channel_sync.py
@@ -54,4 +54,5 @@ def sample_delete_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_DeleteChannel_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_async.py
@@ -54,4 +54,5 @@ async def sample_delete_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_DeleteTrigger_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_delete_trigger_sync.py
@@ -54,4 +54,5 @@ def sample_delete_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_DeleteTrigger_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_async.py
@@ -49,4 +49,5 @@ async def sample_get_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetChannel_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_async.py
@@ -49,4 +49,5 @@ async def sample_get_channel_connection():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetChannelConnection_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_connection_sync.py
@@ -49,4 +49,5 @@ def sample_get_channel_connection():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetChannelConnection_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_channel_sync.py
@@ -49,4 +49,5 @@ def sample_get_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetChannel_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_async.py
@@ -49,4 +49,5 @@ async def sample_get_google_channel_config():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetGoogleChannelConfig_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_google_channel_config_sync.py
@@ -49,4 +49,5 @@ def sample_get_google_channel_config():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetGoogleChannelConfig_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_async.py
@@ -49,4 +49,5 @@ async def sample_get_provider():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetProvider_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_provider_sync.py
@@ -49,4 +49,5 @@ def sample_get_provider():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetProvider_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_async.py
@@ -49,4 +49,5 @@ async def sample_get_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetTrigger_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_get_trigger_sync.py
@@ -49,4 +49,5 @@ def sample_get_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_GetTrigger_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_async.py
@@ -50,4 +50,5 @@ async def sample_list_channel_connections():
     async for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListChannelConnections_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channel_connections_sync.py
@@ -50,4 +50,5 @@ def sample_list_channel_connections():
     for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListChannelConnections_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_async.py
@@ -50,4 +50,5 @@ async def sample_list_channels():
     async for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListChannels_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_channels_sync.py
@@ -50,4 +50,5 @@ def sample_list_channels():
     for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListChannels_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_async.py
@@ -50,4 +50,5 @@ async def sample_list_providers():
     async for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListProviders_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_providers_sync.py
@@ -50,4 +50,5 @@ def sample_list_providers():
     for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListProviders_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_async.py
@@ -50,4 +50,5 @@ async def sample_list_triggers():
     async for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListTriggers_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_list_triggers_sync.py
@@ -50,4 +50,5 @@ def sample_list_triggers():
     for response in page_result:
         print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_ListTriggers_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_async.py
@@ -53,4 +53,5 @@ async def sample_update_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_UpdateChannel_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_channel_sync.py
@@ -53,4 +53,5 @@ def sample_update_channel():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_UpdateChannel_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_async.py
@@ -52,4 +52,5 @@ async def sample_update_google_channel_config():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_UpdateGoogleChannelConfig_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_google_channel_config_sync.py
@@ -52,4 +52,5 @@ def sample_update_google_channel_config():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_UpdateGoogleChannelConfig_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_async.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_async.py
@@ -53,4 +53,5 @@ async def sample_update_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_UpdateTrigger_async]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_sync.py
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/eventarc_v1_generated_eventarc_update_trigger_sync.py
@@ -53,4 +53,5 @@ def sample_update_trigger():
     # Handle the response
     print(response)
 
+
 # [END eventarc_v1_generated_Eventarc_UpdateTrigger_sync]

--- a/tests/integration/goldens/eventarc/samples/generated_samples/snippet_metadata_google.cloud.eventarc.v1.json
+++ b/tests/integration/goldens/eventarc/samples/generated_samples/snippet_metadata_google.cloud.eventarc.v1.json
@@ -68,12 +68,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_CreateChannelConnection_async",
       "segments": [
         {
-          "end": 61,
+          "end": 62,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 61,
+          "end": 62,
           "start": 27,
           "type": "SHORT"
         },
@@ -93,7 +93,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 59,
           "type": "RESPONSE_HANDLING"
         }
@@ -156,12 +156,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_CreateChannelConnection_sync",
       "segments": [
         {
-          "end": 61,
+          "end": 62,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 61,
+          "end": 62,
           "start": 27,
           "type": "SHORT"
         },
@@ -181,7 +181,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 59,
           "type": "RESPONSE_HANDLING"
         }
@@ -245,12 +245,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_CreateChannel_async",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -270,7 +270,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -333,12 +333,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_CreateChannel_sync",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -358,7 +358,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -422,12 +422,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_CreateTrigger_async",
       "segments": [
         {
-          "end": 65,
+          "end": 66,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 65,
+          "end": 66,
           "start": 27,
           "type": "SHORT"
         },
@@ -447,7 +447,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 66,
+          "end": 67,
           "start": 63,
           "type": "RESPONSE_HANDLING"
         }
@@ -510,12 +510,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_CreateTrigger_sync",
       "segments": [
         {
-          "end": 65,
+          "end": 66,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 65,
+          "end": 66,
           "start": 27,
           "type": "SHORT"
         },
@@ -535,7 +535,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 66,
+          "end": 67,
           "start": 63,
           "type": "RESPONSE_HANDLING"
         }
@@ -591,12 +591,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_DeleteChannelConnection_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -616,7 +616,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -671,12 +671,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_DeleteChannelConnection_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -696,7 +696,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -752,12 +752,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_DeleteChannel_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -777,7 +777,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -832,12 +832,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_DeleteChannel_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -857,7 +857,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -917,12 +917,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_DeleteTrigger_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -942,7 +942,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1001,12 +1001,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_DeleteTrigger_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -1026,7 +1026,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1082,12 +1082,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetChannelConnection_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1107,7 +1107,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1162,12 +1162,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetChannelConnection_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1187,7 +1187,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1243,12 +1243,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetChannel_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1268,7 +1268,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1323,12 +1323,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetChannel_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1348,7 +1348,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1404,12 +1404,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetGoogleChannelConfig_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1429,7 +1429,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1484,12 +1484,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetGoogleChannelConfig_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1509,7 +1509,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1565,12 +1565,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetProvider_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1590,7 +1590,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1645,12 +1645,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetProvider_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1670,7 +1670,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1726,12 +1726,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetTrigger_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1751,7 +1751,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1806,12 +1806,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_GetTrigger_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1831,7 +1831,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1887,12 +1887,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListChannelConnections_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1912,7 +1912,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1967,12 +1967,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListChannelConnections_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1992,7 +1992,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2048,12 +2048,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListChannels_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2073,7 +2073,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2128,12 +2128,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListChannels_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2153,7 +2153,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2209,12 +2209,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListProviders_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2234,7 +2234,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2289,12 +2289,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListProviders_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2314,7 +2314,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2370,12 +2370,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListTriggers_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2395,7 +2395,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2450,12 +2450,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_ListTriggers_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -2475,7 +2475,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2535,12 +2535,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_UpdateChannel_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -2560,7 +2560,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -2619,12 +2619,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_UpdateChannel_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -2644,7 +2644,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -2704,12 +2704,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_UpdateGoogleChannelConfig_async",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -2729,7 +2729,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -2788,12 +2788,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_UpdateGoogleChannelConfig_sync",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -2813,7 +2813,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -2877,12 +2877,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_UpdateTrigger_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -2902,7 +2902,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -2965,12 +2965,12 @@
       "regionTag": "eventarc_v1_generated_Eventarc_UpdateTrigger_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -2990,7 +2990,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -605,7 +605,7 @@ class LoggingServiceV2AsyncClient:
 
                 # Initialize request argument(s)
                 request = logging_v2.ListLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # Make the request
@@ -759,8 +759,7 @@ class LoggingServiceV2AsyncClient:
                 client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
-                request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-                )
+                request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
                 # Make the request
                 page_result = client.list_monitored_resource_descriptors(request=request)
@@ -982,7 +981,7 @@ class LoggingServiceV2AsyncClient:
 
                 # Initialize request argument(s)
                 request = logging_v2.TailLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # This method expects an iterator which contains

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -1014,7 +1014,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
                 # Initialize request argument(s)
                 request = logging_v2.ListLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # Make the request
@@ -1167,8 +1167,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 client = logging_v2.LoggingServiceV2Client()
 
                 # Initialize request argument(s)
-                request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-                )
+                request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
                 # Make the request
                 page_result = client.list_monitored_resource_descriptors(request=request)
@@ -1389,7 +1388,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
                 # Initialize request argument(s)
                 request = logging_v2.TailLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # This method expects an iterator which contains

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -33,10 +33,9 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_async.py
@@ -54,4 +54,5 @@ async def sample_copy_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CopyLogEntries_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync.py
@@ -54,4 +54,5 @@ def sample_copy_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CopyLogEntries_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
@@ -50,4 +50,5 @@ async def sample_create_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucket_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_async.py
@@ -54,4 +54,5 @@ async def sample_create_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucketAsync_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
@@ -54,4 +54,5 @@ def sample_create_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucketAsync_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
@@ -50,4 +50,5 @@ def sample_create_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucket_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async.py
@@ -54,4 +54,5 @@ async def sample_create_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateExclusion_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync.py
@@ -54,4 +54,5 @@ def sample_create_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateExclusion_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_async.py
@@ -54,4 +54,5 @@ async def sample_create_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateLink_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync.py
@@ -54,4 +54,5 @@ def sample_create_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateLink_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async.py
@@ -54,4 +54,5 @@ async def sample_create_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateSink_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync.py
@@ -54,4 +54,5 @@ def sample_create_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateSink_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async.py
@@ -50,4 +50,5 @@ async def sample_create_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateView_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync.py
@@ -50,4 +50,5 @@ def sample_create_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateView_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_async.py
@@ -53,4 +53,5 @@ async def sample_delete_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_DeleteLink_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync.py
@@ -53,4 +53,5 @@ def sample_delete_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_DeleteLink_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
@@ -49,4 +49,5 @@ async def sample_get_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetBucket_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
@@ -49,4 +49,5 @@ def sample_get_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetBucket_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async.py
@@ -49,4 +49,5 @@ async def sample_get_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetCmekSettings_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync.py
@@ -49,4 +49,5 @@ def sample_get_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetCmekSettings_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async.py
@@ -49,4 +49,5 @@ async def sample_get_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetExclusion_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync.py
@@ -49,4 +49,5 @@ def sample_get_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetExclusion_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async.py
@@ -49,4 +49,5 @@ async def sample_get_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetLink_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync.py
@@ -49,4 +49,5 @@ def sample_get_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetLink_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async.py
@@ -49,4 +49,5 @@ async def sample_get_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSettings_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync.py
@@ -49,4 +49,5 @@ def sample_get_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSettings_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async.py
@@ -49,4 +49,5 @@ async def sample_get_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSink_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync.py
@@ -49,4 +49,5 @@ def sample_get_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSink_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async.py
@@ -49,4 +49,5 @@ async def sample_get_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetView_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync.py
@@ -49,4 +49,5 @@ def sample_get_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetView_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
@@ -50,4 +50,5 @@ async def sample_list_buckets():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
@@ -50,4 +50,5 @@ def sample_list_buckets():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListBuckets_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async.py
@@ -50,4 +50,5 @@ async def sample_list_exclusions():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListExclusions_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync.py
@@ -50,4 +50,5 @@ def sample_list_exclusions():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListExclusions_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async.py
@@ -50,4 +50,5 @@ async def sample_list_links():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListLinks_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync.py
@@ -50,4 +50,5 @@ def sample_list_links():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListLinks_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async.py
@@ -50,4 +50,5 @@ async def sample_list_sinks():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListSinks_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync.py
@@ -50,4 +50,5 @@ def sample_list_sinks():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListSinks_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async.py
@@ -50,4 +50,5 @@ async def sample_list_views():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListViews_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync.py
@@ -50,4 +50,5 @@ def sample_list_views():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListViews_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
@@ -49,4 +49,5 @@ async def sample_update_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucket_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_async.py
@@ -53,4 +53,5 @@ async def sample_update_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
@@ -53,4 +53,5 @@ def sample_update_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
@@ -49,4 +49,5 @@ def sample_update_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucket_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async.py
@@ -49,4 +49,5 @@ async def sample_update_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync.py
@@ -49,4 +49,5 @@ def sample_update_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async.py
@@ -54,4 +54,5 @@ async def sample_update_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateExclusion_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync.py
@@ -54,4 +54,5 @@ def sample_update_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateExclusion_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async.py
@@ -49,4 +49,5 @@ async def sample_update_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSettings_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync.py
@@ -49,4 +49,5 @@ def sample_update_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSettings_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async.py
@@ -54,4 +54,5 @@ async def sample_update_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSink_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync.py
@@ -54,4 +54,5 @@ def sample_update_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSink_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async.py
@@ -49,4 +49,5 @@ async def sample_update_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateView_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync.py
@@ -49,4 +49,5 @@ def sample_update_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateView_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
@@ -40,7 +40,7 @@ async def sample_list_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.ListLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ async def sample_list_log_entries():
     # Handle the response
     async for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListLogEntries_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
@@ -40,7 +40,7 @@ def sample_list_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.ListLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ def sample_list_log_entries():
     # Handle the response
     for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListLogEntries_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
@@ -50,4 +50,5 @@ async def sample_list_logs():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_ListLogs_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
@@ -50,4 +50,5 @@ def sample_list_logs():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_ListLogs_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
@@ -39,8 +39,7 @@ async def sample_list_monitored_resource_descriptors():
     client = logging_v2.LoggingServiceV2AsyncClient()
 
     # Initialize request argument(s)
-    request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-    )
+    request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
     # Make the request
     page_result = client.list_monitored_resource_descriptors(request=request)
@@ -48,5 +47,6 @@ async def sample_list_monitored_resource_descriptors():
     # Handle the response
     async for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListMonitoredResourceDescriptors_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
@@ -39,8 +39,7 @@ def sample_list_monitored_resource_descriptors():
     client = logging_v2.LoggingServiceV2Client()
 
     # Initialize request argument(s)
-    request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-    )
+    request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
     # Make the request
     page_result = client.list_monitored_resource_descriptors(request=request)
@@ -48,5 +47,6 @@ def sample_list_monitored_resource_descriptors():
     # Handle the response
     for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListMonitoredResourceDescriptors_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
@@ -40,7 +40,7 @@ async def sample_tail_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.TailLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # This method expects an iterator which contains
@@ -59,5 +59,6 @@ async def sample_tail_log_entries():
     # Handle the response
     async for response in stream:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_TailLogEntries_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
@@ -40,7 +40,7 @@ def sample_tail_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.TailLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # This method expects an iterator which contains
@@ -59,5 +59,6 @@ def sample_tail_log_entries():
     # Handle the response
     for response in stream:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_TailLogEntries_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
@@ -52,4 +52,5 @@ async def sample_write_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_WriteLogEntries_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
@@ -52,4 +52,5 @@ def sample_write_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_WriteLogEntries_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async.py
@@ -54,4 +54,5 @@ async def sample_create_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_CreateLogMetric_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync.py
@@ -54,4 +54,5 @@ def sample_create_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_CreateLogMetric_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async.py
@@ -49,4 +49,5 @@ async def sample_get_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_GetLogMetric_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync.py
@@ -49,4 +49,5 @@ def sample_get_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_GetLogMetric_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async.py
@@ -50,4 +50,5 @@ async def sample_list_log_metrics():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_ListLogMetrics_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync.py
@@ -50,4 +50,5 @@ def sample_list_log_metrics():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_ListLogMetrics_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async.py
@@ -54,4 +54,5 @@ async def sample_update_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_UpdateLogMetric_async]

--- a/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
+++ b/tests/integration/goldens/logging/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync.py
@@ -54,4 +54,5 @@ def sample_update_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_UpdateLogMetric_sync]

--- a/tests/integration/goldens/logging/samples/generated_samples/snippet_metadata_google.logging.v2.json
+++ b/tests/integration/goldens/logging/samples/generated_samples/snippet_metadata_google.logging.v2.json
@@ -56,12 +56,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CopyLogEntries_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -81,7 +81,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -132,12 +132,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CopyLogEntries_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -157,7 +157,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -209,12 +209,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucketAsync_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -234,7 +234,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -285,12 +285,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucketAsync_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -310,7 +310,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -362,12 +362,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucket_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -387,7 +387,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -438,12 +438,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucket_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -463,7 +463,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -523,12 +523,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateExclusion_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -548,7 +548,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -607,12 +607,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateExclusion_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -632,7 +632,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -696,12 +696,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateLink_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -721,7 +721,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -784,12 +784,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateLink_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -809,7 +809,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -869,12 +869,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateSink_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -894,7 +894,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -953,12 +953,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateSink_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -978,7 +978,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1030,12 +1030,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateView_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1055,7 +1055,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1106,12 +1106,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateView_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1131,7 +1131,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1489,12 +1489,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_DeleteLink_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -1514,7 +1514,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -1569,12 +1569,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_DeleteLink_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -1594,7 +1594,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -1948,12 +1948,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetBucket_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1973,7 +1973,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2024,12 +2024,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetBucket_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2049,7 +2049,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2101,12 +2101,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetCmekSettings_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2126,7 +2126,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2177,12 +2177,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetCmekSettings_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2202,7 +2202,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2258,12 +2258,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetExclusion_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2283,7 +2283,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2338,12 +2338,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetExclusion_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2363,7 +2363,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2419,12 +2419,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetLink_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2444,7 +2444,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2499,12 +2499,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetLink_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2524,7 +2524,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2580,12 +2580,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSettings_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2605,7 +2605,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2660,12 +2660,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSettings_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2685,7 +2685,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2741,12 +2741,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSink_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2766,7 +2766,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2821,12 +2821,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSink_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2846,7 +2846,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2898,12 +2898,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetView_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2923,7 +2923,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2974,12 +2974,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetView_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2999,7 +2999,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3055,12 +3055,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListBuckets_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3080,7 +3080,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3135,12 +3135,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListBuckets_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3160,7 +3160,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3216,12 +3216,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListExclusions_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3241,7 +3241,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3296,12 +3296,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListExclusions_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3321,7 +3321,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3377,12 +3377,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListLinks_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3402,7 +3402,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3457,12 +3457,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListLinks_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3482,7 +3482,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3538,12 +3538,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListSinks_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3563,7 +3563,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3618,12 +3618,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListSinks_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3643,7 +3643,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3699,12 +3699,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListViews_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3724,7 +3724,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3779,12 +3779,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListViews_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3804,7 +3804,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4003,12 +4003,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -4028,7 +4028,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -4079,12 +4079,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -4104,7 +4104,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -4156,12 +4156,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucket_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4181,7 +4181,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4232,12 +4232,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucket_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4257,7 +4257,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4309,12 +4309,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4334,7 +4334,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4385,12 +4385,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4410,7 +4410,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4474,12 +4474,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateExclusion_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4499,7 +4499,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4562,12 +4562,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateExclusion_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4587,7 +4587,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4647,12 +4647,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSettings_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4672,7 +4672,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4731,12 +4731,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSettings_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4756,7 +4756,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4820,12 +4820,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSink_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4845,7 +4845,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4908,12 +4908,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSink_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4933,7 +4933,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4985,12 +4985,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateView_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -5010,7 +5010,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5061,12 +5061,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateView_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -5086,7 +5086,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5305,12 +5305,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogEntries_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5330,7 +5330,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5393,12 +5393,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogEntries_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5418,7 +5418,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5474,12 +5474,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogs_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5499,7 +5499,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5554,12 +5554,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogs_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5579,7 +5579,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5646,18 +5646,18 @@
           "type": "CLIENT_INITIALIZATION"
         },
         {
-          "end": 44,
+          "end": 43,
           "start": 41,
           "type": "REQUEST_INITIALIZATION"
         },
         {
-          "end": 47,
-          "start": 45,
+          "end": 46,
+          "start": 44,
           "type": "REQUEST_EXECUTION"
         },
         {
           "end": 52,
-          "start": 48,
+          "start": 47,
           "type": "RESPONSE_HANDLING"
         }
       ],
@@ -5722,18 +5722,18 @@
           "type": "CLIENT_INITIALIZATION"
         },
         {
-          "end": 44,
+          "end": 43,
           "start": 41,
           "type": "REQUEST_INITIALIZATION"
         },
         {
-          "end": 47,
-          "start": 45,
+          "end": 46,
+          "start": 44,
           "type": "REQUEST_EXECUTION"
         },
         {
           "end": 52,
-          "start": 48,
+          "start": 47,
           "type": "RESPONSE_HANDLING"
         }
       ],
@@ -5784,12 +5784,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_TailLogEntries_async",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -5809,7 +5809,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 59,
           "type": "RESPONSE_HANDLING"
         }
@@ -5860,12 +5860,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_TailLogEntries_sync",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -5885,7 +5885,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 59,
           "type": "RESPONSE_HANDLING"
         }
@@ -5953,12 +5953,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_WriteLogEntries_async",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -5978,7 +5978,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -6045,12 +6045,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_WriteLogEntries_sync",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -6070,7 +6070,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -6130,12 +6130,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_CreateLogMetric_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6155,7 +6155,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -6214,12 +6214,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_CreateLogMetric_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6239,7 +6239,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -6450,12 +6450,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_GetLogMetric_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -6475,7 +6475,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6530,12 +6530,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_GetLogMetric_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -6555,7 +6555,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6611,12 +6611,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_ListLogMetrics_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -6636,7 +6636,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6691,12 +6691,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_ListLogMetrics_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -6716,7 +6716,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6776,12 +6776,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_UpdateLogMetric_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6801,7 +6801,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -6860,12 +6860,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_UpdateLogMetric_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6885,7 +6885,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/async_client.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/async_client.py
@@ -605,7 +605,7 @@ class LoggingServiceV2AsyncClient:
 
                 # Initialize request argument(s)
                 request = logging_v2.ListLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # Make the request
@@ -759,8 +759,7 @@ class LoggingServiceV2AsyncClient:
                 client = logging_v2.LoggingServiceV2AsyncClient()
 
                 # Initialize request argument(s)
-                request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-                )
+                request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
                 # Make the request
                 page_result = client.list_monitored_resource_descriptors(request=request)
@@ -982,7 +981,7 @@ class LoggingServiceV2AsyncClient:
 
                 # Initialize request argument(s)
                 request = logging_v2.TailLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # This method expects an iterator which contains

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/client.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/client.py
@@ -1014,7 +1014,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
                 # Initialize request argument(s)
                 request = logging_v2.ListLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # Make the request
@@ -1167,8 +1167,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
                 client = logging_v2.LoggingServiceV2Client()
 
                 # Initialize request argument(s)
-                request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-                )
+                request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
                 # Make the request
                 page_result = client.list_monitored_resource_descriptors(request=request)
@@ -1389,7 +1388,7 @@ class LoggingServiceV2Client(metaclass=LoggingServiceV2ClientMeta):
 
                 # Initialize request argument(s)
                 request = logging_v2.TailLogEntriesRequest(
-                    resource_names=['resource_names_value1', 'resource_names_value2'],
+                    resource_names=["resource_names_value1", "resource_names_value2"],
                 )
 
                 # This method expects an iterator which contains

--- a/tests/integration/goldens/logging_internal/noxfile.py
+++ b/tests/integration/goldens/logging_internal/noxfile.py
@@ -33,10 +33,9 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_async_internal.py
@@ -54,4 +54,5 @@ async def sample_copy_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CopyLogEntries_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_copy_log_entries_sync_internal.py
@@ -54,4 +54,5 @@ def sample_copy_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CopyLogEntries_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async.py
@@ -50,4 +50,5 @@ async def sample_create_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucket_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_async.py
@@ -54,4 +54,5 @@ async def sample_create_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucketAsync_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_async_sync.py
@@ -54,4 +54,5 @@ def sample_create_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucketAsync_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_bucket_sync.py
@@ -50,4 +50,5 @@ def sample_create_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateBucket_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_async_internal.py
@@ -54,4 +54,5 @@ async def sample_create_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateExclusion_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_exclusion_sync_internal.py
@@ -54,4 +54,5 @@ def sample_create_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateExclusion_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_async_internal.py
@@ -54,4 +54,5 @@ async def sample_create_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateLink_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_link_sync_internal.py
@@ -54,4 +54,5 @@ def sample_create_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateLink_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_async_internal.py
@@ -54,4 +54,5 @@ async def sample_create_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateSink_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_sink_sync_internal.py
@@ -54,4 +54,5 @@ def sample_create_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateSink_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_async_internal.py
@@ -50,4 +50,5 @@ async def sample_create_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateView_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_create_view_sync_internal.py
@@ -50,4 +50,5 @@ def sample_create_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_CreateView_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_async_internal.py
@@ -53,4 +53,5 @@ async def sample_delete_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_DeleteLink_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_delete_link_sync_internal.py
@@ -53,4 +53,5 @@ def sample_delete_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_DeleteLink_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_async.py
@@ -49,4 +49,5 @@ async def sample_get_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetBucket_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_bucket_sync.py
@@ -49,4 +49,5 @@ def sample_get_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetBucket_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_async_internal.py
@@ -49,4 +49,5 @@ async def sample_get_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetCmekSettings_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_cmek_settings_sync_internal.py
@@ -49,4 +49,5 @@ def sample_get_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetCmekSettings_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_async_internal.py
@@ -49,4 +49,5 @@ async def sample_get_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetExclusion_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_exclusion_sync_internal.py
@@ -49,4 +49,5 @@ def sample_get_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetExclusion_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_async_internal.py
@@ -49,4 +49,5 @@ async def sample_get_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetLink_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_link_sync_internal.py
@@ -49,4 +49,5 @@ def sample_get_link():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetLink_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_async_internal.py
@@ -49,4 +49,5 @@ async def sample_get_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSettings_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_settings_sync_internal.py
@@ -49,4 +49,5 @@ def sample_get_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSettings_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_async_internal.py
@@ -49,4 +49,5 @@ async def sample_get_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSink_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_sink_sync_internal.py
@@ -49,4 +49,5 @@ def sample_get_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetSink_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_async_internal.py
@@ -49,4 +49,5 @@ async def sample_get_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetView_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_get_view_sync_internal.py
@@ -49,4 +49,5 @@ def sample_get_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_GetView_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_async.py
@@ -50,4 +50,5 @@ async def sample_list_buckets():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListBuckets_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_buckets_sync.py
@@ -50,4 +50,5 @@ def sample_list_buckets():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListBuckets_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_async_internal.py
@@ -50,4 +50,5 @@ async def sample_list_exclusions():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListExclusions_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_exclusions_sync_internal.py
@@ -50,4 +50,5 @@ def sample_list_exclusions():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListExclusions_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_async_internal.py
@@ -50,4 +50,5 @@ async def sample_list_links():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListLinks_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_links_sync_internal.py
@@ -50,4 +50,5 @@ def sample_list_links():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListLinks_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_async_internal.py
@@ -50,4 +50,5 @@ async def sample_list_sinks():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListSinks_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_sinks_sync_internal.py
@@ -50,4 +50,5 @@ def sample_list_sinks():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListSinks_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_async_internal.py
@@ -50,4 +50,5 @@ async def sample_list_views():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListViews_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_list_views_sync_internal.py
@@ -50,4 +50,5 @@ def sample_list_views():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_ListViews_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async.py
@@ -49,4 +49,5 @@ async def sample_update_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucket_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_async.py
@@ -53,4 +53,5 @@ async def sample_update_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_async_sync.py
@@ -53,4 +53,5 @@ def sample_update_bucket_async():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_bucket_sync.py
@@ -49,4 +49,5 @@ def sample_update_bucket():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateBucket_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_async_internal.py
@@ -49,4 +49,5 @@ async def sample_update_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_cmek_settings_sync_internal.py
@@ -49,4 +49,5 @@ def sample_update_cmek_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_async_internal.py
@@ -54,4 +54,5 @@ async def sample_update_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateExclusion_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_exclusion_sync_internal.py
@@ -54,4 +54,5 @@ def sample_update_exclusion():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateExclusion_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_async_internal.py
@@ -49,4 +49,5 @@ async def sample_update_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSettings_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_settings_sync_internal.py
@@ -49,4 +49,5 @@ def sample_update_settings():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSettings_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_async_internal.py
@@ -54,4 +54,5 @@ async def sample_update_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSink_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_sink_sync_internal.py
@@ -54,4 +54,5 @@ def sample_update_sink():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateSink_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_async_internal.py
@@ -49,4 +49,5 @@ async def sample_update_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateView_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_config_service_v2_update_view_sync_internal.py
@@ -49,4 +49,5 @@ def sample_update_view():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_ConfigServiceV2_UpdateView_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_async.py
@@ -40,7 +40,7 @@ async def sample_list_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.ListLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ async def sample_list_log_entries():
     # Handle the response
     async for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListLogEntries_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_log_entries_sync.py
@@ -40,7 +40,7 @@ def sample_list_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.ListLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # Make the request
@@ -49,5 +49,6 @@ def sample_list_log_entries():
     # Handle the response
     for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListLogEntries_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_async.py
@@ -50,4 +50,5 @@ async def sample_list_logs():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_ListLogs_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_logs_sync.py
@@ -50,4 +50,5 @@ def sample_list_logs():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_ListLogs_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_async.py
@@ -39,8 +39,7 @@ async def sample_list_monitored_resource_descriptors():
     client = logging_v2.LoggingServiceV2AsyncClient()
 
     # Initialize request argument(s)
-    request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-    )
+    request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
     # Make the request
     page_result = client.list_monitored_resource_descriptors(request=request)
@@ -48,5 +47,6 @@ async def sample_list_monitored_resource_descriptors():
     # Handle the response
     async for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListMonitoredResourceDescriptors_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_list_monitored_resource_descriptors_sync.py
@@ -39,8 +39,7 @@ def sample_list_monitored_resource_descriptors():
     client = logging_v2.LoggingServiceV2Client()
 
     # Initialize request argument(s)
-    request = logging_v2.ListMonitoredResourceDescriptorsRequest(
-    )
+    request = logging_v2.ListMonitoredResourceDescriptorsRequest()
 
     # Make the request
     page_result = client.list_monitored_resource_descriptors(request=request)
@@ -48,5 +47,6 @@ def sample_list_monitored_resource_descriptors():
     # Handle the response
     for response in page_result:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_ListMonitoredResourceDescriptors_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_async.py
@@ -40,7 +40,7 @@ async def sample_tail_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.TailLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # This method expects an iterator which contains
@@ -59,5 +59,6 @@ async def sample_tail_log_entries():
     # Handle the response
     async for response in stream:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_TailLogEntries_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_tail_log_entries_sync.py
@@ -40,7 +40,7 @@ def sample_tail_log_entries():
 
     # Initialize request argument(s)
     request = logging_v2.TailLogEntriesRequest(
-        resource_names=['resource_names_value1', 'resource_names_value2'],
+        resource_names=["resource_names_value1", "resource_names_value2"],
     )
 
     # This method expects an iterator which contains
@@ -59,5 +59,6 @@ def sample_tail_log_entries():
     # Handle the response
     for response in stream:
         print(response)
+
 
 # [END logging_v2_generated_LoggingServiceV2_TailLogEntries_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_async.py
@@ -52,4 +52,5 @@ async def sample_write_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_WriteLogEntries_async]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_logging_service_v2_write_log_entries_sync.py
@@ -52,4 +52,5 @@ def sample_write_log_entries():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_LoggingServiceV2_WriteLogEntries_sync]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_async_internal.py
@@ -54,4 +54,5 @@ async def sample_create_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_CreateLogMetric_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_create_log_metric_sync_internal.py
@@ -54,4 +54,5 @@ def sample_create_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_CreateLogMetric_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_async_internal.py
@@ -49,4 +49,5 @@ async def sample_get_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_GetLogMetric_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_get_log_metric_sync_internal.py
@@ -49,4 +49,5 @@ def sample_get_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_GetLogMetric_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_async_internal.py
@@ -50,4 +50,5 @@ async def sample_list_log_metrics():
     async for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_ListLogMetrics_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_list_log_metrics_sync_internal.py
@@ -50,4 +50,5 @@ def sample_list_log_metrics():
     for response in page_result:
         print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_ListLogMetrics_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_async_internal.py
@@ -54,4 +54,5 @@ async def sample_update_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_UpdateLogMetric_async_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync_internal.py
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/logging_v2_generated_metrics_service_v2_update_log_metric_sync_internal.py
@@ -54,4 +54,5 @@ def sample_update_log_metric():
     # Handle the response
     print(response)
 
+
 # [END logging_v2_generated_MetricsServiceV2_UpdateLogMetric_sync_internal]

--- a/tests/integration/goldens/logging_internal/samples/generated_samples/snippet_metadata_google.logging.v2.json
+++ b/tests/integration/goldens/logging_internal/samples/generated_samples/snippet_metadata_google.logging.v2.json
@@ -56,12 +56,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CopyLogEntries_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -81,7 +81,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -132,12 +132,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CopyLogEntries_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -157,7 +157,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -209,12 +209,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucketAsync_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -234,7 +234,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -285,12 +285,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucketAsync_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -310,7 +310,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -362,12 +362,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucket_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -387,7 +387,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -438,12 +438,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateBucket_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -463,7 +463,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -523,12 +523,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateExclusion_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -548,7 +548,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -607,12 +607,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateExclusion_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -632,7 +632,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -696,12 +696,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateLink_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -721,7 +721,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -784,12 +784,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateLink_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -809,7 +809,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -869,12 +869,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateSink_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -894,7 +894,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -953,12 +953,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateSink_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -978,7 +978,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1030,12 +1030,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateView_async_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1055,7 +1055,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1106,12 +1106,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_CreateView_sync_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1131,7 +1131,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 50,
           "type": "RESPONSE_HANDLING"
         }
@@ -1489,12 +1489,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_DeleteLink_async_internal",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -1514,7 +1514,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -1569,12 +1569,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_DeleteLink_sync_internal",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -1594,7 +1594,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -1948,12 +1948,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetBucket_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1973,7 +1973,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2024,12 +2024,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetBucket_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2049,7 +2049,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2101,12 +2101,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetCmekSettings_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2126,7 +2126,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2177,12 +2177,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetCmekSettings_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2202,7 +2202,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2258,12 +2258,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetExclusion_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2283,7 +2283,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2338,12 +2338,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetExclusion_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2363,7 +2363,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2419,12 +2419,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetLink_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2444,7 +2444,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2499,12 +2499,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetLink_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2524,7 +2524,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2580,12 +2580,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSettings_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2605,7 +2605,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2660,12 +2660,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSettings_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2685,7 +2685,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2741,12 +2741,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSink_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2766,7 +2766,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2821,12 +2821,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetSink_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2846,7 +2846,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2898,12 +2898,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetView_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2923,7 +2923,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -2974,12 +2974,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_GetView_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -2999,7 +2999,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3055,12 +3055,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListBuckets_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3080,7 +3080,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3135,12 +3135,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListBuckets_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3160,7 +3160,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3216,12 +3216,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListExclusions_async_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3241,7 +3241,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3296,12 +3296,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListExclusions_sync_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3321,7 +3321,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3377,12 +3377,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListLinks_async_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3402,7 +3402,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3457,12 +3457,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListLinks_sync_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3482,7 +3482,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3538,12 +3538,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListSinks_async_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3563,7 +3563,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3618,12 +3618,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListSinks_sync_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3643,7 +3643,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3699,12 +3699,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListViews_async_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3724,7 +3724,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -3779,12 +3779,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_ListViews_sync_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -3804,7 +3804,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4003,12 +4003,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -4028,7 +4028,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -4079,12 +4079,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucketAsync_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -4104,7 +4104,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -4156,12 +4156,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucket_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4181,7 +4181,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4232,12 +4232,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateBucket_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4257,7 +4257,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4309,12 +4309,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4334,7 +4334,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4385,12 +4385,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateCmekSettings_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4410,7 +4410,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4474,12 +4474,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateExclusion_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4499,7 +4499,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4562,12 +4562,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateExclusion_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4587,7 +4587,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4647,12 +4647,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSettings_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4672,7 +4672,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4731,12 +4731,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSettings_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -4756,7 +4756,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -4820,12 +4820,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSink_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4845,7 +4845,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4908,12 +4908,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateSink_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -4933,7 +4933,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -4985,12 +4985,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateView_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -5010,7 +5010,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5061,12 +5061,12 @@
       "regionTag": "logging_v2_generated_ConfigServiceV2_UpdateView_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -5086,7 +5086,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5305,12 +5305,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogEntries_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5330,7 +5330,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5393,12 +5393,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogEntries_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5418,7 +5418,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5474,12 +5474,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogs_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5499,7 +5499,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5554,12 +5554,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_ListLogs_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -5579,7 +5579,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -5646,18 +5646,18 @@
           "type": "CLIENT_INITIALIZATION"
         },
         {
-          "end": 44,
+          "end": 43,
           "start": 41,
           "type": "REQUEST_INITIALIZATION"
         },
         {
-          "end": 47,
-          "start": 45,
+          "end": 46,
+          "start": 44,
           "type": "REQUEST_EXECUTION"
         },
         {
           "end": 52,
-          "start": 48,
+          "start": 47,
           "type": "RESPONSE_HANDLING"
         }
       ],
@@ -5722,18 +5722,18 @@
           "type": "CLIENT_INITIALIZATION"
         },
         {
-          "end": 44,
+          "end": 43,
           "start": 41,
           "type": "REQUEST_INITIALIZATION"
         },
         {
-          "end": 47,
-          "start": 45,
+          "end": 46,
+          "start": 44,
           "type": "REQUEST_EXECUTION"
         },
         {
           "end": 52,
-          "start": 48,
+          "start": 47,
           "type": "RESPONSE_HANDLING"
         }
       ],
@@ -5784,12 +5784,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_TailLogEntries_async",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -5809,7 +5809,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 59,
           "type": "RESPONSE_HANDLING"
         }
@@ -5860,12 +5860,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_TailLogEntries_sync",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -5885,7 +5885,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 59,
           "type": "RESPONSE_HANDLING"
         }
@@ -5953,12 +5953,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_WriteLogEntries_async",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -5978,7 +5978,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -6045,12 +6045,12 @@
       "regionTag": "logging_v2_generated_LoggingServiceV2_WriteLogEntries_sync",
       "segments": [
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 54,
+          "end": 55,
           "start": 27,
           "type": "SHORT"
         },
@@ -6070,7 +6070,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 52,
           "type": "RESPONSE_HANDLING"
         }
@@ -6130,12 +6130,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_CreateLogMetric_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6155,7 +6155,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -6214,12 +6214,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_CreateLogMetric_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6239,7 +6239,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -6450,12 +6450,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_GetLogMetric_async_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -6475,7 +6475,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6530,12 +6530,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_GetLogMetric_sync_internal",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -6555,7 +6555,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6611,12 +6611,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_ListLogMetrics_async_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -6636,7 +6636,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6691,12 +6691,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_ListLogMetrics_sync_internal",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -6716,7 +6716,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -6776,12 +6776,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_UpdateLogMetric_async_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6801,7 +6801,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -6860,12 +6860,12 @@
       "regionTag": "logging_v2_generated_MetricsServiceV2_UpdateLogMetric_sync_internal",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -6885,7 +6885,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -33,10 +33,9 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_async.py
@@ -60,4 +60,5 @@ async def sample_create_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_CreateInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
@@ -60,4 +60,5 @@ def sample_create_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_CreateInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_async.py
@@ -53,4 +53,5 @@ async def sample_delete_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_DeleteInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
@@ -53,4 +53,5 @@ def sample_delete_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_DeleteInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_async.py
@@ -57,4 +57,5 @@ async def sample_export_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ExportInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_export_instance_sync.py
@@ -57,4 +57,5 @@ def sample_export_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ExportInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_async.py
@@ -53,4 +53,5 @@ async def sample_failover_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_FailoverInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_failover_instance_sync.py
@@ -53,4 +53,5 @@ def sample_failover_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_FailoverInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
@@ -49,4 +49,5 @@ async def sample_get_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_GetInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_async.py
@@ -49,4 +49,5 @@ async def sample_get_instance_auth_string():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_GetInstanceAuthString_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_auth_string_sync.py
@@ -49,4 +49,5 @@ def sample_get_instance_auth_string():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_GetInstanceAuthString_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
@@ -49,4 +49,5 @@ def sample_get_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_GetInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_async.py
@@ -57,4 +57,5 @@ async def sample_import_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ImportInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_import_instance_sync.py
@@ -57,4 +57,5 @@ def sample_import_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ImportInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
@@ -50,4 +50,5 @@ async def sample_list_instances():
     async for response in page_result:
         print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ListInstances_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
@@ -50,4 +50,5 @@ def sample_list_instances():
     for response in page_result:
         print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ListInstances_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_async.py
@@ -54,4 +54,5 @@ async def sample_reschedule_maintenance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_RescheduleMaintenance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_reschedule_maintenance_sync.py
@@ -54,4 +54,5 @@ def sample_reschedule_maintenance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_RescheduleMaintenance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_async.py
@@ -58,4 +58,5 @@ async def sample_update_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_UpdateInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
@@ -58,4 +58,5 @@ def sample_update_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_UpdateInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_async.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_async.py
@@ -54,4 +54,5 @@ async def sample_upgrade_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_UpgradeInstance_async]

--- a/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_sync.py
+++ b/tests/integration/goldens/redis/samples/generated_samples/redis_v1_generated_cloud_redis_upgrade_instance_sync.py
@@ -54,4 +54,5 @@ def sample_upgrade_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_UpgradeInstance_sync]

--- a/tests/integration/goldens/redis/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
+++ b/tests/integration/goldens/redis/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
@@ -68,12 +68,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_CreateInstance_async",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -93,7 +93,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -156,12 +156,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_CreateInstance_sync",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -181,7 +181,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -237,12 +237,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_DeleteInstance_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -262,7 +262,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -317,12 +317,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_DeleteInstance_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -342,7 +342,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -402,12 +402,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ExportInstance_async",
       "segments": [
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "SHORT"
         },
@@ -427,7 +427,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 57,
           "type": "RESPONSE_HANDLING"
         }
@@ -486,12 +486,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ExportInstance_sync",
       "segments": [
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "SHORT"
         },
@@ -511,7 +511,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 57,
           "type": "RESPONSE_HANDLING"
         }
@@ -571,12 +571,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_FailoverInstance_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -596,7 +596,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -655,12 +655,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_FailoverInstance_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -680,7 +680,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -736,12 +736,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_GetInstanceAuthString_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -761,7 +761,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -816,12 +816,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_GetInstanceAuthString_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -841,7 +841,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -897,12 +897,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_GetInstance_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -922,7 +922,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -977,12 +977,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_GetInstance_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -1002,7 +1002,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1062,12 +1062,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ImportInstance_async",
       "segments": [
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "SHORT"
         },
@@ -1087,7 +1087,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 57,
           "type": "RESPONSE_HANDLING"
         }
@@ -1146,12 +1146,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ImportInstance_sync",
       "segments": [
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 59,
+          "end": 60,
           "start": 27,
           "type": "SHORT"
         },
@@ -1171,7 +1171,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 57,
           "type": "RESPONSE_HANDLING"
         }
@@ -1227,12 +1227,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ListInstances_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1252,7 +1252,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1307,12 +1307,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ListInstances_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -1332,7 +1332,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -1396,12 +1396,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_RescheduleMaintenance_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -1421,7 +1421,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1484,12 +1484,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_RescheduleMaintenance_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -1509,7 +1509,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1569,12 +1569,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_UpdateInstance_async",
       "segments": [
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "SHORT"
         },
@@ -1594,7 +1594,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 61,
+          "end": 62,
           "start": 58,
           "type": "RESPONSE_HANDLING"
         }
@@ -1653,12 +1653,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_UpdateInstance_sync",
       "segments": [
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "SHORT"
         },
@@ -1678,7 +1678,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 61,
+          "end": 62,
           "start": 58,
           "type": "RESPONSE_HANDLING"
         }
@@ -1738,12 +1738,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_UpgradeInstance_async",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -1763,7 +1763,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }
@@ -1822,12 +1822,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_UpgradeInstance_sync",
       "segments": [
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 27,
           "type": "SHORT"
         },
@@ -1847,7 +1847,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 57,
+          "end": 58,
           "start": 54,
           "type": "RESPONSE_HANDLING"
         }

--- a/tests/integration/goldens/redis_selective/noxfile.py
+++ b/tests/integration/goldens/redis_selective/noxfile.py
@@ -33,10 +33,9 @@ LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
 # and less concerned about the line length.
 LINT_LINE_LENGTH = 150
 
-# Add samples to the list of directories to format if the directory exists.
+# Add samples to the list of directories to lint if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_async.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_async.py
@@ -60,4 +60,5 @@ async def sample_create_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_CreateInstance_async]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_create_instance_sync.py
@@ -60,4 +60,5 @@ def sample_create_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_CreateInstance_sync]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_async.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_async.py
@@ -53,4 +53,5 @@ async def sample_delete_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_DeleteInstance_async]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_delete_instance_sync.py
@@ -53,4 +53,5 @@ def sample_delete_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_DeleteInstance_sync]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_async.py
@@ -49,4 +49,5 @@ async def sample_get_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_GetInstance_async]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_get_instance_sync.py
@@ -49,4 +49,5 @@ def sample_get_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_GetInstance_sync]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_async.py
@@ -50,4 +50,5 @@ async def sample_list_instances():
     async for response in page_result:
         print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ListInstances_async]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_list_instances_sync.py
@@ -50,4 +50,5 @@ def sample_list_instances():
     for response in page_result:
         print(response)
 
+
 # [END redis_v1_generated_CloudRedis_ListInstances_sync]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_async.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_async.py
@@ -58,4 +58,5 @@ async def sample_update_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_UpdateInstance_async]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/redis_v1_generated_cloud_redis_update_instance_sync.py
@@ -58,4 +58,5 @@ def sample_update_instance():
     # Handle the response
     print(response)
 
+
 # [END redis_v1_generated_CloudRedis_UpdateInstance_sync]

--- a/tests/integration/goldens/redis_selective/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
+++ b/tests/integration/goldens/redis_selective/samples/generated_samples/snippet_metadata_google.cloud.redis.v1.json
@@ -68,12 +68,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_CreateInstance_async",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -93,7 +93,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -156,12 +156,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_CreateInstance_sync",
       "segments": [
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 62,
+          "end": 63,
           "start": 27,
           "type": "SHORT"
         },
@@ -181,7 +181,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 63,
+          "end": 64,
           "start": 60,
           "type": "RESPONSE_HANDLING"
         }
@@ -237,12 +237,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_DeleteInstance_async",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -262,7 +262,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -317,12 +317,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_DeleteInstance_sync",
       "segments": [
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 55,
+          "end": 56,
           "start": 27,
           "type": "SHORT"
         },
@@ -342,7 +342,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 56,
+          "end": 57,
           "start": 53,
           "type": "RESPONSE_HANDLING"
         }
@@ -398,12 +398,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_GetInstance_async",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -423,7 +423,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -478,12 +478,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_GetInstance_sync",
       "segments": [
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 51,
+          "end": 52,
           "start": 27,
           "type": "SHORT"
         },
@@ -503,7 +503,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -559,12 +559,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ListInstances_async",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -584,7 +584,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -639,12 +639,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_ListInstances_sync",
       "segments": [
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 52,
+          "end": 53,
           "start": 27,
           "type": "SHORT"
         },
@@ -664,7 +664,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 53,
+          "end": 54,
           "start": 49,
           "type": "RESPONSE_HANDLING"
         }
@@ -724,12 +724,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_UpdateInstance_async",
       "segments": [
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "SHORT"
         },
@@ -749,7 +749,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 61,
+          "end": 62,
           "start": 58,
           "type": "RESPONSE_HANDLING"
         }
@@ -808,12 +808,12 @@
       "regionTag": "redis_v1_generated_CloudRedis_UpdateInstance_sync",
       "segments": [
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "FULL"
         },
         {
-          "end": 60,
+          "end": 61,
           "start": 27,
           "type": "SHORT"
         },
@@ -833,7 +833,7 @@
           "type": "REQUEST_EXECUTION"
         },
         {
-          "end": 61,
+          "end": 62,
           "start": 58,
           "type": "RESPONSE_HANDLING"
         }

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_list_resources_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_list_resources_async.py
@@ -51,4 +51,5 @@ async def sample_list_resources():
     async for response in page_result:
         print(response)
 
+
 # [END mollusca_v1_generated_Snippets_ListResources_async]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_list_resources_sync.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_list_resources_sync.py
@@ -51,4 +51,5 @@ def sample_list_resources():
     for response in page_result:
         print(response)
 
+
 # [END mollusca_v1_generated_Snippets_ListResources_sync]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_bidi_streaming_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_bidi_streaming_async.py
@@ -60,4 +60,5 @@ async def sample_method_bidi_streaming():
     async for response in stream:
         print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodBidiStreaming_async]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_bidi_streaming_sync.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_bidi_streaming_sync.py
@@ -60,4 +60,5 @@ def sample_method_bidi_streaming():
     for response in stream:
         print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodBidiStreaming_sync]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_lro_signatures_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_lro_signatures_async.py
@@ -61,4 +61,5 @@ async def sample_method_lro_signatures():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodLroSignatures_async]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_lro_signatures_sync.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_lro_signatures_sync.py
@@ -61,4 +61,5 @@ def sample_method_lro_signatures():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodLroSignatures_sync]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_one_signature_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_one_signature_async.py
@@ -57,4 +57,5 @@ async def sample_method_one_signature():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodOneSignature_async]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_one_signature_sync.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_one_signature_sync.py
@@ -57,4 +57,5 @@ def sample_method_one_signature():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodOneSignature_sync]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_server_streaming_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_server_streaming_async.py
@@ -58,4 +58,5 @@ async def sample_method_server_streaming():
     async for response in stream:
         print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodServerStreaming_async]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_server_streaming_sync.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_method_server_streaming_sync.py
@@ -58,4 +58,5 @@ def sample_method_server_streaming():
     for response in stream:
         print(response)
 
+
 # [END mollusca_v1_generated_Snippets_MethodServerStreaming_sync]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_async.py
@@ -50,4 +50,5 @@ async def sample_one_of_method():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_OneOfMethod_async]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_required_field_async.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_required_field_async.py
@@ -50,4 +50,5 @@ async def sample_one_of_method_required_field():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_OneOfMethodRequiredField_async]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_required_field_sync.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_required_field_sync.py
@@ -50,4 +50,5 @@ def sample_one_of_method_required_field():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_OneOfMethodRequiredField_sync]

--- a/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_sync.py
+++ b/tests/snippetgen/goldens/mollusca_v1_generated_snippets_one_of_method_sync.py
@@ -50,4 +50,5 @@ def sample_one_of_method():
     # Handle the response
     print(response)
 
+
 # [END mollusca_v1_generated_Snippets_OneOfMethod_sync]

--- a/tests/unit/samplegen/golden_snippets/sample_basic.py
+++ b/tests/unit/samplegen/golden_snippets/sample_basic.py
@@ -58,4 +58,5 @@ def sample_classify(video, location):
     # Handle the response
     print(f"Mollusc is a \"{response.taxonomy}\"")
 
+
 # [END mollusc_classify_sync]

--- a/tests/unit/samplegen/golden_snippets/sample_basic_async.py
+++ b/tests/unit/samplegen/golden_snippets/sample_basic_async.py
@@ -58,4 +58,5 @@ async def sample_classify(video, location):
     # Handle the response
     print(f"Mollusc is a \"{response.taxonomy}\"")
 
+
 # [END mollusc_classify_sync]

--- a/tests/unit/samplegen/golden_snippets/sample_basic_internal.py
+++ b/tests/unit/samplegen/golden_snippets/sample_basic_internal.py
@@ -58,4 +58,5 @@ def sample_classify(video, location):
     # Handle the response
     print(f"Mollusc is a \"{response.taxonomy}\"")
 
+
 # [END mollusc_classify_sync_internal]

--- a/tests/unit/samplegen/golden_snippets/sample_basic_unflattenable.py
+++ b/tests/unit/samplegen/golden_snippets/sample_basic_unflattenable.py
@@ -58,4 +58,5 @@ def sample_classify(video, location):
     # Handle the response
     print(f"Mollusc is a \"{response.taxonomy}\"")
 
+
 # [END mollusc_classify_sync]

--- a/tests/unit/samplegen/test_samplegen.py
+++ b/tests/unit/samplegen/test_samplegen.py
@@ -2110,6 +2110,29 @@ def test_validate_request_non_terminal_primitive_field(dummy_api_schema):
         v.validate_and_transform_request(types.CallingForm.Request, request)
 
 
+class TestSamplegenRequest:
+    def setup_method(self):
+        self.dummy_api_schema = DummyApiSchema(
+            services={
+                "Mollusc": DummyService(
+                    client_name="MolluscClient",
+                )
+            },
+            naming=DummyNaming(),
+        )
+
+    def test_validate_request_bytes_value(self):
+        request_type = message_factory("mollusc.species_bytes")
+        v = samplegen.Validator(DummyMethod(input=request_type), self.dummy_api_schema)
+        _, attr_setup = v._normal_request_setup(
+            {},
+            b"bytes_value",
+            {"value": b"bytes_value", "field": "species_bytes"},
+            "species_bytes",
+        )
+        assert attr_setup.value == 'b"bytes_value"'
+
+
 def test_parse_invalid_handwritten_spec(fs):
     fpath = "sampledir/sample.yaml"
     fs.create_file(

--- a/tests/unit/samplegen/test_snippet_index.py
+++ b/tests/unit/samplegen/test_snippet_index.py
@@ -52,6 +52,7 @@ def sample_classify(video, location):
     # Handle the response
     print(f"Mollusc is a \"{response.taxonomy}\"")
 
+
 # [END mollusc_classify_sync]"""
 
 
@@ -69,12 +70,12 @@ def test_snippet_init(sample_str):
         "language": "PYTHON",
         "title": "classify_squid.py",
         "segments": [
-            {"end": 28, "start": 2, "type": "FULL"},
-            {"end": 28, "start": 2, "type": "SHORT"},
+            {"end": 29, "start": 2, "type": "FULL"},
+            {"end": 29, "start": 2, "type": "SHORT"},
             {"end": 8, "start": 6, "type": "CLIENT_INITIALIZATION"},
             {"end": 22, "start": 9, "type": "REQUEST_INITIALIZATION"},
             {"end": 25, "start": 23, "type": "REQUEST_EXECUTION"},
-            {"end": 29, "start": 26, "type": "RESPONSE_HANDLING"},
+            {"end": 30, "start": 26, "type": "RESPONSE_HANDLING"},
         ],
     }
 
@@ -106,6 +107,7 @@ def sample_classify(video, location):
 
     # Handle the response
     print(f"Mollusc is a \"{response.taxonomy}\"")
+
 
 """
 
@@ -278,12 +280,12 @@ def test_get_metadata_json(sample_str):
                     }
                 },
                 "segments": [
-                    {"end": 28, "start": 2, "type": "FULL"},
-                    {"end": 28, "start": 2, "type": "SHORT"},
+                    {"end": 29, "start": 2, "type": "FULL"},
+                    {"end": 29, "start": 2, "type": "SHORT"},
                     {"end": 8, "start": 6, "type": "CLIENT_INITIALIZATION"},
                     {"end": 22, "start": 9, "type": "REQUEST_INITIALIZATION"},
                     {"end": 25, "start": 23, "type": "REQUEST_EXECUTION"},
-                    {"end": 29, "start": 26, "type": "RESPONSE_HANDLING"},
+                    {"end": 30, "start": 26, "type": "RESPONSE_HANDLING"},
                 ],
             }
         ],


### PR DESCRIPTION
This PR depends on https://github.com/googleapis/gapic-generator-python/pull/2497. Similar to https://github.com/googleapis/gapic-generator-python/pull/2497, we're removing code formatting for the `samples` directory while keeping the code formatting verification via the `lint` session.