### PR TITLE
chore: update dev instructions to include  `nox -s format`

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,7 +23,7 @@ Execute unit tests by running one of the sessions prefixed with `unit-`.
 
 ## Formatting
 
--   Lint sources by running `nox -s format`. Use `nox -s lint` to run lint check.
+-   Format sources by running `nox -s format`. Use `nox -s lint` to run lint check.
 
 ## Integration Tests
 


### PR DESCRIPTION
Update instructions so that users are running `nox -s format` instead of the deprecated `nox -s blacken` for formatting code.
