### PR TITLE
fix: add cryptography to constraints file

### DIFF
--- a/gapic/templates/testing/_default_constraints.j2
+++ b/gapic/templates/testing/_default_constraints.j2
@@ -6,6 +6,8 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 {% for package_tuple, package_info in pypi_packages.items() %}
 {# Quick check to make sure `package_info.package_name` is not the package being generated so we don't circularly include this package in its own constraints file. #}
 {% if api.naming.warehouse_package_name != package_info.package_name %}

--- a/gapic/templates/testing/constraints-3.7.txt.j2
+++ b/gapic/templates/testing/constraints-3.7.txt.j2
@@ -7,6 +7,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/asset/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.10.txt
@@ -6,6 +6,8 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 google-cloud-access-context-manager
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.11.txt
@@ -6,6 +6,8 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 google-cloud-access-context-manager
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.12.txt
@@ -6,6 +6,8 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 google-cloud-access-context-manager
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.7.txt
@@ -6,6 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/asset/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.8.txt
@@ -6,6 +6,8 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 google-cloud-access-context-manager
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/asset/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/asset/testing/constraints-3.9.txt
@@ -6,6 +6,8 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 google-cloud-access-context-manager
 google-cloud-os-config
 grpc-google-iam-v1

--- a/tests/integration/goldens/credentials/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.10.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/credentials/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.11.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/credentials/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.12.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/credentials/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.7.txt
@@ -6,6 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/credentials/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.8.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/credentials/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/credentials/testing/constraints-3.9.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.10.txt
@@ -6,4 +6,6 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.11.txt
@@ -6,4 +6,6 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.12.txt
@@ -6,4 +6,6 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.7.txt
@@ -6,6 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.8.txt
@@ -6,4 +6,6 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 grpc-google-iam-v1

--- a/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/eventarc/testing/constraints-3.9.txt
@@ -6,4 +6,6 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography
 grpc-google-iam-v1

--- a/tests/integration/goldens/logging/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.10.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.11.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.12.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.7.txt
@@ -6,6 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/logging/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.8.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/logging/testing/constraints-3.9.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.10.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.11.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.12.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.7.txt
@@ -6,6 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.8.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/logging_internal/testing/constraints-3.9.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.10.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.11.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.12.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.7.txt
@@ -6,6 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/redis/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.8.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis/testing/constraints-3.9.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.10.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.11.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.12.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.7.txt
@@ -6,6 +6,8 @@
 # Then this file should have google-cloud-foo==1.14.0
 google-api-core==1.34.1
 google-auth==2.14.1
+# cryptography is a direct dependency of google-auth
+cryptography==38.0.3
 # TODO(https://github.com/googleapis/gapic-generator-python/issues/2453)
 # Add the minimum supported version of grpcio to constraints files
 proto-plus==1.22.3

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.8.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography

--- a/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
+++ b/tests/integration/goldens/redis_selective/testing/constraints-3.9.txt
@@ -6,3 +6,5 @@ google-auth
 grpcio
 proto-plus
 protobuf
+# cryptography is a direct dependency of google-auth
+cryptography


### PR DESCRIPTION
This PR is needed to address the following failure in the `core_deps_from_source-3.14` presubmit in `google-cloud-python` [here](https://github.com/googleapis/google-cloud-python/actions/runs/20927219906/job/60625400318?pr=14922). See the stack trace below

```

==================================== ERRORS ====================================
____________ ERROR collecting tests/unit/gapic/test_client_info.py _____________
ImportError while importing test module '/home/runner/work/google-cloud-python/google-cloud-python/packages/google-api-core/tests/unit/gapic/test_client_info.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/hostedtoolcache/Python/3.14.2/x64/lib/python3.14/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/unit/gapic/test_client_info.py:23: in <module>
    from google.api_core.gapic_v1 import client_info
google/api_core/gapic_v1/__init__.py:18: in <module>
    from google.api_core.gapic_v1 import method
google/api_core/gapic_v1/method.py:24: in <module>
    from google.api_core import grpc_helpers
google/api_core/grpc_helpers.py:23: in <module>
    import google.auth.transport.grpc
.nox/core_deps_from_source-protobuf_implementation-python/lib/python3.14/site-packages/google/auth/transport/grpc.py:23: in <module>
    from google.oauth2 import service_account
.nox/core_deps_from_source-protobuf_implementation-python/lib/python3.14/site-packages/google/oauth2/service_account.py:78: in <module>
    from google.auth import _service_account_info
.nox/core_deps_from_source-protobuf_implementation-python/lib/python3.14/site-packages/google/auth/_service_account_info.py:20: in <module>
    from google.auth import crypt
.nox/core_deps_from_source-protobuf_implementation-python/lib/python3.14/site-packages/google/auth/crypt/__init__.py:41: in <module>
    from google.auth.crypt import es
.nox/core_deps_from_source-protobuf_implementation-python/lib/python3.14/site-packages/google/auth/crypt/es.py:21: in <module>
    import cryptography.exceptions
```

Dependencies are installed with the `--no-deps` option during this pre-release test in order to ensure that pre-release versions of dependencies are not downgraded to the stable versions. In this case, we want to ensure that pre-release versions are used for the purpose of having a comprehensive pre-release test. This means that when a new dependency is added to a core dependency, we need to manually add it to the constraints file which is used during the pre-release test. 

https://github.com/googleapis/gapic-generator-python/blob/1919b505d7b8e6e3317ae69f065304cb5ca2e533/gapic/templates/noxfile.py.j2#L601-L603

https://github.com/googleapis/gapic-generator-python/blob/1919b505d7b8e6e3317ae69f065304cb5ca2e533/gapic/templates/noxfile.py.j2#L566-L573