### PR TITLE
chore(types): fix mypy checks

### DIFF
--- a/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/ads-templates/%namespace/%name/%version/%sub/services/%service/transports/base.py.j2
@@ -98,8 +98,6 @@ class {{ service.name }}Transport(abc.ABC):
             host += ':443'
         self._host = host
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
 
@@ -114,11 +112,12 @@ class {{ service.name }}Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
 
         # If the credentials are service account credentials, then always try to use self signed JWT.
         if always_use_jwt_access and isinstance(credentials, service_account.Credentials) and hasattr(service_account.Credentials, "with_always_use_jwt_access"):

--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -108,8 +108,6 @@ class {{ service.name }}Transport(abc.ABC):
         self._extended_operations_services: Dict[str, Any] = {}
         {% endif %}
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -123,11 +121,12 @@ class {{ service.name }}Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/gapic/templates/mypy.ini.j2
+++ b/gapic/templates/mypy.ini.j2
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True

--- a/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
+++ b/tests/integration/goldens/asset/google/cloud/asset_v1/services/asset_service/transports/base.py
@@ -85,8 +85,6 @@ class AssetServiceTransport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -100,11 +98,12 @@ class AssetServiceTransport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/asset/mypy.ini
+++ b/tests/integration/goldens/asset/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True

--- a/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
+++ b/tests/integration/goldens/credentials/google/iam/credentials_v1/services/iam_credentials/transports/base.py
@@ -82,8 +82,6 @@ class IAMCredentialsTransport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -97,11 +95,12 @@ class IAMCredentialsTransport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/credentials/mypy.ini
+++ b/tests/integration/goldens/credentials/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True

--- a/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
+++ b/tests/integration/goldens/eventarc/google/cloud/eventarc_v1/services/eventarc/transports/base.py
@@ -93,8 +93,6 @@ class EventarcTransport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -108,11 +106,12 @@ class EventarcTransport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/eventarc/mypy.ini
+++ b/tests/integration/goldens/eventarc/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -88,8 +88,6 @@ class ConfigServiceV2Transport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -103,11 +101,12 @@ class ConfigServiceV2Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -88,8 +88,6 @@ class LoggingServiceV2Transport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -103,11 +101,12 @@ class LoggingServiceV2Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -88,8 +88,6 @@ class MetricsServiceV2Transport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -103,11 +101,12 @@ class MetricsServiceV2Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/logging/mypy.ini
+++ b/tests/integration/goldens/logging/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/config_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/config_service_v2/transports/base.py
@@ -88,8 +88,6 @@ class ConfigServiceV2Transport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -103,11 +101,12 @@ class ConfigServiceV2Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/logging_service_v2/transports/base.py
@@ -88,8 +88,6 @@ class LoggingServiceV2Transport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -103,11 +101,12 @@ class LoggingServiceV2Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
+++ b/tests/integration/goldens/logging_internal/google/cloud/logging_v2/services/metrics_service_v2/transports/base.py
@@ -88,8 +88,6 @@ class MetricsServiceV2Transport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -103,11 +101,12 @@ class MetricsServiceV2Transport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/logging_internal/mypy.ini
+++ b/tests/integration/goldens/logging_internal/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True

--- a/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -85,8 +85,6 @@ class CloudRedisTransport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -100,11 +98,12 @@ class CloudRedisTransport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/redis/mypy.ini
+++ b/tests/integration/goldens/redis/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True

--- a/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/transports/base.py
+++ b/tests/integration/goldens/redis_selective/google/cloud/redis_v1/services/cloud_redis/transports/base.py
@@ -85,8 +85,6 @@ class CloudRedisTransport(abc.ABC):
                 be used for service account credentials.
         """
 
-        scopes_kwargs = {"scopes": scopes, "default_scopes": self.AUTH_SCOPES}
-
         # Save the scopes.
         self._scopes = scopes
         if not hasattr(self, "_ignore_credentials"):
@@ -100,11 +98,12 @@ class CloudRedisTransport(abc.ABC):
         if credentials_file is not None:
             credentials, _ = google.auth.load_credentials_from_file(
                                 credentials_file,
-                                **scopes_kwargs,
-                                quota_project_id=quota_project_id
+                                scopes=scopes,
+                                quota_project_id=quota_project_id,
+                                default_scopes=self.AUTH_SCOPES,
                             )
         elif credentials is None and not self._ignore_credentials:
-            credentials, _ = google.auth.default(**scopes_kwargs, quota_project_id=quota_project_id)
+            credentials, _ = google.auth.default(scopes=scopes, quota_project_id=quota_project_id, default_scopes=self.AUTH_SCOPES)
             # Don't apply audience if the credentials file passed from user.
             if hasattr(credentials, "with_gdch_audience"):
                 credentials = credentials.with_gdch_audience(api_audience if api_audience else host)

--- a/tests/integration/goldens/redis_selective/mypy.ini
+++ b/tests/integration/goldens/redis_selective/mypy.ini
@@ -1,3 +1,3 @@
 [mypy]
-python_version = 3.7
+python_version = 3.14
 namespace_packages = True


### PR DESCRIPTION
Mypy checks are currently failing on generated outputs, because the `google-auth` library [recently added some stricter type annotations](https://github.com/googleapis/google-auth-library-python/pull/1588)

This PR:
- unwraps a `**kwargs` call to provide cleaner typing
- updates mypy.ini to use python 3.14, to avoid warnings about deprecated 3.7 version