### PR TITLE
fix: add cyrptography package to prerelease tests

### DIFF
--- a/gapic/templates/noxfile.py.j2
+++ b/gapic/templates/noxfile.py.j2
@@ -529,6 +529,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -601,6 +604,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",

--- a/tests/integration/goldens/asset/noxfile.py
+++ b/tests/integration/goldens/asset/noxfile.py
@@ -523,6 +523,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -595,6 +598,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",

--- a/tests/integration/goldens/credentials/noxfile.py
+++ b/tests/integration/goldens/credentials/noxfile.py
@@ -523,6 +523,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -595,6 +598,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",

--- a/tests/integration/goldens/eventarc/noxfile.py
+++ b/tests/integration/goldens/eventarc/noxfile.py
@@ -523,6 +523,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -595,6 +598,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",

--- a/tests/integration/goldens/logging/noxfile.py
+++ b/tests/integration/goldens/logging/noxfile.py
@@ -523,6 +523,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -595,6 +598,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",

--- a/tests/integration/goldens/logging_internal/noxfile.py
+++ b/tests/integration/goldens/logging_internal/noxfile.py
@@ -523,6 +523,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -595,6 +598,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",

--- a/tests/integration/goldens/redis/noxfile.py
+++ b/tests/integration/goldens/redis/noxfile.py
@@ -523,6 +523,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -595,6 +598,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",

--- a/tests/integration/goldens/redis_selective/noxfile.py
+++ b/tests/integration/goldens/redis_selective/noxfile.py
@@ -523,6 +523,9 @@ def prerelease_deps(session, protobuf_implementation):
                 f"import {version_namespace}; print({version_namespace}.__version__)",
             )
 
+    # Required by google-auth v3.x
+    session.install("cryptography")
+
     session.run(
         "py.test",
         "tests/unit",
@@ -595,6 +598,9 @@ def core_deps_from_source(session, protobuf_implementation):
     for dep in core_dependencies_from_source:
         session.install(dep, "--no-deps", "--ignore-installed")
         print(f"Installed {dep}")
+
+    # Required by google-auth v3.x
+    session.install("cryptography")
 
     session.run(
         "py.test",


### PR DESCRIPTION
Cryptography is a required dependency of `google-auth` 3.x pre-release and needs to be added to the pre-release tests since we install dependencies with `--no-deps`.

https://github.com/googleapis/gapic-generator-python/blob/d20dd2876fbf8c35f6a994639864815b0d7608ab/gapic/templates/noxfile.py.j2#L508

The reason for using `--no-deps` is to ensure that a pre-release version of a package is not downgraded.