### PR TITLE
chore: librarian release pull request: 20260126T181958Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
 libraries:
   - id: gapic-generator
-    version: 1.30.4
+    version: 1.30.5
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.30.5](https://github.com/googleapis/gapic-generator-python/compare/v1.30.4...v1.30.5) (2026-01-26)
+
+
+### Bug Fixes
+
+* fix mypy for services with extended operations methods (#2536) ([84667d1b55a5dd895585ae40cbd32b2925ecf8e8](https://github.com/googleapis/gapic-generator-python/commit/84667d1b55a5dd895585ae40cbd32b2925ecf8e8))
+
 ## [1.30.4](https://github.com/googleapis/gapic-generator-python/compare/v1.30.3...v1.30.4) (2026-01-20)
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/gapic-generator-python"
-version = "1.30.4"
+version = "1.30.5"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
<details><summary>gapic-generator: 1.30.5</summary>

## [1.30.5](https://github.com/googleapis/gapic-generator-python/compare/v1.30.4...v1.30.5) (2026-01-26)

### Bug Fixes

* fix mypy for services with extended operations methods (#2536) ([84667d1b](https://github.com/googleapis/gapic-generator-python/commit/84667d1b))

</details>