### PR TITLE
chore: librarian release pull request: 20251211T164150Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:4e3486fee9eba44b75a18c67f0c60fa0c4af675132305e3ff3fae2e9b94f94bb
 libraries:
   - id: gapic-generator
-    version: 1.30.0
+    version: 1.30.1
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.30.1](https://github.com/googleapis/google-cloud-python/compare/gapic-generator-v1.30.0...gapic-generator-v1.30.1) (2025-12-11)
+
 ## [1.30.0](https://github.com/googleapis/gapic-generator-python/compare/v1.29.0...v1.30.0) (2025-11-14)
 
 ### Features

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/gapic-generator-python"
-version = "1.30.0"
+version = "1.30.1"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:4e3486fee9eba44b75a18c67f0c60fa0c4af675132305e3ff3fae2e9b94f94bb
<details><summary>gapic-generator: 1.30.1</summary>

## [1.30.1](https://github.com/googleapis/gapic-generator-python/compare/v1.30.0...v1.30.1) (2025-12-11)

</details>