### PR TITLE
fix: fix mypy for services with extended operations methods

### DIFF
--- a/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
+++ b/gapic/templates/%namespace/%name_%version/%sub/services/%service/transports/base.py.j2
@@ -3,7 +3,7 @@
 {% block content %}
 
 import abc
-from typing import Awaitable, Callable, Dict, Optional, Sequence, Union
+from typing import {% if service.any_extended_operations_methods %}Any, {% endif %}Awaitable, Callable, Dict, Optional, Sequence, Union
 
 {% set package_path = api.naming.module_namespace|join('.') + "." + api.naming.versioned_module_name %}
 from {{package_path}} import gapic_version as package_version


### PR DESCRIPTION
This PR fixes the following issue when running `mypy` for `google-cloud-compute` and `google-cloud-compute-v1beta` where we see `error: Name "Any" is not defined  [name-defined]` when running mypy

```
.nox/mypy-3-14/lib/python3.14/site-packages/google/cloud/compute_v1beta/services/wire_groups/transports/base.py:88: error: Name "Any" is not defined  [name-defined]
.nox/mypy-3-14/lib/python3.14/site-packages/google/cloud/compute_v1beta/services/wire_groups/transports/base.py:88: note: Did you forget to import it from "typing"? (Suggestion: "from typing import Any")
.nox/mypy-3-14/lib/python3.14/site-packages/google/cloud/compute_v1beta/services/vpn_tunnels/transports/base.py:88: error: Name "Any" is not defined  [name-defined]
```

See follow up issue to improve the golden files where the `mypy` presubmit is run on generated code.: https://github.com/googleapis/google-cloud-python/issues/16203
See follow up bug for pre-release failure: https://github.com/googleapis/proto-plus-python/issues/558