### PR TITLE
chore: remove pin for types-protobuf to support 3.14

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -739,7 +739,7 @@ def mypy(session):
     # Pin to click==8.1.3 to workaround https://github.com/pallets/click/issues/2558
     session.install(
         "mypy",
-        "types-protobuf<=3.19.7",
+        "types-protobuf",
         "types-PyYAML",
         "types-dataclasses",
         "click==8.1.3",


### PR DESCRIPTION
This is required to support running mypy with the latest version of Python i.e. 3.14
