### PR TITLE
chore: specify verify_format=False when running pypandoc

### DIFF
--- a/gapic/utils/rst.py
+++ b/gapic/utils/rst.py
@@ -61,6 +61,7 @@ def rst(
                 text,
                 "rst",
                 format=source_format,
+                verify_format=False,
                 extra_args=["--columns=%d" % (width - indent)],
             )
             .strip()


### PR DESCRIPTION
Without this, *every* call to pypandoc.convert_text starts pandoc three times: once to list the input formats, once to list the output formats, and once to actually perform the conversion.

With `verify_format=False`, the first two invocations are skipped. For some APIs this can make a huge difference to the speed of generation (listerally about 45% in one test I've performed). We shouldn't need to verify that the formats are supported, as we always use commonmark and rst.

Fixes #2503.
