### PR TITLE
chore: librarian release pull request: 20260130T213357Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
 libraries:
   - id: gapic-generator
-    version: 1.30.5
+    version: 1.30.6
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.30.6](https://github.com/googleapis/gapic-generator-python/compare/v1.30.5...v1.30.6) (2026-01-30)
+
+
+### Bug Fixes
+
+* fix incorrect REST request serialization (#2549) ([46e765e5fa2677b5b0d5c85ae5bdad495f9f7e60](https://github.com/googleapis/gapic-generator-python/commit/46e765e5fa2677b5b0d5c85ae5bdad495f9f7e60))
+* filter sphinx warnings related to adding a new line after lists (#2533) ([ae0a9e817513c6d4d03fc86685f66be8d9699862](https://github.com/googleapis/gapic-generator-python/commit/ae0a9e817513c6d4d03fc86685f66be8d9699862))
+
 ## [1.30.5](https://github.com/googleapis/gapic-generator-python/compare/v1.30.4...v1.30.5) (2026-01-26)
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/gapic-generator-python"
-version = "1.30.5"
+version = "1.30.6"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
<details><summary>gapic-generator: 1.30.6</summary>

## [1.30.6](https://github.com/googleapis/gapic-generator-python/compare/v1.30.5...v1.30.6) (2026-01-30)

### Bug Fixes

* fix incorrect REST request serialization (#2549) ([46e765e5](https://github.com/googleapis/gapic-generator-python/commit/46e765e5))

* filter sphinx warnings related to adding a new line after lists (#2533) ([ae0a9e81](https://github.com/googleapis/gapic-generator-python/commit/ae0a9e81))

</details>