### PR TITLE
fix: revert changes to code formatting in 1.30.1

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -16,21 +16,14 @@ BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
 {% if api.naming.module_namespace %}
-FORMAT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "setup.py"]
 LINT_PATHS = ["docs", "{{ api.naming.module_namespace[0] }}", "tests", "noxfile.py", "setup.py"]
 {% else %}
-FORMAT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "setup.py"]
 LINT_PATHS = ["docs", "{{ api.naming.versioned_module_name }}", "tests", "noxfile.py", "setup.py"]
 {% endif %}
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -159,7 +152,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
 {% if api.naming.module_namespace %}
@@ -175,8 +167,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -192,12 +183,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -214,7 +204,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -245,15 +236,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -316,7 +304,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -393,10 +383,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -464,12 +452,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -480,7 +463,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -492,8 +479,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -564,7 +556,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -576,8 +572,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -26,17 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -161,7 +155,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
     session.run("flake8", "google", "tests")
@@ -173,8 +166,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -190,12 +182,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -212,7 +203,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -243,15 +235,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -309,7 +298,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,10 +377,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -457,12 +446,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -473,7 +457,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -485,8 +473,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -557,7 +550,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -569,8 +566,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -26,17 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -161,7 +155,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
     session.run("flake8", "google", "tests")
@@ -173,8 +166,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -190,12 +182,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -212,7 +203,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -243,15 +235,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -309,7 +298,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,10 +377,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -457,12 +446,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -473,7 +457,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -485,8 +473,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -557,7 +550,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -569,8 +566,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -26,17 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -161,7 +155,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
     session.run("flake8", "google", "tests")
@@ -173,8 +166,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -190,12 +182,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -212,7 +203,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -243,15 +235,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -309,7 +298,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,10 +377,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -457,12 +446,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -473,7 +457,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -485,8 +473,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -557,7 +550,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -569,8 +566,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -26,17 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -161,7 +155,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
     session.run("flake8", "google", "tests")
@@ -173,8 +166,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -190,12 +182,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -212,7 +203,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -243,15 +235,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -309,7 +298,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,10 +377,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -457,12 +446,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -473,7 +457,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -485,8 +473,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -557,7 +550,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -569,8 +566,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/tests/integration/goldens/logging_internal/noxfile.py
+++ b/tests/integration/goldens/logging_internal/noxfile.py
@@ -26,17 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -161,7 +155,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
     session.run("flake8", "google", "tests")
@@ -173,8 +166,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -190,12 +182,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -212,7 +203,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -243,15 +235,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -309,7 +298,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,10 +377,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -457,12 +446,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -473,7 +457,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -485,8 +473,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -557,7 +550,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -569,8 +566,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -26,17 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -161,7 +155,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
     session.run("flake8", "google", "tests")
@@ -173,8 +166,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -190,12 +182,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -212,7 +203,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -243,15 +235,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -309,7 +298,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,10 +377,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -457,12 +446,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -473,7 +457,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -485,8 +473,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -557,7 +550,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -569,8 +566,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)

--- a/tests/integration/goldens/redis_selective/noxfile.py
+++ b/tests/integration/goldens/redis_selective/noxfile.py
@@ -26,17 +26,11 @@ import nox
 BLACK_VERSION = "black[jupyter]==23.7.0"
 ISORT_VERSION = "isort==5.11.0"
 
-FORMAT_PATHS = ["docs", "google", "tests", "setup.py"]
 LINT_PATHS = ["docs", "google", "tests", "noxfile.py", "setup.py"]
-
-# We're most interested in ensuring that code is formatted properly
-# and less concerned about the line length.
-LINT_LINE_LENGTH = 150
 
 # Add samples to the list of directories to format if the directory exists.
 if os.path.isdir("samples"):
     LINT_PATHS.append("samples")
-    FORMAT_PATHS.append("samples")
 
 ALL_PYTHON = [
     "3.7",
@@ -161,7 +155,6 @@ def lint(session):
         "black",
         "--check",
         *LINT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
     )
 
     session.run("flake8", "google", "tests")
@@ -173,8 +166,7 @@ def blacken(session):
     session.install(BLACK_VERSION)
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -190,12 +182,11 @@ def format(session):
     session.run(
         "isort",
         "--fss",
-        *FORMAT_PATHS,
+        *LINT_PATHS,
     )
     session.run(
         "black",
-        *FORMAT_PATHS,
-        f"--line-length={LINT_LINE_LENGTH}",
+        *LINT_PATHS,
     )
 
 
