### PR TITLE
fix: prevent URL-encoding of $alt query parameter in REST transport

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/_shared_macros.j2
@@ -171,16 +171,23 @@ def _get_http_options():
     timeout,
     transcoded_request,
     body=None):
-    
+
     uri = transcoded_request['uri']
     method = transcoded_request['method']
     headers = dict(metadata)
     headers['Content-Type'] = 'application/json'
+    # Build query string manually to avoid URL-encoding special characters like '$'.
+    # The `requests` library encodes '$' as '%24' when using the `params` argument,
+    # which causes API errors for parameters like '$alt'. See:
+    # https://github.com/googleapis/gapic-generator-python/issues/2514
+    _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+    _request_url = "{host}{uri}".format(host=host, uri=uri)
+    if _query_params:
+        _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
     response = {{ await_prefix }}getattr(session, method)(
-        "{host}{uri}".format(host=host, uri=uri),
+        _request_url,
         timeout=timeout,
         headers=headers,
-        params=rest_helpers.flatten_query_params(query_params, strict=True),
         {% if body_spec %}
         data=body,
         {% endif %}

--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/rest.py.j2
@@ -33,10 +33,12 @@ from google.iam.v1 import policy_pb2  # type: ignore
 from google.cloud.location import locations_pb2 # type: ignore
 {% endif %}
 
-from requests import __version__ as requests_version
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
 import warnings
+
+from requests import __version__ as requests_version
 
 {{ shared_macros.operations_mixin_imports(api, service, opts) }}
 

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/_test_mixins.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/_test_mixins.py.j2
@@ -997,3 +997,346 @@ def test_test_iam_permissions_from_dict():
 {% endif %}
 
 {% endif %}
+
+{# REST transport tests for mixin URL query params encoding #}
+{% if 'rest' in opts.transport %}
+
+{# Operations mixin REST URL encoding tests #}
+{% if api.has_operations_mixin %}
+
+{% if "ListOperations" in api.mixin_api_methods %}
+def test_list_operations_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for mixin methods.
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetOperation" in api.mixin_api_methods %}
+def test_get_operation_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "DeleteOperation" in api.mixin_api_methods %}
+def test_delete_operation_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "CancelOperation" in api.mixin_api_methods %}
+def test_cancel_operation_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# operations_mixin #}
+
+{# Location mixin REST URL encoding tests #}
+{% if api.has_location_mixin %}
+
+{% if "ListLocations" in api.mixin_api_methods %}
+def test_list_locations_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetLocation" in api.mixin_api_methods %}
+def test_get_location_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# location_mixin #}
+
+{# IAM mixin REST URL encoding tests #}
+{% if api.has_iam_mixin or opts.add_iam_methods %}
+
+{% if "SetIamPolicy" in api.mixin_api_methods or opts.add_iam_methods %}
+def test_set_iam_policy_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.set_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:setIamPolicy',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetIamPolicy" in api.mixin_api_methods or opts.add_iam_methods %}
+def test_get_iam_policy_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:getIamPolicy',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "TestIamPermissions" in api.mixin_api_methods or opts.add_iam_methods %}
+def test_test_iam_permissions_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.test_iam_permissions.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:testIamPermissions',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# iam_mixin #}
+
+{% endif %} {# rest transport #}

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1060,6 +1060,53 @@ def test_{{ method_name }}_raw_page_lro():
 {% for method in service.methods.values() if 'rest' in opts.transport %}{% with method_name = method.name|snake_case + "_unary" if method.operation_service else method.client_method_name|snake_case %}{% if method.http_options %}
 {# TODO(kbandes): remove this if condition when client streaming are supported. #}
 {% if not method.client_streaming %}
+
+def test_{{ method_name }}_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.{{ method.transport_safe_name|snake_case }}.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': '{{ method.http_options[0].method }}',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, '{{ method.http_options[0].method }}')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 @pytest.mark.parametrize("request_type", [
   {{ method.input.ident }},
   dict,
@@ -1469,52 +1516,6 @@ def test_{{ method_name }}_rest_unset_required_fields():
     assert set(unset_fields) == (set(({% for param in method.query_params|sort %}"{{ param|camel_case }}", {% endfor %})) & set(({% for param in method.input.required_fields %}"{{param.name|camel_case}}", {% endfor %})))
 
     {% endif %}{# required_fields #}
-
-
-def test_{{ method_name }}_rest_url_query_params_encoding():
-    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
-    # when building the URL query string. This tests the urlencode call with safe="$".
-    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials)
-    method_class = transport.{{ method.transport_safe_name|snake_case }}.__class__
-    # Get the _get_response static method from the method class
-    get_response_fn = method_class._get_response
-
-    mock_session = mock.Mock()
-    mock_response = mock.Mock()
-    mock_response.status_code = 200
-    mock_session.get.return_value = mock_response
-    mock_session.post.return_value = mock_response
-    mock_session.put.return_value = mock_response
-    mock_session.patch.return_value = mock_response
-    mock_session.delete.return_value = mock_response
-
-    # Mock flatten_query_params to return query params that include '$' character
-    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
-        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
-
-        transcoded_request = {
-            'uri': '/v1/test',
-            'method': '{{ method.http_options[0].method }}',
-        }
-
-        get_response_fn(
-            host='https://example.com',
-            metadata=[],
-            query_params={},
-            session=mock_session,
-            timeout=None,
-            transcoded_request=transcoded_request,
-        )
-
-        # Verify the session method was called with the URL containing query params
-        session_method = getattr(mock_session, '{{ method.http_options[0].method }}')
-        assert session_method.called
-
-        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
-        call_url = session_method.call_args.args[0]
-        assert '$alt=json' in call_url
-        assert '%24alt' not in call_url
-        assert 'foo=bar' in call_url
 
 
 {% if not method.client_streaming %}

--- a/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/ads-templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -18,6 +18,8 @@ import grpc
 from grpc.experimental import aio
 {% if "rest" in opts.transport %}
 from collections.abc import Iterable
+import urllib.parse
+
 from google.protobuf import json_format
 import json
 {% endif %}
@@ -45,6 +47,7 @@ from google.api_core import client_options
 from google.api_core import exceptions as core_exceptions
 from google.api_core import grpc_helpers
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 {% if service.has_lro %}
 from google.api_core import future
@@ -1451,8 +1454,12 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                 ('$alt', 'json;enum-encoding=int')
               {% endif %}
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_{{ method_name }}_rest_unset_required_fields():
@@ -1461,8 +1468,54 @@ def test_{{ method_name }}_rest_unset_required_fields():
     unset_fields = transport.{{ method.transport_safe_name|snake_case }}._get_unset_required_fields({})
     assert set(unset_fields) == (set(({% for param in method.query_params|sort %}"{{ param|camel_case }}", {% endfor %})) & set(({% for param in method.input.required_fields %}"{{param.name|camel_case}}", {% endfor %})))
 
-
     {% endif %}{# required_fields #}
+
+
+def test_{{ method_name }}_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.{{ method.transport_safe_name|snake_case }}.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': '{{ method.http_options[0].method }}',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, '{{ method.http_options[0].method }}')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
 
 {% if not method.client_streaming %}
 @pytest.mark.parametrize("null_interceptor", [True, False])

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/_shared_macros.j2
@@ -164,16 +164,23 @@ def _get_http_options():
     timeout,
     transcoded_request,
     body=None):
-    
+
     uri = transcoded_request['uri']
     method = transcoded_request['method']
     headers = dict(metadata)
     headers['Content-Type'] = 'application/json'
+    # Build query string manually to avoid URL-encoding special characters like '$'.
+    # The `requests` library encodes '$' as '%24' when using the `params` argument,
+    # which causes API errors for parameters like '$alt'. See:
+    # https://github.com/googleapis/gapic-generator-python/issues/2514
+    _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+    _request_url = "{host}{uri}".format(host=host, uri=uri)
+    if _query_params:
+        _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
     response = {{ await_prefix }}getattr(session, method)(
-        "{host}{uri}".format(host=host, uri=uri),
+        _request_url,
         timeout=timeout,
         headers=headers,
-        params=rest_helpers.flatten_query_params(query_params, strict=True),
         {% if body_spec %}
         data=body,
         {% endif %}

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest.py.j2
@@ -27,10 +27,12 @@ from google.iam.v1 import policy_pb2  # type: ignore
 from google.cloud.location import locations_pb2 # type: ignore
 {% endif %}
 
-from requests import __version__ as requests_version
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
 import warnings
+
+from requests import __version__ as requests_version
 
 {{ shared_macros.operations_mixin_imports(api, service, opts) }}
 

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/rest_asyncio.py.j2
@@ -48,9 +48,10 @@ from google.iam.v1 import policy_pb2  # type: ignore
 from google.cloud.location import locations_pb2 # type: ignore
 {% endif %}
 
-import json  # type: ignore
 import dataclasses
+import json  # type: ignore
 from typing import Any, Dict, List, Callable, Tuple, Optional, Sequence, Union
+from urllib.parse import urlencode
 
 {{ shared_macros.operations_mixin_imports(api, service, opts) }}
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/_test_mixins.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/_test_mixins.py.j2
@@ -2171,4 +2171,369 @@ def test_test_iam_permissions_rest_url_query_params_encoding():
 
 {% endif %} {# iam_mixin #}
 
+{% if rest_async_io_enabled %}
+{# Async REST URL encoding tests for mixin methods #}
+
+{% if api.has_operations_mixin %}
+
+{% if "ListOperations" in api.mixin_api_methods %}
+@pytest.mark.asyncio
+async def test_list_operations_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetOperation" in api.mixin_api_methods %}
+@pytest.mark.asyncio
+async def test_get_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "DeleteOperation" in api.mixin_api_methods %}
+@pytest.mark.asyncio
+async def test_delete_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "CancelOperation" in api.mixin_api_methods %}
+@pytest.mark.asyncio
+async def test_cancel_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# operations_mixin #}
+
+{% if api.has_location_mixin %}
+
+{% if "ListLocations" in api.mixin_api_methods %}
+@pytest.mark.asyncio
+async def test_list_locations_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetLocation" in api.mixin_api_methods %}
+@pytest.mark.asyncio
+async def test_get_location_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# location_mixin #}
+
+{% if api.has_iam_mixin or opts.add_iam_methods %}
+
+{% if "SetIamPolicy" in api.mixin_api_methods or opts.add_iam_methods %}
+@pytest.mark.asyncio
+async def test_set_iam_policy_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.set_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:setIamPolicy',
+            'method': 'post',
+            'body': {},
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetIamPolicy" in api.mixin_api_methods or opts.add_iam_methods %}
+@pytest.mark.asyncio
+async def test_get_iam_policy_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:getIamPolicy',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "TestIamPermissions" in api.mixin_api_methods or opts.add_iam_methods %}
+@pytest.mark.asyncio
+async def test_test_iam_permissions_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.test_iam_permissions.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:testIamPermissions',
+            'method': 'post',
+            'body': {},
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# iam_mixin #}
+
+{% endif %} {# rest_async_io_enabled #}
+
 {% endif %} {# rest transport #}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/_test_mixins.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/_test_mixins.py.j2
@@ -1829,3 +1829,346 @@ async def test_test_iam_permissions_from_dict_async():
         call.assert_called()
 {% endif %}
 {% endif %}
+
+{# REST transport tests for mixin URL query params encoding #}
+{% if 'rest' in opts.transport %}
+
+{# Operations mixin REST URL encoding tests #}
+{% if api.has_operations_mixin %}
+
+{% if "ListOperations" in api.mixin_api_methods %}
+def test_list_operations_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for mixin methods.
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetOperation" in api.mixin_api_methods %}
+def test_get_operation_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "DeleteOperation" in api.mixin_api_methods %}
+def test_delete_operation_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "CancelOperation" in api.mixin_api_methods %}
+def test_cancel_operation_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# operations_mixin #}
+
+{# Location mixin REST URL encoding tests #}
+{% if api.has_location_mixin %}
+
+{% if "ListLocations" in api.mixin_api_methods %}
+def test_list_locations_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetLocation" in api.mixin_api_methods %}
+def test_get_location_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# location_mixin #}
+
+{# IAM mixin REST URL encoding tests #}
+{% if api.has_iam_mixin or opts.add_iam_methods %}
+
+{% if "SetIamPolicy" in api.mixin_api_methods or opts.add_iam_methods %}
+def test_set_iam_policy_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.set_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:setIamPolicy',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "GetIamPolicy" in api.mixin_api_methods or opts.add_iam_methods %}
+def test_get_iam_policy_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:getIamPolicy',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% if "TestIamPermissions" in api.mixin_api_methods or opts.add_iam_methods %}
+def test_test_iam_permissions_rest_url_query_params_encoding():
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.test_iam_permissions.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:testIamPermissions',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+{% endif %}
+
+{% endif %} {# iam_mixin #}
+
+{% endif %} {# rest transport #}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -1118,10 +1118,10 @@ def test_{{ service.client_name|snake_case }}_create_channel_credentials_file(cl
 
 {% for method in service.methods.values() if 'rest' in opts.transport %}
 {% if method.extended_lro %}
-{{ test_macros.rest_required_tests(method, service, numeric_enums=opts.rest_numeric_enums, full_extended_lro=True) }}
+{{ test_macros.rest_required_tests(method, service, numeric_enums=opts.rest_numeric_enums, full_extended_lro=True, rest_async_io_enabled=rest_async_io_enabled) }}
 
 {% endif %}
-{{ test_macros.rest_required_tests(method, service, numeric_enums=opts.rest_numeric_enums) }}
+{{ test_macros.rest_required_tests(method, service, numeric_enums=opts.rest_numeric_enums, rest_async_io_enabled=rest_async_io_enabled) }}
 
 {% endfor -%} {#- method in methods for rest #}
 

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_%service.py.j2
@@ -21,6 +21,8 @@ import grpc
 from grpc.experimental import aio
 {% if "rest" in opts.transport %}
 from collections.abc import Iterable, AsyncIterable
+import urllib.parse
+
 from google.protobuf import json_format
 {% endif %}
 import json
@@ -72,6 +74,7 @@ from google.api_core import exceptions as core_exceptions
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 {% if service.has_lro or service.has_extended_lro %}
 from google.api_core import future

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1004,6 +1004,53 @@ def test_{{ method_name }}_raw_page_lro():
 {% with method_name = method.client_method_name|snake_case + "_unary" if method.extended_lro and not full_extended_lro else method.client_method_name|snake_case, method_output = method.extended_lro.operation_type if method.extended_lro and not full_extended_lro else method.output %}{% if method.http_options %}
 {# TODO(kbandes): remove this if condition when lro and client streaming are supported. #}
 {% if not method.client_streaming %}
+
+def test_{{ method_name }}_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.{{ method.transport_safe_name|snake_case }}.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': '{{ method.http_options[0].method }}',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, '{{ method.http_options[0].method }}')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_{{ method_name }}_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -1215,52 +1262,6 @@ def test_{{ method_name }}_rest_unset_required_fields():
     assert set(unset_fields) == (set(({% for param in method.query_params|sort %}"{{ param|camel_case }}", {% endfor %})) & set(({% for param in method.input.required_fields %}"{{ param.name|camel_case }}", {% endfor %})))
 
     {% endif %}{# required_fields #}
-
-
-def test_{{ method_name }}_rest_url_query_params_encoding():
-    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
-    # when building the URL query string. This tests the urlencode call with safe="$".
-    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials)
-    method_class = transport.{{ method.transport_safe_name|snake_case }}.__class__
-    # Get the _get_response static method from the method class
-    get_response_fn = method_class._get_response
-
-    mock_session = mock.Mock()
-    mock_response = mock.Mock()
-    mock_response.status_code = 200
-    mock_session.get.return_value = mock_response
-    mock_session.post.return_value = mock_response
-    mock_session.put.return_value = mock_response
-    mock_session.patch.return_value = mock_response
-    mock_session.delete.return_value = mock_response
-
-    # Mock flatten_query_params to return query params that include '$' character
-    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
-        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
-
-        transcoded_request = {
-            'uri': '/v1/test',
-            'method': '{{ method.http_options[0].method }}',
-        }
-
-        get_response_fn(
-            host='https://example.com',
-            metadata=[],
-            query_params={},
-            session=mock_session,
-            timeout=None,
-            transcoded_request=transcoded_request,
-        )
-
-        # Verify the session method was called with the URL containing query params
-        session_method = getattr(mock_session, '{{ method.http_options[0].method }}')
-        assert session_method.called
-
-        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
-        call_url = session_method.call_args.args[0]
-        assert '$alt=json' in call_url
-        assert '%24alt' not in call_url
-        assert 'foo=bar' in call_url
 
 
 {% if method.flattened_fields and not method.client_streaming %}

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1000,7 +1000,7 @@ def test_{{ method_name }}_raw_page_lro():
 {% endif %}{# method.paged_result_field #}{% endwith %}
 {% endmacro %}
 
-{% macro rest_required_tests(method, service, numeric_enums=False, full_extended_lro=False) %}
+{% macro rest_required_tests(method, service, numeric_enums=False, full_extended_lro=False, rest_async_io_enabled=False) %}
 {% with method_name = method.client_method_name|snake_case + "_unary" if method.extended_lro and not full_extended_lro else method.client_method_name|snake_case, method_output = method.extended_lro.operation_type if method.extended_lro and not full_extended_lro else method.output %}{% if method.http_options %}
 {# TODO(kbandes): remove this if condition when lro and client streaming are supported. #}
 {% if not method.client_streaming %}
@@ -1050,6 +1050,53 @@ def test_{{ method_name }}_rest_url_query_params_encoding():
         assert '%24alt' not in call_url
         assert 'foo=bar' in call_url
 
+{% if rest_async_io_enabled %}
+
+@pytest.mark.asyncio
+async def test_{{ method_name }}_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.Async{{ service.name }}RestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.{{ method.transport_safe_name|snake_case }}.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': '{{ method.http_options[0].method }}',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, '{{ method.http_options[0].method }}')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+{% endif %}{# if rest_async_io_enabled #}
 
 def test_{{ method_name }}_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,

--- a/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
+++ b/gapic/templates/tests/unit/gapic/%name_%version/%sub/test_macros.j2
@@ -1200,8 +1200,12 @@ def test_{{ method_name }}_rest_required_fields(request_type={{ method.input.ide
                 ('$alt', 'json;enum-encoding=int')
               {% endif %}
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_{{ method_name }}_rest_unset_required_fields():
@@ -1211,6 +1215,52 @@ def test_{{ method_name }}_rest_unset_required_fields():
     assert set(unset_fields) == (set(({% for param in method.query_params|sort %}"{{ param|camel_case }}", {% endfor %})) & set(({% for param in method.input.required_fields %}"{{ param.name|camel_case }}", {% endfor %})))
 
     {% endif %}{# required_fields #}
+
+
+def test_{{ method_name }}_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.{{ service.rest_transport_name }}(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.{{ method.transport_safe_name|snake_case }}.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': '{{ method.http_options[0].method }}',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, '{{ method.http_options[0].method }}')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 {% if method.flattened_fields and not method.client_streaming %}

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/rest.py
@@ -28,10 +28,12 @@ import google.protobuf
 from google.protobuf import json_format
 from google.api_core import operations_v1
 
-from requests import __version__ as requests_version
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
 import warnings
+
+from requests import __version__ as requests_version
 
 
 from google.cloud.asset_v1.types import asset_service
@@ -1194,11 +1196,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1316,11 +1325,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1441,11 +1457,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1563,11 +1586,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1685,11 +1715,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1808,11 +1845,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1931,11 +1975,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2050,11 +2101,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2173,11 +2231,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2303,11 +2368,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2427,11 +2499,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2512,11 +2591,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2597,11 +2683,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2720,11 +2813,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2847,11 +2947,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2968,11 +3075,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3087,11 +3201,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3206,11 +3327,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3325,11 +3453,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -3447,11 +3582,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3566,11 +3708,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3685,11 +3834,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -3815,11 +3971,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -4127,11 +4290,18 @@ class AssetServiceRestTransport(_BaseAssetServiceRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/rest.py
@@ -27,10 +27,12 @@ import google.protobuf
 
 from google.protobuf import json_format
 
-from requests import __version__ as requests_version
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
 import warnings
+
+from requests import __version__ as requests_version
 
 
 from google.iam.credentials_v1.types import common
@@ -375,11 +377,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -497,11 +506,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -619,11 +635,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -741,11 +764,18 @@ class IAMCredentialsRestTransport(_BaseIAMCredentialsRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/rest.py
@@ -31,10 +31,12 @@ from google.iam.v1 import iam_policy_pb2  # type: ignore
 from google.iam.v1 import policy_pb2  # type: ignore
 from google.cloud.location import locations_pb2 # type: ignore
 
-from requests import __version__ as requests_version
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
 import warnings
+
+from requests import __version__ as requests_version
 
 
 from google.cloud.eventarc_v1.types import channel
@@ -1235,11 +1237,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1359,11 +1368,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1483,11 +1499,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1607,11 +1630,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1728,11 +1758,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1849,11 +1886,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1970,11 +2014,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2098,11 +2149,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2225,11 +2283,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2353,11 +2418,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2475,11 +2547,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2597,11 +2676,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2719,11 +2805,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2839,11 +2932,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2959,11 +3059,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3079,11 +3186,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -3203,11 +3317,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -3335,11 +3456,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -3607,11 +3735,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3725,11 +3860,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3843,11 +3985,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3961,11 +4110,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -4082,11 +4238,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -4203,11 +4366,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -4298,11 +4468,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -4390,11 +4567,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -4508,11 +4692,18 @@ class EventarcRestTransport(_BaseEventarcRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 

--- a/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
+++ b/tests/integration/goldens/eventarc/tests/unit/gapic/eventarc_v1/test_eventarc.py
@@ -24,6 +24,8 @@ except ImportError:  # pragma: NO COVER
 import grpc
 from grpc.experimental import aio
 from collections.abc import Iterable, AsyncIterable
+import urllib.parse
+
 from google.protobuf import json_format
 import json
 import math
@@ -52,6 +54,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
@@ -7592,6 +7595,52 @@ async def test_update_google_channel_config_flattened_error_async():
         )
 
 
+def test_get_trigger_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_trigger.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_get_trigger_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -7693,8 +7742,12 @@ def test_get_trigger_rest_required_fields(request_type=eventarc.GetTriggerReques
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_trigger_rest_unset_required_fields():
@@ -7756,6 +7809,52 @@ def test_get_trigger_rest_flattened_error(transport: str = 'rest'):
             eventarc.GetTriggerRequest(),
             name='name_value',
         )
+
+
+def test_list_triggers_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.list_triggers.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_list_triggers_rest_use_cached_wrapped_rpc():
@@ -7861,8 +7960,12 @@ def test_list_triggers_rest_required_fields(request_type=eventarc.ListTriggersRe
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_list_triggers_rest_unset_required_fields():
@@ -7986,6 +8089,52 @@ def test_list_triggers_rest_pager(transport: str = 'rest'):
         pages = list(client.list_triggers(request=sample_request).pages)
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
+
+
+def test_create_trigger_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.create_trigger.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_create_trigger_rest_use_cached_wrapped_rpc():
@@ -8115,8 +8264,12 @@ def test_create_trigger_rest_required_fields(request_type=eventarc.CreateTrigger
                     str(False).lower(),
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_create_trigger_rest_unset_required_fields():
@@ -8180,6 +8333,52 @@ def test_create_trigger_rest_flattened_error(transport: str = 'rest'):
             trigger=gce_trigger.Trigger(name='name_value'),
             trigger_id='trigger_id_value',
         )
+
+
+def test_update_trigger_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.update_trigger.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'patch',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'patch')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_update_trigger_rest_use_cached_wrapped_rpc():
@@ -8294,8 +8493,12 @@ def test_update_trigger_rest_required_fields(request_type=eventarc.UpdateTrigger
                     str(False).lower(),
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_update_trigger_rest_unset_required_fields():
@@ -8359,6 +8562,52 @@ def test_update_trigger_rest_flattened_error(transport: str = 'rest'):
             update_mask=field_mask_pb2.FieldMask(paths=['paths_value']),
             allow_missing=True,
         )
+
+
+def test_delete_trigger_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.delete_trigger.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'delete')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_delete_trigger_rest_use_cached_wrapped_rpc():
@@ -8476,8 +8725,12 @@ def test_delete_trigger_rest_required_fields(request_type=eventarc.DeleteTrigger
                     str(False).lower(),
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_delete_trigger_rest_unset_required_fields():
@@ -8539,6 +8792,52 @@ def test_delete_trigger_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
             allow_missing=True,
         )
+
+
+def test_get_channel_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_channel.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_get_channel_rest_use_cached_wrapped_rpc():
@@ -8642,8 +8941,12 @@ def test_get_channel_rest_required_fields(request_type=eventarc.GetChannelReques
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_channel_rest_unset_required_fields():
@@ -8705,6 +9008,52 @@ def test_get_channel_rest_flattened_error(transport: str = 'rest'):
             eventarc.GetChannelRequest(),
             name='name_value',
         )
+
+
+def test_list_channels_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.list_channels.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_list_channels_rest_use_cached_wrapped_rpc():
@@ -8810,8 +9159,12 @@ def test_list_channels_rest_required_fields(request_type=eventarc.ListChannelsRe
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_list_channels_rest_unset_required_fields():
@@ -8935,6 +9288,52 @@ def test_list_channels_rest_pager(transport: str = 'rest'):
         pages = list(client.list_channels(request=sample_request).pages)
         for page_, token in zip(pages, ['abc','def','ghi', '']):
             assert page_.raw_page.next_page_token == token
+
+
+def test_create_channel_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.create_channel_.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_create_channel_rest_use_cached_wrapped_rpc():
@@ -9064,8 +9463,12 @@ def test_create_channel_rest_required_fields(request_type=eventarc.CreateChannel
                     str(False).lower(),
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_create_channel_rest_unset_required_fields():
@@ -9129,6 +9532,52 @@ def test_create_channel_rest_flattened_error(transport: str = 'rest'):
             channel=gce_channel.Channel(name='name_value'),
             channel_id='channel_id_value',
         )
+
+
+def test_update_channel_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.update_channel.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'patch',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'patch')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_update_channel_rest_use_cached_wrapped_rpc():
@@ -9243,8 +9692,12 @@ def test_update_channel_rest_required_fields(request_type=eventarc.UpdateChannel
                     str(False).lower(),
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_update_channel_rest_unset_required_fields():
@@ -9306,6 +9759,52 @@ def test_update_channel_rest_flattened_error(transport: str = 'rest'):
             channel=gce_channel.Channel(name='name_value'),
             update_mask=field_mask_pb2.FieldMask(paths=['paths_value']),
         )
+
+
+def test_delete_channel_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.delete_channel.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'delete')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_delete_channel_rest_use_cached_wrapped_rpc():
@@ -9423,8 +9922,12 @@ def test_delete_channel_rest_required_fields(request_type=eventarc.DeleteChannel
                     str(False).lower(),
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_delete_channel_rest_unset_required_fields():
@@ -9484,6 +9987,52 @@ def test_delete_channel_rest_flattened_error(transport: str = 'rest'):
             eventarc.DeleteChannelRequest(),
             name='name_value',
         )
+
+
+def test_get_provider_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_provider.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_get_provider_rest_use_cached_wrapped_rpc():
@@ -9587,8 +10136,12 @@ def test_get_provider_rest_required_fields(request_type=eventarc.GetProviderRequ
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_provider_rest_unset_required_fields():
@@ -9650,6 +10203,52 @@ def test_get_provider_rest_flattened_error(transport: str = 'rest'):
             eventarc.GetProviderRequest(),
             name='name_value',
         )
+
+
+def test_list_providers_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.list_providers.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_list_providers_rest_use_cached_wrapped_rpc():
@@ -9755,8 +10354,12 @@ def test_list_providers_rest_required_fields(request_type=eventarc.ListProviders
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_list_providers_rest_unset_required_fields():
@@ -9882,6 +10485,52 @@ def test_list_providers_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
+def test_get_channel_connection_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_channel_connection.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_get_channel_connection_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -9983,8 +10632,12 @@ def test_get_channel_connection_rest_required_fields(request_type=eventarc.GetCh
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_channel_connection_rest_unset_required_fields():
@@ -10046,6 +10699,52 @@ def test_get_channel_connection_rest_flattened_error(transport: str = 'rest'):
             eventarc.GetChannelConnectionRequest(),
             name='name_value',
         )
+
+
+def test_list_channel_connections_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.list_channel_connections.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_list_channel_connections_rest_use_cached_wrapped_rpc():
@@ -10151,8 +10850,12 @@ def test_list_channel_connections_rest_required_fields(request_type=eventarc.Lis
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_list_channel_connections_rest_unset_required_fields():
@@ -10278,6 +10981,52 @@ def test_list_channel_connections_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
+def test_create_channel_connection_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.create_channel_connection.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_create_channel_connection_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -10394,8 +11143,12 @@ def test_create_channel_connection_rest_required_fields(request_type=eventarc.Cr
                     "",
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_create_channel_connection_rest_unset_required_fields():
@@ -10459,6 +11212,52 @@ def test_create_channel_connection_rest_flattened_error(transport: str = 'rest')
             channel_connection=gce_channel_connection.ChannelConnection(name='name_value'),
             channel_connection_id='channel_connection_id_value',
         )
+
+
+def test_delete_channel_connection_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.delete_channel_connection.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'delete')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_delete_channel_connection_rest_use_cached_wrapped_rpc():
@@ -10563,8 +11362,12 @@ def test_delete_channel_connection_rest_required_fields(request_type=eventarc.De
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_delete_channel_connection_rest_unset_required_fields():
@@ -10624,6 +11427,52 @@ def test_delete_channel_connection_rest_flattened_error(transport: str = 'rest')
             eventarc.DeleteChannelConnectionRequest(),
             name='name_value',
         )
+
+
+def test_get_google_channel_config_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_google_channel_config.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_get_google_channel_config_rest_use_cached_wrapped_rpc():
@@ -10727,8 +11576,12 @@ def test_get_google_channel_config_rest_required_fields(request_type=eventarc.Ge
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_google_channel_config_rest_unset_required_fields():
@@ -10790,6 +11643,52 @@ def test_get_google_channel_config_rest_flattened_error(transport: str = 'rest')
             eventarc.GetGoogleChannelConfigRequest(),
             name='name_value',
         )
+
+
+def test_update_google_channel_config_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.update_google_channel_config.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'patch',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'patch')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_update_google_channel_config_rest_use_cached_wrapped_rpc():
@@ -10891,8 +11790,12 @@ def test_update_google_channel_config_rest_required_fields(request_type=eventarc
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_update_google_channel_config_rest_unset_required_fields():
@@ -17235,6 +18138,314 @@ async def test_test_iam_permissions_from_dict_async():
             }
         )
         call.assert_called()
+
+
+def test_list_operations_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for mixin methods.
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_get_operation_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_delete_operation_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_cancel_operation_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+def test_list_locations_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_get_location_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+def test_set_iam_policy_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.set_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:setIamPolicy',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_get_iam_policy_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_iam_policy.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:getIamPolicy',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_test_iam_permissions_rest_url_query_params_encoding():
+    transport = transports.EventarcRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.test_iam_permissions.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/resource:testIamPermissions',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_transport_close_grpc():

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -46,6 +46,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -43,6 +43,7 @@ from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError

--- a/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -46,6 +46,7 @@ from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_config_service_v2.py
@@ -46,6 +46,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_logging_service_v2.py
@@ -43,6 +43,7 @@ from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError

--- a/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
+++ b/tests/integration/goldens/logging_internal/tests/unit/gapic/logging_v2/test_metrics_service_v2.py
@@ -46,6 +46,7 @@ from google.api_core import gapic_v1
 from google.api_core import grpc_helpers
 from google.api_core import grpc_helpers_async
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -29,10 +29,12 @@ from google.protobuf import json_format
 from google.api_core import operations_v1
 from google.cloud.location import locations_pb2 # type: ignore
 
-from requests import __version__ as requests_version
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
 import warnings
+
+from requests import __version__ as requests_version
 
 
 from google.cloud.redis_v1.types import cloud_redis
@@ -901,11 +903,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1025,11 +1034,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1146,11 +1162,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1270,11 +1293,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1394,11 +1424,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1514,11 +1551,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1634,11 +1678,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1758,11 +1809,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1880,11 +1938,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2004,11 +2069,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2128,11 +2200,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2344,11 +2423,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2462,11 +2548,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2580,11 +2673,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2672,11 +2772,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2764,11 +2871,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2882,11 +2996,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3000,11 +3121,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -38,9 +38,10 @@ from google.protobuf import json_format
 from google.api_core import operations_v1
 from google.cloud.location import locations_pb2 # type: ignore
 
-import json  # type: ignore
 import dataclasses
+import json  # type: ignore
 from typing import Any, Dict, List, Callable, Tuple, Optional, Sequence, Union
+from urllib.parse import urlencode
 
 
 from google.cloud.redis_v1.types import cloud_redis
@@ -930,11 +931,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1060,11 +1068,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1187,11 +1202,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1317,11 +1339,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1447,11 +1476,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1571,11 +1607,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1695,11 +1738,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1825,11 +1875,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1951,11 +2008,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2081,11 +2145,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2211,11 +2282,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -2467,11 +2545,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2589,11 +2674,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2711,11 +2803,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2807,11 +2906,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2903,11 +3009,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3025,11 +3138,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -3147,11 +3267,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response

--- a/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -24,6 +24,8 @@ except ImportError:  # pragma: NO COVER
 import grpc
 from grpc.experimental import aio
 from collections.abc import Iterable, AsyncIterable
+import urllib.parse
+
 from google.protobuf import json_format
 import json
 import math
@@ -59,6 +61,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
@@ -4830,6 +4833,97 @@ async def test_reschedule_maintenance_flattened_error_async():
         )
 
 
+def test_list_instances_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.list_instances.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_list_instances_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_instances.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_list_instances_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -4933,8 +5027,12 @@ def test_list_instances_rest_required_fields(request_type=cloud_redis.ListInstan
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_list_instances_rest_unset_required_fields():
@@ -5060,6 +5158,97 @@ def test_list_instances_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
+def test_get_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_get_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_get_instance_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -5161,8 +5350,12 @@ def test_get_instance_rest_required_fields(request_type=cloud_redis.GetInstanceR
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_instance_rest_unset_required_fields():
@@ -5224,6 +5417,97 @@ def test_get_instance_rest_flattened_error(transport: str = 'rest'):
             cloud_redis.GetInstanceRequest(),
             name='name_value',
         )
+
+
+def test_get_instance_auth_string_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_instance_auth_string.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_get_instance_auth_string_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_instance_auth_string.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_get_instance_auth_string_rest_use_cached_wrapped_rpc():
@@ -5327,8 +5611,12 @@ def test_get_instance_auth_string_rest_required_fields(request_type=cloud_redis.
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_instance_auth_string_rest_unset_required_fields():
@@ -5390,6 +5678,97 @@ def test_get_instance_auth_string_rest_flattened_error(transport: str = 'rest'):
             cloud_redis.GetInstanceAuthStringRequest(),
             name='name_value',
         )
+
+
+def test_create_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.create_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_create_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.create_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_create_instance_rest_use_cached_wrapped_rpc():
@@ -5508,8 +5887,12 @@ def test_create_instance_rest_required_fields(request_type=cloud_redis.CreateIns
                     "",
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_create_instance_rest_unset_required_fields():
@@ -5573,6 +5956,97 @@ def test_create_instance_rest_flattened_error(transport: str = 'rest'):
             instance_id='instance_id_value',
             instance=cloud_redis.Instance(name='name_value'),
         )
+
+
+def test_update_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.update_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'patch',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'patch')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_update_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.update_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'patch',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'patch')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_update_instance_rest_use_cached_wrapped_rpc():
@@ -5675,8 +6149,12 @@ def test_update_instance_rest_required_fields(request_type=cloud_redis.UpdateIns
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_update_instance_rest_unset_required_fields():
@@ -5738,6 +6216,97 @@ def test_update_instance_rest_flattened_error(transport: str = 'rest'):
             update_mask=field_mask_pb2.FieldMask(paths=['paths_value']),
             instance=cloud_redis.Instance(name='name_value'),
         )
+
+
+def test_upgrade_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.upgrade_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_upgrade_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.upgrade_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_upgrade_instance_rest_use_cached_wrapped_rpc():
@@ -5847,8 +6416,12 @@ def test_upgrade_instance_rest_required_fields(request_type=cloud_redis.UpgradeI
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_upgrade_instance_rest_unset_required_fields():
@@ -5910,6 +6483,97 @@ def test_upgrade_instance_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
             redis_version='redis_version_value',
         )
+
+
+def test_import_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.import_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_import_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.import_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_import_instance_rest_use_cached_wrapped_rpc():
@@ -6015,8 +6679,12 @@ def test_import_instance_rest_required_fields(request_type=cloud_redis.ImportIns
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_import_instance_rest_unset_required_fields():
@@ -6078,6 +6746,97 @@ def test_import_instance_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
             input_config=cloud_redis.InputConfig(gcs_source=cloud_redis.GcsSource(uri='uri_value')),
         )
+
+
+def test_export_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.export_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_export_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.export_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_export_instance_rest_use_cached_wrapped_rpc():
@@ -6183,8 +6942,12 @@ def test_export_instance_rest_required_fields(request_type=cloud_redis.ExportIns
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_export_instance_rest_unset_required_fields():
@@ -6246,6 +7009,97 @@ def test_export_instance_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
             output_config=cloud_redis.OutputConfig(gcs_destination=cloud_redis.GcsDestination(uri='uri_value')),
         )
+
+
+def test_failover_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.failover_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_failover_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.failover_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_failover_instance_rest_use_cached_wrapped_rpc():
@@ -6351,8 +7205,12 @@ def test_failover_instance_rest_required_fields(request_type=cloud_redis.Failove
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_failover_instance_rest_unset_required_fields():
@@ -6414,6 +7272,97 @@ def test_failover_instance_rest_flattened_error(transport: str = 'rest'):
             name='name_value',
             data_protection_mode=cloud_redis.FailoverInstanceRequest.DataProtectionMode.LIMITED_DATA_LOSS,
         )
+
+
+def test_delete_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.delete_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'delete')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_delete_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.delete_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'delete',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'delete')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_delete_instance_rest_use_cached_wrapped_rpc():
@@ -6518,8 +7467,12 @@ def test_delete_instance_rest_required_fields(request_type=cloud_redis.DeleteIns
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_delete_instance_rest_unset_required_fields():
@@ -6579,6 +7532,97 @@ def test_delete_instance_rest_flattened_error(transport: str = 'rest'):
             cloud_redis.DeleteInstanceRequest(),
             name='name_value',
         )
+
+
+def test_reschedule_maintenance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.reschedule_maintenance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_reschedule_maintenance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.reschedule_maintenance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_reschedule_maintenance_rest_use_cached_wrapped_rpc():
@@ -6684,8 +7728,12 @@ def test_reschedule_maintenance_rest_required_fields(request_type=cloud_redis.Re
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_reschedule_maintenance_rest_unset_required_fields():
@@ -12993,6 +14041,430 @@ async def test_get_location_from_dict_async():
             }
         )
         call.assert_called()
+
+
+def test_list_operations_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for mixin methods.
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_get_operation_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_delete_operation_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_cancel_operation_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+def test_list_locations_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_get_location_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_list_operations_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_get_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_delete_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_cancel_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_list_locations_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_get_location_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_transport_close_grpc():

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/transports/rest.py
@@ -29,10 +29,12 @@ from google.protobuf import json_format
 from google.api_core import operations_v1
 from google.cloud.location import locations_pb2 # type: ignore
 
-from requests import __version__ as requests_version
 import dataclasses
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from urllib.parse import urlencode
 import warnings
+
+from requests import __version__ as requests_version
 
 
 from google.cloud.redis_v1.types import cloud_redis
@@ -637,11 +639,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -761,11 +770,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -882,11 +898,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1002,11 +1025,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1124,11 +1154,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1292,11 +1329,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1410,11 +1454,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1528,11 +1579,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1620,11 +1678,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1712,11 +1777,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1830,11 +1902,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1948,11 +2027,18 @@ class CloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/transports/rest_asyncio.py
@@ -38,9 +38,10 @@ from google.protobuf import json_format
 from google.api_core import operations_v1
 from google.cloud.location import locations_pb2 # type: ignore
 
-import json  # type: ignore
 import dataclasses
+import json  # type: ignore
 from typing import Any, Dict, List, Callable, Tuple, Optional, Sequence, Union
+from urllib.parse import urlencode
 
 
 from google.cloud.redis_v1.types import cloud_redis
@@ -636,11 +637,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -766,11 +774,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -893,11 +908,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1017,11 +1039,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1143,11 +1172,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response
@@ -1363,11 +1399,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1485,11 +1528,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1607,11 +1657,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1703,11 +1760,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1799,11 +1863,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -1921,11 +1992,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 )
             return response
 
@@ -2043,11 +2121,18 @@ class AsyncCloudRedisRestTransport(_BaseCloudRedisRestTransport):
             method = transcoded_request['method']
             headers = dict(metadata)
             headers['Content-Type'] = 'application/json'
+            # Build query string manually to avoid URL-encoding special characters like '$'.
+            # The `requests` library encodes '$' as '%24' when using the `params` argument,
+            # which causes API errors for parameters like '$alt'. See:
+            # https://github.com/googleapis/gapic-generator-python/issues/2514
+            _query_params = rest_helpers.flatten_query_params(query_params, strict=True)
+            _request_url = "{host}{uri}".format(host=host, uri=uri)
+            if _query_params:
+                _request_url = "{}?{}".format(_request_url, urlencode(_query_params, safe="$"))
             response = await getattr(session, method)(
-                "{host}{uri}".format(host=host, uri=uri),
+                _request_url,
                 timeout=timeout,
                 headers=headers,
-                params=rest_helpers.flatten_query_params(query_params, strict=True),
                 data=body,
                 )
             return response

--- a/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
+++ b/tests/integration/goldens/redis_selective/tests/unit/gapic/redis_v1/test_cloud_redis.py
@@ -24,6 +24,8 @@ except ImportError:  # pragma: NO COVER
 import grpc
 from grpc.experimental import aio
 from collections.abc import Iterable, AsyncIterable
+import urllib.parse
+
 from google.protobuf import json_format
 import json
 import math
@@ -59,6 +61,7 @@ from google.api_core import operation
 from google.api_core import operation_async  # type: ignore
 from google.api_core import operations_v1
 from google.api_core import path_template
+from google.api_core import rest_helpers
 from google.api_core import retry as retries
 from google.auth import credentials as ga_credentials
 from google.auth.exceptions import MutualTLSChannelError
@@ -2878,6 +2881,97 @@ async def test_delete_instance_flattened_error_async():
         )
 
 
+def test_list_instances_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.list_instances.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_list_instances_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_instances.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_list_instances_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -2981,8 +3075,12 @@ def test_list_instances_rest_required_fields(request_type=cloud_redis.ListInstan
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_list_instances_rest_unset_required_fields():
@@ -3108,6 +3206,97 @@ def test_list_instances_rest_pager(transport: str = 'rest'):
             assert page_.raw_page.next_page_token == token
 
 
+def test_get_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.get_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_get_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'get')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
 def test_get_instance_rest_use_cached_wrapped_rpc():
     # Clients should use _prep_wrapped_messages to create cached wrapped rpcs,
     # instead of constructing them on each call
@@ -3209,8 +3398,12 @@ def test_get_instance_rest_required_fields(request_type=cloud_redis.GetInstanceR
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_get_instance_rest_unset_required_fields():
@@ -3272,6 +3465,97 @@ def test_get_instance_rest_flattened_error(transport: str = 'rest'):
             cloud_redis.GetInstanceRequest(),
             name='name_value',
         )
+
+
+def test_create_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.create_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_create_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.create_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'post',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'post')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_create_instance_rest_use_cached_wrapped_rpc():
@@ -3390,8 +3674,12 @@ def test_create_instance_rest_required_fields(request_type=cloud_redis.CreateIns
                     "",
                 ),
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_create_instance_rest_unset_required_fields():
@@ -3455,6 +3743,97 @@ def test_create_instance_rest_flattened_error(transport: str = 'rest'):
             instance_id='instance_id_value',
             instance=cloud_redis.Instance(name='name_value'),
         )
+
+
+def test_update_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.update_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'patch',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'patch')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_update_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.update_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'patch',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'patch')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_update_instance_rest_use_cached_wrapped_rpc():
@@ -3557,8 +3936,12 @@ def test_update_instance_rest_required_fields(request_type=cloud_redis.UpdateIns
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_update_instance_rest_unset_required_fields():
@@ -3620,6 +4003,97 @@ def test_update_instance_rest_flattened_error(transport: str = 'rest'):
             update_mask=field_mask_pb2.FieldMask(paths=['paths_value']),
             instance=cloud_redis.Instance(name='name_value'),
         )
+
+
+def test_delete_instance_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string. This tests the urlencode call with safe="$".
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials)
+    method_class = transport.delete_instance.__class__
+    # Get the _get_response static method from the method class
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    # Mock flatten_query_params to return query params that include '$' character
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        # Verify the session method was called with the URL containing query params
+        session_method = getattr(mock_session, 'delete')
+        assert session_method.called
+
+        # The URL should contain '$alt' (not '%24alt') because safe="$" is used
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_delete_instance_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for the async REST transport.
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.delete_instance.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+    mock_session.post.return_value = mock_response
+    mock_session.put.return_value = mock_response
+    mock_session.patch.return_value = mock_response
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test',
+            'method': 'delete',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        session_method = getattr(mock_session, 'delete')
+        assert session_method.called
+
+        call_url = session_method.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_delete_instance_rest_use_cached_wrapped_rpc():
@@ -3724,8 +4198,12 @@ def test_delete_instance_rest_required_fields(request_type=cloud_redis.DeleteIns
 
             expected_params = [
             ]
-            actual_params = req.call_args.kwargs['params']
-            assert expected_params == actual_params
+            # Verify query params are correctly included in the URL
+            # Session.request is called as request(method, url, ...), so url is args[1]
+            actual_url = req.call_args.args[1]
+            parsed_url = urllib.parse.urlparse(actual_url)
+            actual_params = urllib.parse.parse_qsl(parsed_url.query, keep_blank_values=True)
+            assert set(expected_params).issubset(set(actual_params))
 
 
 def test_delete_instance_rest_unset_required_fields():
@@ -8159,6 +8637,430 @@ async def test_get_location_from_dict_async():
             }
         )
         call.assert_called()
+
+
+def test_list_operations_rest_url_query_params_encoding():
+    # Verify that special characters like '$' are correctly preserved (not URL-encoded)
+    # when building the URL query string for mixin methods.
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_get_operation_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_delete_operation_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_cancel_operation_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+def test_list_locations_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+def test_get_location_rest_url_query_params_encoding():
+    transport = transports.CloudRedisRestTransport(credentials=ga_credentials.AnonymousCredentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.Mock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_list_operations_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_operations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_get_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_delete_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.delete_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.delete.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1',
+            'method': 'delete',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.delete.called
+        call_url = mock_session.delete.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_cancel_operation_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.cancel_operation.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.post.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/test/operations/op1:cancel',
+            'method': 'post',
+            'body': {},
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+            body={},
+        )
+
+        assert mock_session.post.called
+        call_url = mock_session.post.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+
+@pytest.mark.asyncio
+async def test_list_locations_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.list_locations.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
+
+@pytest.mark.asyncio
+async def test_get_location_rest_asyncio_url_query_params_encoding():
+    if not HAS_ASYNC_REST_EXTRA:
+        pytest.skip("the library must be installed with the `async_rest` extra to test this feature.")
+    transport = transports.AsyncCloudRedisRestTransport(credentials=async_anonymous_credentials())
+    method_class = transport.get_location.__class__
+    get_response_fn = method_class._get_response
+
+    mock_session = mock.AsyncMock()
+    mock_response = mock.Mock()
+    mock_response.status_code = 200
+    mock_session.get.return_value = mock_response
+
+    with mock.patch.object(rest_helpers, 'flatten_query_params') as mock_flatten:
+        mock_flatten.return_value = [('$alt', 'json;enum-encoding=int'), ('foo', 'bar')]
+
+        transcoded_request = {
+            'uri': '/v1/projects/p1/locations/l1',
+            'method': 'get',
+        }
+
+        await get_response_fn(
+            host='https://example.com',
+            metadata=[],
+            query_params={},
+            session=mock_session,
+            timeout=None,
+            transcoded_request=transcoded_request,
+        )
+
+        assert mock_session.get.called
+        call_url = mock_session.get.call_args.args[0]
+        assert '$alt=json' in call_url
+        assert '%24alt' not in call_url
+        assert 'foo=bar' in call_url
 
 
 def test_transport_close_grpc():


### PR DESCRIPTION
## Description

The `requests` library encodes `$` as `%24` when query parameters are passed via the `params` argument. This causes API errors for parameters like `$alt`:

```
google.api_core.exceptions.BadRequest: 400 POST
https://.../findNeighbors?%24alt=json%3Benum-encoding%3Dint:
Could not find field "%24alt" in the type "...FindNeighborsRequest".
```

## Solution

Build the query string manually using `urlencode(query_params, safe='$')` instead of passing `params` to the `requests` library. This preserves the `$` character in query parameters.

## Changes

- Modified `_get_response` method in `_shared_macros.j2` to build URL with query string manually
- Added `from urllib.parse import urlencode` import to REST transport templates
- Updated test templates to verify query params via URL parsing instead of `kwargs['params']`

## Testing

```python
from urllib.parse import urlencode

# Before: requests encodes $ as %24
# ?%24alt=json%3Benum-encoding%3Dint

# After: $ is preserved
query_params = [('$alt', 'json;enum-encoding=int')]
urlencode(query_params, safe='$')
# ?$alt=json%3Benum-encoding%3Dint
```

## Related Issues

- Fixes googleapis/google-cloud-python#16206
- Related: googleapis/python-aiplatform#5848
- Related: googleapis/python-aiplatform#5467