### PR TITLE
chore: librarian release pull request: 20260309T132416Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
 libraries:
   - id: gapic-generator
-    version: 1.30.9
+    version: 1.30.10
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 [1]: https://pypi.org/project/gapic-generator/#history
 
+## [1.30.10](https://github.com/googleapis/gapic-generator-python/compare/v1.30.9...v1.30.10) (2026-03-09)
+
+
+### Bug Fixes
+
+* improve type checking (#2530) ([bc3836becb7d0a4e06a1e30128370b525c0762f5](https://github.com/googleapis/gapic-generator-python/commit/bc3836becb7d0a4e06a1e30128370b525c0762f5))
+* Allow protobuf 7.x (#2575) ([98137d07f6cbb1aec87826638924c6e0eba78c3d](https://github.com/googleapis/gapic-generator-python/commit/98137d07f6cbb1aec87826638924c6e0eba78c3d))
+
 ## [1.30.9](https://github.com/googleapis/gapic-generator-python/compare/v1.30.8...v1.30.9) (2026-02-19)
 
 ## [1.30.8](https://github.com/googleapis/gapic-generator-python/compare/v1.30.7...v1.30.8) (2026-02-09)

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 name = "gapic-generator"
 description = "Google API Client Generator for Python"
 url = "https://github.com/googleapis/gapic-generator-python"
-version = "1.30.9"
+version = "1.30.10"
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # Ensure that the lower bounds of these dependencies match what we have in the


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.8.3
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:68c7c79adf43af1be4c0527673342dd180aebebf652ea623614eaebff924ca27
<details><summary>gapic-generator: v1.30.10</summary>

## [v1.30.10](https://github.com/googleapis/gapic-generator-python/compare/v1.30.9...v1.30.10) (2026-03-09)

### Bug Fixes

* Allow protobuf 7.x (#2575) ([98137d07](https://github.com/googleapis/gapic-generator-python/commit/98137d07))

* improve type checking (#2530) ([bc3836be](https://github.com/googleapis/gapic-generator-python/commit/bc3836be))

</details>