@@ -212,7 +203,8 @@ def install_unittest_dependencies(session, *constraints):
 
     if UNIT_TEST_EXTERNAL_DEPENDENCIES:
         warnings.warn(
-            "'unit_test_external_dependencies' is deprecated. Instead, please use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
+            "'unit_test_external_dependencies' is deprecated. Instead, please "
+            "use 'unit_test_dependencies' or 'unit_test_local_dependencies'.",
             DeprecationWarning,
         )
         session.install(*UNIT_TEST_EXTERNAL_DEPENDENCIES, *constraints)
@@ -243,15 +235,12 @@ def unit(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     install_unittest_dependencies(session, "-c", constraints_path)
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
@@ -309,7 +298,9 @@ def install_systemtest_dependencies(session, *constraints):
 @nox.session(python=SYSTEM_TEST_PYTHON_VERSIONS)
 def system(session):
     """Run the system test suite."""
-    constraints_path = str(CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt")
+    constraints_path = str(
+        CURRENT_DIRECTORY / "testing" / f"constraints-{session.python}.txt"
+    )
     system_test_path = os.path.join("tests", "system.py")
     system_test_folder_path = os.path.join("tests", "system")
 
@@ -386,10 +377,8 @@ def docs(session):
         "-W",  # warnings as errors
         "-T",  # show full traceback on exception
         "-N",  # no colors
-        "-b",  # builder
-        "html",
-        "-d",  # cache directory
-        os.path.join("docs", "_build", "doctrees", ""),
+        "-b",  "html",  # builder
+        "-d",  os.path.join("docs", "_build", "doctrees", ""),  # cache directory
         # paths to build:
         os.path.join("docs", ""),
         os.path.join("docs", "_build", "html", ""),
@@ -457,12 +446,7 @@ def prerelease_deps(session, protobuf_implementation):
 
     # TODO(https://github.com/googleapis/gapic-generator-python/issues/2388):
     # Remove this check once support for Protobuf 3.x is dropped.
-    if protobuf_implementation == "cpp" and session.python in (
-        "3.11",
-        "3.12",
-        "3.13",
-        "3.14",
-    ):
+    if protobuf_implementation == "cpp" and session.python in ("3.11", "3.12", "3.13", "3.14"):
         session.skip("cpp implementation is not supported in python 3.11+")
 
     # Install all dependencies
@@ -473,7 +457,11 @@ def prerelease_deps(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -485,8 +473,13 @@ def prerelease_deps(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)
@@ -557,7 +550,11 @@ def core_deps_from_source(session, protobuf_implementation):
     session.install(*unit_deps_all)
 
     # Install dependencies for the system test environment
-    system_deps_all = SYSTEM_TEST_STANDARD_DEPENDENCIES + SYSTEM_TEST_EXTERNAL_DEPENDENCIES + SYSTEM_TEST_EXTRAS
+    system_deps_all = (
+        SYSTEM_TEST_STANDARD_DEPENDENCIES
+        + SYSTEM_TEST_EXTERNAL_DEPENDENCIES
+        + SYSTEM_TEST_EXTRAS
+    )
     session.install(*system_deps_all)
 
     # Because we test minimum dependency versions on the minimum Python
@@ -569,8 +566,13 @@ def core_deps_from_source(session, protobuf_implementation):
     ) as constraints_file:
         constraints_text = constraints_file.read()
 
-    # Ignore leading spaces and comment lines.
-    constraints_deps = [match.group(1) for match in re.finditer(r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE)]
+    # Ignore leading whitespace and comment lines.
+    constraints_deps = [
+        match.group(1)
+        for match in re.finditer(
+            r"^\s*(\S+)(?===\S+)", constraints_text, flags=re.MULTILINE
+        )
+    ]
 
     # Install dependencies specified in `testing/constraints-X.txt`.
     session.install(*constraints_deps)


### PR DESCRIPTION
Reverts googleapis/gapic-generator-python#2491

This is causing the lint check to fail downstream in google-cloud-python. See the failures in https://github.com/googleapis/google-cloud-python/pull/14968