### PR TITLE
chore: librarian release pull request: 20251215T231730Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
 libraries:
   - id: gapic-generator
-    version: 1.30.1
+    version: 1.30.2
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.30.2](https://github.com/googleapis/gapic-generator-python/compare/v1.30.1...v1.30.2) (2025-12-15)
+
+
+### Bug Fixes
+
+* revert changes to code formatting in 1.30.1 (#2511) ([1327d4762b02dfd47ddf7f2014f4ab7503d3963d](https://github.com/googleapis/gapic-generator-python/commit/1327d4762b02dfd47ddf7f2014f4ab7503d3963d))
+
 ## [1.30.1](https://github.com/googleapis/gapic-generator-python/compare/v1.30.0...v1.30.1) (2025-12-12)
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/gapic-generator-python"
-version = "1.30.1"
+version = "1.30.2"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
<details><summary>gapic-generator: 1.30.2</summary>

## [1.30.2](https://github.com/googleapis/gapic-generator-python/compare/v1.30.1...v1.30.2) (2025-12-15)

### Bug Fixes

* revert changes to code formatting in 1.30.1 (#2511) ([1327d476](https://github.com/googleapis/gapic-generator-python/commit/1327d476))

</details>